### PR TITLE
Fix course data assignment to handle nested response structure

### DIFF
--- a/client/public/admin-course-editor.html
+++ b/client/public/admin-course-editor.html
@@ -397,7 +397,8 @@ async function saveAll() {
     const token = localStorage.getItem('token');
     const res = await fetch(`${API}/admin/courses/${courseId}`, { method:'PUT', headers:{'Content-Type':'application/json','Authorization':`Bearer ${token}`}, body:JSON.stringify(payload) });
     if (!res.ok) { const e = await res.json().catch(()=>({})); throw new Error(e.message||`HTTP ${res.status}`); }
-    courseData = await res.json().catch(() => payload);
+    const saved = await res.json().catch(() => payload);
+    courseData = saved.course || saved;
     showToast('Saved successfully','success');
     const sEl = document.getElementById('metaStatus'); sEl.textContent = status;
     sEl.className = status==='published' ? 'text-xs px-2.5 py-0.5 rounded-full font-bold bg-green-100 text-green-700' : 'text-xs px-2.5 py-0.5 rounded-full font-bold bg-yellow-100 text-yellow-800';


### PR DESCRIPTION
## Summary
Updated the course save handler to properly extract course data from API responses that may wrap the course object in a `course` property.

## Key Changes
- Modified the response handling in the course save endpoint to store the parsed response in an intermediate variable before assignment
- Added fallback logic to check for `saved.course` property first, then fall back to the entire response object
- This ensures compatibility with API responses that either return the course object directly or wrap it in a `course` property

## Implementation Details
The change addresses a potential mismatch between the API response format and the expected data structure. By using `courseData = saved.course || saved`, the code now gracefully handles both response formats:
- If the API returns `{ course: {...} }`, it extracts the nested course object
- If the API returns the course object directly, it uses that response as-is

This prevents data structure inconsistencies that could occur when the server response format differs from expectations.

https://claude.ai/code/session_01DvjtfgigPBLga5vQqDTRFo