### PR TITLE
Add course expiration support with TTL index

### DIFF
--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -160,12 +160,13 @@ const CourseSchema = new mongoose.Schema({
   author: String,
   publishedAt: Date,
   updatedAt: { type: Date, default: Date.now },
-  status: { 
-    type: String, 
-    enum: ['draft', 'published', 'archived'], 
-    default: 'draft' 
+  status: {
+    type: String,
+    enum: ['draft', 'published', 'archived'],
+    default: 'draft'
   },
-  
+  expiresAt: { type: Date, default: null, index: { expires: 0, sparse: true } },
+
   // Calculated fields
   totalEstimatedTime: Number, // in minutes
   totalContentBlocks: Number,


### PR DESCRIPTION
## Summary
Added course expiration functionality to the InteractiveCourse schema by introducing an `expiresAt` field with MongoDB TTL (Time To Live) index support.

## Key Changes
- Added `expiresAt` field to CourseSchema with:
  - Type: Date
  - Default value: null (no expiration by default)
  - MongoDB TTL index configuration (`expires: 0, sparse: true`) for automatic document deletion
- Fixed whitespace formatting in the `status` field definition for consistency

## Implementation Details
- The `expiresAt` field uses a sparse index, meaning documents without this field (or with null values) won't be included in the TTL index
- The `expires: 0` configuration means MongoDB will delete documents immediately once the `expiresAt` date is reached
- This allows courses to be automatically removed from the database after a specified expiration date without manual cleanup

https://claude.ai/code/session_01ESZjAhP4im62vhQTSMXdnr