### PR TITLE
Add course duplication feature and register missing API routes

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -30,6 +30,9 @@ import helpRoutes from './routes/help.js';
 import bulkUploadRoutes from './routes/bulkUpload.js';
 // FIX: courseBuilder routes were never registered — caused all CourseBuilder save/generate/publish calls to 404
 import courseBuilderRoutes from './routes/courseBuilder.js';
+import narrationRoutes from './routes/narration.js';
+import aiRoutes from './routes/ai.js';
+import aiCourseGeneratorRoutes from './routes/aiCourseGenerator.js';
 
 // Import services
 import { initializeScheduler } from './services/notificationScheduler.js';
@@ -140,6 +143,9 @@ app.use('/api/help', helpRoutes);
 app.use('/api/admin/courses', bulkUploadRoutes);
 // FIX: registered courseBuilder routes so CourseBuilder UI can save/generate/publish
 app.use('/api/course-builder', courseBuilderRoutes);
+app.use('/api/narration', narrationRoutes);
+app.use('/api/ai', aiRoutes);
+app.use('/api/ai-course-generator', aiCourseGeneratorRoutes);
 
 // Serve static files from templates directory (for certificates)
 app.use('/templates', express.static(path.join(__dirname, 'templates')));

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -11,7 +11,7 @@ import Evaluation from '../models/Evaluation.js';
 import User from '../models/User.js';
 import UserCredential from '../models/UserCredential.js';
 import Gamification from '../models/Gamification.js';
-import { protect } from '../middleware/auth.js';
+import { protect, adminOnly } from '../middleware/auth.js';
 import { generateCertificate, generateCertificateNumber } from '../utils/certificate.js';
 import { logActivity, ACTIVITY_TYPES } from '../services/activityTrackingService.js';
 import { sendCourseCompletionEmail, sendCertificateReadyEmail } from '../services/courseEmailService.js';
@@ -1231,6 +1231,44 @@ router.patch('/:id/metadata', protect, async (req, res) => {
   } catch (error) {
     console.error('Error updating course metadata:', error);
     res.status(500).json({ success: false, error: 'Failed to update course metadata' });
+  }
+});
+
+// Duplicate a course (admin only)
+router.post('/:id/duplicate', protect, adminOnly, async (req, res) => {
+  try {
+    const original = await Course.findById(req.params.id).lean();
+    if (!original) {
+      return res.status(404).json({ error: 'Course not found' });
+    }
+
+    const { _id, __v, createdAt, updatedAt, slug, enrollmentCount, ...courseData } = original;
+
+    let baseSlug = (original.slug || original.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')) + '-copy';
+    let newSlug = baseSlug;
+    let counter = 1;
+    while (await Course.exists({ slug: newSlug })) {
+      counter++;
+      newSlug = `${baseSlug}-${counter}`;
+    }
+
+    const duplicate = await Course.create({
+      ...courseData,
+      title: `${original.title} (Copy)`,
+      slug: newSlug,
+      status: 'draft',
+      isPublished: false,
+      enrollmentCount: 0,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: duplicate,
+      message: `Duplicated as "${duplicate.title}"`
+    });
+  } catch (error) {
+    console.error('Duplicate course error:', error);
+    res.status(500).json({ error: 'Failed to duplicate course', details: error.message });
   }
 });
 


### PR DESCRIPTION
## Summary
This PR adds an admin-only course duplication endpoint and registers three previously unregistered API route modules that were causing 404 errors in the application.

## Key Changes

- **Course Duplication Feature**: Added a new `POST /:id/duplicate` endpoint in the interactive course routes that allows admins to create copies of existing courses
  - Duplicated courses are created with a "(Copy)" suffix and unique slug
  - New courses default to draft status and unpublished state
  - Automatically handles slug collision by appending a counter
  - Excludes metadata like creation timestamps, enrollment counts, and version info from the duplicate

- **Route Registration Fixes**: Registered three missing API route modules in the main application file:
  - `narrationRoutes` → `/api/narration`
  - `aiRoutes` → `/api/ai`
  - `aiCourseGeneratorRoutes` → `/api/ai-course-generator`

- **Auth Middleware**: Imported the `adminOnly` middleware to enforce admin-only access on the course duplication endpoint

## Implementation Details

- The duplication endpoint uses `.lean()` for efficient read-only queries
- Slug uniqueness is validated with a while loop that increments a counter if collisions occur
- The endpoint returns the newly created course object with a success message
- Error handling includes detailed error messages for debugging

https://claude.ai/code/session_01EBCCR9JL96uGCqAEd7PQdQ