### PR TITLE
Refine CourseCard thumbnail styling and color palette

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -213,11 +213,11 @@ const CourseCard = ({ course, progress, onClick }) => {
       className="bg-white rounded-xl shadow-sm hover:shadow-lg transition-all cursor-pointer overflow-hidden border border-burgundy-100 group"
     >
       {/* Thumbnail — course image or gradient fallback */}
-      <div className="h-48 bg-gradient-to-br from-burgundy-200 to-forest-200 relative flex items-center justify-center overflow-hidden">
+      <div className="h-48 bg-gradient-to-br from-forest-100 to-burgundy-200 relative flex items-center justify-center overflow-hidden">
         {course.thumbnail ? (
-          <img src={course.thumbnail} alt={course.title} className="w-full h-full object-cover object-top" />
+          <img src={course.thumbnail} alt={course.title} className="w-full h-full object-cover" />
         ) : (
-          <BookOpen className="h-16 w-16 text-burgundy-300" />
+          <BookOpen className="h-16 w-16 text-burgundy-500" />
         )}
         {isCompleted && (
           <div className="absolute top-3 right-3 bg-hunter-600 text-white px-2 py-1 rounded-full text-xs font-medium flex items-center gap-1">


### PR DESCRIPTION
## Summary
Updated the CourseCard component's thumbnail section with improved color gradients and refined styling for better visual consistency.

## Key Changes
- **Gradient colors**: Changed thumbnail background gradient from `from-burgundy-200 to-forest-200` to `from-forest-100 to-burgundy-200` for a more balanced color transition
- **Image positioning**: Removed `object-top` from the thumbnail image class, allowing the image to center naturally with `object-cover`
- **Icon color**: Increased the fallback BookOpen icon color intensity from `text-burgundy-300` to `text-burgundy-500` for better visibility and contrast

## Implementation Details
These changes enhance the visual hierarchy and readability of course cards while maintaining the existing design system's color palette. The gradient adjustment provides a softer starting point, and the icon color improvement ensures the fallback state is more visually prominent when course thumbnails are unavailable.

https://claude.ai/code/session_01KpEAG8y7v6kzH4xUrfexxT