### PR TITLE
Pass client-chosen successUrl through to Stripe Checkout

### DIFF
--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -1023,6 +1023,7 @@
         const token = localStorage.getItem('token');
         const body = { courseId: currentCourse._id };
         if (appliedCouponCode) body.couponCode = appliedCouponCode;
+        body.successUrl = `${window.location.origin}/checkout-success.html?course=${encodeURIComponent(currentCourse.slug)}&slug=${encodeURIComponent(currentCourse.slug)}&name=${encodeURIComponent(currentCourse.title)}&session_id={CHECKOUT_SESSION_ID}`;
 
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 15000);

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -1050,7 +1050,7 @@ router.post('/purchase-course', protect, async (req, res) => {
         userId: user._id.toString(),
         slug: course.slug
       },
-      success_url: `${process.env.CLIENT_URL}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
+      success_url: req.body.successUrl || `${process.env.CLIENT_URL}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
       cancel_url: `${process.env.CLIENT_URL}/course-details.html?slug=${course.slug}&cancelled=true`
     };
 


### PR DESCRIPTION
## Summary
- `client/public/course-details.html` — inside `proceedToCheckout()`, add one line that sets `body.successUrl` to a `/checkout-success.html` URL carrying `course`, `slug`, `name`, and the Stripe `{CHECKOUT_SESSION_ID}` placeholder. Modal, coupon flow, and button wiring are untouched.
- `server/src/routes/payments.js` — inside the `POST /purchase-course` handler, change the hardcoded `success_url` to `req.body.successUrl || <existing hardcoded URL>` so a client-supplied value is preferred but existing callers that don't send one still work.

## Behavior
- Logged-in user clicks **Buy This Course** → existing coupon modal → Continue to Checkout → Stripe Checkout → on success, Stripe redirects to `/checkout-success.html?course=<slug>&slug=<slug>&name=<title>&session_id=<session id>`.
- Any other caller that hits `POST /api/payments/purchase-course` without a `successUrl` in the body falls back to the prior `/purchase-success.html?session_id=…&slug=…` URL — no regression.

## Test plan
- [ ] Load a course-details page as a logged-in user, complete the existing coupon modal, click Continue to Checkout. In DevTools Network, confirm the POST body includes `successUrl` pointing at `/checkout-success.html?...`.
- [ ] Complete a Stripe test checkout end-to-end and verify the browser lands on `/checkout-success.html` with `course`, `slug`, `name`, and a real `session_id` in the query string.
- [ ] Regression: call `POST /api/payments/purchase-course` without `successUrl` (e.g. via curl / another client) and confirm Stripe still returns a checkout URL whose `success_url` points at `/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=<slug>`.
- [ ] Confirm cancel path unchanged — clicking Stripe's back-link still lands on `/course-details.html?slug=<slug>&cancelled=true`.

## Notes
- `server/src/routes/payments.js` is marked locked in `CLAUDE.md`; the one-line edit here was explicitly authorized for this task.

https://claude.ai/code/session_01JRJvnHqT2cFHs8s1HaDFMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRJvnHqT2cFHs8s1HaDFMK)_