### PR TITLE
Improve close button styling in user modal

### DIFF
--- a/client/public/admin-users.html
+++ b/client/public/admin-users.html
@@ -345,9 +345,11 @@
               <p id="modalUserEmail" class="text-white/80 text-sm"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="3f5a525e56537f5a475e524f535a115c5052">[email&#160;protected]</a></p>
             </div>
           </div>
-          <button onclick="closeUserModal()" class="text-white/80 hover:text-white">
-            <i class="fas fa-times text-xl"></i>
-          </button>
+          <button onclick="closeUserModal()"
+            style="width:36px;height:36px;min-width:36px;border-radius:50%;background:rgba(255,255,255,0.2);border:none;cursor:pointer;color:#fff;font-size:18px;display:flex;align-items:center;justify-content:center;transition:background 0.15s;flex-shrink:0"
+            onmouseover="this.style.background='rgba(255,255,255,0.35)'"
+            onmouseout="this.style.background='rgba(255,255,255,0.2)'"
+            aria-label="Close">✕</button>
         </div>
       </div>
       


### PR DESCRIPTION
## Summary
Enhanced the visual design and accessibility of the close button in the user modal dialog by replacing a simple icon-based button with a styled circular button featuring hover effects.

## Key Changes
- Replaced Font Awesome icon (`fa-times`) with a text-based close symbol (✕)
- Added inline styles to create a circular button design (36x36px with 50% border-radius)
- Implemented semi-transparent white background (`rgba(255,255,255,0.2)`) with hover state enhancement
- Added smooth background color transition on hover (0.15s)
- Improved accessibility by adding an `aria-label="Close"` attribute
- Enhanced visual feedback with `onmouseover` and `onmouseout` event handlers for interactive hover effects

## Implementation Details
- The button now uses a consistent circular design pattern with proper spacing and alignment
- Hover state increases background opacity from 0.2 to 0.35 for clear visual feedback
- Flexbox properties ensure the close symbol is properly centered within the circular button
- `flex-shrink:0` prevents the button from shrinking in flex containers

https://claude.ai/code/session_01U6yQCnUuCwTmTaxJPh4oeW