### PR TITLE
Add partners API routes

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -44,6 +44,7 @@ import adminStatsRoutes from './routes/adminStats.js';
 import researchReadyRoutes from './routes/researchReady.js';
 import toolsRoutes from './routes/tools.js';
 import toolRoutes from './routes/toolRoutes.js';
+import partnersRoutes from './routes/partners.js';
 
 // Import services
 import { initializeScheduler } from './services/notificationScheduler.js';
@@ -167,6 +168,7 @@ app.use('/api/admin/stats', adminStatsRoutes);
 app.use('/api/research-ready', researchReadyRoutes);
 app.use('/api/tools', toolsRoutes);
 app.use('/api/tools', toolRoutes);
+app.use('/api/partners', partnersRoutes);
 
 // Serve static files from templates directory (for certificates)
 app.use('/templates', express.static(path.join(__dirname, 'templates')));


### PR DESCRIPTION
## Summary
This PR adds a new partners API route module to the application, enabling endpoints for partner-related functionality.

## Changes
- Import the new `partnersRoutes` module from `./routes/partners.js`
- Register the partners routes at the `/api/partners` endpoint

## Implementation Details
The partners routes are mounted at `/api/partners` following the existing route registration pattern used by other API modules in the application (such as tools, research-ready, and admin stats routes).

https://claude.ai/code/session_013miwtZvMTTgFWLFF7i6BLS