### PR TITLE
Fix remaining brand inconsistencies: header, footer, and copyright

### DIFF
--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -50,7 +50,7 @@
           <span class="font-display font-bold text-lg" style="position: relative; display: inline-block; width: 22px; height: 22px;"><span style="color: #D4A855; position: absolute; top: -3px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 5px; left: 6px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-600">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
       

--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -76,7 +76,7 @@
           <span class="font-display font-bold text-lg" style="position: relative; display: inline-block; width: 22px; height: 22px;"><span style="color: #D4A855; position: absolute; top: -3px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 5px; left: 6px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-600">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
 
@@ -234,9 +234,14 @@
   </div>
 
   <!-- Footer -->
-  <footer class="bg-burgundy-900 text-burgundy-200 py-6 mt-10">
-    <div class="max-w-7xl mx-auto px-6 text-center">
-      <p class="text-xs">GAITP LLC · NBCC ACEP Provider #7760 · Learn. License. Lead.</p>
+  <footer class="mt-12 py-6 px-4 bg-white border-t border-burgundy-100">
+    <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
+      <p class="text-forest-500 text-sm">&copy; 2025 CounselorReady. All rights reserved.</p>
+      <div class="flex items-center gap-4">
+        <a href="/help.html" class="text-forest-500 hover:text-burgundy-700 text-sm">Help</a>
+        <span class="text-forest-300">|</span>
+        <p class="text-forest-400 text-xs">Ga Integrated Therapeutic Perspectives LLC | NBCC ACEP #7760</p>
+      </div>
     </div>
   </footer>
 

--- a/client/public/help.html
+++ b/client/public/help.html
@@ -67,7 +67,7 @@
           <span class="font-display font-bold text-lg" style="position: relative; display: inline-block; width: 22px; height: 22px;"><span style="color: #D4A855; position: absolute; top: -3px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 5px; left: 6px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-600">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
       <nav class="flex items-center gap-6">
@@ -178,13 +178,17 @@
     </section>
   </main>
 
-  <footer class="bg-burgundy-900 text-burgundy-200 py-8">
-    <div class="max-w-6xl mx-auto px-6 text-center">
-      <p>&copy; 2026 CounselorReady. All rights reserved.</p>
-      <div class="flex justify-center gap-6 mt-4">
-        <a href="/privacy.html" class="hover:text-white">Privacy</a>
-        <a href="/terms.html" class="hover:text-white">Terms</a>
-        <a href="/about.html" class="hover:text-white">About</a>
+  <footer class="mt-12 py-6 px-4 bg-white border-t border-burgundy-100">
+    <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
+      <p class="text-forest-500 text-sm">&copy; 2025 CounselorReady. All rights reserved.</p>
+      <div class="flex items-center gap-4">
+        <a href="/privacy.html" class="text-forest-500 hover:text-burgundy-700 text-sm">Privacy</a>
+        <span class="text-forest-300">|</span>
+        <a href="/terms.html" class="text-forest-500 hover:text-burgundy-700 text-sm">Terms</a>
+        <span class="text-forest-300">|</span>
+        <a href="/about.html" class="text-forest-500 hover:text-burgundy-700 text-sm">About</a>
+        <span class="text-forest-300">|</span>
+        <p class="text-forest-400 text-xs">Ga Integrated Therapeutic Perspectives LLC | NBCC ACEP #7760</p>
       </div>
     </div>
   </footer>

--- a/client/public/js/footer.js
+++ b/client/public/js/footer.js
@@ -9,14 +9,14 @@
 (function () {
   const BRAND = {
     legalName: 'GAITP LLC',
-    fullName:  'GA Integrated Therapeutic Perspectives LLC',
-    acep:      'NBCC ACEP Provider #7760',
+    fullName:  'Ga Integrated Therapeutic Perspectives LLC',
+    acep:      'NBCC ACEP #7760',
     startYear: 2024,
   };
   function getCopyright() {
     const y = new Date().getFullYear();
     const range = y > BRAND.startYear ? `${BRAND.startYear}\u2013${y}` : `${BRAND.startYear}`;
-    return `\u00A9 ${range} ${BRAND.legalName}. All rights reserved.`;
+    return `\u00A9 ${range} CounselorReady. All rights reserved.`;
   }
   function isAdminPage() {
     return window.location.pathname.includes('/admin') ||
@@ -31,36 +31,64 @@
     if (document.getElementById('cr-footer')) return;
     const admin  = isAdminPage();
     const course = isCoursePlayer();
-    const bg      = admin ? '#6B1D34' : '#284157';
-    const padding = course ? '10px 24px' : '20px 32px';
-    const links = (!admin && !course) ? `
-      <nav style="margin-bottom:8px;">
-        <a href="/privacy"  style="color:#D4A855;text-decoration:none;margin:0 10px;font-size:0.8rem;">Privacy Policy</a>
-        <a href="/terms"    style="color:#D4A855;text-decoration:none;margin:0 10px;font-size:0.8rem;">Terms of Use</a>
-        <a href="/contact"  style="color:#D4A855;text-decoration:none;margin:0 10px;font-size:0.8rem;">Contact</a>
-      </nav>` : '';
-    const legalLine = !course
-      ? `<p style="margin:2px 0;opacity:0.7;font-size:0.75rem;">${BRAND.fullName}</p>`
-      : '';
+
+    // Admin pages keep the dark burgundy footer
+    if (admin) {
+      const footer = document.createElement('footer');
+      footer.id = 'cr-footer';
+      footer.innerHTML = `
+        <div style="
+          background-color:#6B1D34;
+          color:#F5F5DC;
+          font-family:'Lato',sans-serif;
+          font-size:0.8rem;
+          padding:20px 32px;
+          text-align:center;
+          line-height:1.7;
+          margin-top:auto;
+        ">
+          <p style="margin:2px 0;">
+            <span style="color:#D4A855;font-weight:600;">${BRAND.fullName} | ${BRAND.acep}</span>
+          </p>
+          <p style="margin:2px 0;">${getCopyright()}</p>
+        </div>`;
+      document.body.appendChild(footer);
+      return;
+    }
+
+    // Course player: minimal footer
+    if (course) {
+      const footer = document.createElement('footer');
+      footer.id = 'cr-footer';
+      footer.innerHTML = `
+        <div style="
+          background-color:#ffffff;
+          border-top:1px solid #fae8eb;
+          font-family:'Lato',sans-serif;
+          font-size:0.75rem;
+          padding:10px 24px;
+          text-align:center;
+          color:#547c5f;
+          margin-top:auto;
+        ">
+          <p style="margin:0;">${getCopyright()}</p>
+        </div>`;
+      document.body.appendChild(footer);
+      return;
+    }
+
+    // Public pages: white footer matching dashboard pattern
     const footer = document.createElement('footer');
     footer.id = 'cr-footer';
+    footer.style.cssText = 'margin-top:3rem;padding:1.5rem 1rem;background:#fff;border-top:1px solid #fae8eb;font-family:"Lato",sans-serif;';
     footer.innerHTML = `
-      <div style="
-        background-color:${bg};
-        color:#F5F5DC;
-        font-family:'Lato',sans-serif;
-        font-size:0.8rem;
-        padding:${padding};
-        text-align:center;
-        line-height:1.7;
-        margin-top:auto;
-      ">
-        ${links}
-        <p style="margin:2px 0;">
-          <span style="color:#D4A855;font-weight:600;">${BRAND.acep}</span>
-        </p>
-        <p style="margin:2px 0;">${getCopyright()}</p>
-        ${legalLine}
+      <div style="max-width:80rem;margin:0 auto;display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:1rem;">
+        <p style="color:#547c5f;font-size:0.875rem;margin:0;">${getCopyright()}</p>
+        <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
+          <a href="/help.html" style="color:#547c5f;font-size:0.875rem;text-decoration:none;">Help</a>
+          <span style="color:#a1bba8;">|</span>
+          <p style="color:#759a7f;font-size:0.75rem;margin:0;">${BRAND.fullName} | ${BRAND.acep}</p>
+        </div>
       </div>`;
     document.body.appendChild(footer);
   }

--- a/client/public/messages.html
+++ b/client/public/messages.html
@@ -37,17 +37,37 @@
   <!-- Header -->
   <header class="bg-white border-b border-stone-200 sticky top-0 z-50">
     <div class="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-      <a href="dashboard.html" class="flex items-center gap-3">
-        <div class="w-10 h-10 bg-gradient-to-br from-burgundy-800 to-forest-700 rounded-xl flex items-center justify-center text-white font-bold text-lg">CR</div>
-        <span class="text-xl font-semibold text-burgundy-800">CounselorReady</span>
+      <a href="/" class="flex items-center gap-3">
+        <div class="w-10 h-10 rounded-xl flex items-center justify-center shadow-md" style="background: linear-gradient(135deg, #8b2542, #6b1d34);">
+          <span class="font-display font-bold text-lg" style="position: relative; display: inline-block; width: 22px; height: 22px;"><span style="color: #D4A855; position: absolute; top: -3px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 5px; left: 6px;">R</span></span>
+        </div>
+        <span class="font-display font-semibold text-xl">
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
+        </span>
       </a>
-      <nav class="flex items-center gap-6">
-        <a href="dashboard.html" class="text-hunter-600 hover:text-hunter-700">Dashboard</a>
-        <a href="courses.html" class="text-hunter-600 hover:text-hunter-700">Courses</a>
-        <a href="credentials.html" class="text-hunter-600 hover:text-hunter-700">Credentials</a>
-        <a href="certificates.html" class="text-hunter-600 hover:text-hunter-700">CE Certificates</a>
-        <a href="messages.html" class="text-burgundy-700 font-semibold">Messages</a>
+      <nav class="hidden md:flex items-center gap-8">
+        <a href="/dashboard.html" class="text-hunter-500 hover:text-hunter-700 transition-colors">Dashboard</a>
+        <a href="/courses.html" class="text-hunter-500 hover:text-hunter-700 transition-colors">Courses</a>
+        <a href="/credentials.html" class="text-hunter-500 hover:text-hunter-700 transition-colors">Credentials</a>
+        <a href="/certificates.html" class="text-hunter-500 hover:text-hunter-700 transition-colors">CE Certificates</a>
+        <a href="/messages.html" class="text-hunter-700 font-medium border-b-2 border-hunter-600 pb-1">Messages</a>
       </nav>
+      <div class="flex items-center gap-4">
+        <button onclick="toggleUserMenu()" class="flex items-center gap-2 px-3 py-2 rounded-xl hover:bg-forest-50 transition-colors">
+          <div class="w-8 h-8 bg-burgundy-100 rounded-full flex items-center justify-center">
+            <span id="userInitial" class="text-burgundy-700 font-semibold text-sm">?</span>
+          </div>
+          <svg class="w-4 h-4 text-forest-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </button>
+        <div id="userMenu" class="hidden absolute right-6 top-16 bg-white rounded-xl shadow-xl border border-burgundy-100 py-2 w-48 z-50">
+          <a href="/settings.html" class="block px-4 py-2 text-forest-700 hover:bg-forest-50 transition-colors">Settings</a>
+          <a href="/subscription.html" class="block px-4 py-2 text-forest-700 hover:bg-forest-50 transition-colors">Subscription</a>
+          <hr class="my-2 border-burgundy-100">
+          <button onclick="logout()" class="w-full text-left px-4 py-2 text-burgundy-700 hover:bg-burgundy-50 transition-colors">Sign Out</button>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -202,6 +222,20 @@
   </div>
 
   <script>
+    // User menu
+    function toggleUserMenu() {
+      document.getElementById('userMenu').classList.toggle('hidden');
+    }
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('button') && !e.target.closest('#userMenu')) {
+        document.getElementById('userMenu')?.classList.add('hidden');
+      }
+    });
+    function logout() {
+      localStorage.removeItem('token');
+      window.location.href = '/login.html';
+    }
+
     const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
     let currentConversationId = null;
     let selectedFiles = [];

--- a/client/public/privacy.html
+++ b/client/public/privacy.html
@@ -49,7 +49,7 @@
           <span class="font-display font-bold text-xl" style="position: relative; display: inline-block; width: 28px; height: 28px;"><span style="color: #D4A855; position: absolute; top: -4px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 6px; left: 8px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-700">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
     </div>

--- a/client/public/settings.html
+++ b/client/public/settings.html
@@ -433,7 +433,7 @@
           <span class="font-display font-bold text-lg" style="position: relative; display: inline-block; width: 22px; height: 22px;"><span style="color: #D4A855; position: absolute; top: -3px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 5px; left: 6px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-600">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
 

--- a/client/public/terms.html
+++ b/client/public/terms.html
@@ -49,7 +49,7 @@
           <span class="font-display font-bold text-xl" style="position: relative; display: inline-block; width: 28px; height: 28px;"><span style="color: #D4A855; position: absolute; top: -4px; left: 0;">C</span><span style="color: #4A7C59; position: absolute; top: 6px; left: 8px;">R</span></span>
         </div>
         <span class="font-display font-semibold text-xl">
-          <span class="text-burgundy-800">Counselor</span><span class="text-forest-700">Ready</span>
+          <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </a>
     </div>


### PR DESCRIPTION
Header branding:
- Standardize "Ready" text to text-hunter-600 across all pages (credentials, settings, help, course-details, privacy, terms)
- Fix messages.html header: replace simplified gradient logo with canonical layered C/R monogram, add user menu dropdown

Footer consistency:
- credentials.html: Replace dark bg-burgundy-900 footer with white footer matching dashboard (bg-white, border-t, copyright + NBCC)
- help.html: Replace dark bg-burgundy-900 footer with white footer, fix copyright year from 2026 to 2025
- footer.js: Rewrite to inject white footer for public pages matching dashboard pattern, keep dark footer only for admin pages

https://claude.ai/code/session_01WNB4Ar6tJgGzVmMPyceGSH