### PR TITLE
Refactor image upload: remove admin requirement and improve handling

### DIFF
--- a/client/src/components/CourseBuilder.jsx
+++ b/client/src/components/CourseBuilder.jsx
@@ -177,7 +177,7 @@ function CloudinaryUploader({ onUpload, context = "general", currentImage = null
       setPreview(result.thumbnailUrl || result.url);
       onUpload(result);
     } catch (err) {
-      setError(err.message || "Upload failed — check Cloudinary credentials");
+      setError(err.message || "Upload failed. Please try again.");
     } finally {
       setUploading(false);
     }

--- a/server/src/routes/imageUpload.js
+++ b/server/src/routes/imageUpload.js
@@ -32,16 +32,16 @@ const upload = multer({
   }
 });
 
-router.post('/upload', protect, requireAdmin, upload.single('image'), async (req, res) => {
+router.post('/upload', protect, upload.single('image'), async (req, res) => {
   try {
-    if (!req.file) return res.status(400).json({ success: false, error: { message: 'No image file provided' } });
-    const folder = req.body.folder || 'counselorready/course-content';
+    if (!req.file) return res.status(400).json({ success: false, error: 'No image file provided' });
+    const folder = req.body.folder || 'counselorready/course-images';
     const context = req.body.context || 'general';
 
     const result = await new Promise((resolve, reject) => {
       const stream = cloudinary.v2.uploader.upload_stream(
         { folder, resource_type: 'image', public_id: `${context}_${Date.now()}`,
-          transformation: [{ quality: 'auto:good', fetch_format: 'auto' }],
+          transformation: [{ quality: 'auto', fetch_format: 'auto' }],
           context: { alt: req.body.alt || '', uploadedBy: req.user.email, uploadContext: context }
         },
         (err, res) => err ? reject(err) : resolve(res)
@@ -56,13 +56,16 @@ router.post('/upload', protect, requireAdmin, upload.single('image'), async (req
       url: result.secure_url, publicId: result.public_id,
       width: result.width, height: result.height, format: result.format,
       bytes: result.bytes, alt: req.body.alt || '',
-      thumbnailUrl: cloudinary.v2.url(result.public_id, { width: 200, height: 200, crop: 'fill', quality: 'auto' }),
-      mediumUrl: cloudinary.v2.url(result.public_id, { width: 800, quality: 'auto', fetch_format: 'auto' }),
-      largeUrl: cloudinary.v2.url(result.public_id, { width: 1200, quality: 'auto', fetch_format: 'auto' }),
+      thumbnailUrl: cloudinary.v2.url(result.public_id, { width: 400, crop: 'fill', quality: 'auto' }),
+      mediumUrl: cloudinary.v2.url(result.public_id, { width: 800, crop: 'limit', quality: 'auto' }),
+      largeUrl: result.secure_url,
     }});
   } catch (error) {
     console.error('Image upload error:', error);
-    res.status(500).json({ success: false, error: { message: error.message } });
+    if (error instanceof multer.MulterError || error.message === 'Images only') {
+      return res.status(400).json({ success: false, error: 'Images only, max 10MB' });
+    }
+    res.status(500).json({ success: false, error: error.message });
   }
 });
 


### PR DESCRIPTION
## Summary
This PR refactors the image upload endpoint to remove the admin-only restriction and improves error handling, response formatting, and image transformation settings.

## Key Changes

**Backend (imageUpload.js):**
- Removed `requireAdmin` middleware from POST `/upload` endpoint to allow all authenticated users to upload images
- Simplified error response format from nested `{ error: { message: ... } }` to flat `{ error: '...' }`
- Updated default folder from `counselorready/course-content` to `counselorready/course-images`
- Changed image quality transformation from `'auto:good'` to `'auto'` for consistency
- Updated thumbnail generation: increased width from 200px to 400px and removed height constraint
- Updated medium image: added `crop: 'limit'` parameter for better aspect ratio preservation
- Changed large image URL to return original `secure_url` instead of generating a 1200px variant
- Enhanced error handling to distinguish between Multer validation errors and server errors with appropriate HTTP status codes (400 vs 500)

**Frontend (CourseBuilder.jsx):**
- Updated error message from "Upload failed — check Cloudinary credentials" to "Upload failed. Please try again." for better UX

## Implementation Details
The changes make the upload feature more accessible by removing admin restrictions while maintaining security through the existing `protect` middleware. The image transformation adjustments optimize for different use cases (thumbnails for previews, medium for content, large as original). Error handling now properly categorizes client-side validation failures (400) from server errors (500).

https://claude.ai/code/session_01UpZetFt6qa9tiJv6aQbocj