### PR TITLE
Add missing @aws-sdk/client-s3 dependencies to fix deploy crash

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,8 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.3",
     "uuid": "^9.0.1",
+    "@aws-sdk/client-s3": "^3.525.0",
+    "@aws-sdk/s3-request-presigner": "^3.525.0",
     "cloudinary": "^1.41.0",
     "helmet": "^7.1.0",
     "express-rate-limit": "^7.1.5"


### PR DESCRIPTION
r2Storage.js imports @aws-sdk/client-s3 and @aws-sdk/s3-request-presigner but neither was listed in package.json, causing ERR_MODULE_NOT_FOUND on Render.

https://claude.ai/code/session_01MkyNXhvgEVhwtCQmeYtPQT