### PR TITLE
Standardize premium pricing tier to $98 across all courses

### DIFF
--- a/server/src/scripts/CR-TMH601-Mastering_TeleMental_Health-41451words.js
+++ b/server/src/scripts/CR-TMH601-Mastering_TeleMental_Health-41451words.js
@@ -159,7 +159,7 @@ const COURSE_DATA = {
 
   // Access & Pricing
   accessType: "paid",
-  price: 89.99,
+  price: 98.00,
   pricingTier: "premium",
 
   // Status — save as draft for review

--- a/server/src/scripts/Seedcr tmh603rebuild complete.js
+++ b/server/src/scripts/Seedcr tmh603rebuild complete.js
@@ -42,7 +42,7 @@ const COURSE_DATA = {
   contentAreas: ["TeleMental Health", "Ethics", "Clinical Skills", "Technology"],
   categories: ["Telehealth", "Ethics", "Clinical Skills", "Technology"],
   tags: ["telehealth", "telemental health", "HIPAA", "Rule 135-11", "Georgia", "virtual therapy", "informed consent", "crisis intervention", "BC-TMH", "platform selection"],
-  price: 89, accessType: "paid", pricingTier: "premium",
+  price: 98, accessType: "paid", pricingTier: "premium",
   isActive: true, isFeatured: true, status: "draft", isPublished: false,
   passingScore: 80, maxAttempts: 3,
   accessibility: { wcagLevel: "AA", screenReaderOptimized: true, keyboardNavigable: true, colorContrastCompliant: true, altTextProvided: true },

--- a/server/src/scripts/seedCR-TMH601-Batch1-Sections1to4.js
+++ b/server/src/scripts/seedCR-TMH601-Batch1-Sections1to4.js
@@ -73,7 +73,7 @@ const COURSE_DATA = {
   contentAreas: ["TeleMental Health", "Ethics", "Clinical Skills", "Technology"],
   categories: ["Telehealth", "Ethics", "Clinical Skills", "Technology"],
   tags: ["telehealth", "telemental health", "HIPAA", "Rule 135-11", "Georgia", "virtual therapy", "informed consent", "crisis intervention", "BC-TMH", "platform selection"],
-  price: 89,
+  price: 98,
   accessType: "paid",
   pricingTier: "premium",
   isActive: true,

--- a/server/src/scripts/seedNewCourses021826.js
+++ b/server/src/scripts/seedNewCourses021826.js
@@ -304,7 +304,7 @@ const cr203Course = {
   nbccProviderNumber: '7760',
   isPublished: true,
   isFree: false,
-  price: 59.99,
+  price: 98.00,
   learningObjectives: [
     'Explain the theoretical foundations and neurobiological basis of cognitive reframing for anxiety.',
     'Identify at least five common cognitive distortions in anxious client presentations.',

--- a/server/src/scripts/seedTeleMentalHealth.js
+++ b/server/src/scripts/seedTeleMentalHealth.js
@@ -62,7 +62,7 @@ const TELEMENTAL_COURSE = {
   instructor: "GA Integrated Therapeutic Perspectives LLC",
 
   // Course Settings
-  price: 89,
+  price: 98,
   isActive: true,
   isFeatured: true,
   estimatedMinutes: 360,

--- a/server/src/utils/pricingRules.js
+++ b/server/src/utils/pricingRules.js
@@ -8,7 +8,7 @@
  *   ≤ 12,200 → starter    · $29   · starter, professional, vip
  *   ≤ 18,100 → professional· $39  · professional, vip
  *   ≤ 21,100 → vip        · $59   · vip only
- *   > 21,100 → premium    · custom· individual purchase only (no sub included)
+ *   > 21,100 → premium    · $98   · individual purchase only (no sub included)
  *
  * Plan hierarchy (lowest → highest access):
  *   free < starter < professional < vip
@@ -51,7 +51,7 @@ export const PRICING_TIERS = {
   },
   premium: {
     name: 'premium',
-    price: null,             // set per-course by admin
+    price: 98,               // one-time purchase price for courses > 4 CE hours
     accessType: 'paid',
     minPlan: null,           // no subscription includes premium
     maxWordCount: Infinity,
@@ -96,7 +96,7 @@ export function resolvePricingFromWordCount(wordCount, customPremiumPrice = null
     pricingTier:  tier.name,
     accessTier:   tier.name,
     accessType:   tier.accessType,
-    price:        tier.name === 'premium' ? (customPremiumPrice ?? 0) : tier.price,
+    price:        tier.name === 'premium' ? (customPremiumPrice ?? tier.price) : tier.price,
   };
 }
 


### PR DESCRIPTION
## Summary
This PR standardizes the premium pricing tier to a fixed price of $98 across the pricing system and all premium courses. Previously, the premium tier had a `null` price that was set per-course by admin, leading to inconsistent pricing.

## Key Changes
- **Pricing Rules**: Updated `PRICING_TIERS.premium.price` from `null` to `98` with clarification that this is the one-time purchase price for courses > 4 CE hours
- **Pricing Resolution Logic**: Modified `resolvePricingFromWordCount()` to use the tier's default price (`tier.price`) as fallback when no custom premium price is provided, instead of defaulting to `0`
- **Course Pricing Updates**: Standardized premium course prices to $98.00:
  - CR-TMH601 (Mastering TeleMental Health): $89.99 → $98.00
  - TMH603 rebuild: $89 → $98
  - CR-TMH601 Batch1: $89 → $98
  - CR-203: $59.99 → $98.00
  - TeleMental Health course: $89 → $98

## Implementation Details
- The premium tier now has a consistent base price that can still be overridden via `customPremiumPrice` parameter if needed
- Documentation in the pricing rules file updated to reflect the new fixed price structure
- All premium-tier courses across multiple seed scripts aligned to the new standard pricing

https://claude.ai/code/session_01G87SAnhLUQzSoDYeNx5zQC