### PR TITLE
Add NPS survey modal to course completion flow

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -4265,6 +4265,8 @@ function downloadCertificate() {
           ceHours: course.ceHours || 0
         });
       }
+
+      setTimeout(checkAndShowNPS, 2000);
     })
     .catch(err => {
       console.error('[CR] Certificate generation failed:', err);
@@ -5713,6 +5715,78 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
+// ============================================
+// NPS SURVEY
+// ============================================
+let selectedNPSScore = null;
+
+async function checkAndShowNPS() {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    const res = await fetch(`${API_BASE}/api/analytics/survey/check`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.showSurvey) showNPSModal(data.trigger);
+  } catch (e) {
+    // fail silently - never block the user
+  }
+}
+
+function showNPSModal(trigger) {
+  const modal = document.getElementById('nps-modal');
+  const btnContainer = document.getElementById('nps-buttons');
+  btnContainer.innerHTML = '';
+  for (let i = 0; i <= 10; i++) {
+    const btn = document.createElement('button');
+    btn.textContent = i;
+    btn.dataset.score = i;
+    btn.className = 'w-9 h-9 rounded-lg border border-slate-200 text-sm font-medium hover:bg-burgundy-50 hover:border-burgundy-300 transition-colors';
+    btn.onclick = () => selectNPSScore(i);
+    btnContainer.appendChild(btn);
+  }
+  modal.dataset.trigger = trigger || 'course_completion';
+  modal.classList.remove('hidden');
+}
+
+function selectNPSScore(score) {
+  selectedNPSScore = score;
+  document.querySelectorAll('#nps-buttons button').forEach(btn => {
+    const s = parseInt(btn.dataset.score);
+    btn.className = s === score
+      ? 'w-9 h-9 rounded-lg border-2 border-burgundy-700 bg-burgundy-700 text-white text-sm font-medium transition-colors'
+      : 'w-9 h-9 rounded-lg border border-slate-200 text-sm font-medium hover:bg-burgundy-50 hover:border-burgundy-300 transition-colors';
+  });
+  document.getElementById('nps-followup').classList.remove('hidden');
+  document.getElementById('nps-submit-btn').classList.remove('hidden');
+}
+
+async function submitNPS() {
+  if (selectedNPSScore === null) return;
+  try {
+    const token = localStorage.getItem('token');
+    const comment = document.getElementById('nps-comment').value;
+    await fetch(`${API_BASE}/api/analytics/survey/nps`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        npsScore: selectedNPSScore,
+        whatDoYouLove: comment,
+        trigger: document.getElementById('nps-modal').dataset.trigger
+      })
+    });
+  } catch (e) { /* fail silently */ }
+  finally {
+    dismissNPS();
+  }
+}
+
+function dismissNPS() {
+  document.getElementById('nps-modal').classList.add('hidden');
+}
+
 </script>
 <!-- ═══════════════════════════════════════════════════════════════
      REFERENCES & RESOURCES DRAWERS — Floating edge tabs + slide-out
@@ -5926,5 +6000,25 @@ document.addEventListener('keydown', function(e) {
 <script src="shareWidget.js"></script>
 <script src="/shared/nav-footer.js"></script>
 <div id="cr-footer"></div>
+<div id="nps-modal" class="hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+  <div class="bg-white rounded-2xl p-8 max-w-lg w-full shadow-2xl">
+    <h3 class="font-display text-2xl font-semibold text-burgundy-900 mb-2">One quick question</h3>
+    <p class="text-slate-600 mb-6">How likely are you to recommend CounselorReady to a colleague?</p>
+    <div class="flex justify-between gap-1 mb-2" id="nps-buttons">
+      <!-- 0-10 buttons injected by JS -->
+    </div>
+    <div class="flex justify-between text-xs text-slate-400 mb-6">
+      <span>Not likely</span><span>Very likely</span>
+    </div>
+    <div id="nps-followup" class="hidden mb-4">
+      <textarea id="nps-comment" rows="3" placeholder="What's the main reason for your score? (optional)"
+        class="w-full border border-slate-200 rounded-xl p-3 text-sm focus:outline-none focus:ring-2 focus:ring-burgundy-300 resize-none"></textarea>
+    </div>
+    <div class="flex gap-3 justify-end">
+      <button onclick="dismissNPS()" class="px-4 py-2 text-slate-500 hover:text-slate-700 text-sm">Skip</button>
+      <button id="nps-submit-btn" onclick="submitNPS()" class="hidden px-6 py-2 bg-burgundy-700 hover:bg-burgundy-800 text-white text-sm font-medium rounded-xl transition-colors">Submit</button>
+    </div>
+  </div>
+</div>
 </body>
 </html>

--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -5724,7 +5724,7 @@ async function checkAndShowNPS() {
   try {
     const token = localStorage.getItem('token');
     if (!token) return;
-    const res = await fetch(`${API_BASE}/api/analytics/survey/check`, {
+    const res = await fetch(`${crApiBase()}/api/analytics/survey/check`, {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     if (!res.ok) return;
@@ -5768,7 +5768,7 @@ async function submitNPS() {
   try {
     const token = localStorage.getItem('token');
     const comment = document.getElementById('nps-comment').value;
-    await fetch(`${API_BASE}/api/analytics/survey/nps`, {
+    await fetch(`${crApiBase()}/api/analytics/survey/nps`, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
This PR adds a Net Promoter Score (NPS) survey feature that displays a modal dialog after course completion. The survey collects user feedback on their likelihood to recommend CounselorReady and optional comments about their experience.

## Key Changes
- **NPS Modal UI**: Added a new modal dialog (`nps-modal`) with a 0-10 rating scale, optional comment textarea, and submit/skip buttons
- **Survey Trigger**: Integrated `checkAndShowNPS()` function that fires 2 seconds after certificate generation completes
- **Backend Integration**: Implemented API calls to:
  - Check if survey should be shown via `GET /api/analytics/survey/check`
  - Submit survey responses via `POST /api/analytics/survey/nps`
- **User Interactions**: 
  - Score selection with visual feedback (button styling changes on selection)
  - Optional follow-up comment field that appears after score selection
  - Graceful dismissal with "Skip" button
- **Error Handling**: All API calls fail silently to prevent blocking user experience

## Implementation Details
- Survey data includes: NPS score (0-10), optional comment, and trigger type (e.g., 'course_completion')
- Modal uses Tailwind CSS styling with burgundy color scheme matching the application design
- Token-based authentication required for API requests
- Selected score state managed via `selectedNPSScore` variable with dynamic button styling

https://claude.ai/code/session_01FZSPiAC6muvxkDggiCCapC