### PR TITLE
Fix section hero image by using global currentSectionIndex instead of…

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3269,7 +3269,7 @@ function renderSectionDivider(wrap, block) {
   var heroHtml = '';
   // Auto-inject hero image for courses 3+ CE hours
   if (course && (course.ceHours || course.ceuHours || 0) >= 3) {
-    var imgUrl = getSectionHeroImage(block.title || '', block.sectionNumber || 1);
+    var imgUrl = getSectionHeroImage(block.title || '', currentSectionIndex + 1);
     if (imgUrl) {
       heroHtml = '<img class="cr-section-hero" src="' + imgUrl + '" alt="" loading="lazy" aria-hidden="true">';
     }


### PR DESCRIPTION
… block.sectionNumber

block.sectionNumber was unreliable/missing, causing hero images to not render correctly. currentSectionIndex (already a global at line 2063) correctly tracks the current section position for all courses.

https://claude.ai/code/session_013jmatNmH1dJwsEorV2d5Du