### PR TITLE
Restore 'Enrolled successfully!' alert before redirect to course viewer

### DIFF
--- a/client/public/courses.html
+++ b/client/public/courses.html
@@ -343,6 +343,7 @@
         clearTimeout(timeout);
 
         if (response.ok) {
+          alert('Enrolled successfully!');
           window.location.href = '/interactive-course.html?slug=' + slug;
         } else {
           const data = await response.json();


### PR DESCRIPTION
The alert was accidentally removed — user wants confirmation before being redirected to the course.

https://claude.ai/code/session_01D9im84mpvmi3e4ZdDnMgq1