### PR TITLE
Filter out invalid references with undefined values

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -2348,11 +2348,15 @@ function renderCurrentSection() {
   
   // Render APA 7th references on last section
   const isLast = currentSectionIndex === course.sections.length - 1;
-  if (isLast && course.references?.length > 0) {
+  const validRefs = (course.references || []).filter(ref => {
+    const text = ref.formatted || ref.citation || ref.title || '';
+    return text && !text.includes('undefined');
+  });
+  if (isLast && validRefs.length > 0) {
     const refsDiv = document.createElement('div');
     refsDiv.className = 'cr-references';
     let refsHtml = '<h3 style="text-align:center;font-family:var(--cr-font-display);font-size:1.3em;font-weight:700;color:var(--cr-burgundy);margin-bottom:1em">References</h3>';
-    course.references.forEach(ref => {
+    validRefs.forEach(ref => {
       if (ref.citation) {
         // Pre-formatted citation string
         refsHtml += `<p class="cr-reference">${esc(ref.citation)}</p>`;
@@ -3176,9 +3180,13 @@ function downloadCourseText() {
       }
     });
   });
-  if (course.references?.length) {
+  const validExportRefs = (course.references || []).filter(ref => {
+    const text = ref.formatted || ref.citation || ref.title || '';
+    return text && !text.includes('undefined');
+  });
+  if (validExportRefs.length) {
     text += '\nReferences\n----------\n';
-    course.references.forEach(r => {
+    validExportRefs.forEach(r => {
       if (r.citation) { text += r.citation + '\n'; }
       else { text += `${r.author || ''} (${r.year || ''}). ${r.title || ''}. ${r.source || ''}\n`; }
     });
@@ -4843,7 +4851,11 @@ document.addEventListener('keydown', function(e) {
 
   // ── Renderers ──
   function renderRefs() {
-    var b = document.getElementById('crdRB'), refs = refsData || [], h = '';
+    var b = document.getElementById('crdRB'), h = '';
+    var refs = (refsData || []).filter(function(r) {
+      var text = r.formatted || r.citation || r.title || '';
+      return text && text.indexOf('undefined') === -1;
+    });
     if (!refs.length) { b.innerHTML = '<p style="color:var(--cr-text-muted);text-align:center;margin-top:2em">No references available.</p>'; return; }
     refs.forEach(function(r) {
       if (typeof r === 'string') h += '<p class="crd-ref">' + esc(r) + '</p>';


### PR DESCRIPTION
## Summary
This PR adds validation filtering for course references to prevent rendering of incomplete or malformed reference objects that contain "undefined" string values.

## Key Changes
- Added reference validation filter in three locations where references are rendered/exported:
  - Interactive course section rendering (last section references display)
  - Course export to text format
  - Reference data rendering in the references panel
  
- The filter checks that each reference has at least one valid text field (`formatted`, `citation`, or `title`) and doesn't contain the literal string "undefined"

- Applied consistent filtering logic across all three reference rendering paths to ensure uniform behavior

## Implementation Details
- Filter is applied before checking reference length and before iteration, preventing invalid references from being processed
- Uses defensive programming with fallback to empty array if `course.references` is null/undefined
- Maintains backward compatibility by only filtering out genuinely invalid entries
- The validation catches both missing data and string serialization artifacts (e.g., "undefined" appearing in formatted text)

https://claude.ai/code/session_01J1K6EDW4rGDHi2dBv1TjsC