### PR TITLE
Fix model import in courseBuilder.js save endpoint

### DIFF
--- a/server/src/routes/courseBuilder.js
+++ b/server/src/routes/courseBuilder.js
@@ -680,7 +680,7 @@ function slugify(title) {
 router.post('/save', protect, adminOnly, async (req, res) => {
   try {
     const courseData = req.body;
-    const InteractiveCourse = (await import('../models/InteractiveCourse.js')).default;
+    const { Course: InteractiveCourse } = await import('../models/InteractiveCourse.js');
 
     // Clean transient fields
     delete courseData._wordCount;


### PR DESCRIPTION
The dynamic import pulled .default which returns { Course, CourseProgress, ContentInteraction } (a plain object), not the Mongoose model. Destructure the named export instead.

https://claude.ai/code/session_012eKrNGZH3Rxx6mDFkvJTfG