### PR TITLE
fix(a11y): lift ADA controls z-index above overlays

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1490,6 +1490,12 @@ body.cr-has-timer .cr-glossary-btn { bottom: 220px; }
   body.cr-has-timer .cr-a11y-panel { bottom: 264px; }
   body.cr-has-timer .cr-glossary-btn { bottom: 200px; }
 }
+  /* ADA controls — guaranteed reachability above overlays */
+  .cr-a11y-toggle,
+  .cr-a11y-panel {
+    z-index: 99998;
+    isolation: isolate;
+  }
 </style>
 <!-- .docx parsing -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.6.0/mammoth.browser.min.js"></script>


### PR DESCRIPTION
## Summary

Per CREADY-VIEWER-ARCHITECTURE.md §11, the `.cr-a11y-toggle` and `.cr-a11y-panel` controls were declared at `z-index: 50`, which left them buried beneath every overlay in the viewer:

- Gate overlays at `9999`
- Side panels at `80`
- Modals at `10000`
- Top-of-screen banners at `99999`

That is a WCAG 2.1 AA reachability issue: a user who needs the accessibility controls cannot reach them while any overlay is open.

## Change

Surgical, additive CSS rule appended just before the closing `</style>` in `client/public/interactive-course.html`:

```css
/* ADA controls — guaranteed reachability above overlays */
.cr-a11y-toggle,
.cr-a11y-panel {
  z-index: 99998;
  isolation: isolate;
}
```

- `99998` clears every overlay in the file (highest competing layer is 10000) while staying below the `99999` admin banner.
- `isolation: isolate` creates a new stacking context so descendants cannot accidentally escape this layer.
- No removals, no other CSS or markup edits, no JS changes.

## Verification

```
$ grep -n "z-index: 99998" client/public/interactive-course.html
1496:    z-index: 99998;

$ grep -n "isolation: isolate" client/public/interactive-course.html
1497:    isolation: isolate;

$ git diff --stat main
 client/public/interactive-course.html | 6 ++++++
 1 file changed, 6 insertions(+)
```

Exactly one file changed, six lines inserted.

## Test plan

- [ ] Open a course; confirm the A11y toggle button is visible and clickable in default state.
- [ ] Trigger the subscription gate (`#crGateSubscription`, z-index 9999) — A11y toggle must remain clickable on top.
- [ ] Open a side panel (z-index 80) — A11y toggle must remain clickable on top.
- [ ] Open any modal that uses z-index 10000 — A11y toggle must remain clickable on top.
- [ ] Confirm the admin / status banner at z-index 99999 still renders above the A11y controls (intentional).
- [ ] Tab-navigate to the A11y toggle from within an open overlay — focus must reach it.

Do not merge.

https://claude.ai/code/session_01U5Z4WjisV1mVph3mZPgNXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5Z4WjisV1mVph3mZPgNXF)_