### PR TITLE
Remove legacy courses collection support and consolidate to interactive courses

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,7 +14,6 @@ import ErrorBoundary from './components/ErrorBoundary';
 import Landing from './pages/Landing';
 import Login from './pages/Login';
 import Register from './pages/Register';
-import CourseView from './pages/CourseView';
 import InteractiveCourseCatalog from './pages/InteractiveCourseCatalog';
 import CourseQuickEdit from './pages/CourseQuickEdit';
 import AdminPartners from './pages/AdminPartners';
@@ -53,14 +52,20 @@ import ScholarlyArticles from './pages/ScholarlyArticles';
 
 // Components
 import Layout from './components/Layout';
-import CourseViewer from './components/CourseViewer';
 import CourseBuilder from './components/CourseBuilder';
 import { AccessibilityProvider, SkipToContent, AccessibilityPanel } from './components/AccessibilityProvider';
 
-// Wrapper to pass slug param to CourseViewer
-function CourseViewerWrapper() {
+// Redirect /courses/:slug to CReady Viewer (static HTML player)
+function CourseViewerRedirect() {
   const { slug } = useParams();
-  return <CourseViewer courseSlug={slug} />;
+  useEffect(() => {
+    window.location.replace(`/interactive-course.html?slug=${slug}`);
+  }, [slug]);
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-stone-50">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#6B1D34]"></div>
+    </div>
+  );
 }
 
 // Loading screen with server wake-up awareness
@@ -193,7 +198,7 @@ function AppRoutes() {
       } />
       <Route path="/courses/:slug" element={
         <ProtectedRoute>
-          <CourseViewerWrapper />
+          <CourseViewerRedirect />
         </ProtectedRoute>
       } />
       
@@ -201,7 +206,7 @@ function AppRoutes() {
       <Route path="/learn" element={<Navigate to="/courses" replace />} />
       <Route path="/learn/:slug" element={
         <ProtectedRoute>
-          <CourseViewerWrapper />
+          <CourseViewerRedirect />
         </ProtectedRoute>
       } />
 

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -80,12 +80,12 @@ export default function Dashboard() {
     const fetchData = async (retries = 2) => {
       try {
         const [coursesRes, credentialsRes, certsRes, activityRes] = await Promise.all([
-          api.get('/courses/user/enrolled'),
+          api.get('/interactive-courses/user/my-courses'),
           api.get('/credentials/user/dashboard'),
           api.get('/certificates/my').catch(() => ({ data: { certificates: [] } })),
           api.get('/analytics/my-activity?limit=10').catch(() => ({ data: { activities: [] } }))
         ]);
-        setCourses(coursesRes.data.enrolledCourses || []);
+        setCourses(coursesRes.data.data || coursesRes.data.enrolledCourses || []);
         setCredentials(credentialsRes.data);
         setCertificates(certsRes.data.certificates || certsRes.data || []);
         setActivity(activityRes.data.activities || []);

--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -10,7 +10,7 @@
 // Do NOT change classNames, color values, gradients, spacing, grid layout, or component hierarchy.
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   BookOpen, Clock, ChevronRight, Search,
   Filter, Grid, List, Star, Users, CheckCircle
@@ -18,7 +18,6 @@ import {
 import api from '../services/api';
 
 const InteractiveCourseCatalog = () => {
-  const navigate = useNavigate();
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -77,7 +76,7 @@ const InteractiveCourseCatalog = () => {
   };
 
   const handleCourseClick = (course) => {
-    navigate(`/courses/${course.slug}`);
+    window.location.href = `/interactive-course.html?slug=${course.slug}`;
   };
 
   if (loading) {

--- a/client/src/pages/PartnerCourseCatalog.jsx
+++ b/client/src/pages/PartnerCourseCatalog.jsx
@@ -5,7 +5,6 @@
  */
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { Link } from 'react-router-dom';
 import api from '../services/api';
 import { BookOpen, Clock, Search, Award } from 'lucide-react';
 
@@ -173,21 +172,21 @@ export default function PartnerCourseCatalog() {
                   )}
 
                   {isCompleted ? (
-                    <Link
-                      to={`/courses/${course.slug}`}
+                    <a
+                      href={`/interactive-course.html?slug=${course.slug}`}
                       className="block text-center text-xs font-medium py-2 rounded-lg transition-colors"
                       style={{ background: HUNTER + '15', color: HUNTER }}
                     >
                       Completed — View Certificate
-                    </Link>
+                    </a>
                   ) : isEnrolled ? (
-                    <Link
-                      to={`/courses/${course.slug}`}
+                    <a
+                      href={`/interactive-course.html?slug=${course.slug}`}
                       className="block text-center text-xs font-medium py-2 rounded-lg text-white transition-colors"
                       style={{ background: primaryColor }}
                     >
                       Continue Learning
-                    </Link>
+                    </a>
                   ) : (
                     <button
                       onClick={() => handleEnroll(course._id)}

--- a/client/src/pages/Recommendations.jsx
+++ b/client/src/pages/Recommendations.jsx
@@ -4,15 +4,13 @@
  * Unauthorized copying or distribution is strictly prohibited.
  */
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import api from '../services/api';
 
 export default function Recommendations() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
-
   useEffect(() => {
     async function fetch() {
       try {
@@ -78,7 +76,7 @@ export default function Recommendations() {
         <div className="space-y-4">
           {data.recommendations.map(course => (
             <div key={course._id} className="bg-white rounded-xl border p-5 hover:border-burgundy-400 transition cursor-pointer"
-              onClick={() => navigate(`/courses/${course.slug}`)} role="article">
+              onClick={() => window.location.href = `/interactive-course.html?slug=${course.slug}`} role="article">
               <div className="flex justify-between items-start">
                 <div className="flex-1">
                   <h3 className="font-semibold text-gray-900 mb-1">{course.title}</h3>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -19,7 +19,7 @@ dotenv.config();
 
 // Import routes
 import authRoutes from './routes/auth.js';
-import coursesRoutes from './routes/courses.js';
+// import coursesRoutes from './routes/courses.js'; // Legacy route unmounted — all courses via /api/interactive-courses
 import adminRoutes from './routes/admin.js';
 import usersRoutes from './routes/users.js';
 import certificatesRoutes from './routes/certificates.js';
@@ -240,7 +240,7 @@ app.get('/health', async (req, res) => {
 // API Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/interactive-courses', interactiveCourseRoutes);
-app.use('/api/courses', coursesRoutes);
+// app.use('/api/courses', coursesRoutes); // Legacy route unmounted
 app.use('/api/admin', adminRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/certificates', certificatesRoutes);
@@ -310,7 +310,6 @@ app.use((req, res, next) => {
     availableEndpoints: [
       '/health',
       '/api/auth/*',
-      '/api/courses/*',
       '/api/interactive-courses/*',
       '/api/admin/*',
       '/api/users/*',
@@ -400,6 +399,13 @@ const startServer = async () => {
 startServer().catch(err => {
   console.error('Failed to start server:', err);
   process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('⚠️ Unhandled Rejection at:', promise, 'reason:', reason);
+});
+process.on('uncaughtException', (err) => {
+  console.error('💥 Uncaught Exception:', err);
   process.exit(1);
 });
 

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -54,59 +54,7 @@ async function findCourseByIdOrSlug(param, tenantFilter = {}) {
       : { $or: slugConditions };
   }
 
-  let course = await Course.findOne(query);
-
-  // Fallback: try legacy "courses" collection (same DB, different collection name)
-  if (!course) {
-    const legacyQuery = mongoose.Types.ObjectId.isValid(param)
-      ? { _id: new mongoose.Types.ObjectId(param) }
-      : { $or: [{ slug: param }, { courseCode: param }] };
-
-    const legacyDoc = await mongoose.connection.db
-      .collection('courses')
-      .findOne(legacyQuery);
-
-    if (legacyDoc) {
-      // Normalize legacy course into interactivecourses shape
-      const sections = (legacyDoc.modules || legacyDoc.sections || []).map((mod) => {
-        const contentBlocks = [
-          { type: 'sectionDivider', order: 0, title: mod.title },
-          ...(mod.lessons || mod.contentBlocks || []).map((item, i) => ({
-            type: item.type || 'text',
-            order: i + 1,
-            content: item.content,
-            textContent: item.textContent || item.content,
-            title: item.title,
-            ...item
-          }))
-        ];
-        return { ...mod, title: mod.title, contentBlocks, _id: mod._id };
-      });
-
-      course = {
-        _id: legacyDoc._id,
-        title: legacyDoc.title,
-        slug: legacyDoc.slug,
-        courseCode: legacyDoc.courseCode,
-        description: legacyDoc.description,
-        ceHours: legacyDoc.ceHours,
-        ceProvider: legacyDoc.ceProvider,
-        acepNumber: legacyDoc.acepNumber,
-        objectives: legacyDoc.objectives,
-        assessment: legacyDoc.assessment,
-        status: legacyDoc.status,
-        categories: legacyDoc.categories,
-        tags: legacyDoc.tags,
-        targetAudience: legacyDoc.targetAudience,
-        author: legacyDoc.author,
-        presenter: legacyDoc.presenter,
-        sections,
-        source: 'legacy'
-      };
-    }
-  }
-
-  return course;
+  return Course.findOne(query);
 }
 
 /**
@@ -232,128 +180,29 @@ router.get('/', optionalAuth, async (req, res) => {
 
     const isAdmin = req.user?.role === 'admin';
 
-    if (isAdmin) {
-      // Admin: merge results from both interactivecourses and legacy courses collections
-      const pageNum = parseInt(page);
-      const limitNum = parseInt(limit);
-
-      const [interactiveCourses, interactiveTotal] = await Promise.all([
-        Course.find(query)
-          .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount totalContentBlocks totalQuizQuestions acepNumber accessType price pricingTier status courseCode')
-          .sort({ publishedAt: -1 })
-          .lean(),
-        Course.countDocuments(query)
-      ]);
-
-      // Build a matching filter for the legacy courses collection
-      const legacyFilter = {};
-      if (status && status !== 'all') legacyFilter.status = status;
-      if (category) legacyFilter.categories = category;
-      if (tag) legacyFilter.tags = tag;
-      if (search) {
-        legacyFilter.$or = [
-          { title: { $regex: search, $options: 'i' } },
-          { description: { $regex: search, $options: 'i' } }
-        ];
-      }
-
-      const legacyCollection = mongoose.connection.db.collection('courses');
-      const [legacyCourses, legacyTotal] = await Promise.all([
-        legacyCollection
-          .find(legacyFilter)
-          .project({ title: 1, slug: 1, description: 1, thumbnail: 1, ceHours: 1, totalEstimatedTime: 1, categories: 1, tags: 1, status: 1, publishedAt: 1 })
-          .sort({ publishedAt: -1 })
-          .toArray(),
-        legacyCollection.countDocuments(legacyFilter)
-      ]);
-
-      // Tag each source and merge
-      const taggedInteractive = interactiveCourses.map(c => ({ ...c, source: 'interactive' }));
-      const taggedLegacy = legacyCourses.map(c => ({ ...c, source: 'legacy' }));
-      const merged = [...taggedInteractive, ...taggedLegacy];
-
-      // Sort combined by publishedAt descending
-      merged.sort((a, b) => {
-        const dateA = a.publishedAt ? new Date(a.publishedAt) : new Date(0);
-        const dateB = b.publishedAt ? new Date(b.publishedAt) : new Date(0);
-        return dateB - dateA;
-      });
-
-      const combinedTotal = interactiveTotal + legacyTotal;
-      const paginatedData = merged.slice((pageNum - 1) * limitNum, pageNum * limitNum);
-
-      return res.json({
-        success: true,
-        data: paginatedData,
-        pagination: {
-          page: pageNum,
-          limit: limitNum,
-          total: combinedTotal,
-          pages: Math.ceil(combinedTotal / limitNum)
-        }
-      });
-    }
-
-    // Non-admin: published interactivecourses + legacy courses merged
     const pageNum = parseInt(page);
     const limitNum = parseInt(limit);
 
-    const [interactiveCourses, interactiveTotal] = await Promise.all([
+    const selectFields = 'title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount totalContentBlocks totalQuizQuestions acepNumber accessType price pricingTier status courseCode';
+
+    const [courses, total] = await Promise.all([
       Course.find(query)
-        .select('title slug description thumbnail ceHours totalEstimatedTime categories tags wordCount totalContentBlocks totalQuizQuestions acepNumber accessType price pricingTier status courseCode')
+        .select(selectFields)
         .sort({ publishedAt: -1 })
+        .skip((pageNum - 1) * limitNum)
+        .limit(limitNum)
         .lean(),
       Course.countDocuments(query)
     ]);
 
-    // Also query legacy courses collection for published courses
-    const legacyFilter = {};
-    if (status && status !== 'all') legacyFilter.status = status;
-    if (category) legacyFilter.categories = category;
-    if (tag) legacyFilter.tags = tag;
-    if (search) {
-      legacyFilter.$or = [
-        { title: { $regex: search, $options: 'i' } },
-        { description: { $regex: search, $options: 'i' } }
-      ];
-    }
-
-    const legacyCollection = mongoose.connection.db.collection('courses');
-    const [legacyCourses, legacyTotal] = await Promise.all([
-      legacyCollection
-        .find(legacyFilter)
-        .project({ title: 1, slug: 1, description: 1, thumbnail: 1, ceHours: 1, totalEstimatedTime: 1, categories: 1, tags: 1, status: 1, publishedAt: 1 })
-        .sort({ publishedAt: -1 })
-        .toArray(),
-      legacyCollection.countDocuments(legacyFilter)
-    ]);
-
-    // Deduplicate by slug (interactive takes priority over legacy)
-    const interactiveSlugs = new Set(interactiveCourses.map(c => c.slug));
-    const uniqueLegacy = legacyCourses.filter(c => !interactiveSlugs.has(c.slug));
-
-    const taggedInteractive = interactiveCourses.map(c => ({ ...c, source: 'interactive' }));
-    const taggedLegacy = uniqueLegacy.map(c => ({ ...c, source: 'legacy' }));
-    const merged = [...taggedInteractive, ...taggedLegacy];
-
-    // Sort combined by publishedAt descending
-    merged.sort((a, b) => {
-      const dateA = a.publishedAt ? new Date(a.publishedAt) : new Date(0);
-      const dateB = b.publishedAt ? new Date(b.publishedAt) : new Date(0);
-      return dateB - dateA;
-    });
-
-    const combinedTotal = interactiveTotal + uniqueLegacy.length;
-    const paginatedData = merged.slice((pageNum - 1) * limitNum, pageNum * limitNum);
-
     res.json({
       success: true,
-      data: paginatedData,
+      data: courses,
       pagination: {
         page: pageNum,
         limit: limitNum,
-        total: combinedTotal,
-        pages: Math.ceil(combinedTotal / limitNum)
+        total,
+        pages: Math.ceil(total / limitNum)
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR removes all legacy course collection support and consolidates the application to use only the interactive courses system. The backend no longer queries or merges data from the legacy "courses" collection, and the frontend has been updated to redirect course views to the static HTML player.

## Key Changes

**Backend (server/src/routes/interactiveCourseRoutes.js):**
- Removed legacy course fallback logic from `findCourseByIdOrSlug()` function
- Simplified the function to only query the interactive courses collection
- Removed legacy course normalization and transformation code
- Simplified the GET `/` endpoint to remove admin/non-admin branching and legacy collection merging
- Removed deduplication logic and combined sorting of interactive + legacy courses
- Added proper pagination at the database query level instead of in-memory slicing

**Frontend (client/src/):**
- Removed `CourseView` component import and `CourseViewer` component
- Replaced `CourseViewerWrapper` with `CourseViewerRedirect` that redirects to the static HTML player (`/interactive-course.html?slug=...`)
- Updated all course navigation links to use direct `window.location.href` redirects instead of React Router navigation:
  - `InteractiveCourseCatalog.jsx`: Course click handler now redirects to HTML player
  - `PartnerCourseCatalog.jsx`: Changed `<Link>` elements to `<a>` tags with direct href
  - `Recommendations.jsx`: Updated course click handler to use direct redirect
  - `Dashboard.jsx`: Updated API endpoint from `/courses/user/enrolled` to `/interactive-courses/user/my-courses`

**Server Configuration (server/src/index.js):**
- Commented out legacy `/api/courses` route mounting
- Removed `/api/courses/*` from available endpoints documentation
- Added unhandled rejection and uncaught exception handlers for better error tracking

## Implementation Details
- The static HTML player at `/interactive-course.html` now serves as the single course viewing interface
- All course data flows through the `/api/interactive-courses` endpoint exclusively
- Pagination is now handled at the MongoDB query level for better performance
- The application no longer maintains any dual-collection logic or data transformation for legacy courses

https://claude.ai/code/session_0183qM9LkjaML7vqzJor4ZqF