### PR TITLE
Phase 3: Wire Assessment, References, ACEP tabs into production index…

### DIFF
--- a/client/src/components/course-builder/courseBuilderReducer.js
+++ b/client/src/components/course-builder/courseBuilderReducer.js
@@ -88,6 +88,11 @@ export const A = {
   ADD_REFERENCE:        "ADD_REFERENCE",
   UPDATE_REFERENCE:     "UPDATE_REFERENCE",
   REMOVE_REFERENCE:     "REMOVE_REFERENCE",
+  MOVE_REFERENCE:       "MOVE_REFERENCE",
+
+  // Field-level (used by Phase 3 tabs)
+  SET_FIELD:            "SET_FIELD",
+  UPDATE_OBJECTIVE:     "UPDATE_OBJECTIVE",
 
   // Lifecycle
   LOAD_COURSE:          "LOAD_COURSE",
@@ -329,9 +334,10 @@ export function courseBuilderReducer(state, action) {
     // ── Assessment ────────────────────────────────────────────────────────────
 
     case A.ADD_ASSESSMENT_Q: {
+      const id = uid();
       const q = action.question
-        ? { ...action.question, _tempId: uid() }
-        : newAssessmentQuestion();
+        ? { ...action.question, _tempId: id, id }
+        : { ...newAssessmentQuestion(), id };
       return {
         ...state,
         assessment: {
@@ -342,12 +348,14 @@ export function courseBuilderReducer(state, action) {
     }
 
     case A.UPDATE_ASSESSMENT_Q: {
+      const updates = action.updates || action.changes;
       return {
         ...state,
         assessment: {
           ...state.assessment,
           questions: state.assessment.questions.map((q, i) =>
-            i === action.qIndex ? { ...q, ...action.updates } : q
+            (action.id ? (q._tempId === action.id || q.id === action.id) : i === action.qIndex)
+              ? { ...q, ...updates } : q
           ),
         },
       };
@@ -358,7 +366,9 @@ export function courseBuilderReducer(state, action) {
         ...state,
         assessment: {
           ...state.assessment,
-          questions: state.assessment.questions.filter((_, i) => i !== action.qIndex),
+          questions: state.assessment.questions.filter((q, i) =>
+            action.id ? (q._tempId !== action.id && q.id !== action.id) : i !== action.qIndex
+          ),
         },
       };
     }
@@ -378,18 +388,20 @@ export function courseBuilderReducer(state, action) {
     case A.SET_ASSESSMENT_META: {
       return {
         ...state,
-        assessment: { ...state.assessment, ...action.updates },
+        assessment: { ...state.assessment, ...(action.updates || action.changes) },
       };
     }
 
     // ── References ────────────────────────────────────────────────────────────
 
     case A.ADD_REFERENCE: {
+      const id = uid();
       const ref = {
-        _tempId: uid(),
+        _tempId: id,
+        id,
         title: "",
         author: "",
-        year: new Date().getFullYear(),
+        year: String(new Date().getFullYear()),
         source: "",
         ...(action.reference || {}),
       };
@@ -397,10 +409,12 @@ export function courseBuilderReducer(state, action) {
     }
 
     case A.UPDATE_REFERENCE: {
+      const updates = action.updates || action.changes;
       return {
         ...state,
         references: state.references.map((r, i) =>
-          i === action.refIndex ? { ...r, ...action.updates } : r
+          (action.id ? (r._tempId === action.id || r.id === action.id) : i === action.refIndex)
+            ? { ...r, ...updates } : r
         ),
       };
     }
@@ -408,8 +422,30 @@ export function courseBuilderReducer(state, action) {
     case A.REMOVE_REFERENCE: {
       return {
         ...state,
-        references: state.references.filter((_, i) => i !== action.refIndex),
+        references: state.references.filter((r, i) =>
+          action.id ? (r._tempId !== action.id && r.id !== action.id) : i !== action.refIndex
+        ),
       };
+    }
+
+    case A.MOVE_REFERENCE: {
+      const { from, to } = action;
+      if (from === to) return state;
+      const refs = [...state.references];
+      const [moved] = refs.splice(from, 1);
+      refs.splice(to, 0, moved);
+      return { ...state, references: refs };
+    }
+
+    // ── Field-level (Phase 3 tab compat) ─────────────────────────────────────
+
+    case A.SET_FIELD:
+      return { ...state, [action.field]: action.value };
+
+    case A.UPDATE_OBJECTIVE: {
+      const objs = [...state.objectives];
+      objs[action.index] = action.text;
+      return { ...state, objectives: objs };
     }
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/client/src/components/course-builder/index.jsx
+++ b/client/src/components/course-builder/index.jsx
@@ -1,696 +1,269 @@
-// ─── CourseBuilder index.jsx ─────────────────────────────────────────────
-// DROP INTO: /client/src/components/CourseBuilder/index.jsx
+// ─────────────────────────────────────────────────────────────────────────────
+// CounselorReady CourseBuilder — index.jsx
+// Main export. Wraps provider, renders tab bar and active tab.
+// App.jsx imports from this file — NOT from the old CourseBuilder.jsx.
 //
-// Phase 3 — Wires AssessmentTab, ReferencesTab, ACEPCheckerTab.
-// Exports CourseBuilderContext + useCourseBuilder for all child tabs.
+// Usage in App.jsx:
+//   import CourseBuilder from "./components/course-builder/index.jsx";
 //
-// Tab map:
-//  0  Course Info       — MetadataTab (inline below)
-//  1  Content           — Stub pending Phase 1 ContentEditorTab extraction
-//  2  Assessment        — AssessmentTab (was comingSoon)
-//  3  References        — ReferencesTab (was comingSoon)
-//  4  ACEP Compliance   — ACEPCheckerTab (was comingSoon)
-//  5  Preview           — comingSoon
-//  6  AI Assistant      — comingSoon
+// Route: /admin/course-builder?id=<mongoId>  (edit existing)
+//        /admin/course-builder               (new course)
+// ─────────────────────────────────────────────────────────────────────────────
 
-import { createContext, useContext, useReducer, useState } from "react";
-import AssessmentTab from "./tabs/AssessmentTab.jsx";
-import ReferencesTab from "./tabs/ReferencesTab.jsx";
-import ACEPCheckerTab from "./tabs/ACEPCheckerTab.jsx";
+import { useEffect, useMemo } from "react";
+import { CourseBuilderProvider, useCourseBuilder } from "./CourseBuilderContext.jsx";
+import MetadataTab      from "./tabs/MetadataTab.jsx";
+import ContentEditorTab from "./tabs/ContentEditorTab.jsx";
+import AssessmentTab    from "./tabs/AssessmentTab.jsx";
+import ReferencesTab    from "./tabs/ReferencesTab.jsx";
+import ACEPCheckerTab   from "./tabs/ACEPCheckerTab.jsx";
+import { C, ACEP_RULES } from "./constants.js";
+import { countCourseWords, countKCsInSection } from "./utils.js";
+import { publishCourse } from "./courseBuilderApi.js";
+import { validateCourse } from "./courseBuilderValidator.js";
 
-// ══════════════════════════════════════════════════════════════════════════
-// CONTEXT + HOOK
-// ══════════════════════════════════════════════════════════════════════════
+// Re-export so tabs that import from "../index.jsx" still work
+export { useCourseBuilder } from "./CourseBuilderContext.jsx";
 
-const CourseBuilderContext = createContext(null);
-
-/** Access builder state, dispatch, and tab navigation from any child tab. */
-export function useCourseBuilder() {
-  const ctx = useContext(CourseBuilderContext);
-  if (!ctx) throw new Error("useCourseBuilder must be inside <CourseBuilder>");
-  return ctx;
-}
-
-// ══════════════════════════════════════════════════════════════════════════
-// BRAND COLORS (canonical per Color_Spec_v1)
-// ══════════════════════════════════════════════════════════════════════════
-
-const C = {
-  burgundy: "#6B1D34", burgundyLight: "#8B2D4A", burgundyFaded: "rgba(107,29,52,0.08)",
-  green: "#4A7C59", greenLight: "#5A9469", greenFaded: "rgba(74,124,89,0.08)",
-  gold: "#D4A855", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#284157", navyLight: "#3A5A78",   // ← correct per Color_Spec_v1 (#284157 not #34495E)
-  bg: "#FAFAF8", card: "#FFFFFF",
-  border: "#E8E4DF", borderLight: "#F0EDE8",
-  text: "#2C2C2C", textMuted: "#6B7280", textLight: "#9CA3AF",
-  danger: "#DC2626", dangerFaded: "rgba(220,38,38,0.08)",
-};
-
-// ══════════════════════════════════════════════════════════════════════════
-// INITIAL STATE — canonical schema (sections[], options: [String], _tempId)
-// ══════════════════════════════════════════════════════════════════════════
-
-function tempId() { return `_${Math.random().toString(36).slice(2, 9)}`; }
-
-const INITIAL_STATE = {
-  _id: null,
-  title: "",
-  slug: "",
-  description: "",
-  courseCode: "",
-  ceHours: 3,
-  ceuHours: 3,
-  ceCategory: "General",
-  level: "Intermediate",
-  category: "Clinical Practice",
-  accessType: "subscription",
-  price: 0,
-  pricingTier: "standard",
-  status: "draft",
-  isPublished: false,
-  deliveryMethod: "online",
-  objectives: [],
-  targetAudience: ["LPCs", "LMHCs", "LCSWs", "LMFTs"],
-
-  // ACEP provider — hardcoded defaults, never changes
-  instructor: "GA Integrated Therapeutic Perspectives LLC",
-  approvingBody: "NBCC",
-  approvalNumber: "#7760",
-  ceuEligible: true,
-
-  // Content
-  sections: [],
-
-  // Final exam
-  assessment: {
-    questions: [],
-    passingScore: 80,
-    passThreshold: 0.80,
-    maxAttempts: 3,
-  },
-
-  // References
-  references: [],
-
-  // Settings
-  settings: {
-    passingScore: 80,
-    certificateEnabled: true,
-    requireEvaluation: true,
-    requireAttestation: true,
-  },
-};
-
-// ══════════════════════════════════════════════════════════════════════════
-// REDUCER
-// ══════════════════════════════════════════════════════════════════════════
-
-function reducer(state, action) {
-  switch (action.type) {
-
-    // ── Metadata ─────────────────────────────────────────────────────────
-    case "SET_FIELD":
-      return { ...state, [action.field]: action.value };
-
-    case "SET_FIELDS":
-      return { ...state, ...action.fields };
-
-    case "ADD_OBJECTIVE":
-      return { ...state, objectives: [...state.objectives, action.text || ""] };
-
-    case "UPDATE_OBJECTIVE": {
-      const objs = [...state.objectives];
-      objs[action.index] = action.text;
-      return { ...state, objectives: objs };
-    }
-
-    case "REMOVE_OBJECTIVE":
-      return { ...state, objectives: state.objectives.filter((_, i) => i !== action.index) };
-
-    case "ADD_AUDIENCE":
-      return { ...state, targetAudience: [...state.targetAudience, action.text || ""] };
-
-    case "REMOVE_AUDIENCE":
-      return { ...state, targetAudience: state.targetAudience.filter((_, i) => i !== action.index) };
-
-    // ── Assessment ────────────────────────────────────────────────────────
-    case "ADD_ASSESSMENT_Q":
-      return {
-        ...state,
-        assessment: {
-          ...state.assessment,
-          questions: [
-            ...state.assessment.questions,
-            {
-              _tempId: tempId(),
-              id: tempId(),
-              question: "",
-              type: "multiple_choice",
-              options: ["", "", "", ""],
-              correctAnswer: -1,
-              explanation: "",
-              ...action.question,
-            },
-          ],
-        },
-      };
-
-    case "UPDATE_ASSESSMENT_Q":
-      return {
-        ...state,
-        assessment: {
-          ...state.assessment,
-          questions: state.assessment.questions.map(q =>
-            (q._tempId === action.id || q.id === action.id)
-              ? { ...q, ...action.changes }
-              : q
-          ),
-        },
-      };
-
-    case "REMOVE_ASSESSMENT_Q":
-      return {
-        ...state,
-        assessment: {
-          ...state.assessment,
-          questions: state.assessment.questions.filter(
-            q => q._tempId !== action.id && q.id !== action.id
-          ),
-        },
-      };
-
-    case "MOVE_ASSESSMENT_Q": {
-      const qs = [...state.assessment.questions];
-      const [moved] = qs.splice(action.from, 1);
-      qs.splice(action.to, 0, moved);
-      return { ...state, assessment: { ...state.assessment, questions: qs } };
-    }
-
-    case "SET_ASSESSMENT_META":
-      return {
-        ...state,
-        assessment: { ...state.assessment, ...action.changes },
-      };
-
-    // ── References ────────────────────────────────────────────────────────
-    case "ADD_REFERENCE":
-      return {
-        ...state,
-        references: [
-          ...state.references,
-          {
-            _tempId: tempId(),
-            id: tempId(),
-            author: "",
-            year: "",
-            title: "",
-            source: "",
-            ...action.reference,
-          },
-        ],
-      };
-
-    case "UPDATE_REFERENCE":
-      return {
-        ...state,
-        references: state.references.map(r =>
-          (r._tempId === action.id || r.id === action.id)
-            ? { ...r, ...action.changes }
-            : r
-        ),
-      };
-
-    case "REMOVE_REFERENCE":
-      return {
-        ...state,
-        references: state.references.filter(
-          r => r._tempId !== action.id && r.id !== action.id
-        ),
-      };
-
-    case "MOVE_REFERENCE": {
-      const refs = [...state.references];
-      const [moved] = refs.splice(action.from, 1);
-      refs.splice(action.to, 0, moved);
-      return { ...state, references: refs };
-    }
-
-    // ── Bulk load (import / AI / load from DB) ────────────────────────────
-    case "LOAD_COURSE":
-      return { ...INITIAL_STATE, ...action.courseData };
-
-    case "REPLACE_STATE":
-      return { ...action.state };
-
-    default:
-      return state;
-  }
-}
-
-// ══════════════════════════════════════════════════════════════════════════
-// SHARED STYLES
-// ══════════════════════════════════════════════════════════════════════════
-
-const S = {
-  container: {
-    fontFamily: "'Newsreader', Georgia, serif",
-    background: C.bg, minHeight: "100vh", color: C.text,
-  },
-  header: {
-    background: `linear-gradient(135deg, ${C.burgundy} 0%, #4A1224 100%)`,
-    padding: "16px 28px", display: "flex", alignItems: "center", justifyContent: "space-between",
-  },
-  tabBar: {
-    display: "flex", background: "#fff",
-    borderBottom: `2px solid ${C.border}`,
-    padding: "0 20px", gap: 0, overflowX: "auto",
-  },
-  tab: (active, comingSoon) => ({
-    padding: "13px 20px", fontSize: 14,
-    fontWeight: active ? 700 : 500, cursor: comingSoon ? "default" : "pointer",
-    color: active ? C.burgundy : (comingSoon ? C.textLight : C.textMuted),
-    borderBottom: active ? `3px solid ${C.burgundy}` : "3px solid transparent",
-    display: "flex", alignItems: "center", gap: 7, transition: "all 0.2s",
-    background: active ? C.burgundyFaded : "transparent", whiteSpace: "nowrap",
-    opacity: comingSoon ? 0.5 : 1,
-  }),
-  main: { maxWidth: 1100, margin: "0 auto", padding: "24px 20px" },
-  card: { background: C.card, borderRadius: 12, border: `1px solid ${C.border}`, marginBottom: 18, overflow: "hidden" },
-  cardHeader: { padding: "14px 18px", borderBottom: `1px solid ${C.borderLight}`, display: "flex", alignItems: "center", justifyContent: "space-between" },
-  cardBody: { padding: 18 },
-  label: { fontSize: 13, fontWeight: 600, color: C.navy, marginBottom: 6, display: "block" },
-  input: { width: "100%", padding: "10px 13px", borderRadius: 8, border: `1px solid ${C.border}`, fontSize: 14, fontFamily: "inherit", outline: "none", boxSizing: "border-box", background: "#fff" },
-  textarea: { width: "100%", padding: "10px 13px", borderRadius: 8, border: `1px solid ${C.border}`, fontSize: 14, fontFamily: "inherit", outline: "none", resize: "vertical", minHeight: 90, boxSizing: "border-box", background: "#fff" },
-  btn: (bg, color) => ({ background: bg, color, border: "none", borderRadius: 8, padding: "9px 18px", fontSize: 14, fontWeight: 600, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 7 }),
-  btnSm: (bg, color) => ({ background: bg, color, border: `1px solid ${color}33`, borderRadius: 6, padding: "5px 10px", fontSize: 12, fontWeight: 600, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 4 }),
-  grid2: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 },
-  grid3: { display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 16 },
-  badge: (color) => ({ display: "inline-flex", padding: "3px 10px", borderRadius: 20, fontSize: 12, fontWeight: 700, background: color + "18", color }),
-};
-
-// ══════════════════════════════════════════════════════════════════════════
-// METADATA TAB (Tab 0 — Course Info)
-// ══════════════════════════════════════════════════════════════════════════
-
-const CATEGORIES = [
-  "Clinical Practice", "Ethics", "Crisis Intervention", "Assessment",
-  "Multicultural", "Supervision", "Diversity & Inclusion", "Wellness",
-  "Group Counseling", "Career Development", "Telehealth", "Geriatric",
-];
-
-const CE_CATEGORIES = ["Ethics", "Clinical", "Cultural Competency", "General"];
-const AUDIENCE_OPTIONS = [
-  "LPCs", "LMHCs", "LCSWs", "LMFTs", "NCCs", "Counselors", "Social Workers",
-  "Marriage & Family Therapists", "School Counselors",
-];
-
-function MetadataTab() {
-  const { state, dispatch } = useCourseBuilder();
-  const [newObjective, setNewObjective] = useState("");
-  const [newAudience, setNewAudience] = useState("");
-
-  const set = (field, value) => dispatch({ type: "SET_FIELD", field, value });
-
-  const autoSlug = (title) =>
-    title.toLowerCase().replace(/[^a-z0-9\s-]/g, "").replace(/\s+/g, "-").slice(0, 80);
-
-  return (
-    <div>
-      {/* Basic Info */}
-      <div style={S.card}>
-        <div style={S.cardHeader}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: C.navy }}>Course Information</span>
-          <span style={S.badge(C.burgundy)}>Required</span>
-        </div>
-        <div style={S.cardBody}>
-          <div style={{ marginBottom: 14 }}>
-            <label style={S.label}>Course Title *</label>
-            <input
-              style={S.input}
-              placeholder="e.g., Trauma-Informed Care and PTSD Treatment"
-              value={state.title}
-              onChange={e => {
-                set("title", e.target.value);
-                if (!state._id) set("slug", autoSlug(e.target.value));
-              }}
-            />
-          </div>
-
-          <div style={{ marginBottom: 14 }}>
-            <label style={S.label}>Slug</label>
-            <input
-              style={{ ...S.input, fontFamily: "monospace", fontSize: 13 }}
-              value={state.slug}
-              onChange={e => set("slug", e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))}
-            />
-          </div>
-
-          <div style={{ marginBottom: 14 }}>
-            <label style={S.label}>Description</label>
-            <textarea
-              style={{ ...S.textarea, minHeight: 80 }}
-              placeholder="Brief course summary shown in the catalog..."
-              value={state.description}
-              onChange={e => set("description", e.target.value)}
-            />
-          </div>
-
-          <div style={{ ...S.grid3, marginBottom: 14 }}>
-            <div>
-              <label style={S.label}>Course Code</label>
-              <input
-                style={S.input}
-                placeholder="e.g., CR-301"
-                value={state.courseCode}
-                onChange={e => set("courseCode", e.target.value.toUpperCase())}
-              />
-            </div>
-            <div>
-              <label style={S.label}>CE Hours *</label>
-              <select
-                style={S.input}
-                value={state.ceHours}
-                onChange={e => { const h = Number(e.target.value); set("ceHours", h); set("ceuHours", h); }}
-              >
-                {[1, 2, 3, 4, 5, 6].map(h => (
-                  <option key={h} value={h}>{h} CE Hour{h > 1 ? "s" : ""}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label style={S.label}>CE Category</label>
-              <select style={S.input} value={state.ceCategory} onChange={e => set("ceCategory", e.target.value)}>
-                {CE_CATEGORIES.map(c => <option key={c}>{c}</option>)}
-              </select>
-            </div>
-          </div>
-
-          <div style={S.grid3}>
-            <div>
-              <label style={S.label}>Level</label>
-              <select style={S.input} value={state.level} onChange={e => set("level", e.target.value)}>
-                {["Beginner", "Introductory", "Intermediate", "Advanced"].map(l => <option key={l}>{l}</option>)}
-              </select>
-            </div>
-            <div>
-              <label style={S.label}>Category</label>
-              <select style={S.input} value={state.category} onChange={e => set("category", e.target.value)}>
-                {CATEGORIES.map(c => <option key={c}>{c}</option>)}
-              </select>
-            </div>
-            <div>
-              <label style={S.label}>Status</label>
-              <select style={S.input} value={state.status} onChange={e => set("status", e.target.value)}>
-                <option value="draft">Draft</option>
-                <option value="published">Published</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Pricing */}
-      <div style={S.card}>
-        <div style={S.cardHeader}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: C.navy }}>Access & Pricing</span>
-        </div>
-        <div style={S.cardBody}>
-          <div style={S.grid3}>
-            <div>
-              <label style={S.label}>Access Type</label>
-              <select style={S.input} value={state.accessType} onChange={e => set("accessType", e.target.value)}>
-                <option value="free">Free</option>
-                <option value="subscription">Subscription</option>
-                <option value="paid">Individual Purchase</option>
-              </select>
-            </div>
-            <div>
-              <label style={S.label}>Price (USD)</label>
-              <input
-                type="number" min={0} step={0.01}
-                style={S.input}
-                value={state.price}
-                onChange={e => set("price", Number(e.target.value))}
-                disabled={state.accessType === "free" || state.accessType === "subscription"}
-              />
-            </div>
-            <div>
-              <label style={S.label}>Pricing Tier</label>
-              <select style={S.input} value={state.pricingTier} onChange={e => set("pricingTier", e.target.value)}>
-                <option value="free">Free</option>
-                <option value="standard">Standard</option>
-                <option value="premium">Premium</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Learning Objectives */}
-      <div style={S.card}>
-        <div style={S.cardHeader}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: C.navy }}>Learning Objectives *</span>
-          <span style={S.badge(state.objectives.length > 0 ? C.green : C.danger)}>
-            {state.objectives.length} added
-          </span>
-        </div>
-        <div style={S.cardBody}>
-          {state.objectives.map((obj, i) => (
-            <div key={i} style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "center" }}>
-              <span style={{ ...S.badge(C.navy), minWidth: 22, justifyContent: "center" }}>{i + 1}</span>
-              <input
-                style={{ ...S.input, flex: 1 }}
-                value={obj}
-                onChange={e => dispatch({ type: "UPDATE_OBJECTIVE", index: i, text: e.target.value })}
-                placeholder="Learner will be able to..."
-              />
-              <button
-                onClick={() => dispatch({ type: "REMOVE_OBJECTIVE", index: i })}
-                style={{ ...S.btnSm(C.dangerFaded, C.danger), border: "none" }}
-              >✕</button>
-            </div>
-          ))}
-          <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
-            <input
-              style={{ ...S.input, flex: 1 }}
-              placeholder="Add a learning objective..."
-              value={newObjective}
-              onChange={e => setNewObjective(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === "Enter" && newObjective.trim()) {
-                  dispatch({ type: "ADD_OBJECTIVE", text: newObjective.trim() });
-                  setNewObjective("");
-                }
-              }}
-            />
-            <button
-              style={S.btn(C.green, "#fff")}
-              onClick={() => {
-                if (!newObjective.trim()) return;
-                dispatch({ type: "ADD_OBJECTIVE", text: newObjective.trim() });
-                setNewObjective("");
-              }}
-            >+ Add</button>
-          </div>
-          <p style={{ fontSize: 11, color: C.textMuted, marginTop: 6 }}>Press Enter or click Add. Format: "Learner will be able to..."</p>
-        </div>
-      </div>
-
-      {/* Target Audience */}
-      <div style={S.card}>
-        <div style={S.cardHeader}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: C.navy }}>Target Audience *</span>
-          <span style={S.badge(state.targetAudience.length > 0 ? C.green : C.danger)}>
-            {state.targetAudience.length} selected
-          </span>
-        </div>
-        <div style={S.cardBody}>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 14 }}>
-            {AUDIENCE_OPTIONS.map(opt => {
-              const selected = state.targetAudience.includes(opt);
-              return (
-                <button
-                  key={opt}
-                  onClick={() => {
-                    if (selected) {
-                      dispatch({ type: "REMOVE_AUDIENCE", index: state.targetAudience.indexOf(opt) });
-                    } else {
-                      dispatch({ type: "ADD_AUDIENCE", text: opt });
-                    }
-                  }}
-                  style={{
-                    padding: "6px 14px", borderRadius: 20, fontSize: 13, fontWeight: selected ? 700 : 400,
-                    cursor: "pointer", border: `1.5px solid ${selected ? C.green : C.border}`,
-                    background: selected ? C.greenFaded : "#fff",
-                    color: selected ? C.green : C.textMuted, transition: "all 0.15s",
-                  }}
-                >
-                  {selected ? "✓ " : ""}{opt}
-                </button>
-              );
-            })}
-          </div>
-          <div style={{ display: "flex", gap: 8 }}>
-            <input
-              style={{ ...S.input, flex: 1 }}
-              placeholder="Add custom audience type..."
-              value={newAudience}
-              onChange={e => setNewAudience(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === "Enter" && newAudience.trim()) {
-                  dispatch({ type: "ADD_AUDIENCE", text: newAudience.trim() });
-                  setNewAudience("");
-                }
-              }}
-            />
-            <button
-              style={S.btn(C.green, "#fff")}
-              onClick={() => {
-                if (!newAudience.trim()) return;
-                dispatch({ type: "ADD_AUDIENCE", text: newAudience.trim() });
-                setNewAudience("");
-              }}
-            >+ Add</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ══════════════════════════════════════════════════════════════════════════
-// COMING SOON PLACEHOLDER
-// ══════════════════════════════════════════════════════════════════════════
-
-function ComingSoonTab({ label, note }) {
-  return (
-    <div style={{ ...S.card, textAlign: "center" }}>
-      <div style={{ padding: "56px 20px" }}>
-        <div style={{ fontSize: 40, marginBottom: 12 }}>🚧</div>
-        <div style={{ fontWeight: 700, fontSize: 18, color: C.navy, marginBottom: 8 }}>
-          {label} — Coming Soon
-        </div>
-        {note && (
-          <div style={{ color: C.textMuted, fontSize: 14, maxWidth: 460, margin: "0 auto" }}>
-            {note}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ══════════════════════════════════════════════════════════════════════════
-// MAIN EXPORT
-// ══════════════════════════════════════════════════════════════════════════
+// ─── Tab config ───────────────────────────────────────────────────────────────
 
 const TABS = [
-  { label: "Course Info",     icon: "ℹ",  comingSoon: false },
-  { label: "Content",         icon: "📝", comingSoon: false },
-  { label: "Assessment",      icon: "📋", comingSoon: false },   // ← Phase 3: was comingSoon
-  { label: "References",      icon: "📚", comingSoon: false },   // ← Phase 3: was comingSoon
-  { label: "ACEP Compliance", icon: "✅", comingSoon: false },   // ← Phase 3: was comingSoon
-  { label: "Preview",         icon: "👁", comingSoon: true  },
-  { label: "AI Assistant",    icon: "✨", comingSoon: true  },
+  { label: "Course Info",     icon: "ℹ️" },
+  { label: "Content Editor",  icon: "📝" },
+  { label: "Assessment",      icon: "✅" },
+  { label: "References",      icon: "📚" },
+  { label: "ACEP Compliance", icon: "⚖️" },
+  { label: "Preview",         icon: "👁",  comingSoon: true },
+  { label: "AI Assistant",    icon: "🤖", comingSoon: true },
 ];
 
-export default function CourseBuilder() {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
-  const [activeTab, setActiveTab] = useState(0);
+// ─── Save status badge ────────────────────────────────────────────────────────
 
-  const contextValue = { state, dispatch, setActiveTab };
+function SaveBadge() {
+  const { saveStatus, saveError, lastSaved, isDirty, doSave } = useCourseBuilder();
 
-  const exportJSON = () => {
-    const json = JSON.stringify(state, null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = `${state.slug || state.title?.replace(/[^a-z0-9]/gi, "_") || "course"}.json`;
-    a.click();
-  };
+  const label = saveStatus === "saving"  ? "Saving..."
+              : saveStatus === "saved"   ? `Saved ${lastSaved ? formatTime(lastSaved) : ""}`
+              : saveStatus === "error"   ? `Error: ${saveError}`
+              : isDirty                  ? "Unsaved changes"
+              : lastSaved                ? `Saved ${formatTime(lastSaved)}`
+              : "New course";
+
+  const color = saveStatus === "error"   ? C.danger
+              : saveStatus === "saved"   ? C.hunterGreen
+              : isDirty                  ? C.honey
+              : C.textMuted;
 
   return (
-    <CourseBuilderContext.Provider value={contextValue}>
-      <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700;6..72,800&display=swap" rel="stylesheet" />
-      <div style={S.container}>
+    <span style={{ fontSize: 12, color, fontWeight: 500 }}>{label}</span>
+  );
+}
 
-        {/* Header */}
-        <div style={S.header}>
-          <div>
-            <div style={{ color: "#fff", fontSize: 20, fontWeight: 700, letterSpacing: "-0.02em" }}>
-              CounselorReady Course Builder
-            </div>
-            <div style={{ color: "rgba(255,255,255,0.55)", fontSize: 12, marginTop: 2 }}>
-              NBCC ACEP #7760 · 17 Block Types · sections[] canonical schema
-            </div>
-          </div>
-          <div style={{ display: "flex", gap: 10 }}>
-            {state.title && (
-              <span style={{ color: "rgba(255,255,255,0.6)", fontSize: 13, alignSelf: "center" }}>
-                {state.title}
-                {state.ceHours ? ` · ${state.ceHours} CE` : ""}
-              </span>
-            )}
+function formatTime(date) {
+  const diff = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (diff < 5)   return "just now";
+  if (diff < 60)  return `${diff}s ago`;
+  if (diff < 3600)return `${Math.floor(diff / 60)}m ago`;
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+// ─── Word count bar ───────────────────────────────────────────────────────────
+
+function WordCountBar() {
+  const { state } = useCourseBuilder();
+  const total   = countCourseWords(state.sections);
+  const target  = (state.ceHours || 0) * ACEP_RULES.WORDS_PER_CE_HOUR;
+  const pct     = target > 0 ? Math.min(100, Math.round((total / target) * 100)) : 0;
+  const color   = pct >= 100 ? C.hunterGreen : pct >= 80 ? C.honey : C.danger;
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <span style={{ fontSize: 12, color: C.textMuted, whiteSpace: "nowrap" }}>
+        {total.toLocaleString()} / {target.toLocaleString()} words ({pct}%)
+      </span>
+      <div style={{ width: 80, height: 6, background: C.borderLight, borderRadius: 4, overflow: "hidden" }}>
+        <div style={{ width: `${pct}%`, height: "100%", background: color, borderRadius: 4, transition: "width 0.3s" }} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Main shell ───────────────────────────────────────────────────────────────
+
+function CourseBuilderShell() {
+  const {
+    state, activeTab, setActiveTab,
+    isDirty, doSave, saveStatus,
+    isLoading, loadError,
+    canUndo, canRedo, undo, redo,
+  } = useCourseBuilder();
+
+  // Ensure we start on Section 1 for new courses
+  useEffect(() => {
+    if (!state._id && state.sections.length === 0) {
+      // New course: start on metadata tab
+      setActiveTab(0);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Validation for publish gate
+  const validation = useMemo(() => validateCourse(state), [state]);
+  const errorCount = validation.errors.length;
+
+  async function handlePublish() {
+    if (errorCount > 0) {
+      // Jump to ACEP Compliance tab to show errors
+      setActiveTab(4);
+      return;
+    }
+    if (!confirm("Publish this course? It will become visible to enrolled learners.")) return;
+    try {
+      await doSave(false); // save first
+      const result = await publishCourse(state);
+      if (result?.course?._id) {
+        alert("✓ Course published successfully.");
+        window.location.href = "/public/admin-courses.html";
+      }
+    } catch (err) {
+      alert(`Publish failed: ${err.message}`);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: 300, color: C.textMuted }}>
+        Loading course...
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div style={{ padding: 40, color: C.danger, textAlign: "center" }}>
+        <p style={{ fontWeight: 700, marginBottom: 8 }}>Failed to load course</p>
+        <p style={{ fontSize: 14 }}>{loadError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: C.stone, fontFamily: "system-ui, -apple-system, sans-serif" }}>
+
+      {/* ── Top bar ── */}
+      <div style={{
+        background: C.burgundy, padding: "0 24px",
+        display: "flex", alignItems: "center", gap: 16,
+        height: 56, flexShrink: 0,
+      }}>
+        {/* Logo / back */}
+        <a href="/public/admin-courses.html" style={{ color: "#ffffff80", textDecoration: "none", fontSize: 13, fontWeight: 500 }}>
+          ← Courses
+        </a>
+        <div style={{ width: 1, height: 20, background: "#ffffff30" }} />
+
+        {/* Course title */}
+        <span style={{ color: "#fff", fontWeight: 700, fontSize: 15, flex: 1 }}>
+          {state.title || "Untitled Course"}
+          {state.status === "published" && (
+            <span style={{ marginLeft: 8, fontSize: 10, fontWeight: 700, background: C.hunterGreen, color: "#fff", padding: "2px 8px", borderRadius: 10 }}>LIVE</span>
+          )}
+          {state.status === "draft" && (
+            <span style={{ marginLeft: 8, fontSize: 10, fontWeight: 700, background: "#ffffff30", color: "#fff", padding: "2px 8px", borderRadius: 10 }}>DRAFT</span>
+          )}
+        </span>
+
+        {/* Word count */}
+        <WordCountBar />
+
+        {/* Undo / Redo */}
+        <button title="Undo (Ctrl+Z)" onClick={undo} disabled={!canUndo}
+          style={{ background: "none", border: "none", color: canUndo ? "#fff" : "#ffffff30", cursor: canUndo ? "pointer" : "default", fontSize: 18, padding: "4px 6px" }}>↩</button>
+        <button title="Redo (Ctrl+Shift+Z)" onClick={redo} disabled={!canRedo}
+          style={{ background: "none", border: "none", color: canRedo ? "#fff" : "#ffffff30", cursor: canRedo ? "pointer" : "default", fontSize: 18, padding: "4px 6px" }}>↪</button>
+
+        {/* Save status */}
+        <SaveBadge />
+
+        {/* Save button */}
+        <button
+          onClick={() => doSave(true)}
+          disabled={!isDirty || saveStatus === "saving"}
+          style={{
+            padding: "7px 18px", borderRadius: 7, border: "none",
+            background: isDirty ? "#ffffff20" : "transparent",
+            color: isDirty ? "#fff" : "#ffffff50",
+            fontWeight: 600, fontSize: 13, cursor: isDirty ? "pointer" : "default",
+          }}
+        >
+          {saveStatus === "saving" ? "Saving..." : "Save"}
+        </button>
+
+        {/* Publish button — shows error count when course isn't ready */}
+        <button
+          onClick={handlePublish}
+          style={{
+            padding: "7px 18px", borderRadius: 7, border: "none",
+            background: errorCount > 0 ? C.danger : C.hunterGreen, color: "#fff",
+            fontWeight: 700, fontSize: 13, cursor: "pointer",
+          }}
+        >
+          {errorCount > 0 ? `${errorCount} Error${errorCount !== 1 ? "s" : ""}` : "Publish"}
+        </button>
+      </div>
+
+      {/* ── Tab bar ── */}
+      <div style={{
+        display: "flex", gap: 0, background: "#fff",
+        borderBottom: `1px solid ${C.border}`, flexShrink: 0,
+        paddingLeft: 24, overflowX: "auto",
+      }}>
+        {TABS.map((tab, i) => {
+          const active = activeTab === i;
+          return (
             <button
-              onClick={exportJSON}
-              style={{ background: "transparent", color: "#fff", border: "1px solid rgba(255,255,255,0.25)", borderRadius: 7, padding: "8px 14px", fontSize: 12, fontWeight: 600, cursor: "pointer" }}
-            >
-              💾 Export JSON
-            </button>
-          </div>
-        </div>
-
-        {/* Tab bar */}
-        <div style={S.tabBar}>
-          {TABS.map((tab, i) => (
-            <div
-              key={i}
-              style={S.tab(activeTab === i, tab.comingSoon)}
+              key={tab.label}
               onClick={() => !tab.comingSoon && setActiveTab(i)}
-              title={tab.comingSoon ? "Coming soon" : tab.label}
+              title={tab.comingSoon ? "Coming in Phase 2–3" : undefined}
+              style={{
+                padding: "13px 18px", border: "none", background: "transparent",
+                borderBottom: active ? `3px solid ${C.burgundy}` : "3px solid transparent",
+                color: active ? C.burgundy : tab.comingSoon ? C.textLight : C.navy,
+                fontWeight: active ? 700 : 500, fontSize: 13, cursor: tab.comingSoon ? "default" : "pointer",
+                whiteSpace: "nowrap", display: "flex", alignItems: "center", gap: 6,
+              }}
             >
               <span>{tab.icon}</span>
               {tab.label}
-              {tab.comingSoon && (
-                <span style={{ fontSize: 9, background: C.gold + "30", color: C.gold, borderRadius: 4, padding: "1px 5px", fontWeight: 700 }}>
-                  SOON
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Tab content */}
-        <div style={S.main}>
-          {activeTab === 0 && <MetadataTab />}
-
-          {activeTab === 1 && (
-            <ComingSoonTab
-              label="Content Editor"
-              note="Phase 1 migration in progress. Extract ContentEditorTab.jsx from CourseBuilder.jsx and wire it here. The reducer already handles sections[].contentBlocks[] via LOAD_COURSE."
-            />
-          )}
-
-          {/* ── Phase 3: newly active tabs ── */}
-          {activeTab === 2 && <AssessmentTab />}
-          {activeTab === 3 && <ReferencesTab />}
-          {activeTab === 4 && <ACEPCheckerTab />}
-
-          {activeTab === 5 && (
-            <ComingSoonTab
-              label="Preview"
-              note="Will embed CReady Viewer with the current course state. Phase 5."
-            />
-          )}
-
-          {activeTab === 6 && (
-            <ComingSoonTab
-              label="AI Assistant"
-              note="Real Claude API integration for outline, content expansion, and assessment generation. Phase 4."
-            />
-          )}
-        </div>
+              {tab.comingSoon && <span style={{ fontSize: 9, fontWeight: 700, color: C.textLight, background: C.borderLight, padding: "1px 5px", borderRadius: 8 }}>SOON</span>}
+            </button>
+          );
+        })}
       </div>
-    </CourseBuilderContext.Provider>
+
+      {/* ── Tab content ── */}
+      <div style={{ flex: 1, overflowY: "auto", padding: 24 }}>
+        {activeTab === 0 && <MetadataTab />}
+        {activeTab === 1 && <ContentEditorTab />}
+        {activeTab === 2 && <AssessmentTab />}
+        {activeTab === 3 && <ReferencesTab />}
+        {activeTab === 4 && <ACEPCheckerTab />}
+      </div>
+
+    </div>
+  );
+}
+
+// ─── Root export (with provider) ─────────────────────────────────────────────
+
+export default function CourseBuilder() {
+  // Read course ID from URL param: /admin/course-builder?id=<mongoId>
+  const params = new URLSearchParams(window.location.search);
+  const courseId = params.get("id") || null;
+
+  return (
+    <CourseBuilderProvider initialCourseId={courseId}>
+      <CourseBuilderShell />
+    </CourseBuilderProvider>
   );
 }

--- a/client/src/components/course-builder/tabs/ACEPCheckerTab.jsx
+++ b/client/src/components/course-builder/tabs/ACEPCheckerTab.jsx
@@ -5,13 +5,13 @@
 import { validateCourse } from "../courseBuilderValidator.js";
 import { countSectionWords, countKCsInSection } from "../utils.js";
 import { ACEP_RULES } from "../constants.js";
-import { useCourseBuilder } from "../index.jsx";
+import { useCourseBuilder } from "../CourseBuilderContext.jsx";
 
 const C = {
   burgundy: "#6B1D34", burgundyFaded: "rgba(107,29,52,0.08)",
   green: "#4A7C59", greenFaded: "rgba(74,124,89,0.08)",
   gold: "#D4A855", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#34495E",
+  navy: "#284157",
   bg: "#FAFAF8", card: "#FFFFFF",
   border: "#E8E4DF", borderLight: "#F0EDE8",
   text: "#2C2C2C", textMuted: "#6B7280",

--- a/client/src/components/course-builder/tabs/AssessmentTab.jsx
+++ b/client/src/components/course-builder/tabs/AssessmentTab.jsx
@@ -3,14 +3,14 @@
 // Uses useCourseBuilder() hook — no props.
 
 import { useState } from "react";
-import { useCourseBuilder } from "../index.jsx";
+import { useCourseBuilder } from "../CourseBuilderContext.jsx";
 import { ACEP_RULES } from "../constants.js";
 
 const C = {
   burgundy: "#6B1D34", burgundyLight: "#8B2D4A", burgundyFaded: "rgba(107,29,52,0.08)",
   green: "#4A7C59", greenLight: "#5A9469", greenFaded: "rgba(74,124,89,0.08)",
   gold: "#D4A855", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#34495E", navyLight: "#4A6278",
+  navy: "#284157", navyLight: "#4A6278",
   bg: "#FAFAF8", card: "#FFFFFF",
   border: "#E8E4DF", borderLight: "#F0EDE8",
   text: "#2C2C2C", textMuted: "#6B7280", textLight: "#9CA3AF",

--- a/client/src/components/course-builder/tabs/ReferencesTab.jsx
+++ b/client/src/components/course-builder/tabs/ReferencesTab.jsx
@@ -2,13 +2,13 @@
 // DROP INTO: /client/src/components/CourseBuilder/tabs/ReferencesTab.jsx
 // Uses useCourseBuilder() hook — no props.
 
-import { useCourseBuilder } from "../index.jsx";
+import { useCourseBuilder } from "../CourseBuilderContext.jsx";
 
 const C = {
   burgundy: "#6B1D34", burgundyFaded: "rgba(107,29,52,0.08)",
   green: "#4A7C59", greenFaded: "rgba(74,124,89,0.08)",
   gold: "#D4A855", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#34495E",
+  navy: "#284157",
   bg: "#FAFAF8", card: "#FFFFFF",
   border: "#E8E4DF", borderLight: "#F0EDE8",
   text: "#2C2C2C", textMuted: "#6B7280", textLight: "#9CA3AF",
@@ -43,7 +43,7 @@ function formatAPA(ref) {
   return { authorYear: afterAuthorYear, title, source };
 }
 
-function APAPreview({ ref: r }) {
+function APAPreview({ reference: r }) {
   const parts = formatAPA(r);
   if (!parts) return null;
   const { authorYear, title, source } = parts;
@@ -135,7 +135,7 @@ function ReferenceCard({ ref: r, index, total, onUpdate, onRemove, onMove }) {
           />
         </div>
 
-        <APAPreview ref={r} />
+        <APAPreview reference={r} />
       </div>
     </div>
   );
@@ -205,7 +205,7 @@ export default function ReferencesTab() {
         references.map((ref, i) => (
           <ReferenceCard
             key={ref.id}
-            ref={ref}
+            reference={ref}
             index={i}
             total={references.length}
             onUpdate={changes => updateRef(ref.id, changes)}


### PR DESCRIPTION
….jsx

Restore production index.jsx (save/load/undo/redo/ContentEditorTab intact), then add Phase 3 tabs:

index.jsx:
- Import AssessmentTab, ReferencesTab, ACEPCheckerTab, validateCourse
- Activate tabs 2/3/4 (remove comingSoon)
- Publish button shows error count + jumps to ACEP tab when errors exist
- Re-export useCourseBuilder for tab import compatibility

courseBuilderReducer.js:
- Assessment/Reference cases now support both index-based (qIndex/refIndex) and id-based dispatch, with changes/updates alias
- ADD_ASSESSMENT_Q and ADD_REFERENCE generate both _tempId and id fields
- New cases: MOVE_REFERENCE, SET_FIELD, UPDATE_OBJECTIVE

Tab fixes:
- Import useCourseBuilder from CourseBuilderContext.jsx (not index.jsx)
- Fix deprecated navy #34495E → #284157
- Fix reserved `ref` prop → `reference` in ReferencesTab

https://claude.ai/code/session_01BtYD4ckVhfEUiCLm4E3a9S