### PR TITLE
Fix courses/admin redirect: disable Vercel Clean URLs and fix auth en…

### DIFF
--- a/client/public/admin.html
+++ b/client/public/admin.html
@@ -331,7 +331,7 @@
 
     // Load admin email
     try {
-      fetch(`${API_URL}/api/users/me`, { headers: { 'Authorization': `Bearer ${token}` } })
+      fetch(`${API_URL}/api/auth/me`, { headers: { 'Authorization': `Bearer ${token}` } })
         .then(r => r.json())
         .then(data => {
           const user = data.user || data;

--- a/client/public/audit.html
+++ b/client/public/audit.html
@@ -266,7 +266,7 @@
     async function loadUser() {
       const token = localStorage.getItem('token');
       try {
-        const response = await fetch(`${API_URL}/api/users/me`, {
+        const response = await fetch(`${API_URL}/api/auth/me`, {
           headers: { 'Authorization': `Bearer ${token}` }
         });
         user = await response.json();

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,6 @@
+{
+  "cleanUrls": false,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
…dpoint

The root cause was Vercel's Clean URLs feature serving static HTML files (courses.html, login.html, dashboard.html) at clean paths (/courses, /login, /dashboard), preventing the React SPA from ever loading for those routes. This caused broken auth flows and redirect loops since the static pages have their own incompatible auth/redirect logic.

- Add vercel.json with cleanUrls: false so /courses loads the React SPA (courses.html is only served at /courses.html)
- Add SPA fallback rewrite to serve index.html for all non-file routes
- Fix admin.html and audit.html calling /api/users/me (doesn't exist) to use the correct /api/auth/me endpoint

https://claude.ai/code/session_01RwmY3pKszJCg9c1Z9HfXMm