### PR TITLE
fix: add Courses.jsx stub to prevent Vite build failure

### DIFF
--- a/client/src/pages/Courses.jsx
+++ b/client/src/pages/Courses.jsx
@@ -1,0 +1,5 @@
+// Courses.jsx — stub to prevent build failure
+// The actual courses page is served as static HTML at /courses.html
+// This only exists so App.jsx imports don't break the Vite build
+import InteractiveCourseCatalog from './InteractiveCourseCatalog';
+export default InteractiveCourseCatalog;


### PR DESCRIPTION
Re-exports InteractiveCourseCatalog so App.jsx imports resolve.