### PR TITLE
fix(admin-analytics): populate completion / evaluation stats correctly

### DIFF
--- a/client/public/admin-analytics.html
+++ b/client/public/admin-analytics.html
@@ -69,7 +69,7 @@
           <option value="30">Last 30 days</option>
           <option value="90">Last 90 days</option>
           <option value="365">Last year</option>
-          <option value="all">All time</option>
+          <option value="all" selected>All time</option>
         </select>
         <button onclick="exportData()" class="bg-forest-600 hover:bg-forest-700 px-4 py-2 rounded-lg text-sm font-medium">
           Export CSV

--- a/client/public/admin-analytics.html
+++ b/client/public/admin-analytics.html
@@ -843,17 +843,22 @@
         const user = ev.userId?.email || 'Unknown';
         const name = [ev.userId?.profile?.firstName, ev.userId?.profile?.lastName].filter(Boolean).join(' ');
         const course = ev.courseId?.title || 'Unknown Course';
-        const date = ev.evaluationCompletedAt ? new Date(ev.evaluationCompletedAt).toLocaleDateString() : '';
+        const date = ev.submittedAt
+          ? new Date(ev.submittedAt).toLocaleDateString()
+          : (ev.createdAt ? new Date(ev.createdAt).toLocaleDateString() : '');
 
-        // Extract ratings from evaluation responses
+        // Build ratings line from ratings object + overallRating
         let ratingsHtml = '';
-        if (ev.evaluationResponses && ev.evaluationResponses.length > 0) {
-          const ratingResponses = ev.evaluationResponses.filter(r => r.type === 'rating' && r.answer);
-          if (ratingResponses.length > 0) {
-            ratingsHtml = ratingResponses.slice(0, 3).map(r =>
-              `<span class="text-xs text-forest-600">${r.question?.slice(0, 30) || 'Rating'}: <strong>${r.answer}/5</strong></span>`
-            ).join(' · ');
-          }
+        const r = ev.ratings || {};
+        const parts = [];
+        if (ev.overallRating)   parts.push(`Overall: <strong>${ev.overallRating}/5</strong>`);
+        if (r.contentQuality)   parts.push(`Content: <strong>${r.contentQuality}/5</strong>`);
+        if (r.relevance)        parts.push(`Relevance: <strong>${r.relevance}/5</strong>`);
+        if (r.engagement)       parts.push(`Engagement: <strong>${r.engagement}/5</strong>`);
+        if (parts.length) {
+          ratingsHtml = parts.slice(0, 3)
+            .map(p => `<span class="text-xs text-forest-600">${p}</span>`)
+            .join(' · ');
         }
 
         return `

--- a/server/src/routes/analytics.js
+++ b/server/src/routes/analytics.js
@@ -451,37 +451,55 @@ router.get('/admin/overview', protect, async (req, res) => {
     // Satisfaction averages from platform surveys
     const satisfactionData = await PlatformSurvey.getSatisfactionAverages(startDate, endDate);
     
-    // Get REAL stats from UserCourseProgress
-    const progressFilter = {};
-    if (startDate || endDate) {
-      progressFilter.completedAt = dateFilter;
-    }
-    
-    const progressStats = await UserCourseProgress.aggregate([
-      { $match: progressFilter },
-      {
-        $group: {
-          _id: null,
-          totalEnrollments: { $sum: 1 },
-          totalCompletions: { $sum: { $cond: [{ $eq: ['$status', 'completed'] }, 1, 0] } },
-          totalEvaluations: { $sum: { $cond: [{ $eq: ['$evaluationSubmitted', true] }, 1, 0] } }
+    // Date window applied per-metric via $cond — NOT as a top-level $match.
+    // Ensures in-progress enrollments still count toward totalEnrollments
+    // when a window is active, and that completions without completedAt
+    // stamped (older rows, interactive `certified` rows) aren't silently dropped.
+    const hasWindow = !!(startDate || endDate);
+    const inWindow = (field) => {
+      const conds = [{ $ne: [`$${field}`, null] }];
+      if (startDate) conds.push({ $gte: [`$${field}`, startDate] });
+      if (endDate)   conds.push({ $lte: [`$${field}`, endDate] });
+      return { $and: conds };
+    };
+
+    const buildGroup = (completedStatuses, hasEvalSubmittedAt) => ({
+      _id: null,
+      totalEnrollments: { $sum: 1 },
+      totalCompletions: {
+        $sum: {
+          $cond: [
+            hasWindow
+              ? { $and: [{ $in: ['$status', completedStatuses] }, inWindow('completedAt')] }
+              : { $in: ['$status', completedStatuses] },
+            1, 0
+          ]
+        }
+      },
+      totalEvaluations: {
+        $sum: {
+          $cond: [
+            hasWindow && hasEvalSubmittedAt
+              ? { $and: [{ $eq: ['$evaluationSubmitted', true] }, inWindow('evaluationSubmittedAt')] }
+              : { $eq: ['$evaluationSubmitted', true] },
+            1, 0
+          ]
         }
       }
+    });
+
+    // UserCourseProgress has evaluationCompletedAt but no evaluationSubmittedAt,
+    // so evaluations are counted unconditionally across the whole collection.
+    const legacyHasEvalAt = false;
+
+    const progressStats = await UserCourseProgress.aggregate([
+      { $group: buildGroup(['completed'], legacyHasEvalAt) }
     ]);
 
     const interactiveProgressStats = await mongoose.connection.db
       .collection('interactivecourseprogresses')
-      .aggregate([
-        { $match: progressFilter },
-        {
-          $group: {
-            _id: null,
-            totalEnrollments: { $sum: 1 },
-            totalCompletions: { $sum: { $cond: [{ $in: ['$status', ['completed', 'certified']] }, 1, 0] } },
-            totalEvaluations: { $sum: { $cond: [{ $eq: ['$evaluationSubmitted', true] }, 1, 0] } }
-          }
-        }
-      ]).toArray();
+      .aggregate([{ $group: buildGroup(['completed', 'certified'], false) }])
+      .toArray();
 
     // Get total courses count
     const totalCourses = await Course.countDocuments({ status: 'published' });


### PR DESCRIPTION
## Summary

Admin Analytics (`/admin-analytics.html`) was reporting only **5 completions** despite more existing. Three bugs, all scoped edits — no locked files touched.

### Bug 1 — Default date range hid older data
`client/public/admin-analytics.html` — the `<select id="dateRange">` had no `selected` attribute, so the browser fell back to the first option (Last 30 days). Moved `selected` onto `value="all"`.

### Bug 2 — Aggregation scope in `/api/analytics/admin/overview`
`server/src/routes/analytics.js` (lines ~454-505) applied the `completedAt` date filter as a top-level `$match`, which silently dropped every in-progress enrollment and every completion whose `completedAt` wasn't stamped (older rows, interactive `certified` rows). As a result, `totalEnrollments` collapsed whenever a window was active and `totalCompletions` lost older completions.

Replaced with per-metric `$cond` gating via a `buildGroup()` helper:
- `totalEnrollments` is always lifetime scope.
- `totalCompletions` is window-scoped via `completedAt` only when a window is set.
- `totalEvaluations` stays unconditional for `UserCourseProgress` (no `evaluationSubmittedAt` field exists on that model — verified by grep).

JSON response shape is unchanged.

### Bug 3 — `renderEvaluations` read wrong field names
`client/public/admin-analytics.html` (`renderEvaluations`) read `ev.evaluationCompletedAt` and `ev.evaluationResponses[]` (the legacy `UserCourseProgress` shape), but `/admin/overview` returns `Evaluation` documents that expose `submittedAt`/`createdAt`, `overallRating`, and `ratings{contentQuality, relevance, engagement, …}`. Rows rendered with blank dates and no ratings.

Replaced only the date + ratings block (~846-857). Surrounding row markup is untouched — zero visual changes.

## Files changed

- `server/src/routes/analytics.js` — Bug 2
- `client/public/admin-analytics.html` — Bug 1 (one attribute) + Bug 3 (date/ratings block)

Not touched: `adminStats.js`, `interactiveCourseRoutes.js`, `courses.js`, any model, any locked file.

## Test plan

- [ ] Load `/admin-analytics.html` as admin — "All time" is the default selected option.
- [ ] Course Completions tile equals `db.usercourseprogresses.countDocuments({status:'completed'}) + db.interactivecourseprogresses.countDocuments({status:{$in:['completed','certified']}})`.
- [ ] Switch to "Last 30 days" — Completions drops to recent-only; Total Enrollments **stays at lifetime count** (confirms Bug 2 fix).
- [ ] Recent Course Evaluations rows show a date and a ratings line (Overall/Content/Relevance/Engagement).
- [ ] No visual changes elsewhere (NPS, satisfaction, top-courses, feedback unchanged).

https://claude.ai/code/session_018UtuCmzcuZxBzxe5vsJdP7