### PR TITLE
fix(admin): append cache-buster to regenerated certificate fileUrl

### DIFF
--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -91,7 +91,7 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
 
     const oldPublicId = cert.fileKey;
 
-    cert.fileUrl = newUrl;
+    cert.fileUrl = newUrl.includes('?') ? `${newUrl}&t=${Date.now()}` : `${newUrl}?t=${Date.now()}`;
     const newPublicId = extractCloudinaryPublicId(newUrl);
     if (newPublicId) cert.fileKey = newPublicId;
     await cert.save();


### PR DESCRIPTION
Browsers were serving the cached PDF after regeneration because Cloudinary returned the same secure_url. Appending ?t=<timestamp> forces a fresh fetch. fileKey still stores the clean public_id (extractCloudinaryPublicId runs against the pre-buster newUrl).