### PR TITLE
Fix shebang placement in patchMissingSlugs.js

### DIFF
--- a/server/src/scripts/patchMissingSlugs.js
+++ b/server/src/scripts/patchMissingSlugs.js
@@ -1,9 +1,9 @@
+#!/usr/bin/env node
 /**
  * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
  * All rights reserved. Proprietary and confidential.
  * Unauthorized copying or distribution is strictly prohibited.
  */
-#!/usr/bin/env node
 /**
  * patchMissingSlugs.js
  *


### PR DESCRIPTION
Move #!/usr/bin/env node before the copyright comment block to prevent SyntaxError when running the script.

https://claude.ai/code/session_01PcPYEHbUeQA714R9DHqSwM