### PR TITLE
Improve assessment fallback logic for inline isExam blocks

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -509,7 +509,7 @@ router.post(['/:id/progress/assessment', '/:id/assessment'], ...protectAndScope,
     if (!course) {
       return res.status(404).json({ success: false, error: 'Course not found' });
     }
-    // Normalize: extract assessment from inline isExam quiz blocks if top-level is empty
+    // Normalize: extract assessment from inline isExam content blocks if top-level is empty
     if (!course.assessment || !course.assessment.questions || course.assessment.questions.length === 0) {
       const inlineQuestions = [];
       let inlineSettings = {};
@@ -517,7 +517,7 @@ router.post(['/:id/progress/assessment', '/:id/assessment'], ...protectAndScope,
       for (const section of sections) {
         const blocks = section.contentBlocks || section.blocks || section.lessons || [];
         for (const block of blocks) {
-          if ((block.type === 'quiz' || block.type === 'knowledgeCheck') && block.isExam) {
+          if (block.isExam === true) {
             if (block.questions) inlineQuestions.push(...block.questions);
             if (block.passingScore) inlineSettings.passingScore = block.passingScore;
             if (block.passThreshold) inlineSettings.passThreshold = block.passThreshold;
@@ -526,12 +526,14 @@ router.post(['/:id/progress/assessment', '/:id/assessment'], ...protectAndScope,
         }
       }
       if (inlineQuestions.length > 0) {
+        console.warn(`[Assessment Fallback] Course "${course.title || course._id}" has no top-level assessment. Extracted ${inlineQuestions.length} questions from inline isExam blocks.`);
         course.assessment = {
           questions: inlineQuestions,
           passingScore: inlineSettings.passingScore || course.assessment?.passingScore || 80,
           passThreshold: inlineSettings.passThreshold || course.assessment?.passThreshold || 0.8,
           maxAttempts: inlineSettings.maxAttempts || course.assessment?.maxAttempts || 3,
-          attemptsAllowed: inlineSettings.maxAttempts || course.assessment?.attemptsAllowed || 3
+          attemptsAllowed: inlineSettings.maxAttempts || course.assessment?.attemptsAllowed || 3,
+          isExam: true
         };
       }
     }


### PR DESCRIPTION
## Summary
Refactored the assessment fallback mechanism that extracts exam questions from inline content blocks when a course lacks a top-level assessment. The changes improve the robustness and clarity of this normalization process.

## Key Changes
- **Simplified block detection logic**: Changed from checking multiple block types (`quiz` or `knowledgeCheck`) to a single explicit check for `block.isExam === true`, making the condition more precise and maintainable
- **Added diagnostic logging**: Introduced a console warning when the fallback mechanism is triggered, helping with debugging and monitoring of courses that rely on inline assessments
- **Fixed assessment metadata**: Added `isExam: true` flag to the constructed assessment object to properly mark fallback assessments as exams
- **Updated comment**: Clarified that the normalization extracts from "content blocks" rather than "quiz blocks" to better reflect the actual implementation

## Implementation Details
The assessment fallback now:
1. Only matches blocks with `isExam === true` (more explicit than type checking)
2. Logs a warning when extracting inline questions, aiding in identifying courses with missing top-level assessments
3. Properly marks the constructed assessment as an exam with the `isExam` flag
4. Maintains backward compatibility by preserving all existing fallback behavior for passing scores, thresholds, and attempt limits

https://claude.ai/code/session_01VVCZ6gPTNuZP44jAjYhm4Y