### PR TITLE
Rebuild Dashboard to match intended static dashboard.html design

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -7,33 +7,40 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import api from '../services/api';
-import { 
-  BookOpen, 
-  Award, 
-  Clock, 
-  AlertTriangle,
+import {
+  BookOpen,
+  CheckCircle,
+  FileText,
+  ShieldCheck,
+  Upload,
+  Sliders,
+  BarChart3,
+  Clock,
   ArrowRight,
-  TrendingUp,
-  Calendar
+  MessageCircle,
+  ChevronRight
 } from 'lucide-react';
 
 export default function Dashboard() {
   const { user } = useAuth();
   const [courses, setCourses] = useState([]);
+  const [certificates, setCertificates] = useState([]);
   const [credentials, setCredentials] = useState({ summary: null, credentials: [] });
+  const [activity, setActivity] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async (retries = 2) => {
       try {
-        const [coursesRes, credentialsRes] = await Promise.all([
+        const [coursesRes, credentialsRes, certsRes] = await Promise.all([
           api.get('/courses/user/enrolled'),
-          api.get('/credentials/user/dashboard')
+          api.get('/credentials/user/dashboard'),
+          api.get('/certificates/my').catch(() => ({ data: { certificates: [] } }))
         ]);
         setCourses(coursesRes.data.enrolledCourses || []);
         setCredentials(credentialsRes.data);
+        setCertificates(certsRes.data.certificates || certsRes.data || []);
       } catch (error) {
-        // Retry on network/timeout errors (server may still be waking up)
         if (retries > 0 && !error.response) {
           await new Promise(r => setTimeout(r, 3000));
           return fetchData(retries - 1);
@@ -46,230 +53,236 @@ export default function Dashboard() {
     fetchData();
   }, []);
 
-  const formatDate = (date) => {
-    return new Date(date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
+  const isVip = user?.subscription?.plan === 'vip' || user?.subscription?.plan === 'annual_vip';
+  const completedCourses = courses.filter(c => c.percentComplete === 100).length;
+  const totalCEHours = credentials.summary?.overallProgress?.totalCompleted || 0;
+  const totalCredentials = credentials.summary?.totalCredentials || 0;
+  const certCount = Array.isArray(certificates) ? certificates.length : 0;
 
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-forest-600"></div>
       </div>
     );
   }
 
   return (
     <div>
-      {/* Welcome header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">
-          Welcome back, {user?.profile?.firstName}!
-        </h1>
-        <p className="text-gray-600">Here's your learning and credential overview.</p>
-      </div>
-
-      {/* Stats grid */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <div className="card">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-moss-100 rounded-lg flex items-center justify-center">
-              <BookOpen className="w-5 h-5 text-moss-600" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">{courses.length}</p>
-              <p className="text-sm text-gray-500">Courses enrolled</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="card">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-dustyrose-100 rounded-lg flex items-center justify-center">
-              <Award className="w-5 h-5 text-dustyrose-600" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {credentials.summary?.totalCredentials || 0}
-              </p>
-              <p className="text-sm text-gray-500">Credentials</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="card">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-              <TrendingUp className="w-5 h-5 text-green-600" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {credentials.summary?.overallProgress?.totalCompleted || 0}
-              </p>
-              <p className="text-sm text-gray-500">CEUs completed</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="card">
-          <div className="flex items-center gap-3">
-            <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
-              credentials.summary?.expiringSoon > 0 ? 'bg-amber-100' : 'bg-gray-100'
-            }`}>
-              <Clock className={`w-5 h-5 ${
-                credentials.summary?.expiringSoon > 0 ? 'text-amber-600' : 'text-gray-400'
-              }`} />
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {credentials.summary?.expiringSoon || 0}
-              </p>
-              <p className="text-sm text-gray-500">Expiring soon</p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Main content grid */}
-      <div className="grid lg:grid-cols-2 gap-8">
-        {/* Continue learning */}
+      {/* Welcome Section */}
+      <div className="mb-8 flex items-start justify-between">
         <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Continue Learning</h2>
-            <Link to="/courses" className="text-moss-600 hover:text-moss-700 text-sm font-medium flex items-center gap-1">
-              All Courses <ArrowRight className="w-4 h-4" />
-            </Link>
+          <h1 className="font-display text-3xl font-semibold text-burgundy-900 mb-2">
+            Welcome back, {user?.profile?.firstName || 'there'}!
+          </h1>
+          <p className="text-forest-600">Track your continuing education and stay audit-ready.</p>
+        </div>
+        {isVip && (
+          <button className="inline-flex items-center gap-2 bg-honey-500 hover:bg-honey-600 text-white font-semibold px-5 py-3 rounded-xl transition-colors shadow-md">
+            <MessageCircle className="w-5 h-5" />
+            Request Consult
+          </button>
+        )}
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
+        {/* CE Hours */}
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-forest-600 text-xs">CE Hours Earned</span>
+            <div className="w-7 h-7 bg-forest-100 rounded-lg flex items-center justify-center">
+              <Clock className="w-3.5 h-3.5 text-forest-600" />
+            </div>
+          </div>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCEHours}</p>
+          <p className="text-forest-500 text-xs">This cycle</p>
+        </div>
+
+        {/* Courses Completed */}
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-forest-600 text-xs">Courses Completed</span>
+            <div className="w-7 h-7 bg-burgundy-100 rounded-lg flex items-center justify-center">
+              <CheckCircle className="w-3.5 h-3.5 text-burgundy-600" />
+            </div>
+          </div>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{completedCourses}</p>
+          <p className="text-forest-500 text-xs">All time</p>
+        </div>
+
+        {/* Certificates Stored */}
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-forest-600 text-xs">Certificates Stored</span>
+            <div className="w-7 h-7 bg-honey-100 rounded-lg flex items-center justify-center">
+              <FileText className="w-3.5 h-3.5 text-honey-600" />
+            </div>
+          </div>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{certCount}</p>
+          <p className="text-forest-500 text-xs">Uploaded</p>
+        </div>
+
+        {/* Active Credentials */}
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-forest-600 text-xs">Active Credentials</span>
+            <div className="w-7 h-7 bg-forest-100 rounded-lg flex items-center justify-center">
+              <ShieldCheck className="w-3.5 h-3.5 text-forest-600" />
+            </div>
+          </div>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCredentials}</p>
+          <p className="text-forest-500 text-xs">Tracked</p>
+        </div>
+      </div>
+
+      {/* Main Grid: 2/3 left + 1/3 right */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+        {/* Left Column */}
+        <div className="lg:col-span-2 space-y-6">
+
+          {/* Quick Actions */}
+          <div className="bg-white rounded-xl border border-burgundy-100 shadow-sm p-6">
+            <h2 className="font-display text-xl font-semibold text-burgundy-900 mb-4">Quick Actions</h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Link to="/courses" className="flex flex-col items-center p-4 rounded-xl bg-burgundy-50 hover:bg-burgundy-100 transition-colors group">
+                <div className="w-12 h-12 bg-burgundy-700 rounded-xl flex items-center justify-center mb-3 group-hover:scale-105 transition-transform">
+                  <BookOpen className="w-6 h-6 text-white" />
+                </div>
+                <span className="text-burgundy-800 font-medium text-sm">Browse Courses</span>
+              </Link>
+
+              <Link to="/credentials" className="flex flex-col items-center p-4 rounded-xl bg-forest-50 hover:bg-forest-100 transition-colors group">
+                <div className="w-12 h-12 rounded-xl flex items-center justify-center mb-3 group-hover:scale-105 transition-transform" style={{ background: 'linear-gradient(135deg, #8b2542, #6b1d34)' }}>
+                  <Upload className="w-6 h-6 text-white" />
+                </div>
+                <span className="text-forest-800 font-medium text-sm">Upload Certificate</span>
+              </Link>
+
+              <Link to="/credentials" className="flex flex-col items-center p-4 rounded-xl bg-honey-50 hover:bg-honey-100 transition-colors group">
+                <div className="w-12 h-12 bg-honey-500 rounded-xl flex items-center justify-center mb-3 group-hover:scale-105 transition-transform">
+                  <Sliders className="w-6 h-6 text-white" />
+                </div>
+                <span className="text-honey-800 font-medium text-sm">Add Credential</span>
+              </Link>
+
+              <Link to="/audit-kit" className="flex flex-col items-center p-4 rounded-xl bg-stone-100 hover:bg-stone-200 transition-colors group">
+                <div className="w-12 h-12 bg-stone-600 rounded-xl flex items-center justify-center mb-3 group-hover:scale-105 transition-transform">
+                  <BarChart3 className="w-6 h-6 text-white" />
+                </div>
+                <span className="text-stone-700 font-medium text-sm">Generate Audit</span>
+              </Link>
+            </div>
           </div>
 
-          {courses.length > 0 ? (
+          {/* Recent Activity */}
+          <div className="bg-white rounded-xl border border-burgundy-100 shadow-sm p-6">
+            <h2 className="font-display text-xl font-semibold text-burgundy-900 mb-4">Recent Activity</h2>
             <div className="space-y-3">
-              {courses.slice(0, 3).map((item) => (
-                <Link
-                  key={item.course._id}
-                  to={`/learn/${item.course.slug}`}
-                  className="card block hover:border-moss-200 transition-colors"
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="w-12 h-12 bg-moss-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                      <BookOpen className="w-6 h-6 text-moss-600" />
+              {courses.length > 0 ? (
+                courses.slice(0, 5).map((item) => (
+                  <Link
+                    key={item.course._id}
+                    to={`/learn/${item.course.slug}`}
+                    className="flex items-center gap-4 p-3 rounded-lg bg-stone-50 hover:bg-forest-50 transition-colors"
+                  >
+                    <div className="w-10 h-10 bg-forest-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                      <BookOpen className="w-5 h-5 text-forest-600" />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <h3 className="font-medium text-gray-900 truncate">{item.course.title}</h3>
+                      <p className="text-forest-700 font-medium truncate">{item.course.title}</p>
                       <div className="flex items-center gap-2 mt-1">
-                        <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
-                          <div 
-                            className="h-full bg-moss-500 rounded-full" 
+                        <div className="flex-1 h-1.5 bg-burgundy-100 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-burgundy-600 rounded-full transition-all"
                             style={{ width: `${item.percentComplete}%` }}
                           ></div>
                         </div>
-                        <span className="text-xs text-gray-500">{item.percentComplete}%</span>
+                        <span className="text-xs text-forest-500 flex-shrink-0">{item.percentComplete}%</span>
                       </div>
                     </div>
-                    <ArrowRight className="w-5 h-5 text-gray-400" />
+                    <ChevronRight className="w-4 h-4 text-forest-400 flex-shrink-0" />
+                  </Link>
+                ))
+              ) : (
+                <div className="flex items-center gap-4 p-3 rounded-lg bg-stone-50">
+                  <div className="w-10 h-10 bg-forest-100 rounded-lg flex items-center justify-center">
+                    <BookOpen className="w-5 h-5 text-forest-600" />
                   </div>
-                </Link>
-              ))}
+                  <div className="flex-1">
+                    <p className="text-forest-700">Welcome to CounselorReady!</p>
+                    <p className="text-forest-500 text-sm">Get started by browsing courses or uploading certificates.</p>
+                  </div>
+                </div>
+              )}
             </div>
-          ) : (
-            <div className="card text-center py-8">
-              <BookOpen className="w-12 h-12 text-gray-300 mx-auto mb-3" />
-              <p className="text-gray-500 mb-4">You haven't enrolled in any courses yet</p>
-              <Link to="/courses" className="btn-primary inline-flex items-center gap-2">
-                Browse Courses <ArrowRight className="w-4 h-4" />
-              </Link>
-            </div>
-          )}
+          </div>
         </div>
 
-        {/* Credentials overview */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Your Credentials</h2>
-            <Link to="/credentials" className="text-moss-600 hover:text-moss-700 text-sm font-medium flex items-center gap-1">
-              Manage <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
+        {/* Right Column - Sidebar */}
+        <div className="space-y-6">
 
-          {credentials.credentials.length > 0 ? (
-            <div className="space-y-3">
-              {credentials.credentials.slice(0, 3).map((cred) => (
-                <div key={cred._id} className="card">
-                  <div className="flex items-start justify-between mb-3">
-                    <div>
-                      <h3 className="font-medium text-gray-900">{cred.name}</h3>
-                      <p className="text-sm text-gray-500">
-                        Expires: {formatDate(cred.expirationDate)}
-                      </p>
-                    </div>
-                    <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                      cred.status === 'expired' 
-                        ? 'bg-red-100 text-red-700'
-                        : cred.status === 'expiring_soon'
-                        ? 'bg-amber-100 text-amber-700'
-                        : 'bg-green-100 text-green-700'
-                    }`}>
-                      {cred.status === 'expired' ? 'Expired' : 
-                       cred.status === 'expiring_soon' ? 'Expiring Soon' : 'Active'}
-                    </span>
-                  </div>
-                  <div>
-                    <div className="flex justify-between text-sm mb-1">
-                      <span className="text-gray-600">CEU Progress</span>
-                      <span className="text-moss-600 font-medium">
-                        {cred.totalCEUsCompleted}/{cred.totalCEUsRequired}
+          {/* CE Progress */}
+          <div className="bg-white rounded-xl border border-burgundy-100 shadow-sm p-6">
+            <h2 className="font-display text-xl font-semibold text-burgundy-900 mb-4">CE Progress</h2>
+            {credentials.credentials.length > 0 ? (
+              <div className="space-y-4">
+                {credentials.credentials.map((cred) => (
+                  <div key={cred._id}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-forest-800 font-medium text-sm">{cred.name}</span>
+                      <span className="text-burgundy-600 text-sm font-semibold">
+                        {cred.totalCEUsCompleted}/{cred.totalCEUsRequired} hrs
                       </span>
                     </div>
-                    <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-                      <div 
-                        className="h-full bg-moss-500 rounded-full" 
-                        style={{ width: `${cred.percentComplete}%` }}
+                    <div className="h-2 bg-burgundy-100 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-burgundy-600 rounded-full transition-all"
+                        style={{ width: `${Math.min(100, cred.percentComplete || 0)}%` }}
                       ></div>
                     </div>
                   </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-6">
+                <div className="w-16 h-16 bg-forest-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                  <ShieldCheck className="w-8 h-8 text-forest-500" />
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="card text-center py-8">
-              <Award className="w-12 h-12 text-gray-300 mx-auto mb-3" />
-              <p className="text-gray-500 mb-4">Track your licenses and certifications</p>
-              <Link to="/credentials" className="btn-primary inline-flex items-center gap-2">
-                Add Credential <ArrowRight className="w-4 h-4" />
-              </Link>
-            </div>
-          )}
-        </div>
-      </div>
+                <p className="text-forest-600 text-sm">Add a credential to track CE progress</p>
+                <Link to="/credentials" className="text-burgundy-700 text-sm font-medium hover:text-burgundy-800">
+                  Add Credential <ArrowRight className="w-3 h-3 inline" />
+                </Link>
+              </div>
+            )}
+          </div>
 
-      {/* Upcoming deadlines */}
-      {credentials.summary?.upcomingDeadlines?.length > 0 && (
-        <div className="mt-8">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Upcoming Deadlines</h2>
-          <div className="card bg-amber-50 border-amber-200">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-              <div className="space-y-2">
+          {/* Upcoming Renewals */}
+          <div className="bg-white rounded-xl border border-burgundy-100 shadow-sm p-6">
+            <h2 className="font-display text-xl font-semibold text-burgundy-900 mb-4">Upcoming Renewals</h2>
+            {credentials.summary?.upcomingDeadlines?.length > 0 ? (
+              <div className="space-y-3">
                 {credentials.summary.upcomingDeadlines.map((deadline) => (
-                  <div key={deadline.credentialId} className="flex items-center justify-between">
-                    <div>
-                      <span className="font-medium text-gray-900">{deadline.name}</span>
-                      <span className="text-amber-700 text-sm ml-2">
-                        {deadline.daysRemaining} days remaining
-                      </span>
+                  <div key={deadline.credentialId} className="flex items-center gap-3 p-3 rounded-lg bg-honey-50 border border-honey-200">
+                    <div className="w-8 h-8 bg-honey-200 rounded-full flex items-center justify-center flex-shrink-0">
+                      <Clock className="w-4 h-4 text-honey-700" />
                     </div>
-                    <span className="text-sm text-gray-600">
-                      Need {deadline.ceusRemaining} more CEUs
-                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-forest-800 font-medium text-sm truncate">{deadline.name}</p>
+                      <p className="text-honey-700 text-xs">{deadline.daysRemaining} days remaining</p>
+                    </div>
                   </div>
                 ))}
               </div>
-            </div>
+            ) : (
+              <div className="text-center py-4">
+                <p className="text-forest-500 text-sm">No upcoming renewals</p>
+              </div>
+            )}
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -88,51 +88,35 @@ export default function Dashboard() {
       {/* Stats Grid */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
         {/* CE Hours */}
-        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-forest-600 text-xs">CE Hours Earned</span>
-            <div className="w-7 h-7 bg-forest-100 rounded-lg flex items-center justify-center">
-              <Clock className="w-3.5 h-3.5 text-forest-600" />
-            </div>
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm flex items-center gap-3">
+          <div className="w-10 h-10 bg-forest-100 rounded-lg flex items-center justify-center flex-shrink-0">
+            <Clock className="w-5 h-5 text-forest-600" />
           </div>
-          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCEHours}</p>
-          <p className="text-forest-500 text-xs">This cycle</p>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCEHours} <span className="text-sm font-normal text-forest-500">hrs</span></p>
         </div>
 
         {/* Courses Completed */}
-        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-forest-600 text-xs">Courses Completed</span>
-            <div className="w-7 h-7 bg-burgundy-100 rounded-lg flex items-center justify-center">
-              <CheckCircle className="w-3.5 h-3.5 text-burgundy-600" />
-            </div>
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm flex items-center gap-3">
+          <div className="w-10 h-10 bg-burgundy-100 rounded-lg flex items-center justify-center flex-shrink-0">
+            <CheckCircle className="w-5 h-5 text-burgundy-600" />
           </div>
-          <p className="font-display text-2xl font-semibold text-burgundy-900">{completedCourses}</p>
-          <p className="text-forest-500 text-xs">All time</p>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{completedCourses} <span className="text-sm font-normal text-forest-500">done</span></p>
         </div>
 
         {/* Certificates Stored */}
-        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-forest-600 text-xs">Certificates Stored</span>
-            <div className="w-7 h-7 bg-honey-100 rounded-lg flex items-center justify-center">
-              <FileText className="w-3.5 h-3.5 text-honey-600" />
-            </div>
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm flex items-center gap-3">
+          <div className="w-10 h-10 bg-honey-100 rounded-lg flex items-center justify-center flex-shrink-0">
+            <FileText className="w-5 h-5 text-honey-600" />
           </div>
-          <p className="font-display text-2xl font-semibold text-burgundy-900">{certCount}</p>
-          <p className="text-forest-500 text-xs">Uploaded</p>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{certCount} <span className="text-sm font-normal text-forest-500">certs</span></p>
         </div>
 
         {/* Active Credentials */}
-        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-forest-600 text-xs">Active Credentials</span>
-            <div className="w-7 h-7 bg-forest-100 rounded-lg flex items-center justify-center">
-              <ShieldCheck className="w-3.5 h-3.5 text-forest-600" />
-            </div>
+        <div className="bg-white rounded-xl p-4 border border-burgundy-100 shadow-sm flex items-center gap-3">
+          <div className="w-10 h-10 bg-forest-100 rounded-lg flex items-center justify-center flex-shrink-0">
+            <ShieldCheck className="w-5 h-5 text-forest-600" />
           </div>
-          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCredentials}</p>
-          <p className="text-forest-500 text-xs">Tracked</p>
+          <p className="font-display text-2xl font-semibold text-burgundy-900">{totalCredentials} <span className="text-sm font-normal text-forest-500">active</span></p>
         </div>
       </div>
 


### PR DESCRIPTION
- Restore stone palette to proper neutral grays (#FAFAF9)
- Rewrite Dashboard.jsx to match the branded dashboard.html layout:
  - Serif font (Cormorant Garamond) headings, burgundy-900 text
  - 4 stat cards: CE Hours Earned, Courses Completed, Certificates Stored, Active Credentials with colored icons
  - Quick Actions grid: Browse Courses, Upload Certificate, Add Credential, Generate Audit
  - 2/3 + 1/3 grid: Recent Activity left, CE Progress + Upcoming Renewals right
  - Burgundy/forest/honey color scheme matching brand
  - VIP Request Consult button (gold)

https://claude.ai/code/session_018V6fVrgAM31np1hPNiZrW5