### PR TITLE
Fix: Await async generateCertificateNumber call

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -693,8 +693,8 @@ router.post('/:id/certificate', protect, async (req, res) => {
     });
 
     // Generate certificate number if needed
-    const certificateNumber = certificate?.certificateNumber || 
-      generateCertificateNumber(course._id, req.user._id);
+    const certificateNumber = certificate?.certificateNumber ||
+      await generateCertificateNumber(course._id, req.user._id);
 
     // Generate PDF
     const pdfBuffer = await generateCertificate({


### PR DESCRIPTION
## Summary
Fixed a bug where the `generateCertificateNumber` function call was not being awaited, causing the certificate generation logic to potentially use a Promise instead of the actual certificate number.

## Key Changes
- Added `await` keyword to the `generateCertificateNumber()` function call on line 696
- This ensures the async operation completes before the certificate number is used
- Also cleaned up trailing whitespace on line 695 for consistency

## Implementation Details
The `generateCertificateNumber` function is asynchronous but was being called without `await`, which would assign a Promise object to `certificateNumber` instead of the resolved value. This fix ensures the function properly resolves before the certificate number is used in subsequent PDF generation logic.

https://claude.ai/code/session_01MuR8yHqz5wjVxGNQarWZAd