### PR TITLE
Simplify course access tiers to free and premium

### DIFF
--- a/client/public/admin-course-edit.html
+++ b/client/public/admin-course-edit.html
@@ -377,7 +377,7 @@
       document.getElementById('f-level').value = course.level || 'Intermediate';
       document.getElementById('f-status').value = st;
       document.getElementById('f-tier').value = course.accessTier || course.pricingTier || 'professional';
-      document.getElementById('f-price').value = course.price || '';
+      document.getElementById('f-price').value = course.price != null ? course.price : '';
       document.getElementById('f-slug').value = course.slug || '';
       document.getElementById('f-courseCode').value = course.courseCode || '';
       document.getElementById('f-instructor').value = course.instructor || 'GA Integrated Therapeutic Perspectives LLC';

--- a/client/public/admin-course-edit.html
+++ b/client/public/admin-course-edit.html
@@ -126,7 +126,7 @@
             </div>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
               <div><label class="block text-sm font-semibold text-forest-800 mb-1">Access Tier</label>
-                <select id="f-tier" class="w-full px-3 py-2.5 border border-forest-200 rounded-xl text-sm"><option value="free">Free</option><option value="starter">Starter</option><option value="professional">Professional</option><option value="vip">VIP</option></select></div>
+                <select id="f-tier" class="w-full px-3 py-2.5 border border-forest-200 rounded-xl text-sm" onchange="togglePriceField()"><option value="free">Free</option><option value="premium">Premium (Sold Separately)</option></select></div>
               <div><label class="block text-sm font-semibold text-forest-800 mb-1">Price ($)</label>
                 <input type="number" id="f-price" min="0" step="0.01" placeholder="0.00" class="w-full px-3 py-2.5 border border-forest-200 rounded-xl text-sm"></div>
               <div><label class="block text-sm font-semibold text-forest-800 mb-1">Slug</label>
@@ -376,8 +376,10 @@
       document.getElementById('f-ceHours').value = course.ceHours || course.ceuHours || 0;
       document.getElementById('f-level').value = course.level || 'Intermediate';
       document.getElementById('f-status').value = st;
-      document.getElementById('f-tier').value = course.accessTier || course.pricingTier || 'professional';
+      const rawTier = course.accessTier || course.pricingTier || 'free';
+      document.getElementById('f-tier').value = rawTier === 'free' ? 'free' : 'premium';
       document.getElementById('f-price').value = course.price != null ? course.price : '';
+      togglePriceField();
       document.getElementById('f-slug').value = course.slug || '';
       document.getElementById('f-courseCode').value = course.courseCode || '';
       document.getElementById('f-instructor').value = course.instructor || 'GA Integrated Therapeutic Perspectives LLC';
@@ -630,6 +632,14 @@
     function rmRef(i) { course.references.splice(i,1); renderReferences(); }
     function uRef(el) { const i=+el.dataset.r,f=el.dataset.f; let v=el.value; if(f==='year')v=parseInt(v)||null; if(typeof course.references[i]==='string')course.references[i]={title:course.references[i]}; course.references[i][f]=v; }
 
+    // Toggle price field visibility based on tier
+    function togglePriceField() {
+      const tier = document.getElementById('f-tier').value;
+      const priceWrap = document.getElementById('f-price').closest('div');
+      if (tier === 'free') { priceWrap.style.display = 'none'; document.getElementById('f-price').value = '0'; }
+      else { priceWrap.style.display = ''; }
+    }
+
     // SAVE
     async function saveCourse() {
       const btn=document.getElementById('saveBtn');
@@ -647,7 +657,8 @@
         level:document.getElementById('f-level').value,
         status, isPublished:status==='published',
         accessTier:document.getElementById('f-tier').value,
-        price:parseFloat(document.getElementById('f-price').value)||0,
+        accessType:document.getElementById('f-tier').value==='free'?'free':'paid',
+        price:document.getElementById('f-tier').value==='free'?0:(parseFloat(document.getElementById('f-price').value)||0),
         courseCode:document.getElementById('f-courseCode').value.trim(),
         instructor:document.getElementById('f-instructor').value.trim(),
         deliveryMethod:document.getElementById('f-delivery').value,

--- a/server/src/models/Course.js
+++ b/server/src/models/Course.js
@@ -175,7 +175,7 @@ const courseSchema = new mongoose.Schema({
   stripePriceId: { type: String },
   accessTier: {
     type: String,
-    enum: ['free', 'starter', 'professional', 'vip'],
+    enum: ['free', 'starter', 'professional', 'vip', 'premium'],
     default: 'free'
   },
   

--- a/server/src/models/Course.js
+++ b/server/src/models/Course.js
@@ -173,10 +173,10 @@ const courseSchema = new mongoose.Schema({
     default: 'standard'
   },
   stripePriceId: { type: String },
-  accessTier: { 
-    type: String, 
-    enum: ['free', 'professional', 'vip'], 
-    default: 'free' 
+  accessTier: {
+    type: String,
+    enum: ['free', 'starter', 'professional', 'vip'],
+    default: 'free'
   },
   
   // CEU info

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -391,7 +391,7 @@ router.put('/:id', ...protectAndScope, async (req, res) => {
     const updated = await Course.findByIdAndUpdate(
       req.params.id,
       { $set: updates },
-      { new: true }
+      { new: true, runValidators: true }
     );
 
     res.json({ success: true, data: updated });


### PR DESCRIPTION
## Summary
This PR simplifies the course access tier system from a four-tier model (free, starter, professional, VIP) to a two-tier model (free and premium). It also adds dynamic UI behavior to hide the price field when a course is marked as free.

## Key Changes

- **Simplified tier options**: Reduced access tier dropdown from 4 options to 2 (free and premium)
- **Dynamic price field visibility**: Added `togglePriceField()` function that hides the price input when "free" tier is selected and shows it for "premium"
- **Updated tier mapping logic**: Modified form population to map any non-free tier to "premium" for backward compatibility with existing data
- **Added accessType field**: Introduced new `accessType` field that explicitly marks courses as either 'free' or 'paid' based on the selected tier
- **Price field logic**: Ensured price is always set to 0 for free courses, regardless of user input
- **Schema validation**: Updated Course model to accept the new tier values and added `runValidators: true` to the update route for stricter validation
- **Backward compatibility**: Maintained support for legacy tier values (starter, professional, vip) in the schema enum while normalizing them to "premium" in the UI

## Implementation Details

- The `togglePriceField()` function is called both on tier selection change and during form initialization
- Price field visibility is controlled via CSS display property rather than removing the DOM element
- The save function now sets `accessType` based on the tier selection to provide explicit access control information
- Schema enum was expanded to include all legacy values to prevent validation errors on existing data

https://claude.ai/code/session_013Wk5g3Psxbv8SK1NdaSASn