### PR TITLE
Replace window.location with React Router navigation

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -10,7 +10,7 @@
 // Do NOT change classNames, color values, gradients, spacing, grid layout, or component hierarchy.
 
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   BookOpen, Clock, ChevronRight, Search,
   Filter, Grid, List, Star, Users, CheckCircle
@@ -18,6 +18,7 @@ import {
 import api from '../services/api';
 
 const InteractiveCourseCatalog = () => {
+  const navigate = useNavigate();
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -76,7 +77,7 @@ const InteractiveCourseCatalog = () => {
   };
 
   const handleCourseClick = (course) => {
-    window.location.href = `/course-details.html?slug=${course.slug}`;
+    navigate(`/courses/${course.slug}`);
   };
 
   if (loading) {


### PR DESCRIPTION
## Summary
Updated the course navigation in the Interactive Course Catalog to use React Router's `useNavigate` hook instead of direct window location manipulation, improving the single-page application experience.

## Key Changes
- Added `useNavigate` import from `react-router-dom`
- Initialized `useNavigate` hook in the component
- Replaced `window.location.href` with `navigate()` in `handleCourseClick` method
- Updated navigation path from `/course-details.html?slug=` to `/courses/` route format

## Implementation Details
The change modernizes the navigation approach by leveraging React Router's client-side routing instead of full page reloads. This maintains the SPA experience and allows for smoother transitions between pages without losing component state or triggering unnecessary re-renders.

https://claude.ai/code/session_01D6EKLN5Zra2328ShFJxpgW