### PR TITLE
Show course numbers on admin dashboard and reorder CE hrs before modules

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -561,9 +561,10 @@
             </div>
           </div>
           <div class="flex items-center gap-4 text-sm flex-wrap">
-            <span class="text-forest-600"><strong class="text-forest-800">${sections}</strong> modules</span>
-            <span class="text-forest-300">·</span>
+            ${c.courseCode ? `<span class="font-mono text-xs px-2 py-0.5 rounded bg-forest-50 text-forest-700 border border-forest-200">${esc(c.courseCode)}</span><span class="text-forest-300">·</span>` : ''}
             <span class="text-forest-600"><strong class="text-forest-800">${ceHours}</strong> CE hrs</span>
+            <span class="text-forest-300">·</span>
+            <span class="text-forest-600"><strong class="text-forest-800">${sections}</strong> modules</span>
             <span class="text-forest-300">·</span>
             <span class="text-forest-600"><strong class="text-forest-800">${c._words.toLocaleString()}</strong> words</span>
             ${target > 0 ? `

--- a/server/src/models/Course.js
+++ b/server/src/models/Course.js
@@ -139,6 +139,7 @@ const courseSchema = new mongoose.Schema({
   },
   title: { type: String, required: true },
   subtitle: { type: String },
+  courseCode: { type: String, trim: true },
   description: { type: String, required: true },
   thumbnail: { type: String },
   

--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -97,6 +97,9 @@ const CourseSchema = new mongoose.Schema({
   description: { type: String, required: true },
   thumbnail: String,
   
+  // Course code (admin-assigned identifier, e.g. CR-ETH301)
+  courseCode: { type: String, trim: true },
+
   // CE/Accreditation info
   ceHours: { type: Number, required: true },
   ceProvider: { type: String, default: 'NBCC ACEP #7760' },

--- a/server/src/routes/adminCourses.js
+++ b/server/src/routes/adminCourses.js
@@ -935,7 +935,7 @@ router.get('/enrollments/search', protect, adminOnly, async (req, res) => {
 router.get('/courses', protect, adminOnly, async (req, res) => {
   try {
     const courses = await Course.find()
-      .select('title slug category ceuHours ceHours status enrollmentCount createdAt isExternal externalUrl importType source wordCount moduleCount price ceuCategories modules')
+      .select('title slug category ceuHours ceHours status enrollmentCount createdAt isExternal externalUrl importType source wordCount moduleCount price ceuCategories modules courseCode')
       .sort({ createdAt: -1 })
       .lean();
 

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -62,7 +62,7 @@ router.get('/', async (req, res) => {
     }
 
     const courses = await Course.find(query)
-      .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount sectionCount moduleCount assessmentQuestionCount ceuCategories accessType price pricingTier status ceuHours ceuApprovalNumber')
+      .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount sectionCount moduleCount assessmentQuestionCount ceuCategories accessType price pricingTier status ceuHours ceuApprovalNumber courseCode')
       .sort({ publishedAt: -1 })
       .skip((page - 1) * limit)
       .limit(parseInt(limit));


### PR DESCRIPTION
- Add courseCode field to both Course and InteractiveCourse models
- Include courseCode in admin courses and interactive courses API select fields
- Display course code badge on admin course cards when assigned
- Reorder stats row: course code → CE hrs → modules → words

https://claude.ai/code/session_01VWmcLNPXzmLApaA3dEQUqq