### PR TITLE
Add authentication and enrollment checks to interactive course page

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1825,9 +1825,30 @@ let ttsUtterance = null;
   
   if (slug) {
     const base = apiBase || (location.origin.includes('localhost') ? 'http://localhost:5000' : 'https://api.counselorready.com');
-    fetch(`${base}/api/interactive-courses/slug/${slug}`)
+    const token = localStorage.getItem('token');
+    if (!token) {
+      window.location.href = `/login.html?redirect=${encodeURIComponent(location.href)}`;
+      return;
+    }
+    const headers = { 'Authorization': `Bearer ${token}` };
+    fetch(`${base}/api/interactive-courses/slug/${slug}`, { headers })
       .then(r => r.json())
-      .then(data => loadCourse(data.data || data.course || data))
+      .then(async data => {
+        const course = data.data || data.course || data;
+        if (!course._id) { showError('Course not found: ' + slug); return; }
+        // Check enrollment
+        const progRes = await fetch(`${base}/api/interactive-courses/${course._id}/progress`, { headers });
+        if (progRes.status === 404) {
+          // Not enrolled — send back to course details
+          window.location.href = `/course-details.html?slug=${slug}`;
+          return;
+        }
+        if (progRes.status === 403) {
+          window.location.href = `/subscription.html`;
+          return;
+        }
+        loadCourse(course);
+      })
       .catch(e => showError('Course not found: ' + slug));
     return;
   }


### PR DESCRIPTION
## Summary
Enhanced the interactive course loading page with authentication requirements and enrollment validation to ensure only authorized users can access course content.

## Key Changes
- **Authentication requirement**: Added token validation that redirects unauthenticated users to the login page with a redirect parameter to return to the course after login
- **Authorization header**: Include Bearer token in API requests to the course and progress endpoints
- **Enrollment validation**: Added a check against the progress endpoint to verify user enrollment status:
  - If user is not enrolled (404), redirect to course details page
  - If user lacks subscription access (403), redirect to subscription page
- **Error handling**: Added validation to ensure course data contains an `_id` field before proceeding

## Implementation Details
- Token is retrieved from localStorage and checked before making any API calls
- The progress endpoint serves as the enrollment check mechanism
- Maintains backward compatibility with existing course data structure handling (`data.data || data.course || data`)
- Preserves original error handling for missing courses while adding new validation steps

https://claude.ai/code/session_01MsPZkpUtZJK1P2db92zKSN