### PR TITLE
Add rawMarkdown field to courses and create raw markdown API route

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -60,6 +60,7 @@ import legacyVaultRoutes from './routes/legacyVault.js';
 import adminStatsRoutes from './routes/adminStats.js';
 // ── Whitelabel partner routes ──
 import partnersRoutes from './routes/partners.js';
+import rawMarkdownRoutes from './routes/rawMarkdownRoute.js';
 // Import services
 import { initializeScheduler } from './services/notificationScheduler.js';
 
@@ -260,6 +261,7 @@ app.use('/api/legacy-vault', legacyVaultRoutes);
 app.use('/api/admin/stats', adminStatsRoutes);
 app.use('/api/partners', partnersRoutes);
 app.use('/api/tools', toolsRoutes);
+app.use('/api/rawmd', rawMarkdownRoutes);
 
 // Static templates directory intentionally NOT served publicly
 // Certificate assets (signature.png, certificate_template.pdf) are loaded

--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -170,8 +170,9 @@ const CourseSchema = new mongoose.Schema({
   totalEstimatedTime: Number, // in minutes
   totalContentBlocks: Number,
   totalQuizQuestions: Number,
-  wordCount: Number // pre-computed for admin dashboard
-  
+  wordCount: Number, // pre-computed for admin dashboard
+  rawMarkdown: { type: String }
+
 }, { timestamps: true });
 
 // Pre-save hook to calculate totals


### PR DESCRIPTION
## Summary
This PR adds support for storing and retrieving raw markdown content for interactive courses. A new `rawMarkdown` field is added to the course schema, and a dedicated API route is created to handle raw markdown requests.

## Key Changes
- **Course Schema Update**: Added `rawMarkdown` field (String type) to the `InteractiveCourse` schema to store the raw markdown representation of course content
- **Fixed Schema Formatting**: Corrected trailing comma on `wordCount` field for proper schema syntax
- **New API Route**: Created `/api/rawmd` endpoint by importing and mounting `rawMarkdownRoutes` to handle raw markdown retrieval and management

## Implementation Details
- The `rawMarkdown` field is stored as a string in the MongoDB document, allowing for pre-computed or dynamically generated markdown content
- The new route is mounted at `/api/rawmd` alongside other API endpoints
- This enables the admin dashboard and other consumers to access course content in raw markdown format for editing, export, or display purposes

https://claude.ai/code/session_01QzeQkxsFqS4xAzFp77u7E6