### PR TITLE
Fix assessment submission API endpoint path

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3992,7 +3992,7 @@ function submitAssessment() {
     const submitBtn = document.querySelector('[data-action="submitAssessment"]');
     if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Submitting...'; }
 
-    crApiFetch(`/api/interactive-courses/${course.slug}/progress/assessment`, {
+    crApiFetch(`/api/interactive-courses/${course.slug}/assessment`, {
       answers: assessmentState.answers,
       timeUsed: 0
     }).then(({ ok, data }) => {


### PR DESCRIPTION
## Summary
Updated the assessment submission API endpoint to use the correct path structure.

## Changes
- Modified the assessment submission endpoint from `/api/interactive-courses/{slug}/progress/assessment` to `/api/interactive-courses/{slug}/assessment`
- This simplifies the API route by removing the unnecessary `progress` path segment

## Details
The assessment submission request in the Final Assessment section now targets the correct API endpoint. This change aligns the client-side code with the actual API route structure, ensuring assessment submissions are sent to the proper endpoint.

https://claude.ai/code/session_01SiocQod63eNi1Hf3at9TWM