### PR TITLE
Fix unenrollment logic and update certificate button colors

### DIFF
--- a/client/public/admin-users.html
+++ b/client/public/admin-users.html
@@ -1068,7 +1068,7 @@
             <div class="flex gap-2">
               <button
                 onclick="regenerateUserCertificate('${cert._id}', '${safeCertNumber}', this)"
-                class="inline-flex items-center gap-1.5 bg-honey-600 hover:bg-honey-700 text-white text-xs font-medium px-3 py-1.5 rounded"
+                class="inline-flex items-center gap-1.5 bg-gold-600 hover:bg-gold-700 text-white text-xs font-medium px-3 py-1.5 rounded"
               >
                 <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582A7.003 7.003 0 0119 11m1 9v-5h-.581A7.003 7.003 0 015 13"/>
@@ -1080,7 +1080,7 @@
                   href="${pdfUrl}"
                   target="_blank"
                   rel="noopener"
-                  class="inline-flex items-center gap-1.5 text-hunter-600 hover:text-hunter-700 text-xs font-medium px-3 py-1.5 rounded border border-hunter-200 hover:border-hunter-300"
+                  class="inline-flex items-center gap-1.5 text-forest-600 hover:text-forest-700 text-xs font-medium px-3 py-1.5 rounded border border-forest-200 hover:border-forest-300"
                 >
                   <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"/>

--- a/server/src/routes/adminCourses.js
+++ b/server/src/routes/adminCourses.js
@@ -818,14 +818,14 @@ router.post('/users/:userId/enroll', protect, adminOnly, async (req, res) => {
 router.delete('/users/:userId/enrollments/:courseId', protect, adminOnly, async (req, res) => {
   try {
     const { userId, courseId } = req.params;
-    
-    const enrollment = await UserCourseProgress.findOne({ userId, courseId });
-    if (!enrollment) {
+
+    const legacyResult = await UserCourseProgress.deleteOne({ userId, courseId });
+    const interactiveResult = await InteractiveCourseProgress.deleteOne({ userId, courseId });
+
+    if ((legacyResult.deletedCount || 0) === 0 && (interactiveResult.deletedCount || 0) === 0) {
       return res.status(404).json({ error: 'Enrollment not found' });
     }
-    
-    await UserCourseProgress.deleteOne({ userId, courseId });
-    
+
     res.json({ message: 'User unenrolled successfully' });
   } catch (error) {
     console.error('Admin unenroll error:', error);


### PR DESCRIPTION
## Summary
This PR fixes the user unenrollment endpoint to properly handle both legacy and interactive course progress records, and updates certificate button styling to use the correct color scheme.

## Key Changes
- **Backend (adminCourses.js)**: Updated the DELETE `/users/:userId/enrollments/:courseId` endpoint to:
  - Delete from both `UserCourseProgress` (legacy) and `InteractiveCourseProgress` tables
  - Only return a 404 error if neither record exists
  - Previously only checked and deleted from the legacy table, potentially leaving orphaned interactive course progress records

- **Frontend (admin-users.html)**: Updated certificate management button colors:
  - Changed "Regenerate Certificate" button from `honey-600/honey-700` to `gold-600/gold-700`
  - Changed "Download Certificate" link from `hunter-600/hunter-700` to `forest-600/forest-700` with matching border colors

## Implementation Details
The unenrollment fix ensures data consistency by removing enrollment records from both the legacy and new interactive course progress systems. The deletion is considered successful if at least one record is found and deleted from either table.

https://claude.ai/code/session_01DFb5ugVkRXNhcYy6Cruo8q