### PR TITLE
Fix accessType to match InteractiveCourse enum: free | subscription |…

### DIFF
--- a/client/src/components/course-builder/courseBuilderReducer.js
+++ b/client/src/components/course-builder/courseBuilderReducer.js
@@ -18,7 +18,7 @@ export const INITIAL_STATE = {
   ceCategory: "General",
   level: "Intermediate",
   category: "Clinical Practice",
-  accessType: "paid",
+  accessType: "subscription",
   price: 0,
   pricingTier: "standard",
   status: "draft",

--- a/client/src/components/course-builder/tabs/MetadataTab.jsx
+++ b/client/src/components/course-builder/tabs/MetadataTab.jsx
@@ -247,8 +247,8 @@ export default function MetadataTab() {
             <label style={S.label}>Access Type</label>
             <select style={S.select} {...field("accessType")}>
               <option value="free">Free</option>
-              <option value="paid">Paid</option>
               <option value="subscription">Subscription</option>
+              <option value="purchase">Purchase</option>
             </select>
           </div>
           <div>


### PR DESCRIPTION
… purchase

- courseBuilderReducer.js: INITIAL_STATE "paid" → "subscription"
- MetadataTab.jsx: replace "paid" option with "purchase"

https://claude.ai/code/session_012eKrNGZH3Rxx6mDFkvJTfG