### PR TITLE
Update admin course routes to use InteractiveCourse model

### DIFF
--- a/server/src/routes/adminCourses.js
+++ b/server/src/routes/adminCourses.js
@@ -1128,18 +1128,18 @@ router.post('/courses', protect, adminOnly, async (req, res) => {
 // @access  Admin only
 router.get('/courses/:courseId', protect, adminOnly, async (req, res) => {
   try {
-    const course = await Course.findById(req.params.courseId);
-    
+    const course = await InteractiveCourse.findById(req.params.courseId);
+
     if (!course) {
       return res.status(404).json({ error: 'Course not found' });
     }
-    
+
     // Get enrollment stats
-    const enrollmentCount = await UserCourseProgress.countDocuments({ 
-      courseId: course._id 
+    const enrollmentCount = await InteractiveCourseProgress.countDocuments({
+      courseId: course._id
     });
-    
-    const completionCount = await UserCourseProgress.countDocuments({ 
+
+    const completionCount = await InteractiveCourseProgress.countDocuments({
       courseId: course._id,
       status: 'completed'
     });
@@ -1165,17 +1165,17 @@ router.get('/courses/:courseId', protect, adminOnly, async (req, res) => {
 // @access  Admin only
 router.put('/courses/:courseId', protect, adminOnly, async (req, res) => {
   try {
-    const course = await Course.findById(req.params.courseId);
-    
+    const course = await InteractiveCourse.findById(req.params.courseId);
+
     if (!course) {
       return res.status(404).json({ error: 'Course not found' });
     }
-    
+
     const updates = req.body;
-    
+
     // If slug is being changed, check for conflicts
     if (updates.slug && updates.slug !== course.slug) {
-      const existingCourse = await Course.findOne({ 
+      const existingCourse = await InteractiveCourse.findOne({
         slug: updates.slug,
         _id: { $ne: course._id }
       });


### PR DESCRIPTION
## Summary
Updated the admin courses API routes to use the `InteractiveCourse` model and `InteractiveCourseProgress` model instead of the legacy `Course` and `UserCourseProgress` models.

## Key Changes
- Replaced `Course.findById()` with `InteractiveCourse.findById()` in GET and PUT course endpoints
- Replaced `Course.findOne()` with `InteractiveCourse.findOne()` for slug conflict checking
- Updated enrollment and completion count queries to use `InteractiveCourseProgress` instead of `UserCourseProgress`
- Fixed whitespace inconsistencies (trailing spaces and blank line formatting)

## Details
This change ensures the admin course management endpoints interact with the new interactive course data model, maintaining consistency across the codebase as the application transitions from the legacy course structure to the interactive course system.

https://claude.ai/code/session_0113W6D39j4bPu9NFWUUnpoL