### PR TITLE
Add course metadata fields and redirect on save

### DIFF
--- a/client/src/components/CourseBuilder.jsx
+++ b/client/src/components/CourseBuilder.jsx
@@ -2916,7 +2916,34 @@ export default function CourseBuilderV2() {
           contentBlocks: (mod.blocks || []).map((b, j) => ({ ...b, order: j + 1 })),
         })),
         assessment: courseData.assessment || { questions: [], passThreshold: 0.80 },
-        references: courseData.references || [],
+        courseCode: courseData.courseCode || '',
+        shortDescription: courseData.shortDescription || courseData.description?.slice(0, 200) || '',
+        contentType: courseData.contentType || 'General',
+        ceCategory: courseData.ceCategory || courseData.contentType || 'General',
+        ceuHours: courseData.ceHours || 3,
+        ceuEligible: true,
+
+        presenter: courseData.presenter || {
+          name: 'Kejuiana Johnson',
+          credentials: 'MA, LPC, NCC, CPCS, BC-TMH',
+          license: 'LPC009587',
+          licenseState: 'Georgia',
+          licenseType: 'LPC',
+          category: 'category1'
+        },
+
+        provider: courseData.provider || {
+          name: 'GA Integrated Therapeutic Perspectives LLC',
+          shortName: 'GAITP LLC',
+          acepNumber: '7760',
+          approvalBody: 'NBCC'
+        },
+
+        references: (courseData.references || []).map(r =>
+          typeof r === 'string'
+            ? { citation: r, title: r.slice(0, 80) }
+            : { ...r, title: r.title || r.citation?.slice(0, 80) || '' }
+        ),
         thumbnail: courseData.thumbnail || "",
         thumbnailPublicId: courseData.thumbnailPublicId || "",
         deliverables: (courseData.deliverables || []).map(d => ({
@@ -2939,7 +2966,10 @@ export default function CourseBuilderV2() {
       const result = await res.json();
       if (result.course?._id) setCourseId(result.course._id);
       setSaveMsg(`✓ ${publish ? "Published" : "Saved"} — ${result.action || "success"}`);
-      setTimeout(() => setSaveMsg(null), 4000);
+      // Redirect after 1.5s
+      setTimeout(() => {
+        window.location.href = '/admin-courses.html';
+      }, 1500);
     } catch (err) {
       setSaveMsg(`✗ Error: ${err.message}`);
     } finally {


### PR DESCRIPTION
## Summary
Enhanced the CourseBuilder component to capture additional course metadata fields required for CE (Continuing Education) compliance and improved the post-save user experience with an automatic redirect.

## Key Changes
- **Added course metadata fields**: courseCode, shortDescription, contentType, ceCategory, and ceuHours to the course data structure
- **Added CE eligibility tracking**: ceuEligible flag set to true by default
- **Added presenter information**: Default presenter object with name, credentials, license details, and category
- **Added provider information**: Default provider object with name, shortName, ACEP number, and approval body
- **Enhanced references handling**: Transformed references array to ensure consistent object structure with `citation` and `title` properties, supporting both string and object formats
- **Improved post-save UX**: Changed save confirmation behavior to automatically redirect to `/admin-courses.html` after 1.5 seconds instead of just clearing the message after 4 seconds

## Implementation Details
- References are now normalized to objects with `citation` and `title` fields, with titles auto-generated from citations if not provided
- Default values are provided for presenter and provider to ensure data consistency
- The redirect uses `window.location.href` for a full page navigation after a brief delay to allow users to see the success message

https://claude.ai/code/session_01Duwv1N9nB2zDDngTTcGNvq