### PR TITLE
Add fetch timeouts and error logging in admin-courses loadCourses()

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -377,21 +377,27 @@
 
         // 1. Admin endpoint (old courses collection - has drafts + enrollment counts)
         try {
+          const ctrl1 = new AbortController();
+          setTimeout(() => ctrl1.abort(), 10000);
           const r = await fetch(`${API_URL}/api/admin/courses`, {
-            headers: { Authorization: `Bearer ${token}` }
+            headers: { Authorization: `Bearer ${token}` },
+            signal: ctrl1.signal
           });
           if (r.ok) {
             const d = await r.json();
             courses = (d.courses || []).map(c => ({ ...c, _source: 'courses' }));
           }
-        } catch(e) {}
+        } catch(e) { console.warn('Fetch failed:', e.message); }
 
         // 2. Interactive courses (Architecture A - interactivecourses collection)
         try {
           let p = 1;
           while (true) {
+            const ctrl2 = new AbortController();
+            setTimeout(() => ctrl2.abort(), 10000);
             const r = await fetch(`${API_URL}/api/interactive-courses?page=${p}&limit=50`, {
-              headers: { Authorization: `Bearer ${token}` }
+              headers: { Authorization: `Bearer ${token}` },
+              signal: ctrl2.signal
             });
             if (!r.ok) break;
             const d = await r.json();
@@ -405,7 +411,7 @@
             if (p >= (d.pagination?.pages || 1) || batch.length === 0) break;
             p++;
           }
-        } catch(e) {}
+        } catch(e) { console.warn('Fetch failed:', e.message); }
 
         // Annotate with health
         allCourses = courses.map(c => ({ ...c, _health: healthStatus(c), _words: wordCount(c) }));


### PR DESCRIPTION
## Summary
- Add 10-second `AbortController` timeout to the `GET /api/admin/courses` fetch in `loadCourses()`
- Add 10-second `AbortController` timeout to the `GET /api/interactive-courses` fetch inside the pagination loop (new controller per iteration)
- Replace silent `catch(e){}` blocks with `catch(e){ console.warn('Fetch failed:', e.message); }` so failures are logged
- Verified outer catch block correctly calls `hide('loadingState')`, `show('errorState')`, and sets `errorMsg` text — all element IDs match the HTML

## Test plan
- [ ] Load admin-courses page normally — courses should render as before
- [ ] Simulate a slow/offline API — verify fetches abort after 10s and warnings appear in console
- [ ] Simulate a fetch error — verify the error state UI displays correctly

https://claude.ai/code/session_01TiDgwb5kTammdriS1cpPki