### PR TITLE
Fix admin pages not loading — _redirects catch-all was intercepting .…

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -8,5 +8,10 @@
 /api/debug      /404.html    404
 /api/debug/*    /404.html    404
 
+# Serve static HTML pages directly (bypass SPA catch-all)
+/admin.html              /admin.html              200
+/admin-*.html            /admin-*.html            200
+/about.html              /about.html              200
+
 # SPA catch-all (must be LAST)
 /*    /index.html   200


### PR DESCRIPTION
…html files

The SPA catch-all rule (/* -> /index.html) was rewriting /admin.html requests to index.html, causing React Router's catch-all to redirect back to the dashboard. Added explicit rules to serve admin and other static HTML pages directly before the SPA fallback.

https://claude.ai/code/session_018V6fVrgAM31np1hPNiZrW5