### PR TITLE
Implement Phase 1 CourseBuilder with content editor and metadata tabs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,7 @@ import InteractiveCourseCatalog from './pages/InteractiveCourseCatalog';
 // Components
 import Layout from './components/Layout';
 import CourseViewer from './components/CourseViewer';
-import CourseBuilder from './components/CourseBuilder';
+import CourseBuilder from './components/course-builder/index.jsx';
 import ResearchReadyCE from './pages/ResearchReadyCE';
 import AdminResearchReady from './pages/AdminResearchReady';
 

--- a/client/src/components/course-builder/CourseBuilderContext.jsx
+++ b/client/src/components/course-builder/CourseBuilderContext.jsx
@@ -1,0 +1,239 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — CourseBuilderContext.jsx
+// Provider wrapping the reducer. Handles autosave, dirty state, and keyboard
+// shortcuts. Consumed by all child tabs via useCourseBuilder().
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { createContext, useContext, useReducer, useRef, useCallback, useEffect, useState } from "react";
+import { courseBuilderReducer, INITIAL_STATE, A } from "./courseBuilderReducer.js";
+import { saveCourse, loadCourseById } from "./courseBuilderApi.js";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const CourseBuilderContext = createContext(null);
+
+export function useCourseBuilder() {
+  const ctx = useContext(CourseBuilderContext);
+  if (!ctx) throw new Error("useCourseBuilder must be used inside <CourseBuilderProvider>");
+  return ctx;
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function CourseBuilderProvider({ children, initialCourseId = null }) {
+  const [state, dispatch] = useReducer(courseBuilderReducer, INITIAL_STATE);
+
+  // Save state
+  const [saveStatus, setSaveStatus] = useState("idle"); // "idle" | "saving" | "saved" | "error"
+  const [saveError, setSaveError]   = useState(null);
+  const [lastSaved, setLastSaved]   = useState(null);
+  const [isDirty, setIsDirty]       = useState(false);
+
+  // Loading state (for initial course load)
+  const [isLoading, setIsLoading]   = useState(!!initialCourseId);
+  const [loadError, setLoadError]   = useState(null);
+
+  // Tab navigation
+  const [activeTab, setActiveTab]   = useState(0);
+
+  // Track dirty state (reset on save)
+  const prevStateRef = useRef(state);
+  useEffect(() => {
+    if (prevStateRef.current !== state) {
+      setIsDirty(true);
+    }
+    prevStateRef.current = state;
+  }, [state]);
+
+  // ── Load existing course on mount ───────────────────────────────────────────
+
+  useEffect(() => {
+    if (!initialCourseId) return;
+    (async () => {
+      try {
+        setIsLoading(true);
+        const course = await loadCourseById(initialCourseId);
+        dispatch({ type: A.LOAD_COURSE, courseData: course });
+        setIsDirty(false);
+      } catch (err) {
+        setLoadError(err.message);
+        console.error("CourseBuilderProvider: failed to load course", err);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [initialCourseId]);
+
+  // ── Autosave (debounced, 3 seconds after last change) ───────────────────────
+
+  const autosaveTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (!isDirty || !state._id) return; // only autosave if course already exists in DB
+    clearTimeout(autosaveTimerRef.current);
+    autosaveTimerRef.current = setTimeout(() => {
+      doSave(false, true); // silent autosave
+    }, 3000);
+    return () => clearTimeout(autosaveTimerRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, isDirty]);
+
+  // ── Save ─────────────────────────────────────────────────────────────────────
+
+  const doSave = useCallback(
+    async (showFeedback = true, silent = false) => {
+      if (!silent) setSaveStatus("saving");
+      setSaveError(null);
+      try {
+        const result = await saveCourse(state);
+        // If this was a new course, load the returned _id back into state
+        if (!state._id && result.course?._id) {
+          dispatch({ type: A.SET_METADATA, field: "_id", value: result.course._id });
+        }
+        setLastSaved(new Date());
+        setIsDirty(false);
+        if (!silent) setSaveStatus("saved");
+        return result;
+      } catch (err) {
+        setSaveError(err.message);
+        if (!silent) setSaveStatus("error");
+        throw err;
+      }
+    },
+    [state]
+  );
+
+  // ── Keyboard shortcuts ───────────────────────────────────────────────────────
+
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        doSave(true);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [doSave]);
+
+  // ── Dirty-state beforeunload warning ─────────────────────────────────────────
+
+  useEffect(() => {
+    function handleBeforeUnload(e) {
+      if (!isDirty) return;
+      e.preventDefault();
+      e.returnValue = "You have unsaved changes. Leave anyway?";
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty]);
+
+  // ── Convenience dispatchers ───────────────────────────────────────────────────
+
+  const setMeta      = (field, value) => dispatch({ type: A.SET_METADATA,     field, value });
+  const addObjective = (text)         => dispatch({ type: A.ADD_OBJECTIVE,    text });
+  const removeObjective = (index)     => dispatch({ type: A.REMOVE_OBJECTIVE, index });
+  const addAudience  = (text)         => dispatch({ type: A.ADD_AUDIENCE,     text });
+  const removeAudience = (index)      => dispatch({ type: A.REMOVE_AUDIENCE,  index });
+
+  const addSection    = (title, afterIndex) => dispatch({ type: A.ADD_SECTION,       title, afterIndex });
+  const removeSection = (sectionIndex)      => dispatch({ type: A.REMOVE_SECTION,    sectionIndex });
+  const setSectionTitle = (sectionIndex, title) => dispatch({ type: A.SET_SECTION_TITLE, sectionIndex, title });
+  const moveSection   = (from, to)          => dispatch({ type: A.MOVE_SECTION,      from, to });
+
+  const addBlock    = (sectionIndex, blockType, afterBlockIndex) =>
+    dispatch({ type: A.ADD_BLOCK, sectionIndex, blockType, afterBlockIndex });
+  const updateBlock = (sectionIndex, blockIndex, updates) =>
+    dispatch({ type: A.UPDATE_BLOCK, sectionIndex, blockIndex, updates });
+  const removeBlock = (sectionIndex, blockIndex) =>
+    dispatch({ type: A.REMOVE_BLOCK, sectionIndex, blockIndex });
+  const moveBlock   = (fromSection, fromIndex, toSection, toIndex) =>
+    dispatch({ type: A.MOVE_BLOCK, fromSection, fromIndex, toSection, toIndex });
+  const duplicateBlock = (sectionIndex, blockIndex) =>
+    dispatch({ type: A.DUPLICATE_BLOCK, sectionIndex, blockIndex });
+
+  const addAssessmentQ    = (question)        => dispatch({ type: A.ADD_ASSESSMENT_Q,    question });
+  const updateAssessmentQ = (qIndex, updates) => dispatch({ type: A.UPDATE_ASSESSMENT_Q, qIndex, updates });
+  const removeAssessmentQ = (qIndex)          => dispatch({ type: A.REMOVE_ASSESSMENT_Q, qIndex });
+  const setAssessmentMeta = (updates)         => dispatch({ type: A.SET_ASSESSMENT_META, updates });
+
+  const addReference    = (reference)         => dispatch({ type: A.ADD_REFERENCE,    reference });
+  const updateReference = (refIndex, updates) => dispatch({ type: A.UPDATE_REFERENCE, refIndex, updates });
+  const removeReference = (refIndex)          => dispatch({ type: A.REMOVE_REFERENCE, refIndex });
+
+  const loadCourse = (courseData) => {
+    dispatch({ type: A.LOAD_COURSE, courseData });
+    setIsDirty(false);
+    setLastSaved(null);
+  };
+
+  const resetCourse = () => {
+    dispatch({ type: A.RESET });
+    setIsDirty(false);
+    setLastSaved(null);
+  };
+
+  // ── Context value ─────────────────────────────────────────────────────────────
+
+  const value = {
+    // State
+    state,
+    dispatch,
+
+    // Save state
+    saveStatus,
+    saveError,
+    lastSaved,
+    isDirty,
+
+    // Load state
+    isLoading,
+    loadError,
+
+    // Tab
+    activeTab,
+    setActiveTab,
+
+    // Actions
+    doSave,
+    loadCourse,
+    resetCourse,
+
+    // Metadata
+    setMeta,
+    addObjective,
+    removeObjective,
+    addAudience,
+    removeAudience,
+
+    // Sections
+    addSection,
+    removeSection,
+    setSectionTitle,
+    moveSection,
+
+    // Blocks
+    addBlock,
+    updateBlock,
+    removeBlock,
+    moveBlock,
+    duplicateBlock,
+
+    // Assessment
+    addAssessmentQ,
+    updateAssessmentQ,
+    removeAssessmentQ,
+    setAssessmentMeta,
+
+    // References
+    addReference,
+    updateReference,
+    removeReference,
+  };
+
+  return (
+    <CourseBuilderContext.Provider value={value}>
+      {children}
+    </CourseBuilderContext.Provider>
+  );
+}

--- a/client/src/components/course-builder/constants.js
+++ b/client/src/components/course-builder/constants.js
@@ -1,0 +1,230 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — constants.js
+// Single source of truth for block types, defaults, and ACEP rules.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Brand palette (matches design-tokens.css / Color_Spec_v1)
+export const C = {
+  burgundy:     "#6B1D34",
+  burgundyFaded:"#6B1D3420",
+  hunterGreen:  "#4A7C59",
+  honey:        "#D4A855",
+  navy:         "#284157",   // ← correct value per Color_Spec_v1 (NOT #34495E)
+  stone:        "#F8F7F4",
+  card:         "#FFFFFF",
+  border:       "#E5E0D8",
+  borderLight:  "#F0EDE8",
+  textMuted:    "#8A8178",
+  textLight:    "#B0A89E",
+  danger:       "#DC2626",
+  purple:       "#7C3AED",
+};
+
+// ─── 17 valid block types ────────────────────────────────────────────────────
+
+export const BLOCK_TYPE_CONFIG = {
+  sectionDivider: { label: "Section Divider", icon: "📐", color: C.navy,       category: "Structure"  },
+  text:           { label: "Text Block",       icon: "📝", color: C.hunterGreen,category: "Content"    },
+  accordion:      { label: "Accordion",        icon: "📂", color: C.hunterGreen,category: "Content"    },
+  image:          { label: "Image",            icon: "🖼",  color: "#0891B2",    category: "Media"      },
+  imageText:      { label: "Image + Text",     icon: "🖼",  color: "#0891B2",    category: "Media"      },
+  videoEmbed:     { label: "Video Embed",      icon: "▶️", color: "#DC2626",    category: "Media"      },
+  multipleChoice: { label: "Knowledge Check",  icon: "✅", color: C.burgundy,   category: "Assessment", isKC: true },
+  multiSelect:    { label: "Multi-Select KC",  icon: "☑️", color: C.burgundy,   category: "Assessment", isKC: true },
+  matching:       { label: "Matching",         icon: "🔗", color: C.burgundy,   category: "Assessment", isKC: true },
+  reflection:     { label: "Reflection",       icon: "💭", color: C.purple,     category: "Engagement" },
+  flashcardDeck:  { label: "Flashcard Deck",   icon: "🃏", color: C.purple,     category: "Engagement" },
+  cardSort:       { label: "Card Sort",        icon: "🗂",  color: C.purple,     category: "Engagement" },
+  sequencing:     { label: "Sequencing",       icon: "🔢", color: C.purple,     category: "Engagement" },
+  scenarioTree:   { label: "Scenario Tree",    icon: "🌳", color: C.purple,     category: "Engagement" },
+  hotspot:        { label: "Hotspot Image",    icon: "🎯", color: C.purple,     category: "Engagement" },
+  timeline:       { label: "Timeline",         icon: "📅", color: C.purple,     category: "Engagement" },
+  resources:      { label: "Resources",        icon: "🔗", color: C.honey,      category: "Supplement" },
+};
+
+export const BLOCK_TYPES = Object.keys(BLOCK_TYPE_CONFIG);
+
+// Grouped for the BlockPicker UI
+export const BLOCK_TYPE_GROUPS = [
+  {
+    label: "Structure",
+    types: ["sectionDivider"],
+  },
+  {
+    label: "Content",
+    types: ["text", "accordion"],
+  },
+  {
+    label: "Media",
+    types: ["image", "imageText", "videoEmbed"],
+  },
+  {
+    label: "Assessment",
+    types: ["multipleChoice", "multiSelect", "matching"],
+  },
+  {
+    label: "Engagement",
+    types: ["reflection", "flashcardDeck", "cardSort", "sequencing", "scenarioTree", "hotspot", "timeline"],
+  },
+  {
+    label: "Supplement",
+    types: ["resources"],
+  },
+];
+
+// ─── Block defaults (canonical schema format) ────────────────────────────────
+// options: [String], correctAnswer: Number (0-based) — never {text, isCorrect}
+
+export const BLOCK_DEFAULTS = {
+  sectionDivider: {
+    type: "sectionDivider",
+    title: "New Section",
+    sectionNumber: 1,
+    subtitle: "",
+  },
+  text: {
+    type: "text",
+    content: "",
+    heading: "",
+  },
+  accordion: {
+    type: "accordion",
+    title: "Accordion Title",
+    items: [{ title: "Item 1", content: "" }],
+  },
+  image: {
+    type: "image",
+    url: "",
+    caption: "",
+    alt: "",
+    alignment: "center",
+  },
+  imageText: {
+    type: "imageText",
+    imageUrl: "",
+    imageAlt: "",
+    imageCaption: "",
+    imagePosition: "left",
+    content: "",
+  },
+  videoEmbed: {
+    type: "videoEmbed",
+    url: "",
+    title: "",
+    description: "",
+    markers: [],
+  },
+  multipleChoice: {
+    type: "multipleChoice",
+    question: "",
+    options: ["", "", "", ""],
+    correctAnswer: 0,        // 0-based index
+    explanation: "",
+    rationale: "",
+  },
+  multiSelect: {
+    type: "multiSelect",
+    question: "",
+    options: ["", "", "", ""],
+    correctAnswers: [0],     // array of 0-based indices
+    explanation: "",
+  },
+  matching: {
+    type: "matching",
+    instructions: "Match each term to its definition.",
+    pairs: [{ term: "", definition: "" }],
+  },
+  reflection: {
+    type: "reflection",
+    prompt: "",
+    minWords: 50,
+    placeholder: "Take a moment to reflect...",
+  },
+  flashcardDeck: {
+    type: "flashcardDeck",
+    title: "Flashcard Deck",
+    cards: [{ front: "", back: "" }],
+  },
+  cardSort: {
+    type: "cardSort",
+    instructions: "Sort the following items into categories.",
+    categories: [{ label: "Category A", color: "#E11D48" }, { label: "Category B", color: "#6366F1" }],
+    cards: [{ text: "", category: "" }],
+  },
+  sequencing: {
+    type: "sequencing",
+    instructions: "Place the following steps in the correct order.",
+    steps: [{ text: "", order: 1 }],
+  },
+  scenarioTree: {
+    type: "scenarioTree",
+    title: "Clinical Scenario",
+    nodes: [
+      {
+        id: "root",
+        text: "Describe the scenario...",
+        isRoot: true,
+        choices: [],
+      },
+    ],
+  },
+  hotspot: {
+    type: "hotspot",
+    imageUrl: "",
+    imageAlt: "",
+    instructions: "Click on the highlighted areas to learn more.",
+    pins: [],
+  },
+  timeline: {
+    type: "timeline",
+    title: "Timeline",
+    events: [{ year: "", title: "", description: "" }],
+  },
+  resources: {
+    type: "resources",
+    title: "Additional Resources",
+    links: [{ label: "", url: "" }],
+  },
+};
+
+// ─── ACEP / NBCC compliance rules ────────────────────────────────────────────
+
+export const ACEP_RULES = {
+  WORDS_PER_CE_HOUR: 6000,       // NBCC requirement — non-negotiable
+  MIN_KC_PER_SECTION: 2,
+  MAX_KC_PER_SECTION: 5,
+  MIN_ASSESSMENT_QUESTIONS: 15,
+  MAX_ASSESSMENT_QUESTIONS: 25,
+  PASS_THRESHOLD: 0.80,
+  MAX_ATTEMPTS: 3,
+  MAX_WORDS_PER_TEXT_BLOCK: 1500,
+  MAX_ANSWER_OPTION_FREQUENCY: 0.40,  // no single answer option > 40% of all questions
+};
+
+// KC block types (count toward KC-per-section rule)
+export const KC_BLOCK_TYPES = new Set(["multipleChoice", "multiSelect", "matching"]);
+
+// ACEP provider hardcoded defaults (per platform spec)
+export const ACEP_PROVIDER = {
+  name: "GA Integrated Therapeutic Perspectives LLC",
+  shortName: "GAITP LLC",
+  acepNumber: "7760",
+  approvalBody: "NBCC",
+};
+
+// Validation error codes
+export const VALIDATION_CODES = {
+  WORD_COUNT_LOW:           "WORD_COUNT_LOW",
+  TEXT_BLOCK_TOO_LONG:      "TEXT_BLOCK_TOO_LONG",
+  KC_COUNT_LOW:             "KC_COUNT_LOW",
+  KC_COUNT_HIGH:            "KC_COUNT_HIGH",
+  NO_SECTION_DIVIDER:       "NO_SECTION_DIVIDER",
+  NO_OBJECTIVES:            "NO_OBJECTIVES",
+  NO_TARGET_AUDIENCE:       "NO_TARGET_AUDIENCE",
+  ASSESSMENT_TOO_FEW:       "ASSESSMENT_TOO_FEW",
+  ANSWER_DIST_SKEWED:       "ANSWER_DIST_SKEWED",
+  NO_REFERENCES:            "NO_REFERENCES",
+  MISSING_TITLE:            "MISSING_TITLE",
+  MISSING_CE_HOURS:         "MISSING_CE_HOURS",
+  CORRECT_ANSWER_UNSET:     "CORRECT_ANSWER_UNSET",
+};

--- a/client/src/components/course-builder/courseBuilderApi.js
+++ b/client/src/components/course-builder/courseBuilderApi.js
@@ -1,0 +1,114 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — courseBuilderApi.js
+// All HTTP calls for the course builder. No React, no side effects.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { buildSavePayload } from "./utils.js";
+
+const API_BASE = import.meta.env.VITE_API_URL || "https://api.counselorready.com/api";
+
+function getToken() {
+  return localStorage.getItem("token");
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${getToken()}`,
+  };
+}
+
+async function handleResponse(res) {
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      message = body.error || body.message || message;
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(message);
+  }
+  return res.json();
+}
+
+// ─── Save (create or update draft) ──────────────────────────────────────────
+
+/**
+ * Upsert a course draft.
+ * @param {object} state — current reducer state
+ * @returns {object} { course: savedDocument }
+ */
+export async function saveCourse(state) {
+  const payload = buildSavePayload(state, false);
+  const res = await fetch(`${API_BASE}/course-builder/save`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+  return handleResponse(res);
+}
+
+// ─── Publish ─────────────────────────────────────────────────────────────────
+
+/**
+ * Publish a course (runs server-side validation first).
+ * @param {object} state — current reducer state
+ * @returns {object} { course: publishedDocument }
+ */
+export async function publishCourse(state) {
+  const payload = buildSavePayload(state, true);
+  const res = await fetch(`${API_BASE}/course-builder/publish`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+  return handleResponse(res);
+}
+
+// ─── Load by ID ──────────────────────────────────────────────────────────────
+
+/**
+ * Load a course for editing by MongoDB _id.
+ * @param {string} id
+ * @returns {object} course document
+ */
+export async function loadCourseById(id) {
+  const res = await fetch(`${API_BASE}/course-builder/${id}`, {
+    headers: authHeaders(),
+  });
+  const data = await handleResponse(res);
+  return data.course || data;
+}
+
+// ─── Load by slug ─────────────────────────────────────────────────────────────
+
+/**
+ * Load a course for editing by slug.
+ * @param {string} slug
+ * @returns {object} course document
+ */
+export async function loadCourseBySlug(slug) {
+  const res = await fetch(`${API_BASE}/course-builder/slug/${slug}`, {
+    headers: authHeaders(),
+  });
+  const data = await handleResponse(res);
+  return data.course || data;
+}
+
+// ─── Server-side validation ───────────────────────────────────────────────────
+
+/**
+ * Run ACEP validation on the server.
+ * @param {object} state
+ * @returns {object} { valid: boolean, errors: ValidationResult[] }
+ */
+export async function validateCourse(state) {
+  const payload = buildSavePayload(state, false);
+  const res = await fetch(`${API_BASE}/course-builder/validate`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+  return handleResponse(res);
+}

--- a/client/src/components/course-builder/courseBuilderReducer.js
+++ b/client/src/components/course-builder/courseBuilderReducer.js
@@ -1,0 +1,433 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — courseBuilderReducer.js
+// Pure reducer. No side effects. Every mutation goes through here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { uid, slugify } from "./utils.js";
+import { BLOCK_DEFAULTS, ACEP_PROVIDER } from "./constants.js";
+
+// ─── Initial state ───────────────────────────────────────────────────────────
+
+export const INITIAL_STATE = {
+  _id: null,
+  title: "",
+  slug: "",
+  description: "",
+  courseCode: "",
+  ceHours: 3,
+  ceCategory: "General",
+  level: "Intermediate",
+  category: "Clinical Practice",
+  accessType: "paid",
+  price: 0,
+  pricingTier: "standard",
+  status: "draft",
+  isPublished: false,
+  deliveryMethod: "online",
+  objectives: [],
+  targetAudience: [],
+
+  // ACEP — hardcoded per platform spec
+  instructor:     ACEP_PROVIDER.name,
+  approvingBody:  ACEP_PROVIDER.approvalBody,
+  approvalNumber: `#${ACEP_PROVIDER.acepNumber}`,
+  ceuHours: 3,
+  ceuEligible: true,
+
+  sections: [],
+
+  assessment: {
+    questions: [],
+    passingScore: 80,
+    passThreshold: 0.80,
+    maxAttempts: 3,
+  },
+
+  references: [],
+
+  settings: {
+    passingScore: 80,
+    certificateEnabled: true,
+    requireEvaluation: true,
+    requireAttestation: true,
+  },
+};
+
+// ─── Action types ────────────────────────────────────────────────────────────
+
+export const A = {
+  // Metadata
+  SET_METADATA:         "SET_METADATA",
+  SET_OBJECTIVES:       "SET_OBJECTIVES",
+  ADD_OBJECTIVE:        "ADD_OBJECTIVE",
+  REMOVE_OBJECTIVE:     "REMOVE_OBJECTIVE",
+  ADD_AUDIENCE:         "ADD_AUDIENCE",
+  REMOVE_AUDIENCE:      "REMOVE_AUDIENCE",
+
+  // Sections
+  SET_SECTION_TITLE:    "SET_SECTION_TITLE",
+  ADD_SECTION:          "ADD_SECTION",
+  REMOVE_SECTION:       "REMOVE_SECTION",
+  MOVE_SECTION:         "MOVE_SECTION",
+
+  // Blocks
+  ADD_BLOCK:            "ADD_BLOCK",
+  UPDATE_BLOCK:         "UPDATE_BLOCK",
+  REMOVE_BLOCK:         "REMOVE_BLOCK",
+  MOVE_BLOCK:           "MOVE_BLOCK",
+  DUPLICATE_BLOCK:      "DUPLICATE_BLOCK",
+
+  // Assessment
+  ADD_ASSESSMENT_Q:     "ADD_ASSESSMENT_Q",
+  UPDATE_ASSESSMENT_Q:  "UPDATE_ASSESSMENT_Q",
+  REMOVE_ASSESSMENT_Q:  "REMOVE_ASSESSMENT_Q",
+  MOVE_ASSESSMENT_Q:    "MOVE_ASSESSMENT_Q",
+  SET_ASSESSMENT_META:  "SET_ASSESSMENT_META",
+
+  // References
+  ADD_REFERENCE:        "ADD_REFERENCE",
+  UPDATE_REFERENCE:     "UPDATE_REFERENCE",
+  REMOVE_REFERENCE:     "REMOVE_REFERENCE",
+
+  // Lifecycle
+  LOAD_COURSE:          "LOAD_COURSE",
+  BATCH:                "BATCH",
+  RESET:                "RESET",
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function clampIndex(arr, i) {
+  return Math.max(0, Math.min(arr.length - 1, i));
+}
+
+function arrayMove(arr, from, to) {
+  const out = [...arr];
+  const [item] = out.splice(from, 1);
+  out.splice(to, 0, item);
+  return out;
+}
+
+function newBlock(type) {
+  const defaults = BLOCK_DEFAULTS[type];
+  if (!defaults) throw new Error(`Unknown block type: ${type}`);
+  return { ...defaults, _tempId: uid() };
+}
+
+function newSection(title = "New Section") {
+  return {
+    _tempId: uid(),
+    title,
+    order: 1,
+    contentBlocks: [],
+  };
+}
+
+function newAssessmentQuestion() {
+  return {
+    _tempId: uid(),
+    question: "",
+    type: "multiple_choice",
+    options: ["", "", "", ""],
+    correctAnswer: 0,
+    explanation: "",
+  };
+}
+
+// ─── Normalise a loaded course (ensure _tempIds exist) ───────────────────────
+
+function normaliseLoaded(course) {
+  return {
+    ...INITIAL_STATE,
+    ...course,
+    sections: (course.sections || []).map(s => ({
+      ...s,
+      _tempId: s._tempId || uid(),
+      contentBlocks: (s.contentBlocks || []).map(b => ({
+        ...b,
+        _tempId: b._tempId || uid(),
+      })),
+    })),
+    assessment: {
+      ...INITIAL_STATE.assessment,
+      ...(course.assessment || {}),
+      questions: ((course.assessment || {}).questions || []).map(q => ({
+        ...q,
+        _tempId: q._tempId || uid(),
+      })),
+    },
+    references: (course.references || []).map(r => ({
+      ...r,
+      _tempId: r._tempId || uid(),
+    })),
+  };
+}
+
+// ─── Reducer ─────────────────────────────────────────────────────────────────
+
+export function courseBuilderReducer(state, action) {
+  switch (action.type) {
+
+    // ── Metadata ──────────────────────────────────────────────────────────────
+
+    case A.SET_METADATA: {
+      const updates = { [action.field]: action.value };
+      // Auto-update slug when title changes (unless user has manually set slug)
+      if (action.field === "title" && !state._slugEdited) {
+        updates.slug = slugify(action.value);
+      }
+      if (action.field === "slug") {
+        updates._slugEdited = true;
+      }
+      // Mirror ceHours → ceuHours
+      if (action.field === "ceHours") {
+        updates.ceuHours = action.value;
+      }
+      return { ...state, ...updates };
+    }
+
+    case A.ADD_OBJECTIVE: {
+      const text = (action.text || "").trim();
+      if (!text) return state;
+      return { ...state, objectives: [...state.objectives, text] };
+    }
+
+    case A.REMOVE_OBJECTIVE: {
+      return {
+        ...state,
+        objectives: state.objectives.filter((_, i) => i !== action.index),
+      };
+    }
+
+    case A.ADD_AUDIENCE: {
+      const text = (action.text || "").trim();
+      if (!text) return state;
+      return { ...state, targetAudience: [...state.targetAudience, text] };
+    }
+
+    case A.REMOVE_AUDIENCE: {
+      return {
+        ...state,
+        targetAudience: state.targetAudience.filter((_, i) => i !== action.index),
+      };
+    }
+
+    // ── Sections ──────────────────────────────────────────────────────────────
+
+    case A.SET_SECTION_TITLE: {
+      const sections = state.sections.map((s, i) =>
+        i === action.sectionIndex ? { ...s, title: action.title } : s
+      );
+      return { ...state, sections };
+    }
+
+    case A.ADD_SECTION: {
+      const section = newSection(action.title);
+      const sections = [...state.sections];
+      const after = action.afterIndex ?? sections.length - 1;
+      sections.splice(after + 1, 0, section);
+      return { ...state, sections };
+    }
+
+    case A.REMOVE_SECTION: {
+      if (state.sections.length <= 1) return state; // always keep at least 1
+      return {
+        ...state,
+        sections: state.sections.filter((_, i) => i !== action.sectionIndex),
+      };
+    }
+
+    case A.MOVE_SECTION: {
+      const { from, to } = action;
+      if (from === to) return state;
+      const clamped = clampIndex(state.sections, to);
+      return { ...state, sections: arrayMove(state.sections, from, clamped) };
+    }
+
+    // ── Blocks ────────────────────────────────────────────────────────────────
+
+    case A.ADD_BLOCK: {
+      const { sectionIndex, afterBlockIndex, blockType } = action;
+      const block = newBlock(blockType);
+      const sections = state.sections.map((s, si) => {
+        if (si !== sectionIndex) return s;
+        const blocks = [...s.contentBlocks];
+        const after = afterBlockIndex ?? blocks.length - 1;
+        blocks.splice(after + 1, 0, block);
+        return { ...s, contentBlocks: blocks };
+      });
+      return { ...state, sections };
+    }
+
+    case A.UPDATE_BLOCK: {
+      const { sectionIndex, blockIndex, updates } = action;
+      const sections = state.sections.map((s, si) => {
+        if (si !== sectionIndex) return s;
+        return {
+          ...s,
+          contentBlocks: s.contentBlocks.map((b, bi) =>
+            bi === blockIndex ? { ...b, ...updates } : b
+          ),
+        };
+      });
+      return { ...state, sections };
+    }
+
+    case A.REMOVE_BLOCK: {
+      const { sectionIndex, blockIndex } = action;
+      const sections = state.sections.map((s, si) => {
+        if (si !== sectionIndex) return s;
+        return {
+          ...s,
+          contentBlocks: s.contentBlocks.filter((_, bi) => bi !== blockIndex),
+        };
+      });
+      return { ...state, sections };
+    }
+
+    case A.MOVE_BLOCK: {
+      const { fromSection, fromIndex, toSection, toIndex } = action;
+      if (fromSection === toSection && fromIndex === toIndex) return state;
+
+      const sections = state.sections.map((s, si) => {
+        // Same-section reorder
+        if (fromSection === toSection && si === fromSection) {
+          return { ...s, contentBlocks: arrayMove(s.contentBlocks, fromIndex, toIndex) };
+        }
+        // Cross-section: remove from source
+        if (si === fromSection) {
+          return {
+            ...s,
+            contentBlocks: s.contentBlocks.filter((_, bi) => bi !== fromIndex),
+          };
+        }
+        // Cross-section: insert into destination
+        if (si === toSection) {
+          const block = state.sections[fromSection].contentBlocks[fromIndex];
+          const blocks = [...s.contentBlocks];
+          blocks.splice(toIndex, 0, block);
+          return { ...s, contentBlocks: blocks };
+        }
+        return s;
+      });
+      return { ...state, sections };
+    }
+
+    case A.DUPLICATE_BLOCK: {
+      const { sectionIndex, blockIndex } = action;
+      const sections = state.sections.map((s, si) => {
+        if (si !== sectionIndex) return s;
+        const original = s.contentBlocks[blockIndex];
+        const copy = { ...original, _tempId: uid() };
+        const blocks = [...s.contentBlocks];
+        blocks.splice(blockIndex + 1, 0, copy);
+        return { ...s, contentBlocks: blocks };
+      });
+      return { ...state, sections };
+    }
+
+    // ── Assessment ────────────────────────────────────────────────────────────
+
+    case A.ADD_ASSESSMENT_Q: {
+      const q = action.question
+        ? { ...action.question, _tempId: uid() }
+        : newAssessmentQuestion();
+      return {
+        ...state,
+        assessment: {
+          ...state.assessment,
+          questions: [...state.assessment.questions, q],
+        },
+      };
+    }
+
+    case A.UPDATE_ASSESSMENT_Q: {
+      return {
+        ...state,
+        assessment: {
+          ...state.assessment,
+          questions: state.assessment.questions.map((q, i) =>
+            i === action.qIndex ? { ...q, ...action.updates } : q
+          ),
+        },
+      };
+    }
+
+    case A.REMOVE_ASSESSMENT_Q: {
+      return {
+        ...state,
+        assessment: {
+          ...state.assessment,
+          questions: state.assessment.questions.filter((_, i) => i !== action.qIndex),
+        },
+      };
+    }
+
+    case A.MOVE_ASSESSMENT_Q: {
+      const { from, to } = action;
+      if (from === to) return state;
+      return {
+        ...state,
+        assessment: {
+          ...state.assessment,
+          questions: arrayMove(state.assessment.questions, from, clampIndex(state.assessment.questions, to)),
+        },
+      };
+    }
+
+    case A.SET_ASSESSMENT_META: {
+      return {
+        ...state,
+        assessment: { ...state.assessment, ...action.updates },
+      };
+    }
+
+    // ── References ────────────────────────────────────────────────────────────
+
+    case A.ADD_REFERENCE: {
+      const ref = {
+        _tempId: uid(),
+        title: "",
+        author: "",
+        year: new Date().getFullYear(),
+        source: "",
+        ...(action.reference || {}),
+      };
+      return { ...state, references: [...state.references, ref] };
+    }
+
+    case A.UPDATE_REFERENCE: {
+      return {
+        ...state,
+        references: state.references.map((r, i) =>
+          i === action.refIndex ? { ...r, ...action.updates } : r
+        ),
+      };
+    }
+
+    case A.REMOVE_REFERENCE: {
+      return {
+        ...state,
+        references: state.references.filter((_, i) => i !== action.refIndex),
+      };
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    case A.LOAD_COURSE: {
+      return normaliseLoaded(action.courseData);
+    }
+
+    case A.BATCH: {
+      return (action.actions || []).reduce(courseBuilderReducer, state);
+    }
+
+    case A.RESET: {
+      return { ...INITIAL_STATE };
+    }
+
+    default:
+      console.warn("courseBuilderReducer: unknown action", action.type);
+      return state;
+  }
+}

--- a/client/src/components/course-builder/index.jsx
+++ b/client/src/components/course-builder/index.jsx
@@ -1,0 +1,243 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — index.jsx
+// Main export. Wraps provider, renders tab bar and active tab.
+// App.jsx imports from this file — NOT from the old CourseBuilder.jsx.
+//
+// Usage in App.jsx:
+//   import CourseBuilder from "./components/course-builder/index.jsx";
+//
+// Route: /admin/course-builder?id=<mongoId>  (edit existing)
+//        /admin/course-builder               (new course)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useEffect } from "react";
+import { CourseBuilderProvider, useCourseBuilder } from "./CourseBuilderContext.jsx";
+import MetadataTab      from "./tabs/MetadataTab.jsx";
+import ContentEditorTab from "./tabs/ContentEditorTab.jsx";
+import { C, ACEP_RULES } from "./constants.js";
+import { countCourseWords, countKCsInSection } from "./utils.js";
+import { publishCourse } from "./courseBuilderApi.js";
+
+// ─── Tab config ───────────────────────────────────────────────────────────────
+
+const TABS = [
+  { label: "Course Info",     icon: "ℹ️" },
+  { label: "Content Editor",  icon: "📝" },
+  { label: "Assessment",      icon: "✅", comingSoon: true },
+  { label: "References",      icon: "📚", comingSoon: true },
+  { label: "ACEP Compliance", icon: "⚖️", comingSoon: true },
+  { label: "Preview",         icon: "👁",  comingSoon: true },
+  { label: "AI Assistant",    icon: "🤖", comingSoon: true },
+];
+
+// ─── Save status badge ────────────────────────────────────────────────────────
+
+function SaveBadge() {
+  const { saveStatus, saveError, lastSaved, isDirty, doSave } = useCourseBuilder();
+
+  const label = saveStatus === "saving"  ? "Saving..."
+              : saveStatus === "saved"   ? `Saved ${lastSaved ? formatTime(lastSaved) : ""}`
+              : saveStatus === "error"   ? `Error: ${saveError}`
+              : isDirty                  ? "Unsaved changes"
+              : lastSaved                ? `Saved ${formatTime(lastSaved)}`
+              : "New course";
+
+  const color = saveStatus === "error"   ? C.danger
+              : saveStatus === "saved"   ? C.hunterGreen
+              : isDirty                  ? C.honey
+              : C.textMuted;
+
+  return (
+    <span style={{ fontSize: 12, color, fontWeight: 500 }}>{label}</span>
+  );
+}
+
+function formatTime(date) {
+  const diff = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (diff < 5)   return "just now";
+  if (diff < 60)  return `${diff}s ago`;
+  if (diff < 3600)return `${Math.floor(diff / 60)}m ago`;
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+// ─── Word count bar ───────────────────────────────────────────────────────────
+
+function WordCountBar() {
+  const { state } = useCourseBuilder();
+  const total   = countCourseWords(state.sections);
+  const target  = (state.ceHours || 0) * ACEP_RULES.WORDS_PER_CE_HOUR;
+  const pct     = target > 0 ? Math.min(100, Math.round((total / target) * 100)) : 0;
+  const color   = pct >= 100 ? C.hunterGreen : pct >= 80 ? C.honey : C.danger;
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <span style={{ fontSize: 12, color: C.textMuted, whiteSpace: "nowrap" }}>
+        {total.toLocaleString()} / {target.toLocaleString()} words ({pct}%)
+      </span>
+      <div style={{ width: 80, height: 6, background: C.borderLight, borderRadius: 4, overflow: "hidden" }}>
+        <div style={{ width: `${pct}%`, height: "100%", background: color, borderRadius: 4, transition: "width 0.3s" }} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Main shell ───────────────────────────────────────────────────────────────
+
+function CourseBuilderShell() {
+  const {
+    state, activeTab, setActiveTab,
+    isDirty, doSave, saveStatus,
+    isLoading, loadError,
+  } = useCourseBuilder();
+
+  // Ensure we start on Section 1 for new courses
+  useEffect(() => {
+    if (!state._id && state.sections.length === 0) {
+      // New course: start on metadata tab
+      setActiveTab(0);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handlePublish() {
+    if (!confirm("Publish this course? It will become visible to enrolled learners.")) return;
+    try {
+      await doSave(false); // save first
+      const result = await publishCourse(state);
+      if (result?.course?._id) {
+        alert("✓ Course published successfully.");
+        window.location.href = "/public/admin-courses.html";
+      }
+    } catch (err) {
+      alert(`Publish failed: ${err.message}`);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: 300, color: C.textMuted }}>
+        Loading course...
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div style={{ padding: 40, color: C.danger, textAlign: "center" }}>
+        <p style={{ fontWeight: 700, marginBottom: 8 }}>Failed to load course</p>
+        <p style={{ fontSize: 14 }}>{loadError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: C.stone, fontFamily: "system-ui, -apple-system, sans-serif" }}>
+
+      {/* ── Top bar ── */}
+      <div style={{
+        background: C.burgundy, padding: "0 24px",
+        display: "flex", alignItems: "center", gap: 16,
+        height: 56, flexShrink: 0,
+      }}>
+        {/* Logo / back */}
+        <a href="/public/admin-courses.html" style={{ color: "#ffffff80", textDecoration: "none", fontSize: 13, fontWeight: 500 }}>
+          ← Courses
+        </a>
+        <div style={{ width: 1, height: 20, background: "#ffffff30" }} />
+
+        {/* Course title */}
+        <span style={{ color: "#fff", fontWeight: 700, fontSize: 15, flex: 1 }}>
+          {state.title || "Untitled Course"}
+          {state.status === "published" && (
+            <span style={{ marginLeft: 8, fontSize: 10, fontWeight: 700, background: C.hunterGreen, color: "#fff", padding: "2px 8px", borderRadius: 10 }}>LIVE</span>
+          )}
+          {state.status === "draft" && (
+            <span style={{ marginLeft: 8, fontSize: 10, fontWeight: 700, background: "#ffffff30", color: "#fff", padding: "2px 8px", borderRadius: 10 }}>DRAFT</span>
+          )}
+        </span>
+
+        {/* Word count */}
+        <WordCountBar />
+
+        {/* Save status */}
+        <SaveBadge />
+
+        {/* Save button */}
+        <button
+          onClick={() => doSave(true)}
+          disabled={!isDirty || saveStatus === "saving"}
+          style={{
+            padding: "7px 18px", borderRadius: 7, border: "none",
+            background: isDirty ? "#ffffff20" : "transparent",
+            color: isDirty ? "#fff" : "#ffffff50",
+            fontWeight: 600, fontSize: 13, cursor: isDirty ? "pointer" : "default",
+          }}
+        >
+          {saveStatus === "saving" ? "Saving..." : "Save"}
+        </button>
+
+        {/* Publish button */}
+        <button
+          onClick={handlePublish}
+          style={{
+            padding: "7px 18px", borderRadius: 7, border: "none",
+            background: C.hunterGreen, color: "#fff",
+            fontWeight: 700, fontSize: 13, cursor: "pointer",
+          }}
+        >
+          Publish
+        </button>
+      </div>
+
+      {/* ── Tab bar ── */}
+      <div style={{
+        display: "flex", gap: 0, background: "#fff",
+        borderBottom: `1px solid ${C.border}`, flexShrink: 0,
+        paddingLeft: 24, overflowX: "auto",
+      }}>
+        {TABS.map((tab, i) => {
+          const active = activeTab === i;
+          return (
+            <button
+              key={tab.label}
+              onClick={() => !tab.comingSoon && setActiveTab(i)}
+              title={tab.comingSoon ? "Coming in Phase 2–3" : undefined}
+              style={{
+                padding: "13px 18px", border: "none", background: "transparent",
+                borderBottom: active ? `3px solid ${C.burgundy}` : "3px solid transparent",
+                color: active ? C.burgundy : tab.comingSoon ? C.textLight : C.navy,
+                fontWeight: active ? 700 : 500, fontSize: 13, cursor: tab.comingSoon ? "default" : "pointer",
+                whiteSpace: "nowrap", display: "flex", alignItems: "center", gap: 6,
+              }}
+            >
+              <span>{tab.icon}</span>
+              {tab.label}
+              {tab.comingSoon && <span style={{ fontSize: 9, fontWeight: 700, color: C.textLight, background: C.borderLight, padding: "1px 5px", borderRadius: 8 }}>SOON</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── Tab content ── */}
+      <div style={{ flex: 1, overflowY: "auto", padding: 24 }}>
+        {activeTab === 0 && <MetadataTab />}
+        {activeTab === 1 && <ContentEditorTab />}
+      </div>
+
+    </div>
+  );
+}
+
+// ─── Root export (with provider) ─────────────────────────────────────────────
+
+export default function CourseBuilder() {
+  // Read course ID from URL param: /admin/course-builder?id=<mongoId>
+  const params = new URLSearchParams(window.location.search);
+  const courseId = params.get("id") || null;
+
+  return (
+    <CourseBuilderProvider initialCourseId={courseId}>
+      <CourseBuilderShell />
+    </CourseBuilderProvider>
+  );
+}

--- a/client/src/components/course-builder/tabs/ContentEditorTab.jsx
+++ b/client/src/components/course-builder/tabs/ContentEditorTab.jsx
@@ -1,0 +1,475 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — tabs/ContentEditorTab.jsx
+// Phase 1: sections sidebar + block canvas with textarea editors.
+// Phase 2 will swap textareas for Tiptap and add dnd-kit.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useState } from "react";
+import { useCourseBuilder } from "../CourseBuilderContext.jsx";
+import { C, BLOCK_TYPE_CONFIG, BLOCK_TYPE_GROUPS, KC_BLOCK_TYPES } from "../constants.js";
+import { countSectionWords, countKCsInSection, countBlockWords } from "../utils.js";
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const S = {
+  layout:    { display: "grid", gridTemplateColumns: "240px 1fr", gap: 0, height: "100%", minHeight: 600 },
+  sidebar:   { background: C.stone, borderRight: `1px solid ${C.border}`, padding: 12, overflowY: "auto" },
+  canvas:    { padding: 24, overflowY: "auto", background: "#fff" },
+  sectionBtn: (active) => ({
+    width: "100%", textAlign: "left", padding: "10px 12px", borderRadius: 8,
+    border: "none", cursor: "pointer", marginBottom: 4,
+    background: active ? C.burgundy : "transparent",
+    color: active ? "#fff" : C.navy,
+    fontWeight: active ? 700 : 500,
+    fontSize: 13,
+  }),
+  sectionMeta: { fontSize: 11, opacity: 0.75, marginTop: 2 },
+  addSectionBtn: {
+    width: "100%", padding: "8px 12px", borderRadius: 8,
+    border: `2px dashed ${C.border}`, background: "transparent",
+    color: C.textMuted, fontSize: 13, cursor: "pointer", marginTop: 8,
+  },
+  blockCard: (editing) => ({
+    border: `1px solid ${editing ? C.burgundy : C.border}`,
+    borderLeft: `4px solid ${editing ? C.burgundy : C.border}`,
+    borderRadius: 10, marginBottom: 8, background: "#fff",
+    boxShadow: editing ? `0 0 0 2px ${C.burgundyFaded}` : "none",
+  }),
+  blockHeader: {
+    display: "flex", alignItems: "center", gap: 8,
+    padding: "10px 14px", cursor: "pointer",
+  },
+  blockIcon: (color) => ({
+    width: 28, height: 28, borderRadius: 6,
+    background: color + "20", display: "flex",
+    alignItems: "center", justifyContent: "center", fontSize: 14,
+    flexShrink: 0,
+  }),
+  blockTitle: { fontWeight: 600, fontSize: 13, flex: 1, color: C.navy },
+  blockMeta: { fontSize: 11, color: C.textMuted },
+  blockBody: { padding: "0 14px 14px" },
+  kcBadge: {
+    fontSize: 9, fontWeight: 700, color: C.burgundy,
+    background: C.burgundyFaded, padding: "2px 6px", borderRadius: 4,
+  },
+  actionBtn: (danger) => ({
+    background: "none", border: "none", cursor: "pointer",
+    color: danger ? C.danger : C.textMuted, fontSize: 13, padding: "2px 6px",
+    borderRadius: 4,
+  }),
+  label: { display: "block", fontSize: 12, fontWeight: 600, color: C.navy, marginBottom: 5, marginTop: 12, textTransform: "uppercase", letterSpacing: "0.04em" },
+  input: { width: "100%", padding: "8px 10px", borderRadius: 6, border: `1px solid ${C.border}`, fontSize: 13, color: C.navy, background: C.stone, boxSizing: "border-box" },
+  textarea: { width: "100%", padding: "8px 10px", borderRadius: 6, border: `1px solid ${C.border}`, fontSize: 13, color: C.navy, background: C.stone, resize: "vertical", boxSizing: "border-box" },
+  insertBar: {
+    display: "flex", alignItems: "center", justifyContent: "center",
+    padding: "4px 0", opacity: 0, transition: "opacity 0.15s",
+  },
+  insertBtn: {
+    background: C.hunterGreen, color: "#fff", border: "none",
+    borderRadius: 12, padding: "2px 12px", fontSize: 11, fontWeight: 600, cursor: "pointer",
+  },
+};
+
+// ─── Block picker ─────────────────────────────────────────────────────────────
+
+function BlockPicker({ onPick, onClose }) {
+  return (
+    <div style={{
+      border: `1px solid ${C.border}`, borderRadius: 10, background: "#fff",
+      padding: 12, marginBottom: 8, boxShadow: "0 4px 16px #0001",
+    }}>
+      {BLOCK_TYPE_GROUPS.map(group => (
+        <div key={group.label} style={{ marginBottom: 10 }}>
+          <div style={{ fontSize: 10, fontWeight: 700, color: C.textMuted, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 }}>
+            {group.label}
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {group.types.map(type => {
+              const cfg = BLOCK_TYPE_CONFIG[type];
+              return (
+                <button
+                  key={type}
+                  onClick={() => { onPick(type); onClose(); }}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 6,
+                    padding: "6px 12px", borderRadius: 6, border: `1px solid ${C.border}`,
+                    background: C.stone, cursor: "pointer", fontSize: 12, color: C.navy,
+                    fontWeight: 500,
+                  }}
+                >
+                  <span>{cfg.icon}</span>{cfg.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+      <div style={{ textAlign: "right", marginTop: 8 }}>
+        <button onClick={onClose} style={{ ...S.actionBtn(false), fontSize: 12 }}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Block editor (Phase 1: textarea-based) ───────────────────────────────────
+
+function BlockEditor({ block, onChange }) {
+  switch (block.type) {
+
+    case "sectionDivider":
+      return (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 80px 1fr", gap: 10 }}>
+          <div>
+            <label style={S.label}>Section Title</label>
+            <input style={S.input} value={block.title || ""} onChange={e => onChange({ title: e.target.value })} />
+          </div>
+          <div>
+            <label style={S.label}>Section #</label>
+            <input type="number" style={S.input} value={block.sectionNumber || 1} onChange={e => onChange({ sectionNumber: Number(e.target.value) })} />
+          </div>
+          <div>
+            <label style={S.label}>Subtitle</label>
+            <input style={S.input} value={block.subtitle || ""} onChange={e => onChange({ subtitle: e.target.value })} />
+          </div>
+        </div>
+      );
+
+    case "text":
+      return (
+        <>
+          <label style={S.label}>Heading (optional)</label>
+          <input style={S.input} value={block.heading || ""} onChange={e => onChange({ heading: e.target.value })} placeholder="Section heading..." />
+          <label style={S.label}>Content (HTML)</label>
+          <textarea style={{ ...S.textarea, minHeight: 180 }} value={block.content || ""} onChange={e => onChange({ content: e.target.value })} placeholder="<p>Enter content...</p>" />
+        </>
+      );
+
+    case "accordion":
+      return (
+        <>
+          <label style={S.label}>Accordion Title</label>
+          <input style={S.input} value={block.title || ""} onChange={e => onChange({ title: e.target.value })} />
+          {(block.items || []).map((item, i) => (
+            <div key={i} style={{ marginTop: 10, padding: 10, background: C.stone, borderRadius: 6, border: `1px solid ${C.borderLight}` }}>
+              <label style={S.label}>Item {i + 1} Title</label>
+              <input style={S.input} value={item.title || ""} onChange={e => {
+                const items = [...block.items];
+                items[i] = { ...items[i], title: e.target.value };
+                onChange({ items });
+              }} />
+              <label style={S.label}>Item {i + 1} Content (HTML)</label>
+              <textarea style={{ ...S.textarea, minHeight: 80 }} value={item.content || ""} onChange={e => {
+                const items = [...block.items];
+                items[i] = { ...items[i], content: e.target.value };
+                onChange({ items });
+              }} />
+              <button style={{ ...S.actionBtn(true), marginTop: 6, fontSize: 12 }} onClick={() => {
+                onChange({ items: block.items.filter((_, j) => j !== i) });
+              }}>Remove item</button>
+            </div>
+          ))}
+          <button style={{ marginTop: 10, padding: "6px 14px", borderRadius: 6, border: `1px dashed ${C.border}`, background: "transparent", color: C.hunterGreen, cursor: "pointer", fontSize: 12, fontWeight: 600 }}
+            onClick={() => onChange({ items: [...(block.items || []), { title: `Item ${(block.items || []).length + 1}`, content: "" }] })}>
+            + Add Item
+          </button>
+        </>
+      );
+
+    case "multipleChoice":
+    case "multiSelect": {
+      const isMulti = block.type === "multiSelect";
+      return (
+        <>
+          <label style={S.label}>Question</label>
+          <textarea style={{ ...S.textarea, minHeight: 60 }} value={block.question || ""} onChange={e => onChange({ question: e.target.value })} />
+          <label style={S.label}>Options</label>
+          {(block.options || ["", "", "", ""]).map((opt, i) => (
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+              <input
+                type={isMulti ? "checkbox" : "radio"}
+                checked={isMulti
+                  ? (block.correctAnswers || []).includes(i)
+                  : block.correctAnswer === i}
+                onChange={() => {
+                  if (isMulti) {
+                    const prev = block.correctAnswers || [];
+                    onChange({ correctAnswers: prev.includes(i) ? prev.filter(x => x !== i) : [...prev, i] });
+                  } else {
+                    onChange({ correctAnswer: i });
+                  }
+                }}
+                style={{ accentColor: C.burgundy, width: 16, height: 16, flexShrink: 0 }}
+              />
+              <input style={{ ...S.input, flex: 1 }} value={opt} placeholder={`Option ${i + 1}`}
+                onChange={e => {
+                  const options = [...(block.options || ["", "", "", ""])];
+                  options[i] = e.target.value;
+                  onChange({ options });
+                }}
+              />
+            </div>
+          ))}
+          <p style={{ fontSize: 11, color: C.textMuted, marginTop: 4 }}>
+            {isMulti ? "Check all correct answers." : "Select the correct answer (radio button)."}
+          </p>
+          <label style={S.label}>Explanation / Rationale</label>
+          <textarea style={{ ...S.textarea, minHeight: 60 }} value={block.explanation || ""} onChange={e => onChange({ explanation: e.target.value })} placeholder="Explain why this answer is correct..." />
+        </>
+      );
+    }
+
+    case "reflection":
+      return (
+        <>
+          <label style={S.label}>Reflection Prompt</label>
+          <textarea style={{ ...S.textarea, minHeight: 80 }} value={block.prompt || ""} onChange={e => onChange({ prompt: e.target.value })} />
+          <label style={S.label}>Minimum Words Required</label>
+          <input type="number" style={{ ...S.input, width: 100 }} value={block.minWords || 50} onChange={e => onChange({ minWords: Number(e.target.value) })} />
+        </>
+      );
+
+    case "matching":
+      return (
+        <>
+          <label style={S.label}>Instructions</label>
+          <input style={S.input} value={block.instructions || ""} onChange={e => onChange({ instructions: e.target.value })} />
+          {(block.pairs || []).map((pair, i) => (
+            <div key={i} style={{ display: "grid", gridTemplateColumns: "1fr 1fr auto", gap: 8, marginTop: 8, alignItems: "center" }}>
+              <input style={S.input} value={pair.term || ""} placeholder="Term" onChange={e => {
+                const pairs = [...block.pairs];
+                pairs[i] = { ...pairs[i], term: e.target.value };
+                onChange({ pairs });
+              }} />
+              <input style={S.input} value={pair.definition || ""} placeholder="Definition" onChange={e => {
+                const pairs = [...block.pairs];
+                pairs[i] = { ...pairs[i], definition: e.target.value };
+                onChange({ pairs });
+              }} />
+              <button style={S.actionBtn(true)} onClick={() => onChange({ pairs: block.pairs.filter((_, j) => j !== i) })}>×</button>
+            </div>
+          ))}
+          <button style={{ marginTop: 10, padding: "6px 14px", borderRadius: 6, border: `1px dashed ${C.border}`, background: "transparent", color: C.hunterGreen, cursor: "pointer", fontSize: 12, fontWeight: 600 }}
+            onClick={() => onChange({ pairs: [...(block.pairs || []), { term: "", definition: "" }] })}>
+            + Add Pair
+          </button>
+        </>
+      );
+
+    case "image":
+      return (
+        <>
+          <label style={S.label}>Image URL (Cloudinary)</label>
+          <input style={S.input} value={block.url || ""} onChange={e => onChange({ url: e.target.value })} placeholder="https://res.cloudinary.com/dzfscjhdx/..." />
+          <label style={S.label}>Alt Text</label>
+          <input style={S.input} value={block.alt || ""} onChange={e => onChange({ alt: e.target.value })} />
+          <label style={S.label}>Caption</label>
+          <input style={S.input} value={block.caption || ""} onChange={e => onChange({ caption: e.target.value })} />
+        </>
+      );
+
+    case "resources":
+      return (
+        <>
+          <label style={S.label}>Section Title</label>
+          <input style={S.input} value={block.title || ""} onChange={e => onChange({ title: e.target.value })} />
+          {(block.links || []).map((link, i) => (
+            <div key={i} style={{ display: "grid", gridTemplateColumns: "1fr 1fr auto", gap: 8, marginTop: 8, alignItems: "center" }}>
+              <input style={S.input} value={link.label || ""} placeholder="Label" onChange={e => {
+                const links = [...block.links];
+                links[i] = { ...links[i], label: e.target.value };
+                onChange({ links });
+              }} />
+              <input style={S.input} value={link.url || ""} placeholder="https://..." onChange={e => {
+                const links = [...block.links];
+                links[i] = { ...links[i], url: e.target.value };
+                onChange({ links });
+              }} />
+              <button style={S.actionBtn(true)} onClick={() => onChange({ links: block.links.filter((_, j) => j !== i) })}>×</button>
+            </div>
+          ))}
+          <button style={{ marginTop: 10, padding: "6px 14px", borderRadius: 6, border: `1px dashed ${C.border}`, background: "transparent", color: C.hunterGreen, cursor: "pointer", fontSize: 12, fontWeight: 600 }}
+            onClick={() => onChange({ links: [...(block.links || []), { label: "", url: "" }] })}>
+            + Add Link
+          </button>
+        </>
+      );
+
+    default:
+      return (
+        <p style={{ color: C.textMuted, fontSize: 13, fontStyle: "italic" }}>
+          Editor for <strong>{block.type}</strong> will be added in Phase 2.{" "}
+          Block data is preserved — only the visual editor is pending.
+        </p>
+      );
+  }
+}
+
+// ─── Main tab ─────────────────────────────────────────────────────────────────
+
+export default function ContentEditorTab() {
+  const {
+    state,
+    addSection, removeSection, setSectionTitle,
+    addBlock, updateBlock, removeBlock, duplicateBlock,
+  } = useCourseBuilder();
+
+  const [activeSectionIndex, setActiveSectionIndex] = useState(0);
+  const [editingBlockIndex, setEditingBlockIndex]   = useState(null);
+  const [showBlockMenu, setShowBlockMenu]           = useState(null); // afterBlockIndex | "top"
+
+  const sections       = state.sections || [];
+  const activeSection  = sections[activeSectionIndex];
+
+  // If no sections, prompt to create one
+  if (sections.length === 0) {
+    return (
+      <div style={{ textAlign: "center", padding: 80, color: C.textMuted }}>
+        <div style={{ fontSize: 40, marginBottom: 12 }}>📋</div>
+        <p style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>No sections yet</p>
+        <p style={{ fontSize: 14, marginBottom: 24 }}>Add your first section to start building content.</p>
+        <button
+          onClick={() => addSection("Section 1")}
+          style={{ padding: "10px 24px", borderRadius: 8, border: "none", background: C.hunterGreen, color: "#fff", fontWeight: 700, fontSize: 14, cursor: "pointer" }}
+        >
+          + Add First Section
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={S.layout}>
+
+      {/* ── Sidebar ── */}
+      <div style={S.sidebar}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: C.textMuted, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 8 }}>
+          Sections
+        </div>
+        {sections.map((section, si) => {
+          const wc  = countSectionWords(section);
+          const kcs = countKCsInSection(section);
+          return (
+            <button
+              key={section._tempId || si}
+              style={S.sectionBtn(si === activeSectionIndex)}
+              onClick={() => { setActiveSectionIndex(si); setEditingBlockIndex(null); }}
+            >
+              <div>{section.title || `Section ${si + 1}`}</div>
+              <div style={S.sectionMeta}>{wc.toLocaleString()}w · {kcs} KC{kcs !== 1 ? "s" : ""} · {section.contentBlocks?.length || 0} blocks</div>
+            </button>
+          );
+        })}
+        <button style={S.addSectionBtn} onClick={() => {
+          addSection(`Section ${sections.length + 1}`);
+          setActiveSectionIndex(sections.length);
+        }}>
+          + Add Section
+        </button>
+      </div>
+
+      {/* ── Canvas ── */}
+      <div style={S.canvas}>
+        {activeSection && (
+          <>
+            {/* Section header */}
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 20 }}>
+              <input
+                style={{ ...S.input, flex: 1, fontSize: 18, fontWeight: 700, color: C.navy, background: "transparent", border: "none", borderBottom: `2px solid ${C.border}`, borderRadius: 0, padding: "6px 0" }}
+                value={activeSection.title || ""}
+                onChange={e => setSectionTitle(activeSectionIndex, e.target.value)}
+                placeholder="Section title..."
+              />
+              <span style={{ fontSize: 12, color: C.textMuted, whiteSpace: "nowrap" }}>
+                {countSectionWords(activeSection).toLocaleString()} words
+              </span>
+              {sections.length > 1 && (
+                <button style={S.actionBtn(true)} title="Delete section"
+                  onClick={() => {
+                    if (!confirm("Delete this section and all its blocks?")) return;
+                    removeSection(activeSectionIndex);
+                    setActiveSectionIndex(Math.max(0, activeSectionIndex - 1));
+                  }}>
+                  🗑
+                </button>
+              )}
+            </div>
+
+            {/* Top insert bar */}
+            <div
+              style={{ ...S.insertBar, opacity: 1, marginBottom: 8 }}
+              onMouseEnter={e => e.currentTarget.style.opacity = 1}
+            >
+              <button
+                style={S.insertBtn}
+                onClick={() => setShowBlockMenu(showBlockMenu === "top" ? null : "top")}
+              >
+                + Add Block
+              </button>
+            </div>
+            {showBlockMenu === "top" && (
+              <BlockPicker
+                onPick={type => { addBlock(activeSectionIndex, type, -1); setShowBlockMenu(null); }}
+                onClose={() => setShowBlockMenu(null)}
+              />
+            )}
+
+            {/* Block list */}
+            {(activeSection.contentBlocks || []).map((block, bi) => {
+              const cfg      = BLOCK_TYPE_CONFIG[block.type] || { label: block.type, icon: "📦", color: C.textMuted };
+              const isEditing = editingBlockIndex === bi;
+              const isKC     = KC_BLOCK_TYPES.has(block.type);
+
+              return (
+                <div key={block._tempId || bi}>
+                  <div style={S.blockCard(isEditing)}>
+                    {/* Header */}
+                    <div style={S.blockHeader} onClick={() => setEditingBlockIndex(isEditing ? null : bi)}>
+                      <span style={S.blockIcon(cfg.color)}>{cfg.icon}</span>
+                      <span style={S.blockTitle}>{cfg.label}</span>
+                      {isKC && <span style={S.kcBadge}>KC</span>}
+                      <span style={S.blockMeta}>{countBlockWords(block)}w</span>
+                      <button style={S.actionBtn(false)} title="Duplicate" onClick={e => { e.stopPropagation(); duplicateBlock(activeSectionIndex, bi); }}>⧉</button>
+                      <button style={S.actionBtn(true)} title="Delete" onClick={e => { e.stopPropagation(); removeBlock(activeSectionIndex, bi); }}>✕</button>
+                    </div>
+                    {/* Body */}
+                    {isEditing && (
+                      <div style={S.blockBody}>
+                        <BlockEditor
+                          block={block}
+                          onChange={updates => updateBlock(activeSectionIndex, bi, updates)}
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Insert bar between blocks */}
+                  <div style={{ ...S.insertBar, marginBottom: 4 }}
+                    onMouseEnter={e => e.currentTarget.style.opacity = 1}
+                    onMouseLeave={e => e.currentTarget.style.opacity = 0}
+                  >
+                    <button style={S.insertBtn} onClick={() => setShowBlockMenu(showBlockMenu === bi ? null : bi)}>+ Insert</button>
+                  </div>
+                  {showBlockMenu === bi && (
+                    <BlockPicker
+                      onPick={type => { addBlock(activeSectionIndex, type, bi); setShowBlockMenu(null); }}
+                      onClose={() => setShowBlockMenu(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Empty state */}
+            {(activeSection.contentBlocks || []).length === 0 && (
+              <div style={{ textAlign: "center", padding: 60, color: C.textMuted, border: `2px dashed ${C.border}`, borderRadius: 12 }}>
+                <div style={{ fontSize: 32, marginBottom: 8 }}>📝</div>
+                <p style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>No content blocks yet</p>
+                <p style={{ fontSize: 12 }}>Use "+ Add Block" above to start building this section.</p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/course-builder/tabs/MetadataTab.jsx
+++ b/client/src/components/course-builder/tabs/MetadataTab.jsx
@@ -1,0 +1,293 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — tabs/MetadataTab.jsx
+// Course Info tab: metadata, objectives, target audience, pricing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useState } from "react";
+import { useCourseBuilder } from "../CourseBuilderContext.jsx";
+import { C } from "../constants.js";
+import { slugify } from "../utils.js";
+
+const S = {
+  section: {
+    background: "#fff",
+    border: `1px solid ${C.border}`,
+    borderRadius: 10,
+    padding: 24,
+    marginBottom: 20,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: 700,
+    color: C.navy,
+    marginBottom: 16,
+    paddingBottom: 10,
+    borderBottom: `1px solid ${C.borderLight}`,
+  },
+  row: { display: "grid", gap: 16, marginBottom: 16 },
+  row2: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 16 },
+  row3: { display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 16, marginBottom: 16 },
+  label: { display: "block", fontSize: 12, fontWeight: 600, color: C.navy, marginBottom: 5, textTransform: "uppercase", letterSpacing: "0.04em" },
+  input: {
+    width: "100%", padding: "9px 12px", borderRadius: 7,
+    border: `1px solid ${C.border}`, fontSize: 14, color: C.navy,
+    background: C.stone, outline: "none", boxSizing: "border-box",
+  },
+  textarea: {
+    width: "100%", padding: "9px 12px", borderRadius: 7,
+    border: `1px solid ${C.border}`, fontSize: 14, color: C.navy,
+    background: C.stone, outline: "none", resize: "vertical", boxSizing: "border-box",
+  },
+  select: {
+    width: "100%", padding: "9px 12px", borderRadius: 7,
+    border: `1px solid ${C.border}`, fontSize: 14, color: C.navy,
+    background: C.stone, outline: "none", cursor: "pointer", boxSizing: "border-box",
+  },
+  tag: {
+    display: "inline-flex", alignItems: "center", gap: 6,
+    background: C.burgundyFaded, color: C.burgundy,
+    borderRadius: 20, padding: "4px 12px", fontSize: 13, fontWeight: 500,
+  },
+  tagRemove: {
+    background: "none", border: "none", cursor: "pointer",
+    color: C.burgundy, fontSize: 14, lineHeight: 1, padding: 0,
+  },
+  addRow: { display: "flex", gap: 8, marginTop: 8 },
+  addInput: {
+    flex: 1, padding: "8px 12px", borderRadius: 7,
+    border: `1px solid ${C.border}`, fontSize: 14, color: C.navy,
+    background: C.stone, outline: "none",
+  },
+  addBtn: {
+    padding: "8px 16px", borderRadius: 7, border: "none",
+    background: C.hunterGreen, color: "#fff", fontSize: 13,
+    fontWeight: 600, cursor: "pointer",
+  },
+  hint: { fontSize: 11, color: C.textMuted, marginTop: 4 },
+};
+
+function TagList({ items, onRemove }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6, minHeight: 30 }}>
+      {items.map((item, i) => (
+        <span key={i} style={S.tag}>
+          {item}
+          <button style={S.tagRemove} onClick={() => onRemove(i)} aria-label={`Remove ${item}`}>×</button>
+        </span>
+      ))}
+      {items.length === 0 && <span style={{ fontSize: 13, color: C.textMuted }}>None added yet.</span>}
+    </div>
+  );
+}
+
+function AddItemRow({ placeholder, onAdd }) {
+  const [value, setValue] = useState("");
+  function submit() {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setValue("");
+  }
+  return (
+    <div style={S.addRow}>
+      <input
+        style={S.addInput}
+        value={value}
+        placeholder={placeholder}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); submit(); }}}
+      />
+      <button style={S.addBtn} onClick={submit}>+ Add</button>
+    </div>
+  );
+}
+
+export default function MetadataTab() {
+  const {
+    state,
+    setMeta,
+    addObjective, removeObjective,
+    addAudience,  removeAudience,
+  } = useCourseBuilder();
+
+  function field(name) {
+    return {
+      value: state[name] ?? "",
+      onChange: e => setMeta(name, e.target.value),
+    };
+  }
+
+  function numField(name) {
+    return {
+      value: state[name] ?? "",
+      onChange: e => setMeta(name, Number(e.target.value)),
+    };
+  }
+
+  const targetWordCount = (state.ceHours || 0) * 6000;
+
+  return (
+    <div style={{ maxWidth: 820, margin: "0 auto" }}>
+
+      {/* ── Basic Info ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>Course Information</div>
+
+        <div style={S.row}>
+          <div>
+            <label style={S.label}>Course Title *</label>
+            <input style={S.input} {...field("title")} placeholder="e.g. Cultural Competence in Clinical Practice" />
+          </div>
+        </div>
+
+        <div style={S.row2}>
+          <div>
+            <label style={S.label}>Course Code</label>
+            <input style={S.input} {...field("courseCode")} placeholder="e.g. CR-301" />
+          </div>
+          <div>
+            <label style={S.label}>URL Slug</label>
+            <input
+              style={S.input}
+              value={state.slug || slugify(state.title)}
+              onChange={e => setMeta("slug", e.target.value)}
+              placeholder="auto-generated"
+            />
+            <p style={S.hint}>counselorready.com/learn/{state.slug || slugify(state.title)}</p>
+          </div>
+        </div>
+
+        <div style={S.row}>
+          <div>
+            <label style={S.label}>Description *</label>
+            <textarea
+              style={{ ...S.textarea, minHeight: 100 }}
+              {...field("description")}
+              placeholder="Describe what learners will gain from this course..."
+            />
+          </div>
+        </div>
+
+        <div style={S.row3}>
+          <div>
+            <label style={S.label}>CE Hours *</label>
+            <input type="number" step="0.5" min="1" max="12" style={S.input} {...numField("ceHours")} />
+            <p style={S.hint}>Target: {targetWordCount.toLocaleString()} words</p>
+          </div>
+          <div>
+            <label style={S.label}>CE Category</label>
+            <select style={S.select} {...field("ceCategory")}>
+              <option value="General">General</option>
+              <option value="Ethics">Ethics</option>
+              <option value="Cultural">Cultural Competency</option>
+              <option value="Clinical">Clinical Practice</option>
+              <option value="Supervision">Supervision</option>
+            </select>
+          </div>
+          <div>
+            <label style={S.label}>Level</label>
+            <select style={S.select} {...field("level")}>
+              <option value="Beginner">Beginner</option>
+              <option value="Intermediate">Intermediate</option>
+              <option value="Advanced">Advanced</option>
+            </select>
+          </div>
+        </div>
+
+        <div style={S.row2}>
+          <div>
+            <label style={S.label}>Category</label>
+            <select style={S.select} {...field("category")}>
+              <option>Clinical Practice</option>
+              <option>Ethics</option>
+              <option>Cultural Competency</option>
+              <option>Assessment</option>
+              <option>Career Development</option>
+              <option>Group Counseling</option>
+              <option>Telehealth</option>
+              <option>Trauma</option>
+              <option>Addictions</option>
+              <option>Crisis Intervention</option>
+            </select>
+          </div>
+          <div>
+            <label style={S.label}>Delivery Method</label>
+            <input style={{ ...S.input, background: "#f0ede8", cursor: "default" }} value="Online Self-Study" readOnly />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Objectives ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>Learning Objectives</div>
+        <TagList items={state.objectives || []} onRemove={removeObjective} />
+        <AddItemRow
+          placeholder="Upon completion, participants will be able to..."
+          onAdd={addObjective}
+        />
+        <p style={S.hint}>Add 3–5 measurable objectives. Press Enter or click + Add.</p>
+      </div>
+
+      {/* ── Target Audience ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>Target Audience</div>
+        <TagList items={state.targetAudience || []} onRemove={removeAudience} />
+        <AddItemRow
+          placeholder="e.g. Licensed Professional Counselors (LPCs)"
+          onAdd={addAudience}
+        />
+        <p style={S.hint}>List each license type or credential that this course applies to.</p>
+      </div>
+
+      {/* ── Pricing ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>Pricing & Access</div>
+        <div style={S.row3}>
+          <div>
+            <label style={S.label}>Access Type</label>
+            <select style={S.select} {...field("accessType")}>
+              <option value="free">Free</option>
+              <option value="paid">Paid</option>
+              <option value="subscription">Subscription</option>
+            </select>
+          </div>
+          <div>
+            <label style={S.label}>Price ($)</label>
+            <input
+              type="number" min="0" step="0.01" style={S.input}
+              {...numField("price")}
+              disabled={state.accessType === "free"}
+            />
+          </div>
+          <div>
+            <label style={S.label}>Pricing Tier</label>
+            <select style={S.select} {...field("pricingTier")}>
+              <option value="free">Free</option>
+              <option value="standard">Standard</option>
+              <option value="premium">Premium</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* ── ACEP Provider (read-only) ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>ACEP Provider Info</div>
+        <div style={S.row2}>
+          <div>
+            <label style={S.label}>Provider</label>
+            <input style={{ ...S.input, background: "#f0ede8", cursor: "default" }}
+              value={state.instructor || "GA Integrated Therapeutic Perspectives LLC"} readOnly />
+          </div>
+          <div>
+            <label style={S.label}>ACEP Number</label>
+            <input style={{ ...S.input, background: "#f0ede8", cursor: "default" }}
+              value="NBCC ACEP Provider #7760" readOnly />
+          </div>
+        </div>
+        <p style={S.hint}>Provider info is set at the platform level and cannot be changed per course.</p>
+      </div>
+
+    </div>
+  );
+}

--- a/client/src/components/course-builder/utils.js
+++ b/client/src/components/course-builder/utils.js
@@ -1,0 +1,220 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — utils.js
+// Pure utility functions. No imports from the codebase.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { KC_BLOCK_TYPES } from "./constants.js";
+
+// ─── ID generation ───────────────────────────────────────────────────────────
+
+/** Client-side temp ID for React keys. Stripped before saving to DB. */
+export function uid() {
+  return `_t${Math.random().toString(36).slice(2, 9)}`;
+}
+
+// ─── Slug ────────────────────────────────────────────────────────────────────
+
+export function slugify(title) {
+  return (title || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "untitled-course";
+}
+
+// ─── Word counting ───────────────────────────────────────────────────────────
+
+/** Strip HTML tags and count words in a string. */
+export function countWords(str) {
+  if (!str) return 0;
+  return str
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&[a-z]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+    .length;
+}
+
+/**
+ * Count learner-visible words in a single content block.
+ * Only counts prose that a learner reads — not labels, metadata, or structural fields.
+ */
+export function countBlockWords(block) {
+  if (!block) return 0;
+
+  switch (block.type) {
+    case "text":
+      return countWords(block.content) + countWords(block.heading);
+
+    case "accordion":
+      return (block.items || []).reduce(
+        (sum, item) => sum + countWords(item.title) + countWords(item.content),
+        0
+      );
+
+    case "imageText":
+      return countWords(block.content) + countWords(block.imageCaption);
+
+    case "image":
+      return countWords(block.caption);
+
+    case "multipleChoice":
+    case "multiSelect":
+      return (
+        countWords(block.question) +
+        (block.options || []).reduce((s, o) => s + countWords(o), 0) +
+        countWords(block.explanation)
+      );
+
+    case "matching":
+      return (block.pairs || []).reduce(
+        (sum, p) => sum + countWords(p.term) + countWords(p.definition),
+        0
+      );
+
+    case "reflection":
+      return countWords(block.prompt);
+
+    case "flashcardDeck":
+      return (block.cards || []).reduce(
+        (sum, c) => sum + countWords(c.front) + countWords(c.back),
+        0
+      );
+
+    case "cardSort":
+      return (
+        countWords(block.instructions) +
+        (block.cards || []).reduce((sum, c) => sum + countWords(c.text), 0)
+      );
+
+    case "sequencing":
+      return (
+        countWords(block.instructions) +
+        (block.steps || []).reduce((sum, s) => sum + countWords(s.text), 0)
+      );
+
+    case "scenarioTree":
+      return (block.nodes || []).reduce(
+        (sum, n) =>
+          sum +
+          countWords(n.text) +
+          (n.choices || []).reduce((s, c) => s + countWords(c.label) + countWords(c.feedback), 0),
+        0
+      );
+
+    case "hotspot":
+      return (block.pins || []).reduce(
+        (sum, p) => sum + countWords(p.title) + countWords(p.content),
+        0
+      );
+
+    case "timeline":
+      return (block.events || []).reduce(
+        (sum, e) => sum + countWords(e.title) + countWords(e.description),
+        0
+      );
+
+    case "videoEmbed":
+      return countWords(block.title) + countWords(block.description);
+
+    case "resources":
+      return (block.links || []).reduce((sum, l) => sum + countWords(l.label), 0);
+
+    case "sectionDivider":
+      return 0; // structural, not counted
+
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Count total words across all content blocks in a section.
+ */
+export function countSectionWords(section) {
+  return (section.contentBlocks || []).reduce(
+    (sum, block) => sum + countBlockWords(block),
+    0
+  );
+}
+
+/**
+ * Count total words across the entire course.
+ */
+export function countCourseWords(sections) {
+  return (sections || []).reduce(
+    (sum, section) => sum + countSectionWords(section),
+    0
+  );
+}
+
+// ─── KC counting ─────────────────────────────────────────────────────────────
+
+/** Count knowledge check blocks in a section. */
+export function countKCsInSection(section) {
+  return (section.contentBlocks || []).filter(b => KC_BLOCK_TYPES.has(b.type)).length;
+}
+
+// ─── Strip temp IDs before save ──────────────────────────────────────────────
+
+/**
+ * Recursively remove all _tempId fields from a course payload.
+ * Called by courseBuilderApi.js before POSTing to the backend.
+ */
+export function stripTempIds(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(stripTempIds);
+  }
+  if (obj && typeof obj === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(obj)) {
+      if (key === "_tempId") continue;
+      out[key] = stripTempIds(val);
+    }
+    return out;
+  }
+  return obj;
+}
+
+// ─── Build save payload ──────────────────────────────────────────────────────
+
+/**
+ * Transform builder state into a clean MongoDB document.
+ * - Strips _tempId fields
+ * - Computes wordCount
+ * - Sets ceuHours = ceHours
+ * - Ensures correct collection fields
+ */
+export function buildSavePayload(state, publish = false) {
+  const payload = stripTempIds({ ...state });
+
+  // Ensure canonical fields
+  payload.status      = publish ? "published" : "draft";
+  payload.isPublished = publish;
+  payload.slug        = state.slug || slugify(state.title);
+  payload.ceuHours    = state.ceHours;
+  payload.ceuEligible = true;
+  payload.deliveryMethod = "online";
+
+  // Hardcoded ACEP provider
+  payload.instructor    = "GA Integrated Therapeutic Perspectives LLC";
+  payload.approvingBody = "NBCC";
+  payload.approvalNumber = "#7760";
+
+  // Compute word count from sections
+  payload.wordCount = countCourseWords(state.sections);
+
+  // Normalize section block order fields
+  payload.sections = (state.sections || []).map((section, si) => ({
+    ...section,
+    order: si + 1,
+    contentBlocks: (section.contentBlocks || []).map((block, bi) => ({
+      ...block,
+      order: bi + 1,
+    })),
+  }));
+
+  return payload;
+}


### PR DESCRIPTION
## Summary
Replaces the legacy CourseBuilder component with a new modular architecture featuring a React Context-based state management system, a pure reducer pattern, and two fully functional tabs: Course Info (metadata) and Content Editor (sections & blocks). This is Phase 1 of a multi-phase rebuild; Phase 2 will add rich text editing (Tiptap) and drag-and-drop (dnd-kit).

## Key Changes

### Architecture & State Management
- **CourseBuilderContext.jsx**: New React Context provider wrapping a reducer-based state machine. Handles autosave (3s debounce), dirty state tracking, keyboard shortcuts (Cmd/Ctrl+S), and beforeunload warnings.
- **courseBuilderReducer.js**: Pure reducer with 30+ action types covering metadata, sections, blocks, assessment, and references. Includes helpers for array manipulation and block/section creation.
- **courseBuilderApi.js**: Centralized HTTP layer for save, publish, and load operations. Strips temporary IDs before sending to backend.

### UI Components
- **MetadataTab.jsx**: Course information editor with fields for title, description, CE hours, category, pricing, objectives, and target audience. Includes word count targets and slug auto-generation.
- **ContentEditorTab.jsx**: Section sidebar + block canvas layout. Features:
  - Sections sidebar with word/KC counts per section
  - Block cards with inline textarea editors (Phase 1; Tiptap in Phase 2)
  - BlockPicker UI for inserting 17 block types across 6 categories
  - Support for complex blocks (accordion, multiple choice, multi-select, matching, etc.)
  - Block duplication and removal
  - Insert bars between blocks (placeholder for dnd-kit in Phase 2)

### Constants & Utilities
- **constants.js**: Single source of truth for 17 block types, defaults, ACEP rules, and brand color palette.
- **utils.js**: Pure utilities for ID generation, slug creation, word counting (with HTML stripping), KC counting, and payload serialization.

### Integration
- **index.jsx**: Main export wrapping the provider. Renders tab bar, save badge, word count progress bar, and publish button. Handles loading/error states.
- **App.jsx**: Updated import to use new CourseBuilder from `./components/course-builder/index.jsx`.

## Notable Implementation Details
- **Autosave**: Debounced to 3 seconds after last change; only triggers for existing courses (not new drafts).
- **Word Counting**: Learner-visible prose only; strips HTML, ignores metadata fields, counts per-block type (e.g., accordion items, KC options).
- **Block Schema**: Uses `options: [String]` and `correctAnswer: Number` (0-based index) for consistency; never `{text, isCorrect}` format.
- **Temp IDs**: Client-side `_tempId` fields for React keys; stripped before API calls via `stripTempIds()`.
- **Dirty State**: Tracked via ref comparison; triggers beforeunload warning and disables autosave for new courses.
- **ACEP Compliance**: Hardcoded instructor/approval body per platform spec; word count targets based on CE hours (6000 words/hour).

https://claude.ai/code/session_012eKrNGZH3Rxx6mDFkvJTfG