### PR TITLE
Auto-generate blog post frontmatter when missing

### DIFF
--- a/server/src/routes/blog.js
+++ b/server/src/routes/blog.js
@@ -159,10 +159,29 @@ router.post('/admin/upload', authenticateToken, isAdmin, upload.single('file'), 
 
     const raw = req.file.buffer.toString('utf8');
     const clean = raw.replace(/^\uFEFF/, '');
-    const { data, content } = matter(clean);
+    let { data, content } = matter(clean);
 
+    // Auto-generate frontmatter when missing
     if (!data.title) {
-      return res.status(400).json({ error: 'Title is required in frontmatter' });
+      const body = content.trim() || clean.trim();
+      const h1Match = body.match(/^#\s+(.+)$/m);
+      const title = h1Match ? h1Match[1].trim() : 'Untitled Post';
+
+      const firstPara = body.split('\n\n').find(p => !p.startsWith('#') && p.trim().length > 20);
+      const excerpt = firstPara ? firstPara.trim().substring(0, 200) : '';
+
+      data = {
+        ...data,
+        title,
+        author: 'Kejuiana Johnson, LPC, NCC, CPCS, BC-TMH',
+        date: new Date().toISOString().split('T')[0],
+        category: 'General',
+        tags: [],
+        excerpt
+      };
+
+      // Use full file as content when no frontmatter was present
+      if (!content.trim()) content = clean.trim();
     }
 
     const toArray = (val) => {


### PR DESCRIPTION
## Summary
Modified the blog upload endpoint to automatically generate missing frontmatter fields instead of rejecting uploads. This improves the user experience by allowing posts to be uploaded without complete metadata, which is then intelligently populated.

## Key Changes
- Changed frontmatter validation from hard rejection to auto-generation when title is missing
- Implemented intelligent title extraction from the first H1 heading in the post content, defaulting to "Untitled Post" if none exists
- Auto-generate excerpt by extracting the first paragraph longer than 20 characters (limited to 200 characters)
- Set default values for author, date (current date), category, and tags when not provided
- Preserve full file content when no frontmatter was originally present

## Implementation Details
- Title extraction uses regex pattern `/^#\s+(.+)$/m` to find H1 headings at the start of a line
- Excerpt generation filters out heading paragraphs and requires minimum 20 character length to avoid trivial content
- Default author is set to "Kejuiana Johnson, LPC, NCC, CPCS, BC-TMH"
- Date is automatically set to today's date in ISO format (YYYY-MM-DD)
- The solution maintains backward compatibility while making the upload process more forgiving

https://claude.ai/code/session_014ejpQkLkndq6X1Fv9AYU79