### PR TITLE
Make course description optional with fallback default

### DIFF
--- a/server/src/models/Course.js
+++ b/server/src/models/Course.js
@@ -140,7 +140,7 @@ const courseSchema = new mongoose.Schema({
   title: { type: String, required: true },
   subtitle: { type: String },
   courseCode: { type: String, trim: true },
-  description: { type: String, required: true },
+  description: { type: String },
   thumbnail: { type: String },
   
   // External/Imported course fields

--- a/server/src/routes/courseBuilder.js
+++ b/server/src/routes/courseBuilder.js
@@ -685,6 +685,8 @@ router.post('/save', protect, adminOnly, async (req, res) => {
     delete courseData._wordCount;
     delete courseData._requiredWords;
 
+    if (!courseData.description) courseData.description = courseData.title || 'No description';
+
     let existing = await Course.findOne({ slug: courseData.slug });
     
     if (existing) {


### PR DESCRIPTION
## Summary
This change makes the course description field optional in the Course model and adds a fallback mechanism to ensure a description is always present when saving a course.

## Key Changes
- **Course Model**: Changed `description` field from `required: true` to optional in the schema
- **Course Builder Route**: Added logic to automatically populate description with the course title (or 'No description' fallback) if no description is provided during save

## Implementation Details
The fallback logic is applied in the `/save` endpoint before persisting the course to the database. This ensures backward compatibility and prevents empty description fields while still allowing the schema to accept courses without an explicit description value.

https://claude.ai/code/session_01CDPBwHvHjtZEWvGDs4KKpF