### PR TITLE
fix: strip nbccContentAreas from PUT updates to prevent enum validati…

### DIFF
--- a/server/src/routes/adminCourses.js
+++ b/server/src/routes/adminCourses.js
@@ -1187,6 +1187,9 @@ router.put('/courses/:courseId', protect, adminOnly, async (req, res) => {
       }
     }
     
+    // Strip nbccContentAreas to prevent saving mismatched enum values from stale data
+    delete updates.nbccContentAreas;
+
     // Update fields
     Object.keys(updates).forEach(key => {
       course[key] = updates[key];


### PR DESCRIPTION
…on error

The course editor loads the full document (including nbccContentAreas with stale/mismatched values) then sends it all back on save. The schema enum rejects the bad values, blocking saves. Stripping the field before the Object.keys spread unblocks saves immediately.

https://claude.ai/code/session_01KodbomkMFXpFVocixK7GhS