### PR TITLE
Update certificate download to use server-provided URL

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3912,11 +3912,20 @@ function downloadCertificate() {
   })
     .then(res => {
       if (!res.ok) return res.json().then(err => { throw new Error(err.error || err.message || 'Certificate generation failed'); });
-      return res.blob();
+      return res.json();
     })
-    .then(blob => {
-      const url = URL.createObjectURL(blob);
-      const filename = (course.slug || 'certificate') + '_certificate.pdf';
+    .then(data => {
+      if (!data.success || !data.fileUrl) throw new Error(data.message || 'Certificate generation failed');
+
+      const fileUrl = data.fileUrl;
+
+      // Trigger download via anchor element
+      const a = document.createElement('a');
+      a.href = fileUrl;
+      a.download = 'CounselorReady_Certificate.pdf';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
 
       area.innerHTML = `<div style="max-width:500px;margin:0 auto;padding:40px;text-align:center">
         <div style="font-size:3rem;margin-bottom:16px">🎓</div>
@@ -3925,7 +3934,7 @@ function downloadCertificate() {
           ${esc(course.title || '')} · ${course.ceHours || 1} CE Hour${(course.ceHours || 1) !== 1 ? 's' : ''}
         </p>
 
-        <a href="${url}" download="${esc(filename)}"
+        <a href="${esc(fileUrl)}" download="CounselorReady_Certificate.pdf"
           style="display:inline-flex;align-items:center;gap:8px;padding:14px 28px;background:var(--cr-burgundy);color:#fff;
           font-weight:700;font-size:0.95rem;border-radius:10px;text-decoration:none;transition:background 0.15s"
           onmouseover="this.style.background='var(--cr-burgundy-light)'"


### PR DESCRIPTION
## Summary
Modified the certificate generation flow to handle file downloads via server-provided URLs instead of creating object URLs from blob responses.

## Key Changes
- Changed response handling from `res.blob()` to `res.json()` to receive structured data from the server
- Added validation for the response data structure, checking for `success` flag and `fileUrl` property
- Replaced `URL.createObjectURL()` approach with direct anchor element download using the server-provided file URL
- Simplified filename handling to use a consistent `'CounselorReady_Certificate.pdf'` instead of dynamic course slug-based names
- Updated both the programmatic download trigger and the fallback download link to use the new URL approach

## Implementation Details
- The server now returns a JSON response with `{ success: boolean, fileUrl: string, message?: string }` structure
- Download is triggered via a temporary anchor element that is created, clicked, and removed from the DOM
- Error handling includes validation of the response structure with appropriate error messages
- The fallback download link in the UI is updated to reference the same `fileUrl` from the server response

https://claude.ai/code/session_01AfiRGFTAYScWzwkMbyDGZn