### PR TITLE
Fix certificate generation to use email fallback instead of name

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -905,7 +905,7 @@ router.post('/:id/certificate', protect, async (req, res) => {
       await generateCertificateNumber(course._id, req.user._id);
 
     // Generate certificate PDF buffer via ../utils/certificate.js
-    const userName = `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.name || user.email;
+    const userName = `${(user.firstName || '')} ${(user.lastName || '')}`.trim() || user.email;
     const pdfBuffer = await generateCertificate({
       holderName: userName,
       courseName: course.title,


### PR DESCRIPTION
## Summary
Updated the certificate generation logic to use email as the fallback for the certificate holder's name instead of the user's name field.

## Key Changes
- Modified the `userName` assignment in the certificate generation endpoint to remove the `user.name` fallback
- Changed from: `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.name || user.email`
- Changed to: `${(user.firstName || '')} ${(user.lastName || '')}`.trim() || user.email`
- Added explicit parentheses around firstName and lastName for clarity

## Implementation Details
This change ensures that when a user doesn't have firstName and lastName populated, the certificate will display their email address rather than a potentially undefined or incorrect name field. This provides a more reliable fallback for certificate generation and ensures users always have a valid identifier on their certificates.

https://claude.ai/code/session_01LA6zVJxooMdPVG3gZkTAqA