### PR TITLE
Fix admin overview evaluations endpoint to populate user and course data

### DIFF
--- a/server/src/routes/analytics.js
+++ b/server/src/routes/analytics.js
@@ -7,6 +7,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import { protect } from '../middleware/auth.js';
 import Course from '../models/Course.js';
+import Evaluation from '../models/Evaluation.js';
 import PlatformSurvey from '../models/PlatformSurvey.js';
 import UserCourseProgress from '../models/UserCourseProgress.js';
 import User from '../models/User.js';
@@ -594,13 +595,20 @@ router.get('/admin/overview', protect, async (req, res) => {
       .sort({ createdAt: -1 })
       .limit(10);
     
-    // Also get recent course evaluations (from UserCourseProgress)
-    const recentEvaluations = await mongoose.connection.db
-      .collection('evaluations')
-      .find({ isDeleted: false })
+    // Also get recent course evaluations — populated so frontend can render user + course
+    const recentEvaluationsRaw = await Evaluation.find({ isDeleted: false })
       .sort({ createdAt: -1 })
       .limit(10)
-      .toArray();
+      .populate('user', 'email profile')
+      .populate('course', 'title courseCode')
+      .lean();
+
+    // Rename user → userId and course → courseId to match frontend contract
+    const recentEvaluations = recentEvaluationsRaw.map(ev => ({
+      ...ev,
+      userId: ev.user,
+      courseId: ev.course,
+    }));
     
     res.json({
       nps: npsData,


### PR DESCRIPTION
## Summary
Updated the admin overview analytics endpoint to properly populate user and course data for recent evaluations, ensuring the frontend can render complete evaluation records without additional requests.

## Key Changes
- Imported `Evaluation` model to replace direct collection access
- Changed from raw MongoDB collection query to Mongoose `find()` with `.populate()` calls
- Added population of `user` (email, profile) and `course` (title, courseCode) fields
- Added `.lean()` for query optimization
- Mapped populated fields to match frontend contract (`user` → `userId`, `course` → `courseId`)

## Implementation Details
- The endpoint now returns fully populated evaluation objects instead of requiring the frontend to fetch user and course details separately
- Field renaming ensures backward compatibility with existing frontend expectations
- Using `.lean()` improves query performance by returning plain JavaScript objects instead of Mongoose documents

https://claude.ai/code/session_01NsTTRYvLTTmje1avcMj4GS