### PR TITLE
Add engagement tracking and article metadata fields to RNR

### DIFF
--- a/client/public/research-ready.html
+++ b/client/public/research-ready.html
@@ -112,6 +112,8 @@
     .toast{position:fixed;bottom:100px;left:50%;transform:translateX(-50%) translateY(20px);background:var(--espresso2);color:var(--egg);padding:10px 22px;border-radius:var(--radius-sm);font-size:13px;font-weight:600;font-family:Georgia,serif;box-shadow:var(--shadow-md);opacity:0;transition:all 0.3s ease;z-index:200;pointer-events:none;}
     .toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
 
+    .wg-strip-top{height:14px;width:100%;background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='14'%3E%3Cfilter id='wg'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.015 0.9' numOctaves='5' seed='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0.4 0.3 0 0 0.28 0.25 0.18 0 0 0.16 0.12 0.09 0 0 0.08 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='400' height='14' filter='url(%23wg)'/%3E%3C/svg%3E");background-size:400px 14px;border-bottom:1.5px solid rgba(192,144,64,0.5);}
+    .wg-strip-bottom{height:14px;width:100%;background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='14'%3E%3Cfilter id='wg'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.015 0.9' numOctaves='5' seed='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0.4 0.3 0 0 0.28 0.25 0.18 0 0 0.16 0.12 0.09 0 0 0.08 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='400' height='14' filter='url(%23wg)'/%3E%3C/svg%3E");background-size:400px 14px;border-top:1.5px solid rgba(192,144,64,0.5);}
     @media(max-width:640px){.page{padding:1rem 1rem 6rem;}.hero{padding:1.5rem;}.hero h1{font-size:1.3rem;}.search-wrap{flex-direction:column;}.btn-search{padding:10px;}.hour-selector{gap:6px;}.hour-pill{min-width:70px;padding:8px 12px;}.ac-footer{flex-direction:column;align-items:flex-start;}.navbar{padding:0 1rem;}.navbar-links{gap:0.75rem;}.navbar-links a{font-size:11px;}}
   
     /* Shared nav styles */
@@ -126,6 +128,7 @@
   </style>
 </head>
 <body>
+  <div class="wg-strip-top"></div>
 
   <div id="cr-header"></div>
   <script src="/shared/nav-footer.js"></script>
@@ -165,5 +168,6 @@
   </script>
 
   <div id="cr-footer"></div>
+  <div class="wg-strip-bottom"></div>
 </body>
 </html>

--- a/server/src/models/RNRRequest.js
+++ b/server/src/models/RNRRequest.js
@@ -31,7 +31,15 @@ const articleSchema = new mongoose.Schema({
     type: String,
     enum: ['sufficient', 'borderline', 'thin'],
     default: 'sufficient'
-  }
+  },
+  fullTextSource: {
+    type: String,
+    enum: ['pdf', 'landing_page', 'pmc', 'abstract_only'],
+    default: 'abstract_only'
+  },
+  abstractOnly: { type: Boolean, default: true },
+  instructionalWordCount: { type: Number, default: 0 },
+  rawWordCount: { type: Number, default: 0 }
 }, { _id: false });
 
 const posttestQuestionSchema = new mongoose.Schema({
@@ -130,6 +138,9 @@ const rnrRequestSchema = new mongoose.Schema({
   passingScore: { type: Number, default: 75 },
   bestScore: { type: Number, default: 0 },
   passed: { type: Boolean, default: false },
+
+  // ── Engagement ──
+  engagementConfirmed: { type: Boolean, default: false },
 
   // ── Completion ──
   completedAt: { type: Date },

--- a/server/src/routes/researchReady.js
+++ b/server/src/routes/researchReady.js
@@ -1021,10 +1021,7 @@ router.post('/engagement/:courseId', protect, async (req, res) => {
     });
 
     if (request) {
-      // Store engagement on the request (via a simple field — not in model yet but we track it)
-      if (!request.adminNote?.includes('engagement_confirmed')) {
-        request.adminNote = (request.adminNote || '') + ' engagement_confirmed';
-      }
+      request.engagementConfirmed = true;
       await request.save();
       return res.json({ success: true, engagementConfirmed: true });
     }


### PR DESCRIPTION
## Summary
This PR enhances the Research Ready (RNR) system with improved engagement tracking and article metadata capture. It adds a dedicated `engagementConfirmed` field to the request model, expands article schema with full-text source information and word count metrics, and introduces decorative visual elements to the UI.

## Key Changes

- **Engagement Tracking**: Added `engagementConfirmed` boolean field to RNRRequest schema (defaults to `false`) and refactored the engagement endpoint to use this dedicated field instead of storing flags in admin notes
- **Article Metadata**: Extended the article schema with:
  - `fullTextSource`: enum field tracking the source of full text (pdf, landing_page, pmc, abstract_only)
  - `abstractOnly`: boolean flag indicating if only abstract is available
  - `instructionalWordCount`: numeric field for tracking instructional content word count
  - `rawWordCount`: numeric field for tracking total word count
- **UI Enhancement**: Added decorative SVG-based wood grain texture strips (`.wg-strip-top` and `.wg-strip-bottom`) to the top and bottom of the research-ready.html page for visual polish

## Implementation Details

- The engagement confirmation now uses a proper schema field rather than string concatenation in admin notes, improving data integrity and queryability
- Article metadata fields include sensible defaults to maintain backward compatibility
- The decorative strips use SVG filters with fractal noise for a natural wood grain appearance with subtle gold borders

https://claude.ai/code/session_01VtUbygHDr812gPu4QZG5U7