### PR TITLE
Add payment/access validation to certificate generation endpoint

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -864,6 +864,20 @@ router.post('/:id/certificate', protect, async (req, res) => {
       return res.status(404).json({ success: false, error: 'User not found' });
     }
 
+    // Payment / access check — free courses always allowed; paid courses require purchase, subscription, or admin
+    if (course.accessType !== 'free') {
+      const hasPurchased = user.purchasedCourses && user.purchasedCourses.some(id => id.toString() === course._id.toString());
+      const hasSubscription = user.subscription && (user.subscription.status === 'active' || user.subscription.status === 'lifetime');
+      const isAdmin = user.role === 'admin';
+      if (!hasPurchased && !hasSubscription && !isAdmin) {
+        return res.status(403).json({
+          success: false,
+          code: 'PAYMENT_REQUIRED',
+          message: 'Please complete your purchase to receive your certificate.'
+        });
+      }
+    }
+
     // Check if certificate already exists
     let certificate = await Certificate.findOne({
       userId: req.user._id,


### PR DESCRIPTION
## Summary
Added access control validation to the certificate generation endpoint to ensure users have proper payment or subscription status before receiving certificates for paid courses.

## Key Changes
- Implemented payment/access check in the POST `/:id/certificate` route that:
  - Allows free courses without restrictions
  - Requires users to have either a course purchase, active subscription, or admin role for paid courses
  - Returns a 403 Forbidden response with a `PAYMENT_REQUIRED` error code if access requirements are not met
  - Checks subscription status for both 'active' and 'lifetime' subscriptions

## Implementation Details
- The validation occurs after user and course verification but before certificate creation
- Uses string comparison for course ID matching to handle MongoDB ObjectId comparisons
- Provides clear error messaging to guide users toward completing their purchase
- Maintains backward compatibility by allowing admins to generate certificates regardless of payment status

https://claude.ai/code/session_0174XuLjeKSwU6YcwehcfLWc