### PR TITLE
Replace React Router navigation with direct URL navigation

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -10,7 +10,7 @@
 // Do NOT change classNames, color values, gradients, spacing, grid layout, or component hierarchy.
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   BookOpen, Clock, ChevronRight, Search,
   Filter, Grid, List, Star, Users, CheckCircle
@@ -25,7 +25,6 @@ const InteractiveCourseCatalog = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [viewMode, setViewMode] = useState('grid');
   const [userProgress, setUserProgress] = useState({});
-  const navigate = useNavigate();
 
   useEffect(() => {
     fetchCourses();
@@ -77,7 +76,7 @@ const InteractiveCourseCatalog = () => {
   };
 
   const handleCourseClick = (course) => {
-    navigate(`/learn/${course.slug}`);
+    window.location.href = `/course-details.html?slug=${course.slug}`;
   };
 
   if (loading) {


### PR DESCRIPTION
## Summary
Updated the course navigation mechanism in the Interactive Course Catalog to use direct URL navigation instead of React Router's client-side routing.

## Key Changes
- Removed `useNavigate` hook import from `react-router-dom`
- Removed `useNavigate()` hook initialization
- Changed `handleCourseClick()` to navigate using `window.location.href` with a query parameter instead of React Router's `navigate()` function
- Updated navigation target from `/learn/{slug}` route to `/course-details.html?slug={slug}` URL

## Implementation Details
The course click handler now performs a full page navigation to an external HTML page (`course-details.html`) with the course slug passed as a query parameter, rather than navigating to an internal React route. This suggests a transition toward a hybrid architecture or integration with a separate course details page.

https://claude.ai/code/session_01GvsYoedf77jqohpDUMxfFf