### PR TITLE
Merge legacy and interactive courses in catalog with optional auth

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -65,8 +65,8 @@ const InteractiveCourseCatalog = () => {
   const categories = ['all', ...new Set(courses.flatMap(c => c.categories || []))];
 
   const filteredCourses = courses.filter(course => {
-    const matchesSearch = course.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         course.description.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesSearch = (course.title || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         (course.description || '').toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory = selectedCategory === 'all' ||
                            (course.categories && course.categories.includes(selectedCategory));
     return matchesSearch && matchesCategory;

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -182,7 +182,7 @@ function stripContent(courseObj) {
  * GET /api/interactive-courses
  * List all published courses with optional filtering
  */
-router.get('/', async (req, res) => {
+router.get('/', optionalAuth, async (req, res) => {
   try {
     const {
       category,
@@ -293,23 +293,66 @@ router.get('/', async (req, res) => {
       });
     }
 
-    // Non-admin: only published interactivecourses
-    const courses = await Course.find(query)
-      .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount sectionCount moduleCount assessmentQuestionCount ceuCategories accessType price pricingTier status ceuHours ceuApprovalNumber courseCode')
-      .sort({ publishedAt: -1 })
-      .skip((page - 1) * limit)
-      .limit(parseInt(limit));
+    // Non-admin: published interactivecourses + legacy courses merged
+    const pageNum = parseInt(page);
+    const limitNum = parseInt(limit);
 
-    const total = await Course.countDocuments(query);
+    const [interactiveCourses, interactiveTotal] = await Promise.all([
+      Course.find(query)
+        .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount sectionCount moduleCount assessmentQuestionCount ceuCategories accessType price pricingTier status ceuHours ceuApprovalNumber courseCode')
+        .sort({ publishedAt: -1 })
+        .lean(),
+      Course.countDocuments(query)
+    ]);
+
+    // Also query legacy courses collection for published courses
+    const legacyFilter = {};
+    if (status && status !== 'all') legacyFilter.status = status;
+    if (category) legacyFilter.categories = category;
+    if (tag) legacyFilter.tags = tag;
+    if (search) {
+      legacyFilter.$or = [
+        { title: { $regex: search, $options: 'i' } },
+        { description: { $regex: search, $options: 'i' } }
+      ];
+    }
+
+    const legacyCollection = mongoose.connection.db.collection('courses');
+    const [legacyCourses, legacyTotal] = await Promise.all([
+      legacyCollection
+        .find(legacyFilter)
+        .project({ title: 1, slug: 1, description: 1, thumbnail: 1, ceHours: 1, totalEstimatedTime: 1, categories: 1, tags: 1, status: 1, publishedAt: 1 })
+        .sort({ publishedAt: -1 })
+        .toArray(),
+      legacyCollection.countDocuments(legacyFilter)
+    ]);
+
+    // Deduplicate by slug (interactive takes priority over legacy)
+    const interactiveSlugs = new Set(interactiveCourses.map(c => c.slug));
+    const uniqueLegacy = legacyCourses.filter(c => !interactiveSlugs.has(c.slug));
+
+    const taggedInteractive = interactiveCourses.map(c => ({ ...c, source: 'interactive' }));
+    const taggedLegacy = uniqueLegacy.map(c => ({ ...c, source: 'legacy' }));
+    const merged = [...taggedInteractive, ...taggedLegacy];
+
+    // Sort combined by publishedAt descending
+    merged.sort((a, b) => {
+      const dateA = a.publishedAt ? new Date(a.publishedAt) : new Date(0);
+      const dateB = b.publishedAt ? new Date(b.publishedAt) : new Date(0);
+      return dateB - dateA;
+    });
+
+    const combinedTotal = interactiveTotal + uniqueLegacy.length;
+    const paginatedData = merged.slice((pageNum - 1) * limitNum, pageNum * limitNum);
 
     res.json({
       success: true,
-      data: courses,
+      data: paginatedData,
       pagination: {
-        page: parseInt(page),
-        limit: parseInt(limit),
-        total,
-        pages: Math.ceil(total / limit)
+        page: pageNum,
+        limit: limitNum,
+        total: combinedTotal,
+        pages: Math.ceil(combinedTotal / limitNum)
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR enhances the interactive course catalog to display both interactive and legacy courses in a unified listing, while adding optional authentication to the course list endpoint.

## Key Changes

- **Added optional authentication**: The GET `/api/interactive-courses` endpoint now uses `optionalAuth` middleware, allowing both authenticated and unauthenticated users to access the course list
- **Merged course sources**: The catalog now queries both the interactive `Course` collection and the legacy `courses` collection, combining results into a single paginated response
- **Deduplication logic**: Implemented slug-based deduplication with interactive courses taking priority over legacy courses when duplicates exist
- **Unified sorting and pagination**: Combined results are sorted by `publishedAt` date in descending order and paginated consistently across both sources
- **Source tagging**: Each course is tagged with its source (`interactive` or `legacy`) for potential future use
- **Improved null safety**: Added defensive checks in the frontend to handle missing `title` or `description` fields with fallback empty strings

## Implementation Details

- The backend now performs parallel queries to both collections for efficiency using `Promise.all()`
- Legacy courses are filtered using the same criteria (status, category, tag, search) as interactive courses
- Pagination is applied after merging and sorting to ensure accurate total counts and page calculations
- The combined total reflects the count of unique courses across both sources

https://claude.ai/code/session_01XYbiJFe92CF5PXDKxaXX3Y