### PR TITLE
Replace certificate design + fix admin analytics

### DIFF
--- a/server/src/routes/adminStats.js
+++ b/server/src/routes/adminStats.js
@@ -43,36 +43,20 @@ router.get('/overview', protect, adminOnly, async (req, res) => {
     
     // Get completions from BOTH progress collections
     const [regularCompletions, interactiveCompletions] = await Promise.all([
-      db.collection('usercourseprogresses').countDocuments({ 
-        $or: [
-          { status: 'completed' },
-          { completed: true },
-          { progress: 100 }
-        ]
-      }),
-      db.collection('interactivecourseprogresses').countDocuments({ 
-        $or: [
-          { status: 'completed' },
-          { completed: true },
-          { progress: 100 }
-        ]
-      })
+      db.collection('usercourseprogresses').countDocuments({ status: 'completed' }),
+      db.collection('interactivecourseprogresses').countDocuments({ status: 'completed' })
     ]);
     
     // Get recent completions (last 7 days) from both collections
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const [recentRegular, recentInteractive] = await Promise.all([
       db.collection('usercourseprogresses').countDocuments({
-        $and: [
-          { $or: [{ status: 'completed' }, { completed: true }, { progress: 100 }] },
-          { $or: [{ completedAt: { $gte: sevenDaysAgo } }, { updatedAt: { $gte: sevenDaysAgo } }] }
-        ]
+        status: 'completed',
+        $or: [{ completedAt: { $gte: sevenDaysAgo } }, { updatedAt: { $gte: sevenDaysAgo } }]
       }),
       db.collection('interactivecourseprogresses').countDocuments({
-        $and: [
-          { $or: [{ status: 'completed' }, { completed: true }, { progress: 100 }] },
-          { $or: [{ completedAt: { $gte: sevenDaysAgo } }, { updatedAt: { $gte: sevenDaysAgo } }] }
-        ]
+        status: 'completed',
+        $or: [{ completedAt: { $gte: sevenDaysAgo } }, { updatedAt: { $gte: sevenDaysAgo } }]
       })
     ]);
     
@@ -88,7 +72,7 @@ router.get('/overview', protect, adminOnly, async (req, res) => {
             completed: { $sum: { $cond: [{ $eq: ['$evaluationCompleted', true] }, 1, 0] } },
             pending: { $sum: { $cond: [
               { $and: [
-                { $or: [{ $eq: ['$status', 'completed'] }, { $eq: ['$completed', true] }, { $eq: ['$progress', 100] }] },
+                { $eq: ['$status', 'completed'] },
                 { $ne: ['$evaluationCompleted', true] }
               ]}, 1, 0
             ]}}
@@ -102,7 +86,7 @@ router.get('/overview', protect, adminOnly, async (req, res) => {
             completed: { $sum: { $cond: [{ $eq: ['$evaluationCompleted', true] }, 1, 0] } },
             pending: { $sum: { $cond: [
               { $and: [
-                { $or: [{ $eq: ['$status', 'completed'] }, { $eq: ['$completed', true] }, { $eq: ['$progress', 100] }] },
+                { $eq: ['$status', 'completed'] },
                 { $ne: ['$evaluationCompleted', true] }
               ]}, 1, 0
             ]}}
@@ -114,7 +98,7 @@ router.get('/overview', protect, adminOnly, async (req, res) => {
     // Calculate CE hours from completed courses (join progress with courses)
     const [regularCEHours, interactiveCEHours] = await Promise.all([
       db.collection('usercourseprogresses').aggregate([
-        { $match: { $or: [{ status: 'completed' }, { completed: true }, { progress: 100 }] } },
+        { $match: { status: 'completed' } },
         {
           $lookup: {
             from: 'courses',
@@ -127,7 +111,7 @@ router.get('/overview', protect, adminOnly, async (req, res) => {
         { $group: { _id: null, total: { $sum: { $ifNull: ['$course.ceHours', 0] } } } }
       ]).toArray(),
       db.collection('interactivecourseprogresses').aggregate([
-        { $match: { $or: [{ status: 'completed' }, { completed: true }, { progress: 100 }] } },
+        { $match: { status: 'completed' } },
         {
           $lookup: {
             from: 'interactivecourses',

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -605,10 +605,26 @@ router.post('/:id/attestation', protect, async (req, res) => {
     
     await progress.save();
 
+    // Log course completion activity
+    try {
+      const user = await User.findById(req.user._id);
+      await logActivity(ACTIVITY_TYPES.COURSE_COMPLETED, {
+        courseId: course._id,
+        courseName: course.title,
+        ceHours: course.ceHours || 1
+      }, {
+        userId: req.user._id,
+        userName: `${user?.firstName || ''} ${user?.lastName || ''}`.trim() || user?.name || user?.email,
+        userEmail: user?.email
+      });
+    } catch (activityErr) {
+      console.error('Failed to log course completion activity:', activityErr);
+    }
+
     res.json({
       success: true,
       message: 'Attestation recorded successfully',
-      data: { 
+      data: {
         attestationAgreed: true,
         completedAt: progress.completedAt
       }

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -122,7 +122,7 @@ router.get('/admin/analytics', protect, requireAdmin, async (req, res) => {
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { courseId: { $in: allPartnerCourseIds }, completed: true } },
+          { $match: { courseId: { $in: allPartnerCourseIds }, status: 'completed' } },
           { $group: { _id: '$courseId', count: { $sum: 1 }, hours: { $sum: { $ifNull: ['$ceHours', 0] } } } }
         ]).toArray()
       ]);
@@ -278,7 +278,7 @@ router.get('/my/courses', protect, requirePartnerAdmin, async (req, res) => {
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { courseId: { $in: courseIds }, completed: true } },
+          { $match: { courseId: { $in: courseIds }, status: 'completed' } },
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray()
       ]);
@@ -906,11 +906,11 @@ router.get('/my/stats', protect, requirePartnerAdmin, async (req, res) => {
     if (userIds.length > 0) {
       const [regularCompletions, interactiveCompletions] = await Promise.all([
         db.collection('usercourseprogresses').aggregate([
-          { $match: { userId: { $in: userIds }, completed: true } },
+          { $match: { userId: { $in: userIds }, status: 'completed' } },
           { $group: { _id: null, count: { $sum: 1 }, hours: { $sum: { $ifNull: ['$ceHours', 0] } } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { userId: { $in: userIds }, completed: true } },
+          { $match: { userId: { $in: userIds }, status: 'completed' } },
           { $group: { _id: null, count: { $sum: 1 }, hours: { $sum: { $ifNull: ['$ceHours', 0] } } } }
         ]).toArray()
       ]);
@@ -932,7 +932,7 @@ router.get('/my/stats', protect, requirePartnerAdmin, async (req, res) => {
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { courseId: { $in: courseIds }, completed: true } },
+          { $match: { courseId: { $in: courseIds }, status: 'completed' } },
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray()
       ]);
@@ -1224,7 +1224,7 @@ router.get('/my/reports/courses', protect, requirePartnerAdmin, async (req, res)
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { courseId: { $in: courseIds }, completed: true } },
+          { $match: { courseId: { $in: courseIds }, status: 'completed' } },
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray()
       ]);
@@ -1448,11 +1448,11 @@ router.get('/:id/stats', protect, requireAdmin, async (req, res) => {
     if (userIds.length > 0) {
       const [regularCompletions, interactiveCompletions] = await Promise.all([
         db.collection('usercourseprogresses').aggregate([
-          { $match: { userId: { $in: userIds }, completed: true } },
+          { $match: { userId: { $in: userIds }, status: 'completed' } },
           { $group: { _id: null, count: { $sum: 1 }, hours: { $sum: { $ifNull: ['$ceHours', 0] } } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { userId: { $in: userIds }, completed: true } },
+          { $match: { userId: { $in: userIds }, status: 'completed' } },
           { $group: { _id: null, count: { $sum: 1 }, hours: { $sum: { $ifNull: ['$ceHours', 0] } } } }
         ]).toArray()
       ]);
@@ -1475,7 +1475,7 @@ router.get('/:id/stats', protect, requireAdmin, async (req, res) => {
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray(),
         db.collection('interactivecourseprogresses').aggregate([
-          { $match: { courseId: { $in: courseIds }, completed: true } },
+          { $match: { courseId: { $in: courseIds }, status: 'completed' } },
           { $group: { _id: '$courseId', count: { $sum: 1 } } }
         ]).toArray()
       ]);
@@ -1564,7 +1564,7 @@ router.get('/:id/courses', protect, requireAdmin, async (req, res) => {
         { $group: { _id: '$courseId', count: { $sum: 1 } } }
       ]).toArray(),
       db.collection('interactivecourseprogresses').aggregate([
-        { $match: { courseId: { $in: courseIds }, completed: true } },
+        { $match: { courseId: { $in: courseIds }, status: 'completed' } },
         { $group: { _id: '$courseId', count: { $sum: 1 } } }
       ]).toArray()
     ]);
@@ -1601,7 +1601,7 @@ router.get('/:id/courses/:courseId/analytics', protect, requireAdmin, async (req
 
     const [enrollments, completions, avgProgress] = await Promise.all([
       db.collection('interactivecourseprogresses').countDocuments({ courseId }),
-      db.collection('interactivecourseprogresses').countDocuments({ courseId, completed: true }),
+      db.collection('interactivecourseprogresses').countDocuments({ courseId, status: 'completed' }),
       db.collection('interactivecourseprogresses').aggregate([
         { $match: { courseId } },
         { $group: { _id: null, avg: { $avg: { $ifNull: ['$progressPercent', 0] } } } }


### PR DESCRIPTION
## Summary

- **Replaced certificate generator** with NBCC ACEP #7760 compliant design: brand colors (burgundy, hunter green, honey gold, navy), triple decorative borders, logo watermark, signature image, NBCC seal centered between signature lines, learning objectives, GAITP compliance footer
- **Fixed certificate layout**: completion date after course title, instructor/asynchronous below, content area + CE hours on left signature line, certificate # sharing that line, authorized signature on right, verify URL + ACEP statement in footer
- **Fixed .pdf extension**: Cloudinary `format: 'pdf'` so certificates download as PDF not .bin
- **Fixed certificate params**: proper name fallback chain, hardcoded ACEP #7760 and NBCC, passes ceCategory and objectives
- **Fixed admin analytics zero completions**: replaced `completed: true` (non-existent field) with `status: 'completed'` across all queries in partners.js (11 occurrences) and adminStats.js (8 occurrences)
- **Fixed missing activity logging**: added `logActivity(COURSE_COMPLETED)` to attestation endpoint so Dashboard activity feed shows interactive course completions

## Files changed

- `server/src/utils/certificate.js` — full redesign
- `server/src/routes/interactiveCourseRoutes.js` — .pdf format, param fixes, activity logging
- `server/src/routes/partners.js` — completed:true → status:'completed'
- `server/src/routes/adminStats.js` — same query fix

## Test plan

- [ ] Complete a course and verify certificate downloads as .pdf with correct layout
- [ ] Verify certificate shows: provider name once (header), cert # once (bottom left), CE hours once (bottom left), NBCC seal centered, all on 1 page
- [ ] Check admin analytics page shows accurate completion counts
- [ ] Check Dashboard activity feed shows course completion after attestation

https://claude.ai/code/session_016koQKSepnksUQDqDgKgLjP