### PR TITLE
Register missing route imports and add course duplicate endpoint

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -30,6 +30,9 @@ import helpRoutes from './routes/help.js';
 import bulkUploadRoutes from './routes/bulkUpload.js';
 // FIX: courseBuilder routes were never registered — caused all CourseBuilder save/generate/publish calls to 404
 import courseBuilderRoutes from './routes/courseBuilder.js';
+import narrationRoutes from './routes/narration.js';
+import aiRoutes from './routes/ai.js';
+import aiCourseGeneratorRoutes from './routes/aiCourseGenerator.js';
 
 // Import services
 import { initializeScheduler } from './services/notificationScheduler.js';
@@ -140,6 +143,9 @@ app.use('/api/help', helpRoutes);
 app.use('/api/admin/courses', bulkUploadRoutes);
 // FIX: registered courseBuilder routes so CourseBuilder UI can save/generate/publish
 app.use('/api/course-builder', courseBuilderRoutes);
+app.use('/api/narration', narrationRoutes);
+app.use('/api/ai', aiRoutes);
+app.use('/api/ai-course-generator', aiCourseGeneratorRoutes);
 
 // Serve static files from templates directory (for certificates)
 app.use('/templates', express.static(path.join(__dirname, 'templates')));

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -1234,4 +1234,50 @@ router.patch('/:id/metadata', protect, async (req, res) => {
   }
 });
 
+// Admin-only middleware
+const adminOnly = async (req, res, next) => {
+  if (req.user?.role !== 'admin') {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+  next();
+};
+
+// Duplicate a course (admin only)
+router.post('/:id/duplicate', protect, adminOnly, async (req, res) => {
+  try {
+    const original = await Course.findById(req.params.id).lean();
+    if (!original) {
+      return res.status(404).json({ error: 'Course not found' });
+    }
+
+    const { _id, __v, createdAt, updatedAt, slug, enrollmentCount, ...courseData } = original;
+
+    let baseSlug = (original.slug || original.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')) + '-copy';
+    let newSlug = baseSlug;
+    let counter = 1;
+    while (await Course.exists({ slug: newSlug })) {
+      counter++;
+      newSlug = `${baseSlug}-${counter}`;
+    }
+
+    const duplicate = await Course.create({
+      ...courseData,
+      title: `${original.title} (Copy)`,
+      slug: newSlug,
+      status: 'draft',
+      isPublished: false,
+      enrollmentCount: 0,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: duplicate,
+      message: `Duplicated as "${duplicate.title}"`
+    });
+  } catch (error) {
+    console.error('Duplicate course error:', error);
+    res.status(500).json({ error: 'Failed to duplicate course', details: error.message });
+  }
+});
+
 export default router;


### PR DESCRIPTION
- Add narrationRoutes, aiRoutes, aiCourseGeneratorRoutes imports and mount them in server/src/index.js (courseBuilderRoutes was already registered)
- Add POST /:id/duplicate admin-only endpoint to interactiveCourseRoutes.js for cloning courses with unique slug generation

https://claude.ai/code/session_01Atr627YWXJ7AwSB364vvnF