### PR TITLE
Rename saveEditModal function to saveEdit

### DIFF
--- a/client/admin-courses.html
+++ b/client/admin-courses.html
@@ -1014,7 +1014,7 @@
     <!-- Buttons -->
     <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:8px">
       <button onclick="closeEditModal()" style="padding:10px 20px;border:1px solid #E5E2DC;border-radius:10px;background:#fff;font-family:inherit;font-size:14px;font-weight:600;color:#6B7280;cursor:pointer">Cancel</button>
-      <button onclick="saveEditModal()" id="editSaveBtn" style="padding:10px 24px;border:none;border-radius:10px;background:#4A7C59;color:#fff;font-family:inherit;font-size:14px;font-weight:700;cursor:pointer">Save Changes</button>
+      <button onclick="saveEdit()" id="editSaveBtn" style="padding:10px 24px;border:none;border-radius:10px;background:#4A7C59;color:#fff;font-family:inherit;font-size:14px;font-weight:700;cursor:pointer">Save Changes</button>
     </div>
   </div>
 </div>
@@ -1113,7 +1113,7 @@
     document.getElementById('editModal').style.display = 'none';
   }
 
-  async function saveEditModal() {
+  async function saveEdit() {
     const courseId = document.getElementById('editCourseId').value;
     const source = document.getElementById('editCourseSource').value;
     const isNew = !courseId;


### PR DESCRIPTION
## Summary
Refactored the course edit modal save function to use a more concise naming convention.

## Changes
- Renamed `saveEditModal()` function to `saveEdit()` for improved clarity and consistency
- Updated the onclick handler in the "Save Changes" button to call the renamed function
- No functional changes to the implementation logic

## Details
This is a straightforward refactoring that improves code readability by using a shorter, more direct function name. The function behavior remains identical - it still handles saving course edits with the same parameters and logic.

https://claude.ai/code/session_01XDzSMJSi8EnkH2pXGfxCdo