### PR TITLE
Add one-time script to strip corrupted references from MongoDB

### DIFF
--- a/server/src/scripts/fix-corrupted-refs.js
+++ b/server/src/scripts/fix-corrupted-refs.js
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const MONGO_URI = process.env.MONGODB_URI || process.env.MONGO_URI;
+
+async function fixCorruptedRefs() {
+  await mongoose.connect(MONGO_URI);
+  console.log('Connected to MongoDB');
+
+  const db = mongoose.connection.db;
+  const collection = db.collection('interactivecourses');
+
+  // Find all courses with references containing "undefined"
+  const courses = await collection.find({
+    'references.formatted': { $regex: /undefined/ }
+  }).toArray();
+
+  console.log(`Found ${courses.length} courses with corrupted references`);
+
+  for (const course of courses) {
+    const before = course.references.length;
+    const clean = course.references.filter(ref => {
+      const text = ref.formatted || ref.title || '';
+      return text && !text.includes('undefined');
+    });
+
+    await collection.updateOne(
+      { _id: course._id },
+      { $set: { references: clean } }
+    );
+
+    console.log(`${course.slug}: ${before} → ${clean.length} refs`);
+  }
+
+  console.log('\nDone. Disconnecting.');
+  await mongoose.disconnect();
+}
+
+fixCorruptedRefs().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Finds interactive courses with references containing 'undefined' in the formatted field and removes those entries.

https://claude.ai/code/session_01J1K6EDW4rGDHi2dBv1TjsC