### PR TITLE
Disable caching for GET /me endpoint

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -204,6 +204,7 @@ router.post('/login', async (req, res) => {
 // Get current user
 router.get('/me', protect, async (req, res) => {
   try {
+    res.set('Cache-Control', 'no-store');
     res.json({ user: req.user.toJSON() });
   } catch (error) {
     console.error('Get user error:', error);


### PR DESCRIPTION
## Summary
Added cache control headers to the GET `/me` endpoint to prevent browsers and intermediaries from caching the current user response.

## Key Changes
- Set `Cache-Control: no-store` header on the `/me` endpoint to ensure user data is always fetched fresh from the server

## Implementation Details
The `Cache-Control: no-store` directive prevents the response from being stored in any cache, which is important for security-sensitive endpoints like the current user endpoint. This ensures that user information is never served from a stale cache and always reflects the current authentication state.

https://claude.ai/code/session_01278aNCk4grUYUJwmv6dHEC