### PR TITLE
Add dashboard redirect route to navigate to static HTML

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -151,7 +151,8 @@ function AppRoutes() {
       <Route path="/register" element={
         <PublicRoute><Register /></PublicRoute>
       } />
-      
+      <Route path="/dashboard" element={<Navigate to="/dashboard.html" replace />} />
+
       {/* ══════════════════════════════════════════════════════════════
           COURSES ONLY - React handles interactive course player
           Everything else is static HTML


### PR DESCRIPTION
## Summary
Added a new route handler to redirect dashboard requests from the React router to the static HTML dashboard page.

## Key Changes
- Added a new `/dashboard` route that redirects to `/dashboard.html` using React Router's `Navigate` component
- This allows the dashboard to be served as a static HTML file while maintaining compatibility with the React routing structure

## Implementation Details
- Uses `<Navigate to="/dashboard.html" replace />` to perform a client-side redirect
- The `replace` prop ensures the redirect replaces the history entry rather than adding a new one
- Positioned after the register route and before the courses section comments, indicating this is part of the main application routing structure

https://claude.ai/code/session_013H1Mruhw9dkYC1wivqUGrK