### PR TITLE
Add PostHog analytics integration to interactive course

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1410,6 +1410,14 @@ button, a, input, select, textarea, [tabindex], [draggable="true"] {
 <!-- .pdf parsing -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script>if(window.pdfjsLib)pdfjsLib.GlobalWorkerOptions.workerSrc='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';</script>
+<!-- PostHog analytics -->
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!=="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phx_rDRXmxgT8fDYO1uqisPDyOrcEm5kvD319ebxWUNlLUC8ZIC', {
+    api_host: 'https://us.i.posthog.com',
+    person_profiles: 'identified_only'
+  });
+</script>
 </head>
 <body data-text-size="medium" data-line-spacing="normal" data-dyslexia="false" data-high-contrast="false" data-dark-mode="false" data-reduced-motion="false" data-enhanced-focus="false" data-reading-guide="false">
 

--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1413,7 +1413,7 @@ button, a, input, select, textarea, [tabindex], [draggable="true"] {
 <!-- PostHog analytics -->
 <script>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!=="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init('phx_rDRXmxgT8fDYO1uqisPDyOrcEm5kvD319ebxWUNlLUC8ZIC', {
+  posthog.init('phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb', {
     api_host: 'https://us.i.posthog.com',
     person_profiles: 'identified_only'
   });


### PR DESCRIPTION
## Summary
Integrated PostHog analytics into the interactive course HTML page to enable product analytics and feature flag tracking.

## Key Changes
- Added PostHog initialization script to `client/public/interactive-course.html`
- Configured PostHog with project key `phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb`
- Set API host to `https://us.i.posthog.com` (US region)
- Enabled identified-only person profiles for privacy-conscious tracking

## Implementation Details
- PostHog library is loaded asynchronously from CDN to avoid blocking page load
- The initialization script is placed in the `<head>` section alongside other analytics/tracking code
- Configuration uses `person_profiles: 'identified_only'` to only track identified users, reducing data collection scope

https://claude.ai/code/session_019dcr3C7m8JvhguwxhjnLcq