### PR TITLE
Add admin courses route handler to API

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -56,6 +56,7 @@ import boardAlertsRoutes from './routes/boardAlerts.js';
 import cePlannerRoutes from './routes/cePlanner.js';
 import imageUploadRoutes from './routes/imageUpload.js';
 import researchReadyRoutes from './routes/researchReady.js';
+import adminCoursesRoutes from './routes/adminCourses.js';
 import toolsRoutes from './routes/tools.js';
 import toolRoutes from './routes/toolRoutes.js';
 import partnersRoutes from './routes/partners.js';
@@ -170,6 +171,7 @@ app.use('/api/lti', ltiRoutes);
 app.use('/api/xapi', xapiRoutes);
 app.use('/api/cebroker', cebrokerRoutes);
 app.use('/api/help', helpRoutes);
+app.use('/api/admin', adminCoursesRoutes);
 app.use('/api/admin/courses', bulkUploadRoutes);
 app.use('/api/course-builder', courseBuilderRoutes);
 app.use('/api/narration', narrationRoutes);
@@ -219,6 +221,7 @@ const REQUIRED_ROUTES = {
   '/api/recommendations':     recommendationsRoutes,
   '/api/images':              imageUploadRoutes,
   '/api/admin/courses':       bulkUploadRoutes,
+  '/api/admin/course-mgmt':   adminCoursesRoutes,
   '/api/blog':                blogRoutes,
 };
 


### PR DESCRIPTION
## Summary
This PR adds a new admin courses route handler to the API server, enabling administrative course management functionality.

## Key Changes
- Import new `adminCoursesRoutes` module from `./routes/adminCourses.js`
- Register the admin courses routes at `/api/admin` endpoint
- Add the route to the `REQUIRED_ROUTES` configuration object under `/api/admin/course-mgmt` for route validation/tracking

## Implementation Details
The new route handler is mounted at `/api/admin` and also registered in the required routes configuration as `/api/admin/course-mgmt`, allowing the application to track and validate this route as part of its startup requirements. This follows the existing pattern used by other route handlers in the application.

https://claude.ai/code/session_01KodbomkMFXpFVocixK7GhS