### PR TITLE
Rename external link property to static and add Free Tools to landing nav

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -23,7 +23,7 @@ const navLinks = [
     { name: 'Recommendations',   href: '/recommendations' },
     { name: 'Achievements',      href: '/achievements' },
   ]},
-  { name: 'Free Tools', href: '/tools/index.html', external: true },
+  { name: 'Free Tools', href: '/tools/index.html', static: true },
   { name: 'Credentials', href: '/credentials', children: [
     { name: 'My Credentials',    href: '/credentials' },
     { name: 'CE Planner',        href: '/ce-planner' },
@@ -177,7 +177,7 @@ export default function Layout({ children }) {
               };
 
               if (!hasChildren) {
-                if (link.external) {
+                if (link.static) {
                   return (
                     <a key={link.href} href={link.href} style={style}
                       onMouseEnter={e => { if (!active) e.currentTarget.style.background = '#f5f5f4'; }}
@@ -407,7 +407,7 @@ export default function Layout({ children }) {
               const linkStyle = { display: 'block', padding: '0.625rem 1rem', borderRadius: '0.5rem', fontSize: '0.875rem', fontWeight: 500, textDecoration: 'none', color: active ? BURGUNDY : '#57534e', background: active ? BURGUNDY_LIGHT : 'transparent' };
 
               if (!link.children) {
-                if (link.external) {
+                if (link.static) {
                   return <a key={link.href} href={link.href} onClick={() => setMobileOpen(false)} style={linkStyle}>{link.name}</a>;
                 }
                 return <Link key={link.href} to={link.href} onClick={() => setMobileOpen(false)} style={linkStyle}>{link.name}</Link>;

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -41,6 +41,7 @@ export default function Landing() {
           <nav className="hidden md:flex items-center gap-8">
             <a href="#features" style={{ color: '#355E3B' }} className="text-sm font-medium tracking-wide hover:opacity-70 transition-opacity">Features</a>
             <a href="#pricing" style={{ color: '#355E3B' }} className="text-sm font-medium tracking-wide hover:opacity-70 transition-opacity">Pricing</a>
+            <a href="/tools/index.html" style={{ color: '#355E3B' }} className="text-sm font-medium tracking-wide hover:opacity-70 transition-opacity">Free Tools</a>
             <a href="/about.html" style={{ color: '#355E3B' }} className="text-sm font-medium tracking-wide hover:opacity-70 transition-opacity">About</a>
           </nav>
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
This PR updates the navigation link handling to use a more semantically accurate property name and adds the Free Tools link to the landing page navigation.

## Key Changes
- Renamed the `external` property to `static` in the navLinks configuration to better reflect that these links point to static HTML files rather than React routes
- Updated all references to `link.external` to use `link.static` in both desktop and mobile navigation rendering logic (Layout.jsx)
- Added "Free Tools" link to the landing page navigation header, maintaining consistent styling with other navigation items

## Implementation Details
- The property rename is purely semantic and doesn't change functionality—links marked as `static: true` are still rendered as standard `<a>` tags instead of React Router `<Link>` components
- The Free Tools link in the landing page uses the same styling pattern as existing navigation links (Features, Pricing, About)
- Changes are consistent across both responsive breakpoints (desktop and mobile navigation)

https://claude.ai/code/session_01Ki1HLymB1RF5QxxkfVhRmC