### PR TITLE
Add course details button to enrolled course cards

### DIFF
--- a/client/public/courses.html
+++ b/client/public/courses.html
@@ -282,9 +282,14 @@
               <!-- Action Button -->
               <div class="flex items-center justify-between">
                 ${isEnrolled ? `
-            <a href="/interactive-course.html?slug=${course.slug}" class="flex-1 text-center bg-burgundy-800 hover:bg-burgundy-900 text-white font-semibold px-4 py-2 rounded-xl transition-colors">
-                    Continue Learning
-                  </a>
+                  <div class="flex gap-2 flex-1">
+                    <a href="/course-details.html?slug=${course.slug}" class="text-center border border-burgundy-300 text-burgundy-700 hover:bg-burgundy-50 font-semibold px-3 py-2 rounded-xl transition-colors text-sm">
+                      Details
+                    </a>
+                    <a href="/interactive-course.html?slug=${course.slug}" class="flex-1 text-center bg-burgundy-800 hover:bg-burgundy-900 text-white font-semibold px-4 py-2 rounded-xl transition-colors">
+                      Continue Learning
+                    </a>
+                  </div>
                 ` : isFree ? `
                   <button onclick="enrollCourse('${course._id}')" class="flex-1 bg-forest-700 hover:bg-forest-800 text-white font-semibold px-4 py-2 rounded-xl transition-colors">
                     Start Free Course


### PR DESCRIPTION
## Summary
Enhanced the enrolled course card UI by adding a "Details" button alongside the existing "Continue Learning" button, allowing users to view course information before resuming.

## Key Changes
- Added a new "Details" link button that navigates to `/course-details.html?slug=${course.slug}`
- Restructured the action button layout to use a flex container with gap spacing
- "Details" button uses a secondary style (bordered, text-based) while "Continue Learning" remains the primary action
- Both buttons are now displayed side-by-side for enrolled courses

## Implementation Details
- The new Details button uses a border-based design with burgundy-300 border and burgundy-700 text
- Hover state applies a subtle burgundy-50 background
- Flex layout with `gap-2` provides consistent spacing between the two buttons
- The "Continue Learning" button maintains `flex-1` to take remaining space, while Details button uses fixed padding
- Text size reduced to `text-sm` for the Details button to maintain visual hierarchy

https://claude.ai/code/session_01V3UGV16coeifpD36Env216