### PR TITLE
Remove unused navbar markup and imports from Research Ready

### DIFF
--- a/client/public/research-ready.html
+++ b/client/public/research-ready.html
@@ -129,8 +129,6 @@
 
   <div id="cr-header"></div>
   <script src="/shared/nav-footer.js"></script>
-
-  <nav class="navbar"><a href="/dashboard" class="navbar-brand"><div class="logo-mark"><span class="c">C</span><span class="r">R</span></div><div class="navbar-title"><span class="counselor">Counselor</span><span class="ready">Ready</span></div></a><div class="navbar-links"><a href="/dashboard">Dashboard</a><a href="/courses">Courses</a><a href="/credentials">Credentials</a><a href="/research-ready" class="active">Research CE</a><a href="/settings">Settings</a></div></nav>
   <div class="page">
     <div class="hero"><div class="hero-badge"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 14l9-5-9-5-9 5 9 5z"/><path d="M12 14l6.16-3.422A12.083 12.083 0 0121 17.5C21 20 16.97 22 12 22S3 20 3 17.5a12.083 12.083 0 012.84-6.922L12 14z"/></svg>NBCC ACEP #7760</div><h1>Researched-N-Ready CE</h1><p>Current research. Earned credit. Search open-access articles, verify currency, and build CE courses backed by peer-reviewed scholarship.</p></div>
     <div class="section-label">Select target hours</div>

--- a/server/src/routes/researchReady.js
+++ b/server/src/routes/researchReady.js
@@ -12,7 +12,7 @@
 
 import express from 'express';
 import { protect, requireAdmin } from '../middleware/auth.js';
-import { searchArticles, enrichWithFullText, fetchArticleWithFullText } from '../services/openAlex.js';
+import { searchArticles } from '../services/openAlex.js';
 import { checkCurrency } from '../services/currencyCheck.js';
 import { buildCE } from '../services/ceBuild.js';
 import { generateArticleContent } from '../services/articleContentGenerator.js';


### PR DESCRIPTION
## Summary
This PR removes redundant navbar markup from the Research Ready page and cleans up unused imports from the backend route handler.

## Key Changes
- **Removed hardcoded navbar HTML** from `research-ready.html` - the navbar is now dynamically injected via the `nav-footer.js` script that was already present
- **Removed unused imports** from `researchReady.js` - deleted imports for `enrichWithFullText` and `fetchArticleWithFullText` functions that were not being utilized in the route handler

## Implementation Details
The navbar markup was being duplicated in the HTML file despite already being loaded through the shared `nav-footer.js` script. This cleanup eliminates the redundancy and reduces the HTML file size. The unused service imports in the backend route were likely remnants from previous refactoring and have been safely removed.

https://claude.ai/code/session_018MLAaNqjUi3fku2ZGSpD7E