### PR TITLE
Remove enrollment check from course loading flow

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1833,20 +1833,9 @@ let ttsUtterance = null;
     const headers = { 'Authorization': `Bearer ${token}` };
     fetch(`${base}/api/interactive-courses/slug/${slug}`, { headers })
       .then(r => r.json())
-      .then(async data => {
+      .then(data => {
         const course = data.data || data.course || data;
         if (!course._id) { showError('Course not found: ' + slug); return; }
-        // Check enrollment
-        const progRes = await fetch(`${base}/api/interactive-courses/${course._id}/progress`, { headers });
-        if (progRes.status === 404) {
-          // Not enrolled — send back to course details
-          window.location.href = `/course-details.html?slug=${slug}`;
-          return;
-        }
-        if (progRes.status === 403) {
-          window.location.href = `/subscription.html`;
-          return;
-        }
         loadCourse(course);
       })
       .catch(e => showError('Course not found: ' + slug));


### PR DESCRIPTION
## Summary
Removed the enrollment validation logic that was checking user progress and redirecting based on enrollment status when loading an interactive course.

## Key Changes
- Removed `async` keyword from the `.then()` callback in the course fetch chain
- Deleted the progress API call to `/api/interactive-courses/{id}/progress`
- Removed 404 redirect logic that sent unenrolled users back to course details
- Removed 403 redirect logic that sent unauthorized users to the subscription page

## Implementation Details
The enrollment checks have been completely removed from the client-side course loading flow. The course will now load directly after being fetched by slug without any intermediate authorization validation. This suggests that enrollment/authorization checks may have been moved to a different layer (e.g., server-side, API middleware, or a different part of the application flow).

https://claude.ai/code/session_016qtTpHr7VJdDo5Xm1ymayF