### PR TITLE
fix(admin): pass objectives + ceCategory to generateCertificate in regenerate route

### DIFF
--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -75,7 +75,7 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
 
     const cert = await Certificate.findOne({ _id: certId, userId })
       .populate('userId', 'profile.firstName profile.lastName profile.certificateName email')
-      .populate('courseId', 'title ceHours nbccProgramNumber slug');
+      .populate('courseId', 'title ceHours nbccProgramNumber slug learningObjectives objectives ceCategory contentArea categories');
 
     if (!cert) {
       return res.status(404).json({ success: false, error: 'Certificate not found for this user' });
@@ -97,8 +97,11 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
       completionDate: cert.completionDate,
       ceHours: cert.ceHours,
       certificateNumber: cert.certificateNumber,
+      verificationCode: cert.verificationCode || cert.certificateNumber,
       acepNumber: cert.acepNumber || 'ACEP #7760',
-      ceCategory: cert.category || ''
+      ceCategory: course.ceCategory || course.contentArea || course.categories?.[0] || 'Counseling Theory/Practice and the Counseling Relationship',
+      objectives: course.learningObjectives || course.objectives || [],
+      approvingBody: 'NBCC'
     });
 
     const uploadResult = await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Single follow-up to #364. The admin certificate regenerate handler was missing two fields the new generator needs and that `interactiveCourseRoutes.js` already passes correctly:

- **`objectives`** — Learning Objectives weren't fetched or passed, so admin-regenerated certs render with no numbered objectives list.
- **`ceCategory`** — was sourcing `cert.category` (wrong field, usually empty), so the CE category line was blank.

Also wires up `verificationCode` and `approvingBody` to match the interactive route. Single file, single commit.

## Diff (1 file, +5 / -2)

```diff
diff --git a/server/src/routes/admin.js b/server/src/routes/admin.js
@@ -75,7 +75,7 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly

     const cert = await Certificate.findOne({ _id: certId, userId })
       .populate('userId', 'profile.firstName profile.lastName profile.certificateName email')
-      .populate('courseId', 'title ceHours nbccProgramNumber slug');
+      .populate('courseId', 'title ceHours nbccProgramNumber slug learningObjectives objectives ceCategory contentArea categories');

     if (!cert) {
       return res.status(404).json({ success: false, error: 'Certificate not found for this user' });
@@ -97,8 +97,11 @@ router.post('/users/:userId/certificates/:certId/regenerate', protect, adminOnly
       completionDate: cert.completionDate,
       ceHours: cert.ceHours,
       certificateNumber: cert.certificateNumber,
+      verificationCode: cert.verificationCode || cert.certificateNumber,
       acepNumber: cert.acepNumber || 'ACEP #7760',
-      ceCategory: cert.category || ''
+      ceCategory: course.ceCategory || course.contentArea || course.categories?.[0] || 'Counseling Theory/Practice and the Counseling Relationship',
+      objectives: course.learningObjectives || course.objectives || [],
+      approvingBody: 'NBCC'
     });
```

## Commit

```
539d0a2 Align admin regenerate populate + generateCertificate call with interactiveCourseRoutes
```

`git log --oneline origin/main..claude/fix-admin-regenerate-fields-9JV1X` → exactly one commit.
`git diff --stat origin/main...claude/fix-admin-regenerate-fields-9JV1X` →
```
server/src/routes/admin.js | 7 +++++--
1 file changed, 5 insertions(+), 2 deletions(-)
```

## Test plan — DO NOT MERGE until smoke test passes

- [ ] Hit `POST /api/admin/users/:userId/certificates/:certId/regenerate` on an existing cert (e.g. `CR-2026-745375494` or any other), download the PDF.
- [ ] Compare against the cert generated by the live course-completion path (which already works correctly post-#364).
- [ ] Confirm regenerated cert now renders:
  - The "Learning Objectives" header followed by the **numbered list of objectives** (was missing before this commit)
  - A populated **CE category line** (was blank/empty before)
  - The verification code at the bottom matches `verificationCode` (or `certificateNumber` if unset)
- [ ] Post a screenshot of the regenerated cert in this PR before merging.

## Scope guardrails (preserved)

- No other files touched. `git diff --stat` shows exactly `server/src/routes/admin.js`.
- No new dependencies.
- `generateCertificate` signature unchanged.
- Cloudinary upload code untouched.
- `userName` fallback chain unchanged from #364.
- Certificate number format unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JByg9U5RE8jAZxP7yFMoaL)_