### PR TITLE
Apply RNR CE design palette and expand ArticleCard action strip

### DIFF
--- a/client/src/components/researchReady/ArticleCard.jsx
+++ b/client/src/components/researchReady/ArticleCard.jsx
@@ -1,52 +1,92 @@
 /**
- * ArticleCard — Displays an article search result with word count badge.
+ * ArticleCard — Displays an article search result with word count badge
+ * and full action strip. RNR CE design palette applied.
  */
 import { useState } from 'react';
-import { ExternalLink, ChevronDown, ChevronUp, Plus } from 'lucide-react';
+import { ExternalLink, ChevronDown, ChevronUp, Plus, Printer, Download, Bookmark } from 'lucide-react';
 import WordCountBadge from './WordCountBadge';
 
-export default function ArticleCard({ article, onCreateCE, onSelectForPairing, isPairingMode }) {
+export default function ArticleCard({ article, onCreateCE, onSelectForPairing, isPairingMode, onSaveArticle }) {
   const [expanded, setExpanded] = useState(false);
 
+  const isSufficient = article.wcStatus === 'sufficient';
+  const isThin = article.wcStatus === 'thin';
+
+  const cardClass = isSufficient
+    ? 'bg-[#F8EEDC] border-l-[3px] border-l-[#7B2D3E] border-t-0 border-r-0 border-b-0 rounded-r-[6px]'
+    : 'bg-[#F5EEE0] border border-[#DDD9D3]';
+
+  function handlePrint() {
+    if (article.oaUrl) {
+      const w = window.open(article.oaUrl, '_blank');
+      if (w) setTimeout(() => w.print(), 1500);
+    } else {
+      window.print();
+    }
+  }
+
+  function handleDownload() {
+    if (article.oaUrl) {
+      const a = document.createElement('a');
+      a.href = article.oaUrl;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.click();
+    }
+  }
+
+  function handleSave() {
+    if (onSaveArticle) {
+      onSaveArticle(article);
+    } else {
+      const saved = JSON.parse(localStorage.getItem('rnr_saved_articles') || '[]');
+      if (!saved.find(s => s.openAlexId === article.openAlexId)) {
+        saved.push(article);
+        localStorage.setItem('rnr_saved_articles', JSON.stringify(saved));
+      }
+    }
+  }
+
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md transition-shadow">
+    <div className={`${cardClass} p-5 hover:shadow-md transition-shadow`}>
       {/* Title */}
-      <h3 className="text-base font-semibold text-gray-900 mb-2 leading-snug">
+      <h3 className="font-[Georgia,serif] text-[13px] text-[#2A1F0E] font-semibold mb-2 leading-snug">
         {article.title}
       </h3>
 
       {/* Badges row */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
-        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-burgundy-100 text-burgundy-800">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[#F8EEDC] text-[#8B5E2E]">
           {article.year}
         </span>
-        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[#F4F1ED] text-[#5C4D3A]">
           Open Access
         </span>
         {article.topic && (
-          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium text-[#7B2D3E]">
             {article.topic}
           </span>
         )}
       </div>
 
-      {/* Meta */}
-      <p className="text-sm text-gray-500 mb-1">
-        <span className="font-medium text-gray-700">{article.journal}</span>
+      {/* Journal */}
+      <p className="font-[Georgia,serif] text-[10px] italic text-[#5C4D3A] mb-1">
+        {article.journal}
       </p>
-      <p className="text-sm text-gray-500 mb-3 line-clamp-1">
+      {/* Authors */}
+      <p className="text-[10px] text-[#7A6A54] mb-3 line-clamp-1">
         {article.authors}
       </p>
 
       {/* Abstract */}
       {article.abstract && (
         <div className="mb-3">
-          <p className={`text-sm text-gray-600 ${expanded ? '' : 'line-clamp-2'}`}>
+          <p className={`text-[11px] italic text-[#7A6A54] font-[Georgia,serif] ${expanded ? '' : 'line-clamp-2'}`}>
             {article.abstract}
           </p>
           <button
             onClick={() => setExpanded(!expanded)}
-            className="text-xs text-burgundy-600 hover:text-burgundy-800 mt-1 flex items-center gap-1"
+            className="text-[10px] text-[#7B2D3E] hover:text-[#9B3A4E] mt-1 flex items-center gap-1 font-[Georgia,serif]"
           >
             {expanded ? <><ChevronUp className="w-3 h-3" /> Show less</> : <><ChevronDown className="w-3 h-3" /> Read more</>}
           </button>
@@ -54,46 +94,82 @@ export default function ArticleCard({ article, onCreateCE, onSelectForPairing, i
       )}
 
       {/* Word count + CE hours */}
-      <div className="flex flex-wrap items-center gap-3 mb-4">
+      <div className="flex flex-wrap items-center gap-3 mb-3">
         <WordCountBadge
           wordCount={article.wordCount}
           ceHours={article.ceHours}
           wcStatus={article.wcStatus}
         />
         {article.ceHours > 0 && (
-          <span className="text-xs text-gray-500">
+          <span className="text-[10px] text-[#7A6A54] font-[Georgia,serif]">
             {article.researchHours} research hr{article.researchHours !== 1 ? 's' : ''}
           </span>
         )}
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-3">
-        {isPairingMode ? (
+      {/* Action Strip */}
+      <div className="border-t border-[#DDD9D3] pt-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Primary action */}
+          {isPairingMode ? (
+            <button
+              onClick={() => onSelectForPairing(article)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[#7B2D3E] text-[#FAF5EC] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:bg-[#9B3A4E] transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" /> Pair Article
+            </button>
+          ) : isThin ? (
+            <button
+              onClick={() => onCreateCE(article)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[#8B5E2E] text-[#FAF5EC] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:bg-[#A5712E] transition-colors"
+            >
+              Pair with another article
+            </button>
+          ) : (
+            <button
+              onClick={() => onCreateCE(article)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[#7B2D3E] text-[#FAF5EC] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:bg-[#9B3A4E] transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" /> Create CE
+            </button>
+          )}
+
+          {/* Read article */}
+          {article.oaUrl && (
+            <a
+              href={article.oaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 bg-[#F5EEE0] border border-[#DDD9D3] text-[#3D2E18] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:border-[#C49040] hover:text-[#8B5E2E] hover:bg-[#FDF8EE] transition-colors"
+            >
+              <ExternalLink className="w-3 h-3" /> Read article
+            </a>
+          )}
+
+          {/* Print */}
           <button
-            onClick={() => onSelectForPairing(article)}
-            className="inline-flex items-center gap-1.5 px-4 py-2 bg-burgundy-700 text-white text-sm font-medium rounded-lg hover:bg-burgundy-800 transition-colors"
+            onClick={handlePrint}
+            className="inline-flex items-center gap-1 px-3 py-1.5 bg-[#F5EEE0] border border-[#DDD9D3] text-[#3D2E18] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:border-[#C49040] hover:text-[#8B5E2E] hover:bg-[#FDF8EE] transition-colors"
           >
-            <Plus className="w-4 h-4" /> Pair Article
+            <Printer className="w-3 h-3" /> Print
           </button>
-        ) : (
+
+          {/* Download */}
           <button
-            onClick={() => onCreateCE(article)}
-            className="inline-flex items-center gap-1.5 px-4 py-2 bg-burgundy-700 text-white text-sm font-medium rounded-lg hover:bg-burgundy-800 transition-colors"
+            onClick={handleDownload}
+            className="inline-flex items-center gap-1 px-3 py-1.5 bg-[#F5EEE0] border border-[#DDD9D3] text-[#3D2E18] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:border-[#C49040] hover:text-[#8B5E2E] hover:bg-[#FDF8EE] transition-colors"
           >
-            <Plus className="w-4 h-4" /> Create CE
+            <Download className="w-3 h-3" /> Download
           </button>
-        )}
-        {article.oaUrl && (
-          <a
-            href={article.oaUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-sm text-burgundy-600 hover:text-burgundy-800"
+
+          {/* Save */}
+          <button
+            onClick={handleSave}
+            className="inline-flex items-center gap-1 px-3 py-1.5 bg-[#F5EEE0] border border-[#DDD9D3] text-[#3D2E18] rounded font-[Georgia,serif] text-[10px] uppercase tracking-[0.05em] hover:border-[#C49040] hover:text-[#8B5E2E] hover:bg-[#FDF8EE] transition-colors"
           >
-            <ExternalLink className="w-3.5 h-3.5" /> View Article
-          </a>
-        )}
+            <Bookmark className="w-3 h-3" /> Save
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/researchReady/CEHoursSelector.jsx
+++ b/client/src/components/researchReady/CEHoursSelector.jsx
@@ -12,21 +12,21 @@ const options = [
 export default function CEHoursSelector({ selected, onSelect }) {
   return (
     <div className="flex flex-wrap gap-2 mb-4">
-      <span className="text-sm font-medium text-gray-600 self-center mr-2">CE Hours:</span>
+      <span className="font-[Georgia,serif] text-[10px] uppercase tracking-[0.12em] text-[#5C4D3A] italic self-center mr-2">CE Hours:</span>
       {options.map((opt) => {
         const isActive = selected === opt.value;
         return (
           <button
             key={opt.label}
             onClick={() => onSelect(opt.value)}
-            className={`flex flex-col items-center px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
+            className={`flex flex-col items-center px-4 py-2 rounded-full text-sm font-[Georgia,serif] transition-colors border ${
               isActive
-                ? 'bg-burgundy-700 text-white border-burgundy-700'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-burgundy-300 hover:bg-burgundy-50'
+                ? 'bg-[#FDF8EE] border-[1.5px] border-[#7B2D3E] text-[#7B2D3E]'
+                : 'bg-[#F5EEE0] text-[#5C4D3A] border-[#C8C3BC] hover:border-[#7B2D3E] hover:text-[#7B2D3E]'
             }`}
           >
             <span>{opt.label}</span>
-            <span className={`text-[10px] ${isActive ? 'text-burgundy-200' : 'text-gray-400'}`}>
+            <span className={`text-[10px] ${isActive ? 'text-[#7B2D3E]/70' : 'text-[#7A6A54]'}`}>
               {opt.subtext}
             </span>
           </button>

--- a/client/src/pages/CEPlanner.jsx
+++ b/client/src/pages/CEPlanner.jsx
@@ -7,7 +7,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import api from '../services/api';
-import { Calendar, Clock, Target, AlertTriangle, CheckCircle, BookOpen, ArrowLeft, ArrowRight, TrendingUp, FileText, Award, Beaker } from 'lucide-react';
+import { Calendar, Clock, Target, AlertTriangle, CheckCircle, BookOpen, ArrowLeft, ArrowRight, TrendingUp, FileText, Award, Beaker, Plus } from 'lucide-react';
 
 const urgencyColors = {
   expired: { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200', badge: 'bg-red-100 text-red-800' },
@@ -35,7 +35,7 @@ function ResearchReadyRecs({ deficits }) {
           const { data } = await api.get('/research-ready/search', {
             params: { q: d.category, per_page: 3, desired_hours: d.remaining }
           });
-          if (data.results?.length > 0) results[d.category] = data.results;
+          if (data.results?.length > 0) results[d.category] = { articles: data.results, deficit: d };
         } catch { /* non-fatal */ }
       }
       setArticles(results);
@@ -44,31 +44,55 @@ function ResearchReadyRecs({ deficits }) {
     fetchAll();
   }, [deficits]);
 
-  if (!loaded || Object.keys(articles).length === 0) return null;
+  if (!loaded) return null;
+
+  // If no results at all, show fallback
+  if (Object.keys(articles).length === 0) {
+    return (
+      <div className="p-4 border-t border-[#DDD9D3]">
+        <div className="bg-[#FDF8EE] border-l-[3px] border-l-[#7B2D3E] rounded-r-lg p-4">
+          <p className="font-[Georgia,serif] text-[11px] italic text-[#5C4D3A]">
+            No open-access articles currently matched.{' '}
+            <Link to="/research-ready" className="text-[#7B2D3E] underline hover:text-[#9B3A4E]">
+              Search manually &rarr;
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="p-4 border-t">
-      {Object.entries(articles).map(([category, arts]) => (
-        <div key={category} className="mb-3">
-          <div className="flex items-center gap-2 mb-2">
-            <Beaker className="w-4 h-4 text-burgundy-600" />
-            <h3 className="text-sm font-medium text-burgundy-800">
-              Researched-N-Ready CE — Fill your {category} deficit
+    <div className="p-4 border-t border-[#DDD9D3]">
+      {Object.entries(articles).map(([category, { articles: arts, deficit }]) => (
+        <div key={category} className="mb-4 bg-[#FDF8EE] border-l-[3px] border-l-[#7B2D3E] rounded-r-lg p-4">
+          <div className="flex items-center gap-2 mb-1">
+            <Beaker className="w-4 h-4 text-[#7B2D3E]" />
+            <h3 className="font-[Georgia,serif] text-sm font-semibold text-[#7B2D3E]">
+              RNR CE — Fill your {category} deficit
             </h3>
           </div>
+          <p className="font-[Georgia,serif] text-[10px] italic text-[#5C4D3A] mb-3">
+            {deficit.remaining} hours needed &middot; matched articles below
+          </p>
           <div className="space-y-2">
             {arts.slice(0, 3).map((article, i) => (
-              <a key={i} href={`/research-ready?q=${encodeURIComponent(category)}`}
-                className="flex items-center justify-between p-3 bg-burgundy-50 rounded-lg hover:bg-burgundy-100 transition-colors">
-                <div className="flex items-center gap-3">
-                  <BookOpen className="w-4 h-4 text-burgundy-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-900 line-clamp-1">{article.title}</p>
-                    <p className="text-xs text-gray-500">{article.ceHours} CE hours &bull; {article.year} &bull; Researched-N-Ready</p>
+              <Link key={i} to={`/research-ready?q=${encodeURIComponent(category)}&desired_hours=${deficit.remaining}`}
+                className="flex items-center justify-between p-3 bg-[#F8EEDC] rounded-lg hover:bg-[#F5EEE0] transition-colors">
+                <div className="flex items-center gap-3 min-w-0">
+                  <BookOpen className="w-4 h-4 text-[#7B2D3E] flex-shrink-0" />
+                  <div className="min-w-0">
+                    <p className="font-[Georgia,serif] text-[12px] font-medium text-[#2A1F0E] line-clamp-1">{article.title}</p>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-[#7B2D3E] text-[#FAF5EC]">{article.ceHours} CE hrs</span>
+                      <span className="px-1.5 py-0.5 rounded text-[9px] bg-[#F4F1ED] text-[#5C4D3A]">{category}</span>
+                    </div>
                   </div>
                 </div>
-                <ArrowRight className="w-4 h-4 text-burgundy-600 flex-shrink-0" />
-              </a>
+                <span className="inline-flex items-center gap-1 px-2 py-1 bg-[#7B2D3E] text-[#FAF5EC] rounded text-[9px] font-[Georgia,serif] uppercase tracking-[0.05em] hover:bg-[#9B3A4E] flex-shrink-0 ml-2">
+                  <Plus className="w-3 h-3" /> Create CE
+                </span>
+              </Link>
             ))}
           </div>
         </div>

--- a/client/src/pages/Credentials.jsx
+++ b/client/src/pages/Credentials.jsx
@@ -266,7 +266,17 @@ export default function Credentials() {
         <>
           {certificates.length > 0 ? (
             <div className="grid grid-cols-3 gap-4">
-              {certificates.map((cert) => (
+              {certificates.map((cert) => {
+                // Parse RNR metadata from notes
+                let rnrMeta = null;
+                try { rnrMeta = cert.notes ? JSON.parse(cert.notes) : null; } catch { /* not JSON */ }
+                const isRnr = rnrMeta?.type === 'research_ready';
+
+                if (isRnr) {
+                  return <RnrCertTile key={cert._id} cert={cert} rnrMeta={rnrMeta} formatDate={formatDate} onDelete={handleDeleteCertificate} />;
+                }
+
+                return (
                 <div key={cert._id} className="border border-stone-200 rounded-xl p-5 hover:border-hunter-300 transition-colors">
                   <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                     <div className="flex items-start gap-3 flex-1 min-w-0">
@@ -325,7 +335,8 @@ export default function Credentials() {
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           ) : (
             <div className="border border-stone-200 rounded-xl text-center py-12 px-6">
@@ -387,6 +398,128 @@ export default function Credentials() {
   );
 }
 
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RNR CE Certificate Tile — research_ready type
+// ─────────────────────────────────────────────────────────────────────────────
+function RnrCertTile({ cert, rnrMeta, formatDate, onDelete }) {
+  const [expanded, setExpanded] = useState(false);
+  const courseTitle = rnrMeta.courseTitle || cert.title;
+  const articleTitles = rnrMeta.articleTitles || [];
+
+  return (
+    <div
+      className="bg-[#F8EEDC] border-l-[3px] border-l-[#7B2D3E] rounded-r-xl p-5 hover:shadow-md transition-shadow cursor-pointer"
+      onClick={() => setExpanded(!expanded)}
+    >
+      {/* At-a-glance (collapsed) */}
+      <h3 className="font-[Georgia,serif] text-[13px] text-[#2A1F0E] font-semibold mb-2 line-clamp-2">
+        {courseTitle}
+      </h3>
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[#7B2D3E] text-[#FAF5EC]">
+          {cert.ceHours} CE hrs
+        </span>
+        {cert.category && (
+          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[#F4F1ED] text-[#5C4D3A]">
+            {cert.category}
+          </span>
+        )}
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700">
+          NBCC Approved
+        </span>
+      </div>
+      <p className="font-[Georgia,serif] text-[10px] text-[#7A6A54] mb-3">
+        Completed {formatDate(cert.completionDate)}
+      </p>
+
+      <div className="flex items-center gap-2">
+        {cert.fileUrl && (
+          <a
+            href={cert.fileUrl}
+            download
+            onClick={e => e.stopPropagation()}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[#7B2D3E] text-[#FAF5EC] rounded text-[10px] font-[Georgia,serif] uppercase tracking-[0.05em] hover:bg-[#9B3A4E] transition-colors"
+          >
+            <Download className="w-3 h-3" /> Download Syllabus
+          </a>
+        )}
+        <button
+          onClick={e => { e.stopPropagation(); onDelete(cert._id); }}
+          className="p-1.5 text-[#7A6A54] hover:text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+          title="Delete certificate"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Expanded view */}
+      {expanded && (
+        <div className="mt-4 pt-4 border-t border-[#DDD9D3] space-y-3" onClick={e => e.stopPropagation()}>
+          {/* Authors, journal, year, DOI */}
+          {rnrMeta.authors && (
+            <p className="font-[Georgia,serif] text-[11px] italic text-[#5C4D3A]">
+              {rnrMeta.authors}
+            </p>
+          )}
+          {rnrMeta.journals && (
+            <p className="font-[Georgia,serif] text-[11px] italic text-[#7A6A54]">
+              {rnrMeta.journals}
+            </p>
+          )}
+          {rnrMeta.dois?.length > 0 && (
+            <p className="font-[Georgia,serif] text-[10px] text-[#7A6A54]">
+              DOI: {rnrMeta.dois.join('; ')}
+            </p>
+          )}
+
+          {/* Learning objectives */}
+          {rnrMeta.objectivesMet?.length > 0 && (
+            <div>
+              <p className="font-[Georgia,serif] text-[10px] uppercase tracking-[0.12em] text-[#5C4D3A] italic mb-1">
+                Learning Objectives Met
+              </p>
+              <ol className="list-decimal list-inside space-y-1">
+                {rnrMeta.objectivesMet.map((obj, i) => (
+                  <li key={i} className="font-[Georgia,serif] text-[11px] text-[#2A1F0E]">{obj}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {/* Assessment score */}
+          {rnrMeta.assessmentScore != null && (
+            <p className="font-[Georgia,serif] text-[11px] text-[#2A1F0E]">
+              Assessment Score: <strong>{rnrMeta.assessmentScore}%</strong>
+              {rnrMeta.correctCount != null && rnrMeta.totalQuestions && (
+                <span className="text-[#7A6A54]"> — {rnrMeta.correctCount} of {rnrMeta.totalQuestions} correct</span>
+              )}
+            </p>
+          )}
+
+          {/* CE hour calculation */}
+          {rnrMeta.ceCalcFormula && (
+            <p className="font-[Georgia,serif] text-[10px] text-[#7A6A54]">
+              {rnrMeta.ceCalcFormula}
+            </p>
+          )}
+
+          {/* Certificate ID */}
+          {cert.certificateNumber && (
+            <p className="font-[Georgia,serif] text-[10px] text-[#7A6A54]">
+              Certificate ID: {cert.certificateNumber}
+            </p>
+          )}
+
+          {/* NBCC stamp */}
+          <p className="font-[Georgia,serif] text-[10px] font-semibold text-[#7B2D3E] uppercase tracking-[0.05em]">
+            {rnrMeta.nbccAcepStamp || 'NBCC ACEP #7760'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Scan Certificate Modal — supports both CE certificates and credential docs

--- a/client/src/pages/ResearchReadyCE.jsx
+++ b/client/src/pages/ResearchReadyCE.jsx
@@ -199,9 +199,9 @@ export default function ResearchReadyCE() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-1">Researched-N-Ready CE</h1>
-      <p className="text-sm text-gray-500 mb-6">
+    <div className="bg-[#FAF5EC] min-h-screen -m-6 p-6">
+      <h1 className="font-[Georgia,serif] text-2xl font-bold text-[#2A1F0E] mb-1">Researched-N-Ready CE</h1>
+      <p className="font-[Georgia,serif] text-[10px] uppercase tracking-[0.12em] text-[#5C4D3A] italic mb-6">
         Earn NBCC-approved CE credit by reading peer-reviewed scholarly articles. ACEP #7760
       </p>
 
@@ -211,23 +211,26 @@ export default function ResearchReadyCE() {
       {/* Search Bar */}
       <form onSubmit={handleSearch} className="flex gap-3 mb-4">
         <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#7A6A54]" />
           <input
             type="text"
             value={query}
             onChange={e => setQuery(e.target.value)}
             placeholder="Search for scholarly articles (e.g., clinical supervision, trauma therapy)..."
-            className="w-full pl-10 pr-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:ring-2 focus:ring-burgundy-300 focus:border-burgundy-500 outline-none"
+            className="w-full pl-10 pr-4 py-2.5 bg-[#F5EEE0] border border-[#C8C3BC] rounded-xl text-sm font-[Georgia,serif] focus:ring-2 focus:ring-[#7B2D3E]/30 focus:border-[#7B2D3E] outline-none"
           />
         </div>
         <button
           type="submit"
           disabled={loading}
-          className="px-6 py-2.5 bg-burgundy-700 text-white text-sm font-medium rounded-xl hover:bg-burgundy-800 transition-colors disabled:opacity-50"
+          className="px-6 py-2.5 bg-[#7B2D3E] text-[#FAF5EC] text-sm font-medium font-[Georgia,serif] rounded-xl hover:bg-[#9B3A4E] transition-colors disabled:opacity-50"
         >
           {loading ? 'Searching...' : 'Search'}
         </button>
       </form>
+
+      {/* Section label */}
+      <p className="font-[Georgia,serif] text-[10px] uppercase tracking-[0.12em] text-[#5C4D3A] italic mb-2">Browse by topic</p>
 
       {/* Topic Chips */}
       <div className="flex flex-wrap gap-2 mb-5">
@@ -235,10 +238,10 @@ export default function ResearchReadyCE() {
           <button
             key={topic}
             onClick={() => handleChipClick(topic)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+            className={`px-3 py-1.5 rounded-full text-xs font-[Georgia,serif] uppercase transition-colors ${
               query === topic
-                ? 'bg-burgundy-700 text-white border-burgundy-700'
-                : 'bg-white text-gray-600 border-gray-300 hover:border-burgundy-300 hover:bg-burgundy-50'
+                ? 'bg-[#FDF8EE] border-[1.5px] border-[#7B2D3E] text-[#7B2D3E]'
+                : 'bg-[#F5EEE0] border border-[#C8C3BC] text-[#5C4D3A] hover:border-[#7B2D3E] hover:text-[#7B2D3E]'
             }`}
           >
             {topic}
@@ -249,11 +252,11 @@ export default function ResearchReadyCE() {
       {/* Filter Bar */}
       <div className="flex items-center gap-4 mb-6">
         <div className="flex items-center gap-2">
-          <Filter className="w-4 h-4 text-gray-400" />
+          <Filter className="w-4 h-4 text-[#7A6A54]" />
           <select
             value={yearFrom}
             onChange={e => setYearFrom(parseInt(e.target.value))}
-            className="text-sm border border-gray-300 rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-burgundy-300 outline-none"
+            className="text-sm font-[Georgia,serif] bg-[#F5EEE0] border border-[#C8C3BC] rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-[#7B2D3E]/30 outline-none"
           >
             {YEAR_OPTIONS.map(opt => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -263,7 +266,7 @@ export default function ResearchReadyCE() {
         <select
           value={sortBy}
           onChange={e => setSortBy(e.target.value)}
-          className="text-sm border border-gray-300 rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-burgundy-300 outline-none"
+          className="text-sm font-[Georgia,serif] bg-[#F5EEE0] border border-[#C8C3BC] rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-[#7B2D3E]/30 outline-none"
         >
           {SORT_OPTIONS.map(opt => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -273,7 +276,7 @@ export default function ResearchReadyCE() {
 
       {/* Desired Hours Match Notice */}
       {desiredHours && results.length > 0 && (
-        <div className="bg-burgundy-50 border border-burgundy-200 rounded-xl p-3 mb-4 text-sm text-burgundy-800">
+        <div className="bg-[#FDF8EE] border border-[#DDD9D3] rounded-xl p-3 mb-4 text-sm text-[#5C4D3A] font-[Georgia,serif]">
           Showing articles matching your <strong>{desiredHours} hr</strong> target
           {results.length < 3 && ' — Fewer articles at this length. Try "Any" or broaden your search.'}
         </div>
@@ -282,19 +285,26 @@ export default function ResearchReadyCE() {
       {/* Loading */}
       {loading && (
         <div className="flex justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-burgundy-700"></div>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#7B2D3E]"></div>
         </div>
       )}
 
       {/* Building CE overlay */}
       {buildingCE && (
         <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-40">
-          <div className="bg-white rounded-2xl p-8 text-center shadow-xl">
-            <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-burgundy-700 mx-auto mb-4"></div>
-            <p className="text-gray-700 font-medium">Processing with AI...</p>
-            <p className="text-sm text-gray-500 mt-1">This may take 15-30 seconds</p>
+          <div className="bg-[#FAF5EC] rounded-2xl p-8 text-center shadow-xl">
+            <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-[#7B2D3E] mx-auto mb-4"></div>
+            <p className="text-[#2A1F0E] font-medium font-[Georgia,serif]">Processing with AI...</p>
+            <p className="text-sm text-[#7A6A54] mt-1 font-[Georgia,serif]">This may take 15-30 seconds</p>
           </div>
         </div>
+      )}
+
+      {/* Results count */}
+      {!loading && results.length > 0 && (
+        <p className="font-[Georgia,serif] text-[10px] italic text-[#5C4D3A] mb-3">
+          {meta.count} results found
+        </p>
       )}
 
       {/* Results */}
@@ -315,15 +325,15 @@ export default function ResearchReadyCE() {
       {/* Empty state */}
       {!loading && query && results.length === 0 && (
         <div className="text-center py-16">
-          <BookOpen className="w-12 h-12 mx-auto text-gray-300 mb-4" />
-          <h2 className="text-lg font-semibold text-gray-600 mb-2">No articles found</h2>
-          <p className="text-sm text-gray-400">Try a different search term or adjust your filters.</p>
+          <BookOpen className="w-12 h-12 mx-auto text-[#C8C3BC] mb-4" />
+          <h2 className="text-lg font-semibold text-[#5C4D3A] mb-2 font-[Georgia,serif]">No articles found</h2>
+          <p className="text-sm text-[#7A6A54] font-[Georgia,serif]">Try a different search term or adjust your filters.</p>
         </div>
       )}
 
       {/* Meta */}
       {!loading && results.length > 0 && (
-        <p className="text-xs text-gray-400 text-center mb-4">
+        <p className="font-[Georgia,serif] text-[10px] italic text-[#7A6A54] text-center mb-4">
           {meta.count} total results &middot; Page {meta.page} &middot; Powered by OpenAlex
         </p>
       )}

--- a/server/src/models/RNRRequest.js
+++ b/server/src/models/RNRRequest.js
@@ -100,6 +100,7 @@ const rnrRequestSchema = new mongoose.Schema({
   },
 
   // ── AI-generated posttest ──
+  courseTitle: { type: String, default: '' },
   objectives: [{ type: String }],
   questions: [posttestQuestionSchema],
   format: {

--- a/server/src/models/ResearchReadyCourse.js
+++ b/server/src/models/ResearchReadyCourse.js
@@ -15,6 +15,7 @@ const questionSchema = new mongoose.Schema({
 
 const researchReadyCourseSchema = new mongoose.Schema({
   title: { type: String, required: true, trim: true },
+  courseTitle: { type: String, default: '' },
   authors: { type: String, required: true },
   journal: { type: String, required: true },
   year: { type: Number, required: true },

--- a/server/src/routes/researchReady.js
+++ b/server/src/routes/researchReady.js
@@ -265,6 +265,7 @@ router.patch('/request/:id/approve', protect, requireAdmin, async (req, res) => 
         format: request.articles.length > 1 ? 'comparative' : 'standalone'
       });
 
+      request.courseTitle = ceContent.course_title || '';
       request.objectives = ceContent.objectives || [];
       request.questions = ceContent.questions || [];
       request.status = 'test_ready';
@@ -345,6 +346,7 @@ router.post('/request/:id/rebuild', protect, requireAdmin, async (req, res) => {
       format: request.articles.length > 1 ? 'comparative' : 'standalone'
     });
 
+    request.courseTitle = ceContent.course_title || '';
     request.objectives = ceContent.objectives || [];
     request.questions = ceContent.questions || [];
     request.status = 'test_ready';
@@ -423,6 +425,7 @@ router.post('/request/:id/complete', protect, async (req, res) => {
     try {
       syllabusUrl = await generateSyllabus({
         course: {
+          courseTitle: request.courseTitle || '',
           title: request.articles.map(a => a.title).join(' & '),
           authors: request.articles.map(a => a.authors).join('; '),
           journal: request.articles.map(a => a.journal).join('; '),
@@ -446,9 +449,11 @@ router.post('/request/:id/complete', protect, async (req, res) => {
     }
 
     // Create certificate
+    const courseTitle = request.courseTitle || request.articles.map(a => a.title).join(' & ');
+
     const certificate = new Certificate({
       userId,
-      title: `RNR CE: ${request.articles.map(a => a.title).join(' & ')}`,
+      title: `RNR CE: ${courseTitle}`,
       provider: 'CounselorReady',
       completionDate: request.completedAt,
       ceHours: request.ceHours,
@@ -463,6 +468,7 @@ router.post('/request/:id/complete', protect, async (req, res) => {
       fileUrl: syllabusUrl,
       notes: JSON.stringify({
         type: 'research_ready',
+        courseTitle,
         articleTitles: request.articles.map(a => a.title),
         authors: request.articles.map(a => a.authors).join('; '),
         journals: request.articles.map(a => `${a.journal} (${a.year})`).join('; '),
@@ -472,6 +478,8 @@ router.post('/request/:id/complete', protect, async (req, res) => {
         researchHours: request.researchHours,
         objectivesMet: request.objectives,
         assessmentScore: score,
+        correctCount,
+        totalQuestions: request.questions.length,
         nbccAcepStamp: 'NBCC ACEP #7760',
         passingScore: '75%',
         syllabusUrl

--- a/server/src/services/ceBuild.js
+++ b/server/src/services/ceBuild.js
@@ -48,6 +48,7 @@ Format: ${format}
 
 Respond ONLY in valid JSON — no markdown:
 {
+  "course_title": "Professional CE course title max 80 chars — rules below",
   "content_areas": ["array of NBCC content area strings"],
   "objectives": ["4 NBCC-compliant learning objectives using Bloom's taxonomy action verbs"],
   "questions": [
@@ -61,7 +62,13 @@ Respond ONLY in valid JSON — no markdown:
   ]
 }
 
-Generate exactly 10 questions. Map content areas to NBCC domains. Use action verbs (identify, describe, apply, evaluate, analyze, compare) in objectives.`;
+Generate exactly 10 questions. Map content areas to NBCC domains. Use action verbs (identify, describe, apply, evaluate, analyze, compare) in objectives.
+
+course_title rules:
+- Standalone article: trim and reformat the article title as a professional CE course name. Drop filler openings like "A study of...", "An analysis of...", etc. Example: "The supervisory working alliance and counselor development: A longitudinal study of LPC trainees" → "Supervisory Alliance and Counselor Development: A CE Review"
+- Comparative format: "Then and Now: Evolution of [Topic]" or "Comparative Analysis: [Topic]"
+- Integrative format: "Integrative Review: [Topic Area]"
+- Max 80 characters.`;
 
   const rawResponse = await callClaude(prompt);
 
@@ -79,6 +86,11 @@ Generate exactly 10 questions. Map content areas to NBCC domains. Use action ver
 
   if (ceContent.questions.length !== 10) {
     console.warn(`CE build returned ${ceContent.questions.length} questions instead of 10`);
+  }
+
+  // Ensure course_title exists — fall back to truncated article title
+  if (!ceContent.course_title) {
+    ceContent.course_title = title.substring(0, 80);
   }
 
   return ceContent;

--- a/server/src/services/syllabusGenerator.js
+++ b/server/src/services/syllabusGenerator.js
@@ -120,7 +120,7 @@ export async function generateSyllabus({
                     new Paragraph({
                       alignment: AlignmentType.CENTER,
                       spacing: { after: 60 },
-                      children: [textRun(course.title, { bold: true, size: 22, color: WHITE })]
+                      children: [textRun(course.courseTitle || course.title, { bold: true, size: 22, color: WHITE })]
                     }),
                     new Paragraph({
                       alignment: AlignmentType.CENTER,


### PR DESCRIPTION
## Summary
Implements the RNR CE design system across the research-ready module, introducing the custom color palette (#7B2D3E burgundy, #F8EEDC cream, #FAF5EC off-white, Georgia serif typography) and significantly expanding the ArticleCard component with a full action strip including print, download, and save functionality.

## Key Changes

**ArticleCard Component (`client/src/components/researchReady/ArticleCard.jsx`)**
- Applied RNR CE design palette: custom burgundy (#7B2D3E), cream backgrounds (#F8EEDC), serif typography (Georgia)
- Expanded action strip with new buttons: Print, Download, Save (in addition to existing Create CE/Pair Article and Read Article)
- Implemented `handlePrint()` to open OA URL in new window and trigger print dialog
- Implemented `handleDownload()` to open OA PDF in new tab
- Implemented `handleSave()` to persist articles to localStorage or via callback
- Added conditional styling based on word count status (sufficient vs. thin articles)
- Updated typography: smaller font sizes (10-13px), Georgia serif for titles and metadata
- Reorganized layout with border-top separator for action strip

**Credentials Page (`client/src/pages/Credentials.jsx`)**
- Added `RnrCertTile` component to display research-ready CE certificates with custom styling
- Parses RNR metadata from certificate notes JSON
- Expandable tile showing course title, CE hours, category, completion date at-a-glance
- Expanded view displays: authors, journals, DOIs, learning objectives, assessment score, CE calculation formula, certificate ID, NBCC stamp
- Applied RNR design palette to certificate tiles (cream background, burgundy accents)

**CEPlanner Component (`client/src/pages/CEPlanner.jsx`)**
- Updated `ResearchReadyRecs` to restructure article results with deficit metadata
- Enhanced recommendation cards with RNR design palette
- Added "Create CE" button to article recommendations with proper styling
- Improved fallback messaging when no articles matched
- Updated typography and spacing to match design system

**ResearchReadyCE Page (`client/src/pages/ResearchReadyCE.jsx`)**
- Applied full RNR CE design palette to page background, inputs, buttons, and text
- Updated search input styling with cream background and custom focus states
- Redesigned topic chips with new active/inactive states
- Updated filter dropdowns and sort selector with new colors
- Applied Georgia serif typography throughout
- Updated loading spinner and overlay colors

**CEHoursSelector Component (`client/src/components/researchReady/CEHoursSelector.jsx`)**
- Applied RNR design palette to button states and typography
- Updated to use Georgia serif and custom color scheme

**Backend CE Build Service (`server/src/services/ceBuild.js`)**
- Added `course_title` field to AI-generated CE content
- Implemented rules for generating professional course titles from articles:
  - Standalone articles: reformatted article titles as CE course names
  - Comparative format: "Then and Now: Evolution of [Topic]"
  - Integrative format: "Integrative Review: [Topic Area]"
  - Max 80 character limit

**Backend Routes & Models**
- Updated `RNRRequest` model to include `courseTitle` field
- Updated `ResearchReadyCourse` model to include `courseTitle` field
- Modified `/request/:id/approve` and `/request/:id/rebuild` endpoints to capture `course_title` from AI response
- Updated `/request/:id/complete` endpoint to pass `courseTitle` to syllabus generator

**Syllabus Generator (`server/src/services/syllabusGenerator.js`)**
- Updated to use `courseTitle` from request object in document generation

## Notable Implementation Details
- ArticleCard now supports both callback-based (`onSaveArticle` prop) and localStorage-based article saving
- RnrCertTile uses expandable accordion pattern for detailed metadata display
- Design palette uses specific hex values throughout (no Tailwind color names) for precise brand consistency
- Typography hierarchy uses 10px, 11px, 12px, and 13px sizes with

https://claude.ai/code/session_01RiKWuD8PcuK9FDAU5CPWdo