### PR TITLE
Route paid unenrolled courses through course-details page

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -10,7 +10,7 @@
 // Do NOT change classNames, color values, gradients, spacing, grid layout, or component hierarchy.
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+
 import {
   BookOpen, Clock, ChevronRight, Search,
   Filter, Grid, List, Star, Users, CheckCircle
@@ -18,7 +18,6 @@ import {
 import api from '../services/api';
 
 const InteractiveCourseCatalog = () => {
-  const navigate = useNavigate();
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -77,7 +76,15 @@ const InteractiveCourseCatalog = () => {
   };
 
   const handleCourseClick = (course) => {
-    navigate(`/courses/${course.slug}`);
+    const progress = getProgressForCourse(course._id);
+    const isEnrolled = !!progress;
+    const isFree = !course.accessType || course.accessType === 'free';
+
+    if (isEnrolled || isFree) {
+      window.location.href = `/interactive-course.html?slug=${course.slug}`;
+    } else {
+      window.location.href = `/course-details.html?slug=${course.slug}`;
+    }
   };
 
   if (loading) {

--- a/client/src/pages/Recommendations.jsx
+++ b/client/src/pages/Recommendations.jsx
@@ -4,14 +4,13 @@
  * Unauthorized copying or distribution is strictly prohibited.
  */
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import api from '../services/api';
 
 export default function Recommendations() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
 
   useEffect(() => {
     async function fetch() {
@@ -78,7 +77,12 @@ export default function Recommendations() {
         <div className="space-y-4">
           {data.recommendations.map(course => (
             <div key={course._id} className="bg-white rounded-xl border p-5 hover:border-burgundy-400 transition cursor-pointer"
-              onClick={() => navigate(`/courses/${course.slug}`)} role="article">
+              onClick={() => {
+                const isFree = !course.accessType || course.accessType === 'free' || course.accessTier === 'free';
+                window.location.href = isFree
+                  ? `/interactive-course.html?slug=${course.slug}`
+                  : `/course-details.html?slug=${course.slug}`;
+              }} role="article">
               <div className="flex justify-between items-start">
                 <div className="flex-1">
                   <h3 className="font-semibold text-gray-900 mb-1">{course.title}</h3>


### PR DESCRIPTION
Catalog click handler now checks enrollment and access type: enrolled/free → CReady Viewer, paid unenrolled → course-details page with overview, instructor, pricing, and subscribe CTAs.

https://claude.ai/code/session_01PcPYEHbUeQA714R9DHqSwM