### PR TITLE
Add Free Tools nav link and landing page CTA

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -13,6 +13,7 @@ import { Menu, X, ChevronDown, LogOut, Settings, ShieldCheck, Trophy, Users, Sta
 const navLinks = [
   { name: 'Dashboard',       href: '/dashboard',          static: false },
   { name: 'Courses',         href: '/courses',            static: false },
+  { name: 'Free Tools',      href: '/tools/index.html',   static: true  },
   { name: 'Credentials',     href: '/credentials',        static: false },
   { name: 'CE Planner',      href: '/ce-planner',         static: false },
   { name: 'Audit Kit',       href: '/audit-kit',          static: false },

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -86,7 +86,13 @@ export default function Landing() {
               Learn more
             </a>
           </div>
-          <p className="mt-6 text-sm" style={{ color: 'rgba(53,94,59,0.6)' }}>No credit card required · Cancel anytime</p>
+          <div className="mt-6 flex flex-col items-center gap-2">
+            <a href="/tools/index.html" className="inline-flex items-center gap-2 text-sm font-semibold px-5 py-2.5 rounded-full border-2 transition-all hover:opacity-80" style={{ borderColor: '#4A7C59', color: '#355E3B', background: 'rgba(74,124,89,0.07)' }}>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
+              Free Clinical Tools — No account needed
+            </a>
+            <p className="text-sm" style={{ color: 'rgba(53,94,59,0.6)' }}>No credit card required · Cancel anytime</p>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
- Layout.jsx: insert 'Free Tools' nav entry after 'Courses' (static link → /tools/index.html)
- Landing.jsx: add 'Free Clinical Tools — No account needed' pill button in hero below primary CTAs

https://claude.ai/code/session_01YA19BVjKX76SiZMsAur7FV