### PR TITLE
Change default course access type from paid to subscription

### DIFF
--- a/client/src/components/course-builder/courseBuilderReducer.js
+++ b/client/src/components/course-builder/courseBuilderReducer.js
@@ -18,7 +18,7 @@ export const INITIAL_STATE = {
   ceCategory: "General",
   level: "Intermediate",
   category: "Clinical Practice",
-  accessType: "paid",
+  accessType: "subscription",
   price: 0,
   pricingTier: "standard",
   status: "draft",


### PR DESCRIPTION
## Summary
Updated the default access type for new courses in the course builder from "paid" to "subscription".

## Changes
- Modified the `INITIAL_STATE` in `courseBuilderReducer.js` to set `accessType` default value to "subscription" instead of "paid"

## Details
This change affects the initial state of newly created courses, ensuring they default to a subscription-based access model rather than a one-time paid model. This aligns with the platform's preferred monetization strategy for courses.

https://claude.ai/code/session_01BtYD4ckVhfEUiCLm4E3a9S