### PR TITLE
Expand subscription tier levels with starter and premium options

### DIFF
--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -801,7 +801,7 @@
       
       if (userStatus !== 'active') return false;
       
-      const tierLevels = { 'free': 0, 'professional': 1, 'vip': 2 };
+      const tierLevels = { 'free': 0, 'starter': 1, 'professional': 2, 'premium': 3, 'vip': 4 };
       return tierLevels[userTier] >= tierLevels[requiredTier];
     }
     


### PR DESCRIPTION
## Summary
Updated the subscription tier hierarchy to support additional tier levels between free and VIP, providing more granular subscription options for users.

## Key Changes
- Expanded `tierLevels` mapping from 3 tiers to 5 tiers
- Added new tier levels:
  - `'starter'` at level 1 (between free and professional)
  - `'premium'` at level 3 (between professional and VIP)
- Adjusted existing tier levels:
  - `'free'` remains at level 0
  - `'professional'` moved from level 1 to level 2
  - `'vip'` moved from level 2 to level 4

## Implementation Details
The tier comparison logic remains unchanged - the function continues to validate user access by comparing numeric tier levels, ensuring users with higher tier subscriptions can access content restricted to lower tiers.

https://claude.ai/code/session_016vfuHs7bnAQesXZWXfXRf4