### PR TITLE
Enable trust proxy for accurate client IP detection

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -78,6 +78,9 @@ const __dirname = path.dirname(__filename);
 // Initialize Express app
 const app = express();
 
+// Trust first proxy (Render's load balancer) so rate limiters see real client IPs
+app.set('trust proxy', 1);
+
 // ===========================================
 // MIDDLEWARE
 // ===========================================


### PR DESCRIPTION
## Summary
Configure Express to trust the first proxy (Render's load balancer) so that rate limiters and other IP-dependent middleware receive the real client IP address instead of the load balancer's IP.

## Changes
- Added `app.set('trust proxy', 1)` configuration to trust Render's load balancer as a proxy
- This ensures that `req.ip` and `req.ips` reflect the actual client IP address when behind a reverse proxy

## Implementation Details
The `trust proxy` setting is set to `1` to trust only the first proxy in the chain, which corresponds to Render's load balancer. This is a security best practice that prevents IP spoofing while allowing legitimate proxy headers to be processed correctly.

https://claude.ai/code/session_01Ue2QVYqRtozRtksFsj5u8g