### PR TITLE
Redirect index.html to landing.html with meta refresh

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,72 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CounselorReady - Professional CE Management</title>
-    <meta name="description" content="CounselorReady - Learn. License. Lead. Professional continuing education management for mental health counselors. NBCC-Approved CE Provider (ACEP #7760)." />
-    <link rel="canonical" href="https://counselorready.com/" />
-
-    <!-- Open Graph -->
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="CounselorReady - Learn. License. Lead." />
-    <meta property="og:description" content="Professional continuing education for licensed mental health professionals. NBCC-Approved CE Provider (ACEP #7760)." />
-    <meta property="og:url" content="https://counselorready.com/" />
-    <meta property="og:site_name" content="CounselorReady" />
-    <meta property="og:image" content="https://counselorready.com/og-image.png" />
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="CounselorReady - Learn. License. Lead." />
-    <meta name="twitter:description" content="Professional continuing education for licensed mental health professionals." />
-  </head>
-  <body>
-    <a href="#main-content" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;" onfocus="this.style.cssText='position:fixed;top:0;left:0;z-index:9999;padding:12px 24px;background:#6B1D34;color:white;font-size:16px;font-family:Lato,sans-serif;text-decoration:none;'" onblur="this.style.cssText='position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;'">Skip to main content</a>
-    <div id="root"></div>
-
-    <!-- Structured data for search engines -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "EducationalOrganization",
-      "name": "CounselorReady",
-      "alternateName": "GA Integrated Therapeutic Perspectives LLC",
-      "url": "https://counselorready.com",
-      "description": "NBCC-Approved Continuing Education Provider (ACEP #7760) for licensed mental health professionals.",
-      "sameAs": [],
-      "contactPoint": {
-        "@type": "ContactPoint",
-        "email": "support@counselorready.com",
-        "contactType": "customer service"
-      }
-    }
-    </script>
-
-    <!-- Fallback content for crawlers / noscript / screen readers before React hydrates -->
-    <noscript>
-      <header>
-        <nav><a href="/">Home</a> | <a href="/login">Sign In</a> | <a href="/register">Register</a></nav>
-      </header>
-      <main>
-        <h1>CounselorReady — Continuing Education for Mental Health Professionals</h1>
-        <p>NBCC-Approved Continuing Education Provider (ACEP #7760). Learn. License. Lead.</p>
-        <p>Professional CE courses for LPCs, LMHCs, LCSWs, LMFTs, NCCs, and psychologists.</p>
-        <p><a href="/register">Start Your Free Trial</a></p>
-      </main>
-      <footer>
-        <p>© 2026 CounselorReady — GA Integrated Therapeutic Perspectives LLC (GAITP LLC)</p>
-        <p>NBCC Approved Continuing Education Provider — ACEP #7760</p>
-        <nav>
-          <a href="/privacy.html">Privacy Policy</a> |
-          <a href="/terms.html">Terms of Service</a> |
-          <a href="/refund-policy.html">Refund Policy</a> |
-          <a href="mailto:support@counselorready.com">Contact / Complaint / Grievance</a>
-        </nav>
-        <p>ADA accommodations available upon request. Contact support@counselorready.com.</p>
-      </footer>
-    </noscript>
-
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+<html>
+<head>
+<meta http-equiv="refresh" content="0;url=/landing.html">
+<link rel="canonical" href="https://counselorready.com/landing.html">
+</head>
+<body></body>
 </html>


### PR DESCRIPTION
## Summary
Simplified the root `index.html` file to serve as a redirect page that forwards all traffic to `/landing.html` using an HTTP meta refresh tag.

## Key Changes
- Removed all metadata, Open Graph tags, and Twitter Card configuration from the HTML head
- Removed the skip-to-content accessibility link
- Removed the React root div (`#root`)
- Removed structured data (JSON-LD schema)
- Removed noscript fallback content with navigation, header, main, and footer elements
- Removed the React module script reference (`/src/main.jsx`)
- Added HTTP meta refresh redirect (`<meta http-equiv="refresh" content="0;url=/landing.html">`)
- Added canonical link pointing to the new landing page location

## Implementation Details
- Uses a 0-second refresh delay for immediate redirection
- Maintains canonical link for SEO purposes to indicate the authoritative URL
- Minimal HTML structure appropriate for a redirect page
- This approach suggests the main application entry point has been moved to a separate `landing.html` file

https://claude.ai/code/session_013UBCG2bdpWtZcfmSnuWYbK