### PR TITLE
Increase logo size and improve visual prominence

### DIFF
--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -6,6 +6,6 @@
     </linearGradient>
   </defs>
   <rect width="100" height="100" rx="20" fill="url(#bgGrad)"/>
-  <text x="20" y="58" font-family="Georgia, serif" font-size="52" font-weight="bold" fill="#D4A855">C</text>
-  <text x="42" y="72" font-family="Georgia, serif" font-size="52" font-weight="bold" fill="#4A7C59">R</text>
+  <text x="20" y="58" font-family="Georgia, serif" font-size="54" font-weight="bold" fill="#D4A855">C</text>
+  <text x="42" y="72" font-family="Georgia, serif" font-size="54" font-weight="bold" fill="#4A7C59">R</text>
 </svg>

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -100,13 +100,13 @@ export default function Layout({ children }) {
 
           {/* Logo */}
           <Link to="/dashboard" className="flex items-center gap-3 flex-shrink-0">
-            <div style={{ width: 40, height: 40, borderRadius: '0.75rem', background: '#6B1D34', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: '0 2px 8px rgba(107,29,52,0.25)' }}>
-              <span style={{ position: 'relative', display: 'inline-block', width: 22, height: 22 }}>
-                <span style={{ color: GOLD, position: 'absolute', top: -3, left: 0, fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 700, fontSize: 17 }}>C</span>
-                <span style={{ color: '#7A9E84', position: 'absolute', top: 4, left: 6, fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 700, fontSize: 14 }}>R</span>
+            <div style={{ width: 42, height: 42, borderRadius: '0.75rem', background: '#6B1D34', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: '0 2px 8px rgba(107,29,52,0.25)' }}>
+              <span style={{ position: 'relative', display: 'inline-block', width: 24, height: 24 }}>
+                <span style={{ color: GOLD, position: 'absolute', top: -3, left: 0, fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 700, fontSize: 19 }}>C</span>
+                <span style={{ color: '#7A9E84', position: 'absolute', top: 4, left: 6, fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 700, fontSize: 16 }}>R</span>
               </span>
             </div>
-            <span style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 600, fontSize: '1.35rem', letterSpacing: '0.015em' }}>
+            <span style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontWeight: 600, fontSize: '1.5rem', letterSpacing: '0.015em' }}>
               <span style={{ color: BURGUNDY }}>Counselor</span><span style={{ color: HUNTER }}>Ready</span>
             </span>
           </Link>


### PR DESCRIPTION
## Summary
This PR increases the size of the CounselorReady logo across the application to improve visual prominence and brand recognition.

## Key Changes
- **Layout component logo icon**: Increased container size from 40x40px to 42x42px, inner span from 22x22px to 24x24px
- **Logo text sizing**: Increased "C" character from 17px to 19px and "R" character from 14px to 16px
- **Brand name text**: Increased "CounselorReady" text from 1.35rem to 1.5rem
- **Favicon**: Updated SVG font sizes from 52px to 54px for both "C" and "R" characters

## Implementation Details
All changes maintain the existing color scheme (gold for "C", hunter green for "R", burgundy for "Counselor", hunter for "Ready") and layout structure. The proportional increases ensure the logo remains visually balanced while being more prominent in the navigation header.

https://claude.ai/code/session_01JBWsTR3jttYfRmk9wbRWbs