### PR TITLE
Make word count and CE hours dynamic based on desired hours

### DIFF
--- a/server/src/services/articleContentGenerator.js
+++ b/server/src/services/articleContentGenerator.js
@@ -15,8 +15,8 @@ const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
 
-const TARGET_WORDS_PER_SECTION = 2100;
-const MIN_TOTAL_WORDS = 6000;
+const WORDS_PER_CE_HOUR = 6000;
+const WORDS_BUFFER = 200;
 
 // ── Claude helper ──
 async function callClaude(systemPrompt, userPrompt, maxTokens = 5000) {
@@ -264,15 +264,23 @@ function summarizeSection(html) {
  * @param {String} [opts.courseTitle] - Optional course title
  * @returns {Promise<{ content: String, wordCount: Number, sections: Number }>}
  */
-export async function generateArticleContent({ articles, contentArea, format = 'standalone', courseTitle = '' }) {
+export async function generateArticleContent({ articles, contentArea, format = 'standalone', courseTitle = '', targetCeHours = 1.0 }) {
   if (!articles || articles.length === 0) {
     throw new Error('At least one article is required');
   }
 
+  // Target: 6,000 words per CE hour + 200 word buffer
+  const targetWords = Math.round(targetCeHours * WORDS_PER_CE_HOUR) + WORDS_BUFFER;
+  // One section per CE hour, minimum 3
+  const sectionsNeeded = Math.max(3, Math.ceil(targetCeHours * 3));
+  const wordsPerSection = Math.ceil(targetWords / sectionsNeeded);
+
   const systemPrompt = getSystemPrompt(contentArea);
   const articleContext = buildArticleContext(articles);
 
-  console.log(`[RNR Content] Generating 3-section article for: ${courseTitle || articles[0].title}`);
+  console.log(`[RNR Content] Generating ${sectionsNeeded}-section article ` +
+    `(${targetCeHours} CE hrs = ${targetWords} words target) ` +
+    `for: ${courseTitle || articles[0].title}`);
   console.log(`[RNR Content] Format: ${format}, Content area: ${contentArea}`);
 
   // ── Section 1 ──
@@ -311,15 +319,43 @@ export async function generateArticleContent({ articles, contentArea, format = '
 
   // ── Combine ──
   const divider = '<hr style="margin:2em 0;border:none;border-top:2px solid #4A7C59;">';
-  const fullContent = [section1, divider, section2, divider, section3].join('\n');
+  const contentParts = [section1, divider, section2, divider, section3];
+  let currentSectionCount = 3;
+  let prevSummaries = `${s1Summary} ... ${s2Summary}`;
+
+  // ── Additional sections if sectionsNeeded > 3 ──
+  if (sectionsNeeded > 3) {
+    for (let i = 4; i <= sectionsNeeded; i++) {
+      console.log(`[RNR Content] Generating Section ${i}/${sectionsNeeded}: Supplemental...`);
+      const additional = await callClaude(
+        systemPrompt,
+        `SUPPLEMENTAL SECTION ${i} OF ${sectionsNeeded}: Write an additional ${wordsPerSection}+ words expanding on clinical application of the research below. Include another detailed case vignette and specific intervention techniques. Do NOT repeat content from previous sections.
+
+SCHOLARLY SOURCE(S):
+${articleContext}
+
+Previously covered (do not repeat): ${prevSummaries}
+
+Write clean HTML with <h3> subheadings and <p> paragraphs. Target: ${wordsPerSection} words minimum.`,
+        5000
+      );
+      const addWords = countWords(additional);
+      console.log(`[RNR Content] Section ${i} complete: ${addWords} words`);
+      contentParts.push(divider, additional);
+      prevSummaries += ' ... ' + summarizeSection(additional);
+      currentSectionCount++;
+    }
+  }
+
+  const fullContent = contentParts.join('\n');
   const totalWords = countWords(fullContent);
 
-  console.log(`[RNR Content] Total: ${totalWords} words (S1: ${s1Words}, S2: ${s2Words}, S3: ${s3Words})`);
+  console.log(`[RNR Content] Total: ${totalWords} words across ${currentSectionCount} sections`);
 
-  // ── Safety check: if under 6000, generate a supplemental section ──
-  if (totalWords < MIN_TOTAL_WORDS) {
-    console.log(`[RNR Content] Under ${MIN_TOTAL_WORDS} words — generating supplemental section...`);
-    const deficit = MIN_TOTAL_WORDS - totalWords + 200; // 200 word buffer
+  // ── Safety check: if under target, generate a supplemental section ──
+  if (totalWords < targetWords) {
+    console.log(`[RNR Content] Under ${targetWords} words — generating supplemental section...`);
+    const deficit = targetWords - totalWords + WORDS_BUFFER;
     const supplemental = await callClaude(
       systemPrompt,
       `SUPPLEMENTAL SECTION: Write an additional ${deficit}+ words expanding on clinical application of the research below. Include another detailed case vignette and specific intervention techniques. Do NOT repeat content from previous sections.
@@ -327,7 +363,7 @@ export async function generateArticleContent({ articles, contentArea, format = '
 SCHOLARLY SOURCE(S):
 ${articleContext}
 
-Previously covered (do not repeat): ${s1Summary} ... ${s2Summary}
+Previously covered (do not repeat): ${prevSummaries}
 
 Write clean HTML with <h3> subheadings and <p> paragraphs. Target: ${deficit} words minimum.`,
       3000
@@ -342,14 +378,14 @@ Write clean HTML with <h3> subheadings and <p> paragraphs. Target: ${deficit} wo
     return {
       content: finalContent,
       wordCount: finalWords,
-      sections: 4
+      sections: sectionsNeeded
     };
   }
 
   return {
     content: fullContent,
     wordCount: totalWords,
-    sections: 3
+    sections: sectionsNeeded
   };
 }
 

--- a/server/src/services/openAlex.js
+++ b/server/src/services/openAlex.js
@@ -13,10 +13,6 @@
 const OPENALEX_BASE = 'https://api.openalex.org/works';
 const MAILTO = process.env.CROSSREF_MAILTO || 'contact@gaintegrated.com';
 
-// Every approved RNR request generates 6,200+ words (1 CE hour)
-const GENERATED_WORD_COUNT = 6200;
-const GENERATED_CE_HOURS = 1.0;
-const GENERATED_RESEARCH_HOURS = 0.5;
 
 /**
  * Decode OpenAlex abstract_inverted_index into plain text.
@@ -67,7 +63,7 @@ export function getAbstractStatus(abstractWordCount) {
 /**
  * Map a single OpenAlex work object to our result format.
  */
-function mapWork(work) {
+function mapWork(work, desiredHours = 1.0) {
   const abstract = decodeAbstractInvertedIndex(work.abstract_inverted_index);
   const abstractWordCount = abstract ? abstract.split(/\s+/).filter(w => w.length > 0).length : 0;
 
@@ -81,6 +77,10 @@ function mapWork(work) {
     || '';
   const topic = work.primary_topic?.display_name || '';
 
+  const ceHours = desiredHours;
+  const wordCount = ceHours * 6000; // target, not actual
+  const researchHours = calculateResearchHours(ceHours);
+
   return {
     openAlexId: work.id,
     title: work.title || 'Untitled',
@@ -88,16 +88,15 @@ function mapWork(work) {
     journal,
     authors,
     abstract,
-    // Generated content stats (what the learner will actually read)
-    wordCount: GENERATED_WORD_COUNT,
-    ceHours: GENERATED_CE_HOURS,
-    researchHours: GENERATED_RESEARCH_HOURS,
+    wordCount,
+    ceHours,
+    researchHours,
     // Abstract quality indicator
     abstractWordCount,
     abstractStatus: getAbstractStatus(abstractWordCount),
     oaUrl,
     topic,
-    wcStatus: 'sufficient', // Always sufficient — content is AI-generated
+    wcStatus: ceHours <= 3 ? 'sufficient' : 'extended',
     citedByCount: work.cited_by_count || 0,
     doi: work.primary_location?.source?.id || ''
   };
@@ -137,7 +136,7 @@ export async function searchArticles({
   }
 
   const data = await response.json();
-  let results = (data.results || []).map(mapWork);
+  let results = (data.results || []).map(w => mapWork(w, desired_hours || 1.0));
 
   // Filter out articles with no abstract (thin abstracts produce poor content)
   results = results.filter(r => r.abstractWordCount >= 50);
@@ -172,5 +171,5 @@ export async function fetchNewerArticles({ topic, title, yearAfter }) {
   }
 
   const data = await response.json();
-  return (data.results || []).map(mapWork);
+  return (data.results || []).map(w => mapWork(w, 1.0));
 }


### PR DESCRIPTION
## Summary
- **articleContentGenerator.js**: Replace hardcoded `MIN_TOTAL_WORDS = 6000` with `WORDS_PER_CE_HOUR` + `WORDS_BUFFER` constants. Add `targetCeHours` parameter to `generateArticleContent()` to derive `targetWords`, `sectionsNeeded`, and `wordsPerSection` dynamically. Generate additional sections in a loop when `sectionsNeeded > 3`. Update safety check and deficit calculation to use `targetWords`.
- **openAlex.js**: Remove hardcoded `GENERATED_WORD_COUNT` / `GENERATED_CE_HOURS` / `GENERATED_RESEARCH_HOURS` constants. Update `mapWork()` to accept `desiredHours` and compute values dynamically. Pass `desired_hours` from `searchArticles()` into `mapWork()`. Add `wcStatus` threshold (`'extended'` when CE > 3 hours).

## Test plan
- [ ] Verify `grep -n "MIN_TOTAL_WORDS\|6000\b" server/src/services/articleContentGenerator.js` returns only the constant definition line
- [ ] Verify `grep -n "GENERATED_WORD_COUNT\|GENERATED_CE_HOURS\|GENERATED_RESEARCH_HOURS" server/src/services/openAlex.js` returns zero results
- [ ] Test search with `desired_hours=2.0` and confirm articles return `wordCount: 12000`, `ceHours: 2.0`
- [ ] Test content generation with `targetCeHours=2.0` and confirm 6-section article targeting 12200 words
- [ ] Test default behavior (no `targetCeHours`) still produces ~6200 word / 3-section articles

https://claude.ai/code/session_01WG4uDmFbxDfix6VcuZMeQ8