### PR TITLE
Fix 3 bugs: dashboard API endpoint, SupervisionTracker data handling,…

### DIFF
--- a/client/src/pages/SupervisionTracker.jsx
+++ b/client/src/pages/SupervisionTracker.jsx
@@ -40,8 +40,9 @@ export default function SupervisionTracker() {
     try {
       setLoading(true);
       const { data } = await api.get('/supervision');
-      setLogs(data);
-      if (data.length > 0 && !selectedLog) setSelectedLog(data[0]);
+      setLogs(data.logs || (Array.isArray(data) ? data : []));
+      const logList = data.logs || (Array.isArray(data) ? data : []);
+      if (logList.length > 0 && !selectedLog) setSelectedLog(logList[0]);
     } catch (err) {
       setError(err.response?.data?.error || 'Failed to load supervision logs');
     } finally {

--- a/dashboard.html
+++ b/dashboard.html
@@ -385,7 +385,7 @@
         const [certsR, credsR, progR] = await Promise.all([
           fetch(`${API_URL}/api/certificates`, { headers: { Authorization: `Bearer ${token}` } }),
           fetch(`${API_URL}/api/credentials`, { headers: { Authorization: `Bearer ${token}` } }),
-          fetch(`${API_URL}/api/interactive-courses/my-progress`, { headers: { Authorization: `Bearer ${token}` } }).catch(() => null),
+          fetch(`${API_URL}/api/interactive-courses/user/my-courses`, { headers: { Authorization: `Bearer ${token}` } }).catch(() => null),
         ]);
         if (certsR.ok) {
           const c = await certsR.json(), list = Array.isArray(c) ? c : (c.certificates || []);
@@ -400,7 +400,7 @@
         }
         if (progR?.ok) {
           const p = await progR.json();
-          document.getElementById('coursesCompleted').textContent = Array.isArray(p) ? p.filter(x => x.completed || x.assessmentPassed).length : 0;
+          const list=p.data||(Array.isArray(p)?p:[]);document.getElementById('coursesCompleted').textContent=list.filter(x=>x.status==='completed').length;
         }
       } catch (e) { console.error('Stats:', e); }
     }
@@ -446,18 +446,17 @@
 
     async function loadRecentActivity() {
       try {
-        const res = await fetch(`${API_URL}/api/interactive-courses/my-progress`, { headers: { Authorization: `Bearer ${token}` } });
+        const res = await fetch(`${API_URL}/api/interactive-courses/user/my-courses`, { headers: { Authorization: `Bearer ${token}` } });
         if (!res.ok) return;
         const prog = await res.json();
-        if (!Array.isArray(prog) || !prog.length) return;
+        const progList=prog.data||(Array.isArray(prog)?prog:[]);if(!progList.length) return;
         const el = document.getElementById('activityList');
-        const recent = prog.filter(p => p.course).sort((a, b) => new Date(b.lastAccessed||b.updatedAt||0) - new Date(a.lastAccessed||a.updatedAt||0)).slice(0, 5);
+        const recent = progList.filter(p => p.course).sort((a, b) => new Date(b.lastAccessedAt||0) - new Date(a.lastAccessedAt||0)).slice(0, 5);
         if (!recent.length) return;
         el.innerHTML = recent.map(p => {
           const c = p.course, t = c.title||'Untitled', ce = c.ceHours||'';
-          const done = p.completed||p.assessmentPassed;
-          const tot = c.sections?.length||0, comp = p.completedSections?.length||0;
-          const pct = tot > 0 ? Math.round((comp/tot)*100) : 0;
+          const done = p.status==='completed';
+          const pct = Math.round(p.progress||0);
           return `<a href="/learn/${c.slug||c._id}" class="activity-row flex items-center gap-3 p-3 rounded-lg group">
             <div class="w-9 h-9 ${done?'bg-hunter-100':'bg-burgundy-50'} rounded-lg flex items-center justify-center flex-shrink-0">
               ${done

--- a/server/src/routes/cePlanner.js
+++ b/server/src/routes/cePlanner.js
@@ -79,7 +79,7 @@ router.get('/plan', async (req, res) => {
       .select('title slug ceHours category sections.title metadata');
 
     // Get user's completed courses
-    const completedProgress = await UserCourseProgress.find({ userId, completed: true });
+    const completedProgress = await UserCourseProgress.find({ userId, status: 'completed' });
     const completedCourseIds = new Set(completedProgress.map(p => p.courseId.toString()));
 
     // Build plan per credential


### PR DESCRIPTION
… CE planner query

1. dashboard.html: Update API endpoint from my-progress to user/my-courses, fix response parsing to handle {data:[]} wrapper, use status==='completed' instead of completed||assessmentPassed, use progress field instead of computing from completedSections, use lastAccessedAt instead of lastAccessed.

2. SupervisionTracker.jsx: Handle API response where logs are wrapped in {logs:[]} object instead of bare array.

3. cePlanner.js: Query UserCourseProgress with status:'completed' instead of completed:true to match current schema.

https://claude.ai/code/session_01JdhjRujMQ7EcXE5dmjW3GB