### PR TITLE
Remove nested sections data from course list query

### DIFF
--- a/server/src/routes/courseRoutes.js
+++ b/server/src/routes/courseRoutes.js
@@ -50,7 +50,7 @@ router.get('/', async (req, res) => {
     }
 
     const courses = await Course.find(query)
-      .select('title slug description thumbnail ceHours ceuHours totalEstimatedTime categories tags status wordCount sectionCount sections.title sections.contentBlocks price accessTier pricingTier publishedAt createdAt')
+      .select('title slug description thumbnail ceHours ceuHours totalEstimatedTime categories tags status wordCount sectionCount price accessTier pricingTier publishedAt createdAt')
       .sort({ publishedAt: -1 })
       .skip((page - 1) * limit)
       .limit(parseInt(limit));


### PR DESCRIPTION
## Summary
Optimized the course list endpoint by removing unnecessary nested section data from the database query selection.

## Key Changes
- Removed `sections.title` and `sections.contentBlocks` from the `.select()` projection in the GET `/courses` endpoint
- The endpoint now retrieves only top-level course metadata without nested section details

## Implementation Details
This change reduces the amount of data transferred from the database and over the network for the course listing endpoint. Since the list view likely doesn't need detailed section content, this optimization improves query performance and response payload size. The `sectionCount` field is retained to provide information about the number of sections without fetching the full section objects.

https://claude.ai/code/session_01WHQ8dcmU6FR8V5SLFg5Zyu