### PR TITLE
Add audit and publish scripts for CR-C1 through CR-C5 courses

### DIFF
--- a/server/src/scripts/checkCRC1toCRC5.js
+++ b/server/src/scripts/checkCRC1toCRC5.js
@@ -1,0 +1,103 @@
+/**
+ * checkCRC1toCRC5.js
+ * Verify CR-C1 through CR-C5 exist in interactivecourses collection
+ * Run: node src/scripts/checkCRC1toCRC5.js
+ *
+ * Does NOT modify any data — read-only audit.
+ */
+
+import { MongoClient } from "mongodb";
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error("❌  MONGODB_URI not set");
+  process.exit(1);
+}
+
+const TARGET_SLUGS = [
+  "moral-injury-counselors",
+  "racial-trauma-affirming-practice",
+  "ai-ethics-mental-health",
+  "clinician-burnout-sustainable-practice",
+  "neurodivergent-affirming-practice",
+];
+
+const TARGET_CODES = ["CR-C1", "CR-C2", "CR-C3", "CR-C4", "CR-C5"];
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  try {
+    await client.connect();
+    const db = client.db();
+    const col = db.collection("interactivecourses");
+
+    console.log("\n══════════════════════════════════════════════════════");
+    console.log("  CR-C1 through CR-C5 — interactivecourses audit");
+    console.log("══════════════════════════════════════════════════════\n");
+
+    // Query by courseCode
+    const docs = await col
+      .find({ courseCode: { $in: TARGET_CODES } })
+      .project({ courseCode: 1, slug: 1, title: 1, status: 1, isPublished: 1, ceHours: 1, _id: 0 })
+      .sort({ courseCode: 1 })
+      .toArray();
+
+    if (docs.length === 0) {
+      console.log("⚠️  No documents found by courseCode. Trying slug fallback...\n");
+
+      // Fallback: search by slug keyword
+      const slugResults = await col
+        .find({
+          slug: {
+            $in: TARGET_SLUGS,
+          },
+        })
+        .project({ courseCode: 1, slug: 1, title: 1, status: 1, isPublished: 1, ceHours: 1, _id: 0 })
+        .sort({ courseCode: 1 })
+        .toArray();
+
+      if (slugResults.length === 0) {
+        console.log("❌  No CR-C1 through CR-C5 courses found in interactivecourses.\n");
+        console.log("   These courses have NOT been seeded yet.\n");
+        return;
+      }
+      docs.push(...slugResults);
+    }
+
+    // Report found courses
+    const foundCodes = new Set(docs.map((d) => d.courseCode));
+    for (const doc of docs) {
+      const published = doc.isPublished ? "✅ isPublished=true" : "⬜ isPublished=false";
+      const status = doc.status || "(no status field)";
+      console.log(`  ${doc.courseCode || "??"} | ${doc.slug}`);
+      console.log(`    Title    : ${doc.title}`);
+      console.log(`    Status   : ${status}   ${published}`);
+      console.log(`    CE Hours : ${doc.ceHours}`);
+      console.log();
+    }
+
+    // Report missing
+    const missing = TARGET_CODES.filter((c) => !foundCodes.has(c));
+    if (missing.length > 0) {
+      console.log("⚠️  MISSING courses (not in interactivecourses):");
+      for (const code of missing) {
+        console.log(`   • ${code}`);
+      }
+      console.log();
+    } else {
+      console.log("✅  All 5 courses found in interactivecourses.\n");
+    }
+
+    // Summary
+    const draftCount = docs.filter((d) => d.status === "draft").length;
+    const publishedCount = docs.filter((d) => d.status === "published").length;
+    console.log(`Summary: ${docs.length} found | ${publishedCount} published | ${draftCount} draft | ${missing.length} missing`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("❌  Script error:", err);
+  process.exit(1);
+});

--- a/server/src/scripts/publishCRC1toCRC5.js
+++ b/server/src/scripts/publishCRC1toCRC5.js
@@ -1,0 +1,73 @@
+/**
+ * publishCRC1toCRC5.js
+ * Set status: "published" and isPublished: true for CR-C1 through CR-C5
+ * in the interactivecourses collection.
+ *
+ * Run: node src/scripts/publishCRC1toCRC5.js
+ * Uses native MongoDB driver (not Mongoose).
+ */
+
+import { MongoClient } from "mongodb";
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error("❌  MONGODB_URI not set");
+  process.exit(1);
+}
+
+const TARGET_CODES = ["CR-C1", "CR-C2", "CR-C3", "CR-C4", "CR-C5"];
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  try {
+    await client.connect();
+    const db = client.db();
+    const col = db.collection("interactivecourses");
+
+    console.log("\n══════════════════════════════════════════════════════");
+    console.log("  publishCRC1toCRC5 — publishing CR-C1 through CR-C5");
+    console.log("══════════════════════════════════════════════════════\n");
+
+    // Fetch current state first for logging
+    const docs = await col
+      .find({ courseCode: { $in: TARGET_CODES } })
+      .project({ courseCode: 1, slug: 1, title: 1, status: 1, isPublished: 1 })
+      .sort({ courseCode: 1 })
+      .toArray();
+
+    if (docs.length === 0) {
+      console.error("❌  No CR-C1 through CR-C5 courses found. Run the seed first.");
+      process.exit(1);
+    }
+
+    // Publish each one
+    for (const doc of docs) {
+      const result = await col.updateOne(
+        { _id: doc._id },
+        { $set: { status: "published", isPublished: true } }
+      );
+      const changed = result.modifiedCount > 0 ? "✅ published" : "⬜ already published (no change)";
+      console.log(`  ${doc.courseCode} | ${doc.title}`);
+      console.log(`    was: status=${doc.status}, isPublished=${doc.isPublished}`);
+      console.log(`    now: ${changed}`);
+      console.log();
+    }
+
+    // Report any missing
+    const foundCodes = new Set(docs.map((d) => d.courseCode));
+    const missing = TARGET_CODES.filter((c) => !foundCodes.has(c));
+    if (missing.length > 0) {
+      console.warn("⚠️  These course codes were NOT found — not published:");
+      for (const code of missing) console.warn(`   • ${code}`);
+    }
+
+    console.log(`\nDone. ${docs.length} courses processed, ${missing.length} missing.\n`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("❌  Script error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Add two utility scripts to manage the CR-C1 through CR-C5 interactive courses: one for auditing their existence and publication status, and another for publishing them in bulk.

## Key Changes
- **checkCRC1toCRC5.js**: Read-only audit script that verifies CR-C1 through CR-C5 courses exist in the `interactivecourses` collection
  - Queries by `courseCode` with fallback to slug-based search
  - Reports course details (title, status, publication state, CE hours)
  - Identifies missing courses and provides summary statistics
  
- **publishCRC1toCRC5.js**: Data modification script that publishes CR-C1 through CR-C5 courses
  - Sets `status: "published"` and `isPublished: true` for target courses
  - Logs before/after state for each course
  - Reports which courses were already published vs. newly updated
  - Validates that courses exist before attempting updates

## Implementation Details
- Both scripts use the native MongoDB driver (`MongoClient`) rather than Mongoose
- Require `MONGODB_URI` environment variable; exit with error if not set
- Include clear console output with emoji indicators for status (✅, ⚠️, ❌)
- Target five specific courses: moral-injury-counselors, racial-trauma-affirming-practice, ai-ethics-mental-health, clinician-burnout-sustainable-practice, neurodivergent-affirming-practice
- Audit script is non-destructive; publish script includes safety checks and detailed logging

https://claude.ai/code/session_01Rzb2xGHcJxiRNdAncVYLiF