### PR TITLE
Fix cold start loading issue with retry logic and user feedback

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -40,64 +40,47 @@ function CourseViewerWrapper() {
   return <CourseViewer courseSlug={slug} />;
 }
 
+// Loading screen with server wake-up awareness
+function LoadingScreen() {
+  const { serverWaking } = useAuth();
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-stone-50">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-600"></div>
+      {serverWaking && (
+        <div className="text-center animate-fade-in">
+          <p className="text-gray-600 text-sm font-medium">Server is waking up...</p>
+          <p className="text-gray-400 text-xs mt-1">This may take up to 30 seconds on first visit</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Protected Route wrapper
 function ProtectedRoute({ children }) {
   const { isAuthenticated, loading } = useAuth();
-  
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-600"></div>
-      </div>
-    );
-  }
-  
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-  
+
+  if (loading) return <LoadingScreen />;
+  if (!isAuthenticated) return <Navigate to="/login" replace />;
   return children;
 }
 
 // Admin Route wrapper (must be logged in + admin role)
 function AdminRoute({ children }) {
   const { isAuthenticated, loading, user } = useAuth();
-  
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-600"></div>
-      </div>
-    );
-  }
-  
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-  
-  if (user?.role !== 'admin') {
-    return <Navigate to="/courses" replace />;
-  }
-  
+
+  if (loading) return <LoadingScreen />;
+  if (!isAuthenticated) return <Navigate to="/login" replace />;
+  if (user?.role !== 'admin') return <Navigate to="/courses" replace />;
   return children;
 }
 
 // Public Route wrapper (redirect if already logged in)
 function PublicRoute({ children }) {
   const { isAuthenticated, loading } = useAuth();
-  
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-600"></div>
-      </div>
-    );
-  }
-  
-  if (isAuthenticated) {
-    return <Navigate to="/courses" replace />;
-  }
-  
+
+  if (loading) return <LoadingScreen />;
+  if (isAuthenticated) return <Navigate to="/courses" replace />;
   return children;
 }
 

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -11,6 +11,7 @@ const AuthContext = createContext(null);
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [serverWaking, setServerWaking] = useState(false);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -23,20 +24,42 @@ export function AuthProvider({ children }) {
   }, []);
 
   const fetchUser = async () => {
-    // Timeout after 8 seconds — if API is cold-starting, don't block forever
-    const timeout = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('timeout')), 8000)
-    );
-    try {
-      const { data } = await Promise.race([api.get('/auth/me'), timeout]);
-      setUser(data.user);
-    } catch (error) {
-      // On timeout or error, clear token so user sees login page cleanly
-      localStorage.removeItem('token');
-      delete api.defaults.headers.common['Authorization'];
-    } finally {
-      setLoading(false);
+    // Retry up to 3 times with increasing timeouts for Render cold starts
+    const attempts = [
+      { timeout: 10000, delay: 0 },
+      { timeout: 20000, delay: 2000 },
+      { timeout: 30000, delay: 3000 },
+    ];
+
+    for (let i = 0; i < attempts.length; i++) {
+      const { timeout: ms, delay } = attempts[i];
+      if (delay > 0) {
+        setServerWaking(true);
+        await new Promise(r => setTimeout(r, delay));
+      }
+
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), ms);
+        const { data } = await api.get('/auth/me', { signal: controller.signal });
+        clearTimeout(timer);
+        setUser(data.user);
+        setServerWaking(false);
+        setLoading(false);
+        return;
+      } catch (error) {
+        // If it's not a timeout/network error, don't retry (e.g. 401 = bad token)
+        if (error.response?.status === 401) break;
+        if (i === attempts.length - 1) break; // last attempt
+        // Otherwise retry
+      }
     }
+
+    // All attempts failed — clear token
+    localStorage.removeItem('token');
+    delete api.defaults.headers.common['Authorization'];
+    setServerWaking(false);
+    setLoading(false);
   };
 
   const login = async (email, password) => {
@@ -64,6 +87,7 @@ export function AuthProvider({ children }) {
   const value = {
     user,
     loading,
+    serverWaking,
     login,
     register,
     logout,

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -24,7 +24,7 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (retries = 2) => {
       try {
         const [coursesRes, credentialsRes] = await Promise.all([
           api.get('/courses/user/enrolled'),
@@ -33,6 +33,11 @@ export default function Dashboard() {
         setCourses(coursesRes.data.enrolledCourses || []);
         setCredentials(credentialsRes.data);
       } catch (error) {
+        // Retry on network/timeout errors (server may still be waking up)
+        if (retries > 0 && !error.response) {
+          await new Promise(r => setTimeout(r, 3000));
+          return fetchData(retries - 1);
+        }
         console.error('Error fetching dashboard data:', error);
       } finally {
         setLoading(false);

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -7,6 +7,7 @@ import axios from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'https://api.counselorready.com/api',
+  timeout: 30000, // 30s timeout to handle Render cold starts
   headers: {
     'Content-Type': 'application/json'
   }
@@ -21,15 +22,26 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// Handle auth errors
+// Retry on network errors (cold start resilience)
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('token');
-      window.location.href = '/login';
+  async (error) => {
+    const config = error.config;
+
+    // Don't retry if already retried, or if it's a real HTTP error (not network)
+    if (config._retried || error.response) {
+      // Handle 401 specifically
+      if (error.response?.status === 401) {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+      }
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
+
+    // Network error or timeout — retry once after 3s
+    config._retried = true;
+    await new Promise(r => setTimeout(r, 3000));
+    return api(config);
   }
 );
 


### PR DESCRIPTION
- AuthContext: retry /auth/me up to 3 times with increasing timeouts (10s, 20s, 30s) instead of timing out at 8s and clearing the token
- API service: add 30s default timeout and automatic network-error retry interceptor
- Dashboard: add retry logic for data fetching on network failures
- App.jsx: show "Server is waking up..." message during cold start retries instead of a blank spinner

Root cause: Render.com spins down the server after inactivity. The 8-second auth timeout was too short for cold starts (30-60s), causing the token to be cleared and forcing re-login.

https://claude.ai/code/session_018V6fVrgAM31np1hPNiZrW5