### PR TITLE
Improve knowledge checks UI: smaller, more natural inline placement

### DIFF
--- a/client/src/components/CourseViewer.jsx
+++ b/client/src/components/CourseViewer.jsx
@@ -581,7 +581,7 @@ function SectionView({
 
       {/* Content Blocks */}
       {!showQuiz ? (
-        <div className="space-y-8">
+        <div className="space-y-6">
           {section.contentBlocks.map((block, index) => (
             <div 
               key={index}
@@ -603,30 +603,34 @@ function SectionView({
 
           {/* Section Quiz CTA */}
           {section.hasQuiz && !quizPassed && (
-            <div className="bg-hunter-50 border border-hunter-200 rounded-2xl p-6 text-center">
-              <h3 className="text-xl font-bold text-navy-700 mb-2">Section Quiz</h3>
-              <p className="text-navy-500 mb-4">
-                Complete all content and activities above to unlock the section quiz.
-              </p>
+            <div className="bg-hunter-50 border border-hunter-200 rounded-xl px-5 py-4 flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-sm font-bold text-navy-700">Section Quiz</h3>
+                <p className="text-xs text-navy-400 mt-0.5">
+                  {canTakeQuiz ? 'Ready to test your knowledge' : `Complete all content first (${viewedBlocks.size}/${section.contentBlocks.length})`}
+                </p>
+              </div>
               <button
                 onClick={() => setShowQuiz(true)}
                 disabled={!canTakeQuiz}
-                className={`px-6 py-3 rounded-xl font-semibold transition-all ${
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all flex-shrink-0 ${
                   canTakeQuiz
                     ? 'bg-hunter-600 hover:bg-hunter-700 text-white'
                     : 'bg-stone-200 text-forest-400 cursor-not-allowed'
                 }`}
               >
-                {canTakeQuiz ? 'Take Quiz' : `Complete all content first (${viewedBlocks.size}/${section.contentBlocks.length})`}
+                Take Quiz
               </button>
             </div>
           )}
 
           {quizPassed && (
-            <div className="bg-hunter-50 border border-hunter-200 rounded-2xl p-6 text-center">
-              <CheckCircle2 className="w-12 h-12 text-hunter-600 mx-auto mb-3" />
-              <h3 className="text-xl font-bold text-hunter-700 mb-2">Section Complete!</h3>
-              <p className="text-hunter-600">You passed the section quiz.</p>
+            <div className="bg-hunter-50 border border-hunter-200 rounded-xl px-5 py-3 flex items-center gap-3">
+              <CheckCircle2 className="w-5 h-5 text-hunter-600 flex-shrink-0" />
+              <div>
+                <span className="text-sm font-bold text-hunter-700">Section Complete</span>
+                <span className="text-xs text-hunter-600 ml-2">Quiz passed</span>
+              </div>
             </div>
           )}
         </div>
@@ -710,30 +714,30 @@ function SectionQuiz({ section, courseSlug, sectionIndex, onComplete, onBack }) 
 
   if (submitted && results) {
     return (
-      <div className="bg-white rounded-2xl border border-forest-200 shadow-lg p-8 text-center">
-        <div className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6 ${
+      <div className="bg-white rounded-xl border border-forest-200 p-5 text-center">
+        <div className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 ${
           results.passed ? 'bg-hunter-100' : 'bg-honey-100'
         }`}>
           {results.passed ? (
-            <CheckCircle2 className="w-10 h-10 text-hunter-600" />
+            <CheckCircle2 className="w-6 h-6 text-hunter-600" />
           ) : (
-            <AlertCircle className="w-10 h-10 text-honey-600" />
+            <AlertCircle className="w-6 h-6 text-honey-600" />
           )}
         </div>
-        <h2 className="text-2xl font-bold text-navy-700 mb-2">
+        <h2 className="text-lg font-bold text-navy-700 mb-1">
           {results.passed ? 'Quiz Passed!' : 'Keep Trying!'}
         </h2>
-        <p className="text-navy-500 mb-4">
+        <p className="text-sm text-navy-500 mb-1">
           You scored {results.score}/{results.totalQuestions} ({results.percentage}%)
         </p>
-        <p className="text-sm text-navy-400 mb-6">
-          {results.passed 
+        <p className="text-xs text-navy-400 mb-4">
+          {results.passed
             ? 'You can now proceed to the next section.'
             : `You need ${Math.round(section.quizPassThreshold * 100)}% to pass.`}
         </p>
         <button
           onClick={() => onComplete(results)}
-          className={`px-6 py-3 rounded-xl font-semibold ${
+          className={`px-5 py-2 rounded-lg text-sm font-semibold ${
             results.passed
               ? 'bg-hunter-600 hover:bg-hunter-700 text-white'
               : 'bg-stone-100 hover:bg-stone-200 text-navy-600'
@@ -748,63 +752,66 @@ function SectionQuiz({ section, courseSlug, sectionIndex, onComplete, onBack }) 
   const question = section.quizQuestions[currentQuestion];
 
   return (
-    <div className="bg-white rounded-2xl border border-forest-200 shadow-lg overflow-hidden">
-      <div className="bg-burgundy-800 px-6 py-4 flex items-center justify-between">
-        <h3 className="text-white font-bold">Section Quiz</h3>
-        <span className="text-burgundy-200 text-sm">
-          Question {currentQuestion + 1} of {section.quizQuestions.length}
+    <div className="bg-white rounded-xl border border-forest-200 overflow-hidden">
+      <div className="px-5 py-3 border-b border-forest-200 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="w-1.5 h-1.5 rounded-full bg-burgundy-700" />
+          <h3 className="text-xs font-bold text-navy-500 uppercase tracking-wide">Section Quiz</h3>
+        </div>
+        <span className="text-navy-400 text-xs">
+          {currentQuestion + 1}/{section.quizQuestions.length}
         </span>
       </div>
 
-      <div className="p-6">
-        <p className="text-lg text-navy-700 font-medium mb-6">{question.question}</p>
+      <div className="p-5">
+        <p className="text-[15px] text-navy-700 font-medium mb-4 leading-relaxed">{question.question}</p>
 
-        <div className="space-y-3 mb-8">
+        <div className="space-y-2 mb-5">
           {question.options.map((option, index) => (
             <button
               key={index}
               onClick={() => setAnswers(prev => ({ ...prev, [currentQuestion]: index }))}
-              className={`w-full text-left px-5 py-4 rounded-xl border-2 transition-all flex items-center gap-4 ${
+              className={`w-full text-left px-3.5 py-2.5 rounded-lg border-[1.5px] transition-all flex items-center gap-3 text-sm ${
                 answers[currentQuestion] === index
                   ? 'bg-burgundy-50 border-burgundy-500'
                   : 'bg-stone-50 border-forest-200 hover:border-burgundy-300'
               }`}
             >
-              <div className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${
+              <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${
                 answers[currentQuestion] === index
                   ? 'bg-burgundy-700 border-burgundy-700 text-white'
                   : 'border-forest-300'
               }`}>
-                {answers[currentQuestion] === index && <CheckCircle2 className="w-4 h-4" />}
+                {answers[currentQuestion] === index && <CheckCircle2 className="w-3 h-3" />}
               </div>
               <span className="text-navy-600">{option.text}</span>
             </button>
           ))}
         </div>
 
-        <div className="flex items-center justify-between pt-4 border-t border-forest-200">
+        <div className="flex items-center justify-between pt-3 border-t border-forest-200">
           <button
             onClick={onBack}
-            className="text-navy-500 hover:text-navy-700"
+            className="text-xs text-navy-500 hover:text-navy-700"
           >
-            ← Back to Content
+            ← Back
           </button>
 
-          <div className="flex gap-3">
+          <div className="flex gap-2">
             {currentQuestion > 0 && (
               <button
                 onClick={() => setCurrentQuestion(prev => prev - 1)}
-                className="px-4 py-2 text-navy-600 hover:bg-stone-100 rounded-lg"
+                className="px-3 py-1.5 text-sm text-navy-600 hover:bg-stone-100 rounded-lg"
               >
                 Previous
               </button>
             )}
-            
+
             {currentQuestion < section.quizQuestions.length - 1 ? (
               <button
                 onClick={() => setCurrentQuestion(prev => prev + 1)}
                 disabled={answers[currentQuestion] === undefined}
-                className={`px-4 py-2 rounded-lg ${
+                className={`px-3 py-1.5 text-sm rounded-lg ${
                   answers[currentQuestion] !== undefined
                     ? 'bg-burgundy-800 hover:bg-burgundy-700 text-white'
                     : 'bg-stone-200 text-forest-400 cursor-not-allowed'
@@ -816,7 +823,7 @@ function SectionQuiz({ section, courseSlug, sectionIndex, onComplete, onBack }) 
               <button
                 onClick={handleSubmit}
                 disabled={Object.keys(answers).length < section.quizQuestions.length}
-                className={`px-6 py-2 rounded-lg font-semibold ${
+                className={`px-4 py-1.5 text-sm rounded-lg font-semibold ${
                   Object.keys(answers).length >= section.quizQuestions.length
                     ? 'bg-hunter-600 hover:bg-hunter-700 text-white'
                     : 'bg-stone-200 text-forest-400 cursor-not-allowed'
@@ -1047,49 +1054,75 @@ function CourseSidebar({
 
           {/* Sections */}
           <nav className="flex-1 overflow-y-auto p-4" aria-label="Course sections">
-            <ul className="space-y-2">
-              {course.sections.map((section, index) => {
-                const sectionProgress = progress?.sectionProgress?.[index];
-                const isCompleted = sectionProgress?.status === 'completed';
-                const isCurrent = currentView === 'section' && progress?.currentSectionIndex === index;
-                const isLocked = index > 0 && progress?.sectionProgress?.[index - 1]?.status !== 'completed';
+            <ul className="space-y-1">
+              {(() => {
+                let lastModule = null;
+                return course.sections.map((section, index) => {
+                  const sectionProgress = progress?.sectionProgress?.[index];
+                  const isCompleted = sectionProgress?.status === 'completed';
+                  const isCurrent = currentView === 'section' && progress?.currentSectionIndex === index;
+                  const isLocked = index > 0 && progress?.sectionProgress?.[index - 1]?.status !== 'completed';
 
-                return (
-                  <li key={index}>
-                    <button
-                      onClick={() => !isLocked && onNavigate(index)}
-                      disabled={isLocked}
-                      aria-current={isCurrent ? 'step' : undefined}
-                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${
-                        isCurrent
-                          ? 'bg-burgundy-50 text-burgundy-800'
-                          : isLocked
-                            ? 'text-slate-300 cursor-not-allowed'
-                            : 'text-navy-600 hover:bg-stone-50'
-                      }`}
-                    >
-                      <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 ${
-                        isCompleted
-                          ? 'bg-hunter-600 text-white'
-                          : isCurrent
-                            ? 'bg-burgundy-700 text-white'
+                  const showModuleHeader = section.module && section.module !== lastModule;
+                  lastModule = section.module || lastModule;
+
+                  // Count module progress
+                  let moduleCompleted = 0;
+                  let moduleTotal = 0;
+                  if (showModuleHeader) {
+                    course.sections.forEach((s, i) => {
+                      if (s.module === section.module) {
+                        moduleTotal++;
+                        if (progress?.sectionProgress?.[i]?.status === 'completed') moduleCompleted++;
+                      }
+                    });
+                  }
+
+                  return (
+                    <li key={index}>
+                      {showModuleHeader && (
+                        <div className={`${index > 0 ? 'mt-4 pt-3 border-t border-forest-100' : ''} mb-2 px-2`}>
+                          <div className="flex items-center justify-between">
+                            <span className="text-[11px] font-bold text-navy-400 uppercase tracking-wider">{section.module}</span>
+                            <span className="text-[10px] text-navy-300 font-medium">{moduleCompleted}/{moduleTotal}</span>
+                          </div>
+                        </div>
+                      )}
+                      <button
+                        onClick={() => !isLocked && onNavigate(index)}
+                        disabled={isLocked}
+                        aria-current={isCurrent ? 'step' : undefined}
+                        className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                          isCurrent
+                            ? 'bg-burgundy-50 text-burgundy-800'
                             : isLocked
-                              ? 'bg-stone-100 text-slate-300'
-                              : 'bg-stone-200 text-navy-500'
-                      }`}>
-                        {isCompleted ? (
-                          <CheckCircle2 className="w-4 h-4" />
-                        ) : isLocked ? (
-                          <Lock className="w-3 h-3" />
-                        ) : (
-                          <span className="text-xs font-semibold">{index + 1}</span>
-                        )}
-                      </div>
-                      <span className="text-sm font-medium line-clamp-2">{section.title}</span>
-                    </button>
-                  </li>
-                );
-              })}
+                              ? 'text-slate-300 cursor-not-allowed'
+                              : 'text-navy-600 hover:bg-stone-50'
+                        }`}
+                      >
+                        <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${
+                          isCompleted
+                            ? 'bg-hunter-600 text-white'
+                            : isCurrent
+                              ? 'bg-burgundy-700 text-white'
+                              : isLocked
+                                ? 'bg-stone-100 text-slate-300'
+                                : 'bg-stone-200 text-navy-500'
+                        }`}>
+                          {isCompleted ? (
+                            <CheckCircle2 className="w-3 h-3" />
+                          ) : isLocked ? (
+                            <Lock className="w-2.5 h-2.5" />
+                          ) : (
+                            <span className="text-[10px] font-semibold">{index + 1}</span>
+                          )}
+                        </div>
+                        <span className="text-[13px] font-medium line-clamp-2">{section.title}</span>
+                      </button>
+                    </li>
+                  );
+                });
+              })()}
 
               {/* References */}
               {course.references?.length > 0 && (

--- a/client/src/components/InteractiveCourseComponents.jsx
+++ b/client/src/components/InteractiveCourseComponents.jsx
@@ -123,39 +123,40 @@ export function MatchingExercise({ pairs, instructions = "Drag each term to its 
   const avail = terms.filter(t => !used.includes(t.id));
 
   return (
-    <div style={{ background: B.card, borderRadius: 16, border: `1px solid ${B.border}`, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0,0,0,0.06)' }}>
-      <div style={{ background: B.green, padding: '16px 24px' }}>
-        <h3 style={{ color: '#fff', fontWeight: 700, fontSize: 17, margin: 0, display: 'flex', alignItems: 'center', gap: 8 }}><GripVertical size={20} /> Matching Exercise</h3>
-        <p style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13, marginTop: 4 }}>{instructions}</p>
-      </div>
-      <div style={{ padding: 24 }}>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24 }}>
+    <div style={{ background: B.card, borderRadius: 12, border: `1px solid ${B.border}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <GripVertical size={14} style={{ color: B.green }} />
+          <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: B.muted }}>Matching Exercise</span>
+        </div>
+        <p style={{ fontSize: 13, color: B.light, marginBottom: 16 }}>{instructions}</p>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
           <div>
-            <h4 style={{ fontWeight: 600, color: B.navy, marginBottom: 12, fontSize: 14 }}>Terms</h4>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <h4 style={{ fontWeight: 600, color: B.navy, marginBottom: 8, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.03em' }}>Terms</h4>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {avail.map(t => (
                 <div key={t.id} draggable={!done} onDragStart={(e) => { setDragged(t); e.dataTransfer.effectAllowed = 'move'; }}
-                  style={{ padding: '12px 16px', background: B.greenBg, border: `2px solid ${B.green}33`, borderRadius: 10, cursor: done ? 'default' : 'grab', fontWeight: 500, color: B.green, fontSize: 14, opacity: done ? 0.5 : 1 }}>
+                  style={{ padding: '8px 12px', background: B.greenBg, border: `1.5px solid ${B.green}33`, borderRadius: 8, cursor: done ? 'default' : 'grab', fontWeight: 500, color: B.green, fontSize: 13, opacity: done ? 0.5 : 1 }}>
                   {t.term}
                 </div>
               ))}
-              {avail.length === 0 && !show && <p style={{ color: B.light, fontSize: 13, fontStyle: 'italic' }}>All terms matched!</p>}
+              {avail.length === 0 && !show && <p style={{ color: B.light, fontSize: 12, fontStyle: 'italic' }}>All terms matched!</p>}
             </div>
           </div>
           <div>
-            <h4 style={{ fontWeight: 600, color: B.navy, marginBottom: 12, fontSize: 14 }}>Definitions</h4>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <h4 style={{ fontWeight: 600, color: B.navy, marginBottom: 8, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.03em' }}>Definitions</h4>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {defs.map(d => {
                 const m = matches[d.id]; const ok = show && m?.term === d.term; const bad = show && m && m.term !== d.term;
                 return (
                   <div key={d.id} onDragOver={(e) => e.preventDefault()} onDrop={(e) => { e.preventDefault(); if (dragged && !matches[d.id]) setMatches(p => ({ ...p, [d.id]: dragged })); setDragged(null); }}
-                    style={{ minHeight: 60, padding: '12px 16px', borderRadius: 10, border: `2px dashed ${m ? (ok ? B.ok : bad ? B.err : B.gold) : B.border}`, background: m ? (ok ? B.okBg : bad ? B.errBg : B.goldBg) : B.navyBg }}>
-                    <p style={{ fontSize: 13, color: B.muted, marginBottom: m ? 8 : 0 }}>{d.definition}</p>
+                    style={{ minHeight: 48, padding: '8px 12px', borderRadius: 8, border: `1.5px dashed ${m ? (ok ? B.ok : bad ? B.err : B.gold) : B.border}`, background: m ? (ok ? B.okBg : bad ? B.errBg : B.goldBg) : B.navyBg }}>
+                    <p style={{ fontSize: 12, color: B.muted, marginBottom: m ? 6 : 0 }}>{d.definition}</p>
                     {m && (
-                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 12px', borderRadius: 6, background: ok ? 'rgba(5,150,105,0.12)' : bad ? 'rgba(220,38,38,0.12)' : B.goldBg }}>
-                        <span style={{ fontWeight: 600, fontSize: 13, color: ok ? B.ok : bad ? B.err : '#92400E' }}>{m.term}</span>
-                        {!done && <button onClick={() => setMatches(p => { const n = {...p}; delete n[d.id]; return n; })} style={{ ...btnReset, background: 'none', color: B.light, padding: 2 }}><X size={16} /></button>}
-                        {show && (ok ? <CheckCircle2 size={16} color={B.ok} /> : <X size={16} color={B.err} />)}
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 8px', borderRadius: 4, background: ok ? 'rgba(5,150,105,0.12)' : bad ? 'rgba(220,38,38,0.12)' : B.goldBg }}>
+                        <span style={{ fontWeight: 600, fontSize: 12, color: ok ? B.ok : bad ? B.err : '#92400E' }}>{m.term}</span>
+                        {!done && <button onClick={() => setMatches(p => { const n = {...p}; delete n[d.id]; return n; })} style={{ ...btnReset, background: 'none', color: B.light, padding: 2 }}><X size={14} /></button>}
+                        {show && (ok ? <CheckCircle2 size={14} color={B.ok} /> : <X size={14} color={B.err} />)}
                       </div>
                     )}
                   </div>
@@ -164,18 +165,18 @@ export function MatchingExercise({ pairs, instructions = "Drag each term to its 
             </div>
           </div>
         </div>
-        <div style={{ marginTop: 24, paddingTop: 16, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: show ? 'space-between' : 'flex-end', alignItems: 'center' }}>
+        <div style={{ marginTop: 16, paddingTop: 12, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: show ? 'space-between' : 'flex-end', alignItems: 'center' }}>
           {show ? (
             <>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 16px', borderRadius: 10, background: score === pairs.length ? B.okBg : B.goldBg }}>
-                <Award size={20} color={score === pairs.length ? B.ok : B.gold} /><span style={{ fontWeight: 700 }}>Score: {score}/{pairs.length} ({Math.round(score/pairs.length*100)}%)</span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 12px', borderRadius: 8, background: score === pairs.length ? B.okBg : B.goldBg }}>
+                <Award size={16} color={score === pairs.length ? B.ok : B.gold} /><span style={{ fontWeight: 700, fontSize: 13 }}>Score: {score}/{pairs.length}</span>
               </div>
-              <button onClick={reset} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', background: B.navyBg, borderRadius: 10, fontWeight: 600, color: B.navy }}><RotateCcw size={16} /> Try Again</button>
+              <button onClick={reset} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 5, padding: '6px 12px', background: B.navyBg, borderRadius: 8, fontWeight: 600, fontSize: 13, color: B.navy }}><RotateCcw size={14} /> Try Again</button>
             </>
           ) : (
             <button onClick={check} disabled={Object.keys(matches).length !== defs.length}
-              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 24px', borderRadius: 10, fontWeight: 700, fontSize: 14, background: Object.keys(matches).length === defs.length ? B.green : B.border, color: Object.keys(matches).length === defs.length ? '#fff' : B.light }}>
-              <Check size={16} /> Check Answers
+              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 18px', borderRadius: 8, fontWeight: 600, fontSize: 13, background: Object.keys(matches).length === defs.length ? B.green : B.border, color: Object.keys(matches).length === defs.length ? '#fff' : B.light }}>
+              <Check size={14} /> Check Answers
             </button>
           )}
         </div>
@@ -192,42 +193,43 @@ export function MultipleChoice({ question, options, explanation, onAnswer }) {
   const [sub, setSub] = useState(false);
   const ok = sel !== null && options[sel]?.isCorrect;
   return (
-    <div style={{ background: B.card, borderRadius: 16, border: `1px solid ${B.border}`, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0,0,0,0.06)' }}>
-      <div style={{ background: B.navy, padding: '16px 24px' }}>
-        <h3 style={{ color: '#fff', fontWeight: 700, fontSize: 17, margin: 0 }}>Question</h3>
-      </div>
-      <div style={{ padding: 24 }}>
-        <p style={{ fontSize: 17, color: B.navy, fontWeight: 600, marginBottom: 24 }}>{question}</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+    <div style={{ background: B.card, borderRadius: 12, border: `1px solid ${B.border}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+          <div style={{ width: 6, height: 6, borderRadius: '50%', background: B.navy, flexShrink: 0 }} />
+          <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: B.muted }}>Knowledge Check</span>
+        </div>
+        <p style={{ fontSize: 15, color: B.navy, fontWeight: 600, marginBottom: 14, lineHeight: 1.5 }}>{question}</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {options.map((o, i) => {
             const s = sel === i; const gc = sub && o.isCorrect; const bc = sub && s && !o.isCorrect;
             return (
               <button key={i} onClick={() => !sub && setSel(i)} disabled={sub}
-                style={{ ...btnReset, width: '100%', textAlign: 'left', padding: '16px 20px', borderRadius: 12, border: `2px solid ${gc ? B.ok : bc ? B.err : s ? B.green : B.border}`, background: gc ? B.okBg : bc ? B.errBg : s ? B.greenBg : B.bg, display: 'flex', alignItems: 'center', gap: 14 }}>
-                <div style={{ width: 32, height: 32, borderRadius: '50%', border: `2px solid ${gc ? B.ok : bc ? B.err : s ? B.green : B.border}`, background: gc ? B.ok : bc ? B.err : s ? B.green : 'transparent', color: (gc||bc||s) ? '#fff' : B.muted, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                  {gc ? <Check size={16} /> : bc ? <X size={16} /> : <span style={{ fontSize: 14, fontWeight: 600 }}>{String.fromCharCode(65+i)}</span>}
+                style={{ ...btnReset, width: '100%', textAlign: 'left', padding: '10px 14px', borderRadius: 8, border: `1.5px solid ${gc ? B.ok : bc ? B.err : s ? B.green : B.border}`, background: gc ? B.okBg : bc ? B.errBg : s ? B.greenBg : B.bg, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ width: 22, height: 22, borderRadius: '50%', border: `2px solid ${gc ? B.ok : bc ? B.err : s ? B.green : B.border}`, background: gc ? B.ok : bc ? B.err : s ? B.green : 'transparent', color: (gc||bc||s) ? '#fff' : B.muted, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  {gc ? <Check size={12} /> : bc ? <X size={12} /> : <span style={{ fontSize: 11, fontWeight: 600 }}>{String.fromCharCode(65+i)}</span>}
                 </div>
-                <span style={{ fontWeight: 500, color: gc ? B.ok : bc ? B.err : B.text }}>{o.text}</span>
+                <span style={{ fontWeight: 500, fontSize: 14, color: gc ? B.ok : bc ? B.err : B.text }}>{o.text}</span>
               </button>
             );
           })}
         </div>
         {sub && explanation && (
-          <div style={{ marginTop: 24, padding: 16, borderRadius: 12, background: ok ? B.okBg : B.goldBg, display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-            <Info size={20} style={{ color: ok ? B.ok : B.gold, marginTop: 2, flexShrink: 0 }} />
+          <div style={{ marginTop: 14, padding: 12, borderRadius: 8, background: ok ? B.okBg : B.goldBg, display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+            <Info size={16} style={{ color: ok ? B.ok : B.gold, marginTop: 1, flexShrink: 0 }} />
             <div>
-              <p style={{ fontWeight: 700, color: ok ? B.ok : '#92400E', margin: 0 }}>{ok ? 'Correct!' : 'Explanation'}</p>
-              <p style={{ fontSize: 13, color: ok ? B.ok : '#92400E', marginTop: 4 }}>{explanation}</p>
+              <p style={{ fontWeight: 700, fontSize: 13, color: ok ? B.ok : '#92400E', margin: 0 }}>{ok ? 'Correct!' : 'Explanation'}</p>
+              <p style={{ fontSize: 13, color: ok ? B.ok : '#92400E', marginTop: 2 }}>{explanation}</p>
             </div>
           </div>
         )}
-        <div style={{ marginTop: 24, paddingTop: 16, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: 'flex-end' }}>
           {sub ? (
-            <button onClick={() => { setSel(null); setSub(false); }} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', background: B.navyBg, borderRadius: 10, fontWeight: 600, color: B.navy }}><RotateCcw size={16} /> Try Again</button>
+            <button onClick={() => { setSel(null); setSub(false); }} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 5, padding: '6px 12px', background: B.navyBg, borderRadius: 8, fontWeight: 600, fontSize: 13, color: B.navy }}><RotateCcw size={14} /> Try Again</button>
           ) : (
             <button onClick={() => { setSub(true); if (onAnswer) onAnswer(ok); }} disabled={sel === null}
-              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 24px', borderRadius: 10, fontWeight: 700, fontSize: 14, background: sel !== null ? B.green : B.border, color: sel !== null ? '#fff' : B.light }}>
-              Submit Answer <ArrowRight size={16} />
+              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 18px', borderRadius: 8, fontWeight: 600, fontSize: 13, background: sel !== null ? B.green : B.border, color: sel !== null ? '#fff' : B.light }}>
+              Submit <ArrowRight size={14} />
             </button>
           )}
         </div>
@@ -249,43 +251,43 @@ export function MultiSelect({ question, options, explanation, onAnswer }) {
   const perfect = cc === tc && ic === 0;
 
   return (
-    <div style={{ background: B.card, borderRadius: 16, border: `1px solid ${B.border}`, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0,0,0,0.06)' }}>
-      <div style={{ background: B.navy, padding: '16px 24px' }}>
-        <h3 style={{ color: '#fff', fontWeight: 700, fontSize: 17, margin: 0 }}>Select All That Apply</h3>
-      </div>
-      <div style={{ padding: 24 }}>
-        <p style={{ fontSize: 17, color: B.navy, fontWeight: 600, marginBottom: 8 }}>{question}</p>
-        <p style={{ fontSize: 13, color: B.muted, marginBottom: 24 }}>Select all correct answers</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+    <div style={{ background: B.card, borderRadius: 12, border: `1px solid ${B.border}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+          <div style={{ width: 6, height: 6, borderRadius: '50%', background: B.navy, flexShrink: 0 }} />
+          <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: B.muted }}>Select All That Apply</span>
+        </div>
+        <p style={{ fontSize: 15, color: B.navy, fontWeight: 600, marginBottom: 14, lineHeight: 1.5 }}>{question}</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {options.map((o, i) => {
             const s = sel.has(i); const gc = sub && o.isCorrect && s; const bc = sub && !o.isCorrect && s; const miss = sub && o.isCorrect && !s;
             return (
               <button key={i} onClick={() => toggle(i)} disabled={sub}
-                style={{ ...btnReset, width: '100%', textAlign: 'left', padding: '16px 20px', borderRadius: 12, border: `2px solid ${gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : B.border}`, background: gc ? B.okBg : bc ? B.errBg : miss ? B.goldBg : s ? B.greenBg : B.bg, display: 'flex', alignItems: 'center', gap: 14 }}>
-                <div style={{ width: 24, height: 24, borderRadius: 6, border: `2px solid ${gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : B.border}`, background: gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : 'transparent', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                  {(s || miss) && <Check size={14} />}
+                style={{ ...btnReset, width: '100%', textAlign: 'left', padding: '10px 14px', borderRadius: 8, border: `1.5px solid ${gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : B.border}`, background: gc ? B.okBg : bc ? B.errBg : miss ? B.goldBg : s ? B.greenBg : B.bg, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ width: 18, height: 18, borderRadius: 4, border: `2px solid ${gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : B.border}`, background: gc ? B.ok : bc ? B.err : miss ? B.gold : s ? B.green : 'transparent', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  {(s || miss) && <Check size={11} />}
                 </div>
-                <span style={{ fontWeight: 500, color: gc ? B.ok : bc ? B.err : miss ? '#92400E' : B.text }}>{o.text}</span>
+                <span style={{ fontWeight: 500, fontSize: 14, color: gc ? B.ok : bc ? B.err : miss ? '#92400E' : B.text }}>{o.text}</span>
               </button>
             );
           })}
         </div>
         {sub && (
-          <div style={{ marginTop: 24, padding: 16, borderRadius: 12, background: perfect ? B.okBg : B.goldBg, display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-            <Info size={20} style={{ color: perfect ? B.ok : B.gold, marginTop: 2, flexShrink: 0 }} />
+          <div style={{ marginTop: 14, padding: 12, borderRadius: 8, background: perfect ? B.okBg : B.goldBg, display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+            <Info size={16} style={{ color: perfect ? B.ok : B.gold, marginTop: 1, flexShrink: 0 }} />
             <div>
-              <p style={{ fontWeight: 700, color: perfect ? B.ok : '#92400E', margin: 0 }}>{perfect ? 'Perfect!' : `${cc}/${tc} correct`}</p>
-              {explanation && <p style={{ fontSize: 13, color: perfect ? B.ok : '#92400E', marginTop: 4 }}>{explanation}</p>}
+              <p style={{ fontWeight: 700, fontSize: 13, color: perfect ? B.ok : '#92400E', margin: 0 }}>{perfect ? 'Perfect!' : `${cc}/${tc} correct`}</p>
+              {explanation && <p style={{ fontSize: 13, color: perfect ? B.ok : '#92400E', marginTop: 2 }}>{explanation}</p>}
             </div>
           </div>
         )}
-        <div style={{ marginTop: 24, paddingTop: 16, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: `1px solid ${B.border}`, display: 'flex', justifyContent: 'flex-end' }}>
           {sub ? (
-            <button onClick={() => { setSel(new Set()); setSub(false); }} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', background: B.navyBg, borderRadius: 10, fontWeight: 600, color: B.navy }}><RotateCcw size={16} /> Try Again</button>
+            <button onClick={() => { setSel(new Set()); setSub(false); }} style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 5, padding: '6px 12px', background: B.navyBg, borderRadius: 8, fontWeight: 600, fontSize: 13, color: B.navy }}><RotateCcw size={14} /> Try Again</button>
           ) : (
             <button onClick={() => { setSub(true); if (onAnswer) onAnswer(perfect); }} disabled={sel.size === 0}
-              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 24px', borderRadius: 10, fontWeight: 700, fontSize: 14, background: sel.size > 0 ? B.green : B.border, color: sel.size > 0 ? '#fff' : B.light }}>
-              Submit Answer <ArrowRight size={16} />
+              style={{ ...btnReset, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 18px', borderRadius: 8, fontWeight: 600, fontSize: 13, background: sel.size > 0 ? B.green : B.border, color: sel.size > 0 ? '#fff' : B.light }}>
+              Submit <ArrowRight size={14} />
             </button>
           )}
         </div>

--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -70,6 +70,7 @@ const ContentBlockSchema = new mongoose.Schema({
 const SectionSchema = new mongoose.Schema({
   title: { type: String, required: true },
   description: String,
+  module: String, // Group label for sidebar navigation (e.g. "Module 1: Foundations")
   order: { type: Number, required: true },
   contentBlocks: [ContentBlockSchema],
   


### PR DESCRIPTION
- Replace heavy full-width colored header bars on MultipleChoice, MultiSelect, and MatchingExercise with subtle uppercase label dots ("Knowledge Check", "Select All That Apply", "Matching Exercise")
- Reduce padding, font sizes, border radius, and icon sizes across all knowledge check components for a less overwhelming inline feel
- Slim down SectionQuiz: replace burgundy header bar with light bordered label, tighten option buttons, reduce result icon sizes
- Convert quiz CTA from centered block to compact inline row layout
- Convert quiz-passed banner from tall centered card to compact inline row
- Reduce content block spacing from space-y-8 to space-y-6
- Add module field to InteractiveCourse section schema for sidebar grouping
- Update CourseSidebar to group sections under module headers with completion counters, adding visual breaks between course modules

https://claude.ai/code/session_015mYD2dvHh9BJTqNaMy3EHp