### PR TITLE
Route all course clicks to course-details page

### DIFF
--- a/client/src/pages/InteractiveCourseCatalog.jsx
+++ b/client/src/pages/InteractiveCourseCatalog.jsx
@@ -76,15 +76,7 @@ const InteractiveCourseCatalog = () => {
   };
 
   const handleCourseClick = (course) => {
-    const progress = getProgressForCourse(course._id);
-    const isEnrolled = !!progress;
-    const isFree = !course.accessType || course.accessType === 'free';
-
-    if (isEnrolled || isFree) {
-      window.location.href = `/interactive-course.html?slug=${course.slug}`;
-    } else {
-      window.location.href = `/course-details.html?slug=${course.slug}`;
-    }
+    window.location.href = `/course-details.html?slug=${course.slug}`;
   };
 
   if (loading) {

--- a/client/src/pages/Recommendations.jsx
+++ b/client/src/pages/Recommendations.jsx
@@ -77,12 +77,7 @@ export default function Recommendations() {
         <div className="space-y-4">
           {data.recommendations.map(course => (
             <div key={course._id} className="bg-white rounded-xl border p-5 hover:border-burgundy-400 transition cursor-pointer"
-              onClick={() => {
-                const isFree = !course.accessType || course.accessType === 'free' || course.accessTier === 'free';
-                window.location.href = isFree
-                  ? `/interactive-course.html?slug=${course.slug}`
-                  : `/course-details.html?slug=${course.slug}`;
-              }} role="article">
+              onClick={() => window.location.href = `/course-details.html?slug=${course.slug}`} role="article">
               <div className="flex justify-between items-start">
                 <div className="flex-1">
                   <h3 className="font-semibold text-gray-900 mb-1">{course.title}</h3>


### PR DESCRIPTION
Every course in the catalog goes to course-details.html first so learners can review overview, instructor, approval body, and pricing before starting. The details page CTA leads to the CReady Viewer.

https://claude.ai/code/session_01PcPYEHbUeQA714R9DHqSwM