### PR TITLE
Add tools API routes and CORS configuration

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -42,6 +42,8 @@ import cePlannerRoutes from './routes/cePlanner.js';
 import imageUploadRoutes from './routes/imageUpload.js';
 import adminStatsRoutes from './routes/adminStats.js';
 import researchReadyRoutes from './routes/researchReady.js';
+import toolsRoutes from './routes/tools.js';
+import toolRoutes from './routes/toolRoutes.js';
 
 // Import services
 import { initializeScheduler } from './services/notificationScheduler.js';
@@ -163,6 +165,8 @@ app.use('/api/ce-planner', cePlannerRoutes);
 app.use('/api/images', imageUploadRoutes);
 app.use('/api/admin/stats', adminStatsRoutes);
 app.use('/api/research-ready', researchReadyRoutes);
+app.use('/api/tools', toolsRoutes);
+app.use('/api/tools', toolRoutes);
 
 // Serve static files from templates directory (for certificates)
 app.use('/templates', express.static(path.join(__dirname, 'templates')));
@@ -192,7 +196,8 @@ app.use((req, res, next) => {
       '/api/referrals/*',
       '/api/board-alerts/*',
       '/api/ce-planner/*',
-      '/api/scan/*'
+      '/api/scan/*',
+      '/api/tools/*'
     ]
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for a new tools API endpoint by importing and registering two new route modules and updating the CORS configuration to allow requests to the tools API.

## Key Changes
- Import two new route modules: `toolsRoutes` and `toolRoutes` from their respective route files
- Register both route modules under the `/api/tools` endpoint
- Add `/api/tools/*` to the CORS whitelist to allow cross-origin requests to the tools API

## Implementation Details
- Both `toolsRoutes` and `toolRoutes` are mounted at the same `/api/tools` path, allowing them to handle different tool-related endpoints
- The CORS configuration has been updated to include the new tools API path alongside other existing API endpoints like `/api/scan/*`, `/api/ce-planner/*`, etc.

https://claude.ai/code/session_014rxMyHaYGBJK3eSNLfn9KX