### PR TITLE
Fix /tools/* routing in _redirects

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -80,5 +80,8 @@
 /admin/help           /admin-help.html           200
 /admin/health         /admin-health.html         200
 
+# ── Static tools (must precede catch-all) ──
+/tools/*             /tools/:splat             200
+
 # ── Catch-all: 404 (NOT SPA rewrite) ──
 /*                   /404.html                 404


### PR DESCRIPTION
## Summary
- Adds `/tools/*  /tools/:splat  200` rewrite rule above the `/* → /404.html` catch-all in `client/public/_redirects`
- Without this rule, Render's catch-all was returning 404 for all `/tools/*.html` pages even though the static files exist in `client/public/tools/`

## Note on Landing.jsx
Landing.jsx was inspected and is **not stripped** — it contains the full design (header, hero, features, stats bar, pricing tiers, testimonial, CTA, footer). No changes needed there.

## Test plan
- [ ] Verify `/tools/index.html` loads correctly on Render after deploy
- [ ] Verify individual tool pages (e.g. `/tools/safety-plan.html`) are accessible
- [ ] Verify other routes still work as expected
- [ ] Confirm the catch-all still returns 404 for unknown paths

https://claude.ai/code/session_01NKyv787b89VJdERCmYoEwC