### PR TITLE
Remove 401 error handling from API interceptor

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -30,11 +30,6 @@ api.interceptors.response.use(
 
     // Don't retry if already retried, or if it's a real HTTP error (not network)
     if (config._retried || error.response) {
-      // Handle 401 specifically
-      if (error.response?.status === 401) {
-        localStorage.removeItem('token');
-        window.location.href = '/login';
-      }
       return Promise.reject(error);
     }
 


### PR DESCRIPTION
## Summary
Removed the 401 Unauthorized error handling logic from the API response interceptor. This inline authentication error handling has been deleted, allowing 401 errors to be handled elsewhere in the application.

## Key Changes
- Removed 401 status code check and associated token cleanup logic from the response interceptor
- Removed `localStorage.removeItem('token')` call that was triggered on 401 errors
- Removed redirect to `/login` route that was triggered on 401 errors

## Implementation Details
The 401 error handling was previously embedded in the API interceptor's error handling block. This change suggests that authentication error handling should be managed at a different layer (likely in individual API call handlers, a dedicated auth service, or a higher-level error boundary) rather than globally in the interceptor.

https://claude.ai/code/session_01RwmY3pKszJCg9c1Z9HfXMm