### PR TITLE
Fix InteractiveCourse import to use named export

### DIFF
--- a/server/src/routes/analytics.js
+++ b/server/src/routes/analytics.js
@@ -8,7 +8,7 @@ import mongoose from 'mongoose';
 import { protect } from '../middleware/auth.js';
 import Course from '../models/Course.js';
 import Evaluation from '../models/Evaluation.js';
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 import PlatformSurvey from '../models/PlatformSurvey.js';
 import UserCourseProgress from '../models/UserCourseProgress.js';
 import User from '../models/User.js';


### PR DESCRIPTION
## Summary
Updated the import statement for InteractiveCourse in the analytics route to correctly use the named export from the InteractiveCourse model.

## Changes
- Changed `import InteractiveCourse from '../models/InteractiveCourse.js'` to `import { Course as InteractiveCourse } from '../models/InteractiveCourse.js'`
- This aligns the import with the actual export structure of the InteractiveCourse model, which exports `Course` as a named export rather than a default export

## Details
The InteractiveCourse model exports `Course` as a named export, but the analytics route was attempting to import it as a default export. This change corrects the import statement to properly destructure the named export and alias it as `InteractiveCourse` for consistency with the rest of the codebase.

https://claude.ai/code/session_01Fpu8WpzY1y4JxpccNzSB5d