### PR TITLE
Support multiple articles in CE course builder prompt

### DIFF
--- a/server/src/services/ceBuild.js
+++ b/server/src/services/ceBuild.js
@@ -59,7 +59,7 @@ export async function buildCE({
 
   const prompt = `You are a CE course designer for CounselorReady, an NBCC ACEP-approved provider (#7760).
 
-Article: "${title}" (${authors}, ${journal}, ${year})
+${title.includes(' | ') ? `Articles:\n${title.split(' | ').map((t, i) => `  ${i+1}. "${t.trim()}"`).join('\n')}\nAuthors: ${authors}\nJournals: ${journal}` : `Article: "${title}" (${authors}, ${journal}, ${year})`}
 Topic area: ${topic}
 CE Hours: ${ceHours} (${researchHours} Research)
 Format: ${format}
@@ -89,6 +89,7 @@ course_title rules:
 - Standalone article: trim and reformat the article title as a professional CE course name. Drop filler openings like "A study of...", "An analysis of...", etc. Example: "The supervisory working alliance and counselor development: A longitudinal study of LPC trainees" → "Supervisory Alliance and Counselor Development: A CE Review"
 - Comparative format: "Then and Now: Evolution of [Topic]" or "Comparative Analysis: [Topic]"
 - Integrative format: "Integrative Review: [Topic Area]"
+- Multiple articles: synthesize the shared themes into one unified academic title. Example: articles about supervision models + ethical gatekeeping → "Clinical Supervision and Ethical Gatekeeping: A Meta-Analytic Review". Never join article titles with | or &. Find the conceptual thread.
 - Max 80 characters.`;
 
   const rawResponse = await callClaude(prompt);


### PR DESCRIPTION
## Summary
Updated the CE course builder to handle multiple articles as input, allowing the system to generate integrated CE courses from multiple research sources rather than just single articles.

## Key Changes
- Modified the prompt construction logic to detect and parse multiple articles separated by pipe delimiters (`|`)
- When multiple articles are detected, the prompt now formats them as a numbered list with separate fields for authors and journals
- Added guidance to the course title rules instructing Claude to synthesize shared themes across multiple articles into a unified academic title, rather than concatenating article titles
- Included an example showing how to derive a cohesive course title from conceptually related articles (supervision models + ethical gatekeeping)

## Implementation Details
- The change uses a ternary operator to conditionally format the article section based on whether the title contains the `|` delimiter
- For multiple articles: splits the title string, trims each article, and formats as a numbered list with proper indentation
- For single articles: maintains the original format with inline author, journal, and year information
- The new instruction explicitly warns against joining article titles with `|` or `&`, emphasizing the need to find the conceptual thread connecting the articles

https://claude.ai/code/session_01PLUgvcU3HNvJwtEvhaGqVY