### PR TITLE
Add format: 'pdf' to Cloudinary upload options in certificate route

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -713,7 +713,7 @@ router.post('/:id/certificate', protect, async (req, res) => {
     // Upload PDF to Cloudinary
     const uploadResult = await new Promise((resolve, reject) => {
       const uploadStream = cloudinary.uploader.upload_stream(
-        { resource_type: 'raw', folder: 'certificates', public_id: `cert_${certificate?._id || 'new'}_${Date.now()}` },
+        { resource_type: 'raw', folder: 'certificates', format: 'pdf', public_id: `cert_${certificate?._id || 'new'}_${Date.now()}` },
         (error, result) => {
           if (error) return reject(error);
           resolve(result);


### PR DESCRIPTION
The certificate route already correctly calls generateCertificate() from ../utils/certificate.js, but the Cloudinary upload_stream was missing the format: 'pdf' option, causing the returned URL to not end in .pdf.

https://claude.ai/code/session_01KXZBzcNCr8kT9fHRmiJk4u