### PR TITLE
Add Twilio SMS notifications for enrollment and course purchase

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -16,6 +16,11 @@ import Gamification from '../models/Gamification.js';
 import { protect, requireAdmin, optionalAuth } from '../middleware/auth.js';
 import { generateCertificate, generateCertificateNumber } from '../utils/certificate.js';
 import { logActivity, ACTIVITY_TYPES } from '../services/activityTrackingService.js';
+import twilio from 'twilio';
+
+const twilioClient = process.env.TWILIO_ACCOUNT_SID
+  ? twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN)
+  : null;
 
 const router = express.Router();
 
@@ -419,6 +424,15 @@ router.post('/:id/enroll', protect, async (req, res) => {
         : req.user.email,
       userEmail: req.user.email
     }).catch(err => console.error('Activity log error:', err));
+
+    // SMS notification (fire-and-forget)
+    if (twilioClient && process.env.ADMIN_PHONE) {
+      twilioClient.messages.create({
+        body: `CounselorReady: New enrollment\n${req.user.email} enrolled in "${course.title}"`,
+        from: process.env.TWILIO_PHONE_NUMBER,
+        to: process.env.ADMIN_PHONE
+      }).catch(e => console.error('SMS error:', e));
+    }
 
     res.status(201).json({ success: true, message: 'Enrolled successfully', data: progress });
   } catch (error) {

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -12,6 +12,11 @@ import Partner from '../models/Partner.js';
 import { protect } from '../middleware/auth.js';
 import { logActivity, ACTIVITY_TYPES } from '../services/activityTrackingService.js';
 import { sendPaymentFailedEmail, sendPaymentRecoveredEmail } from '../services/hardshipEmailService.js';
+import twilio from 'twilio';
+
+const twilioClient = process.env.TWILIO_ACCOUNT_SID
+  ? twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN)
+  : null;
 
 const router = express.Router();
 
@@ -697,6 +702,15 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
             userName: buyer?.profile?.firstName || '',
             userEmail: buyer?.email || ''
           }).catch(() => {});
+
+          // SMS notification (fire-and-forget)
+          if (twilioClient && process.env.ADMIN_PHONE) {
+            twilioClient.messages.create({
+              body: `CounselorReady: Payment\n${buyer?.email} paid for "${slug}"`,
+              from: process.env.TWILIO_PHONE_NUMBER,
+              to: process.env.ADMIN_PHONE
+            }).catch(e => console.error('SMS error:', e));
+          }
           break;
         }
 


### PR DESCRIPTION
- interactiveCourseRoutes.js: Send SMS after logActivity in POST /:id/enroll
- payments.js: Send SMS after logActivity in course_purchase webhook block
- Both use fire-and-forget pattern with .catch() to avoid blocking
- Phone number read from process.env.ADMIN_PHONE (no hardcoded numbers)
- twilioClient only initializes if TWILIO_ACCOUNT_SID is set

https://claude.ai/code/session_01LUm3T9FFMaNEQ9J4LgqJAR