### PR TITLE
Add admin courses endpoint integration to course loading

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -375,6 +375,20 @@
       try {
         let courses = [];
 
+        // Admin courses
+        try {
+          const ctrl1 = new AbortController();
+          setTimeout(() => ctrl1.abort(), 10000);
+          const r = await fetch(`${API_URL}/api/admin/courses`, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: ctrl1.signal
+          });
+          if (r.ok) {
+            const d = await r.json();
+            courses = (d.data || d || []).map(c => ({ ...c, _source: 'admincourses' }));
+          }
+        } catch(e) { console.warn('Fetch failed:', e.message); }
+
         // Interactive courses (all courses live here now)
         try {
           let p = 1;


### PR DESCRIPTION
## Summary
Added integration with the admin courses API endpoint to fetch and include admin-managed courses in the course list alongside interactive courses.

## Key Changes
- Added a new fetch request to `/api/admin/courses` endpoint with Bearer token authentication
- Implemented a 10-second timeout using AbortController to prevent hanging requests
- Mapped fetched admin courses with a `_source: 'admincourses'` identifier to distinguish them from other course sources
- Added error handling with console warning for failed admin course fetches
- Maintains existing course loading logic for interactive courses

## Implementation Details
- The admin courses fetch is wrapped in its own try-catch block to prevent failures from blocking the interactive courses fetch
- Uses the same data normalization pattern as other course sources: `(d.data || d || [])` to handle various response formats
- Courses are merged into a single array that will be processed by subsequent course loading logic

https://claude.ai/code/session_01M8AyeqVm8T2DzNRjF5hUFr