### PR TITLE
Fix My Courses icon and progress bar colors to match brand palette

### DIFF
--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -216,13 +216,13 @@
         const pct=Math.round(p.progress||0);
         const slug=c.slug||c._id;
         return`<a href="/learn/${slug}" class="activity-row flex items-center gap-3 p-3 rounded-lg">
-          <div class="w-10 h-10 ${done?'bg-hunter-100':'bg-burgundy-50'} rounded-lg flex items-center justify-center flex-shrink-0">
-            ${done?'<svg class="w-5 h-5 text-hunter-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>':'<svg class="w-5 h-5 text-burgundy-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>'}
+          <div class="w-10 h-10 ${done?'bg-hunter-100':'bg-honey-50'} rounded-lg flex items-center justify-center flex-shrink-0">
+            ${done?'<svg class="w-5 h-5 text-hunter-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>':'<svg class="w-5 h-5 text-honey-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>'}
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-burgundy-800 truncate">${t}</p>
             <div class="flex items-center gap-2 mt-1.5">
-              <div class="flex-1 h-1.5 bg-stone-100 rounded-full overflow-hidden"><div class="progress-fill h-full rounded-full" style="width:${done?100:pct}%;background:${done?'#4A7C59':'#6B1D34'}"></div></div>
+              <div class="flex-1 h-1.5 bg-stone-100 rounded-full overflow-hidden"><div class="progress-fill h-full rounded-full" style="width:${done?100:pct}%;background:${done?'#4A7C59':'#284157'}"></div></div>
               <span class="text-[10px] text-navy-300 flex-shrink-0 w-7 text-right">${done?'100':pct}%</span>
             </div>
           </div>


### PR DESCRIPTION
- In-progress icon: burgundy play button → honey book icon (bg-honey-50)
- Progress bar: burgundy #6B1D34 → navy #284157 for in-progress
- Resume button stays burgundy #6B1D34 as CTA
- Done checkmark stays hunter green

https://claude.ai/code/session_01JakLjJMUvMxZFcXiYUnYDP