### PR TITLE
fix(certificate): read name from user.profile.firstName/lastName

### DIFF
--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -65,7 +65,7 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
     const { userId, certId } = req.params;
 
     const cert = await Certificate.findOne({ _id: certId, userId })
-      .populate('userId', 'firstName lastName email')
+      .populate('userId', 'profile.firstName profile.lastName email')
       .populate('courseId', 'title ceHours nbccProgramNumber slug');
 
     if (!cert) {
@@ -76,7 +76,7 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
     const course = cert.courseId || {};
 
     const userName =
-      `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.email || 'Unknown';
+      `${user.profile?.firstName || ''} ${user.profile?.lastName || ''}`.trim() || user.email || 'Unknown';
     const courseTitle = course.title || cert.title;
 
     const newUrl = await certificateService.generatePDF({

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -905,7 +905,7 @@ router.post('/:id/certificate', protect, async (req, res) => {
       await generateCertificateNumber(course._id, req.user._id);
 
     // Generate certificate PDF buffer via ../utils/certificate.js
-    const userName = `${(user.firstName || '')} ${(user.lastName || '')}`.trim() || user.email;
+    const userName = `${(user.profile?.firstName || '')} ${(user.profile?.lastName || '')}`.trim() || user.email;
     const pdfBuffer = await generateCertificate({
       holderName: userName,
       courseName: course.title,

--- a/server/src/scripts/bulkRegenerateBadCerts.js
+++ b/server/src/scripts/bulkRegenerateBadCerts.js
@@ -39,7 +39,7 @@ async function main() {
 
   // 2. Look up each cert's user
   const userIds = [...new Set(allCerts.map(c => c.userId?.toString()).filter(Boolean))];
-  const users = await User.find({ _id: { $in: userIds } }).select('firstName lastName email').lean();
+  const users = await User.find({ _id: { $in: userIds } }).select('profile.firstName profile.lastName email').lean();
   const userMap = {};
   users.forEach(u => { userMap[u._id.toString()] = u; });
 
@@ -47,7 +47,7 @@ async function main() {
   const needsRegen = allCerts.filter(cert => {
     const user = userMap[cert.userId?.toString()];
     if (!user) return false;
-    return (user.firstName || '').trim().length > 0;
+    return (user.profile?.firstName || '').trim().length > 0;
   });
 
   console.log(`Eligible for regeneration: ${needsRegen.length}`);
@@ -56,7 +56,7 @@ async function main() {
     console.log('\n--- DRY RUN ---');
     for (const cert of needsRegen) {
       const u = userMap[cert.userId.toString()];
-      const name = `${u.firstName || ''} ${u.lastName || ''}`.trim();
+      const name = `${u.profile?.firstName || ''} ${u.profile?.lastName || ''}`.trim();
       const hasUrl = cert.fileUrl ? 'has URL' : 'NO URL';
       console.log(`  ${cert.certificateNumber} | ${u.email} → "${name}" | ${hasUrl}`);
     }
@@ -97,7 +97,7 @@ async function main() {
     await Promise.all(batch.map(async (cert) => {
       const user = userMap[cert.userId.toString()];
       const course = courseMap[cert.courseId?.toString()];
-      const userName = `${(user.firstName || '')} ${(user.lastName || '')}`.trim() || user.email;
+      const userName = `${(user.profile?.firstName || '')} ${(user.profile?.lastName || '')}`.trim() || user.email;
 
       if (!course) {
         console.log(`  SKIP ${cert.certificateNumber} — course not found`);
@@ -154,4 +154,6 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('Fata
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/server/src/services/courseCompletionService.js
+++ b/server/src/services/courseCompletionService.js
@@ -52,7 +52,7 @@ export async function processCourseCompletion({ userId, courseId, assessmentScor
     const certificateNumber = await Certificate.getNextCertificateNumber();
 
     // 4. Generate PDF
-    const userName = `${(user.firstName || '')} ${(user.lastName || '')}`.trim() || user.email;
+    const userName = `${(user.profile?.firstName || '')} ${(user.profile?.lastName || '')}`.trim() || user.email;
 
     const fileUrl = await certificateService.generatePDF({
       certificateNumber,


### PR DESCRIPTION
The certificate holder name was falling through to the user's email because every generator path read user.firstName and user.lastName at the top level, but the User schema nests them under user.profile. With those reads always undefined, the `|| user.email` fallback fired every time and the PDF printed the email.

Fixed in all four sites that build the userName string:
- server/src/routes/admin.js — admin Regenerate endpoint (populate and read nested profile path)
- server/src/routes/interactiveCourseRoutes.js:908 — interactive course certificate issuance (targeted edit; not a rewrite)
- server/src/services/courseCompletionService.js:55 — legacy course certificate issuance
- server/src/scripts/bulkRegenerateBadCerts.js — select, filter, dry-run print, and regen all read the nested profile path now; previously the filter excluded every user and the script regenerated zero certs. Also completed a truncated trailing catch handler that prevented the script from parsing.

https://claude.ai/code/session_01VFv7JrxMvHKVAoCzmTSHg2