### PR TITLE
Register toolRoutes module for /api/tools endpoint

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,6 +37,7 @@ import cebrokerRoutes from './routes/cebroker.js';
 import helpRoutes from './routes/help.js';
 import bulkUploadRoutes from './routes/bulkUpload.js';
 import toolsRoutes from './routes/tools.js';
+import toolRoutes from './routes/toolRoutes.js';
 // ── Previously unregistered routes (wiring audit fix 2026-03-04) ──
 import aiRoutes from './routes/ai.js';
 import aiCourseGeneratorRoutes from './routes/aiCourseGenerator.js';
@@ -275,6 +276,7 @@ app.use('/api/legacy-vault', legacyVaultRoutes);
 app.use('/api/admin/stats', adminStatsRoutes);
 app.use('/api/partners', partnersRoutes);
 app.use('/api/tools', toolsRoutes);
+app.use('/api/tools', toolRoutes);
 app.use('/api/rawmd', rawMarkdownRoutes);
 app.use('/api/dashboard', dashboardRoutes);
 // ── Research Ready CE ──


### PR DESCRIPTION
## Summary
Added registration of a new `toolRoutes` module to the Express application, mounting it at the `/api/tools` endpoint alongside the existing `toolsRoutes`.

## Changes Made
- Imported the new `toolRoutes` module from `./routes/toolRoutes.js`
- Registered the `toolRoutes` module with `app.use('/api/tools', toolRoutes)` to handle requests to the `/api/tools` endpoint

## Notes
- Both `toolsRoutes` and `toolRoutes` are now mounted on the same `/api/tools` path, which may indicate either a gradual migration between modules or intentional route consolidation
- This follows the pattern of previously unregistered routes being wired up (as noted in the existing code comments)

https://claude.ai/code/session_01BenA1xsym3MYwXUVjoRZMk