### PR TITLE
Add trial conversion and non-paid user engagement notifications

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -73,6 +73,7 @@ import { initializeScheduler } from './services/notificationScheduler.js';
 import { initializeBoardMonitor } from './services/boardMonitorService.js';
 import cron from 'node-cron';
 import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
+import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -310,6 +311,12 @@ const startServer = async () => {
     runDeadlineReminders().catch(err => console.error('CE deadline reminder error:', err.message));
   }, { timezone: 'America/New_York' });
   console.log('CE deadline reminder cron scheduled (daily 9 AM ET)');
+
+  // Daily notification check — credentials, insurance, stale courses, trial expiry — daily at 10 AM ET
+  cron.schedule('0 10 * * *', () => {
+    runDailyNotificationCheck().catch(err => console.error('Daily notification check error:', err.message));
+  }, { timezone: 'America/New_York' });
+  console.log('Daily notification check cron scheduled (daily 10 AM ET)');
   verifyRoutes();
   app.listen(PORT, () => {
     console.log(`

--- a/server/src/jobs/dailyNotificationCheck.js
+++ b/server/src/jobs/dailyNotificationCheck.js
@@ -11,7 +11,11 @@ import {
   triggerLowHoursAlert,
   triggerCredentialExpiring,
   triggerInsuranceExpiring,
-  triggerCourseReminder
+  triggerCourseReminder,
+  triggerTrialEndingSoon,
+  triggerTrialEndingTomorrow,
+  triggerTrialEnded,
+  triggerNonPaidCheckIn
 } from '../services/notificationTriggerService.js';
 
 /**
@@ -26,7 +30,7 @@ export async function runDailyNotificationCheck() {
     const users = await User.find({
       'notifications.unsubscribeAll': { $ne: true },
       disabled: { $ne: true }
-    }).select('_id notifications liabilityInsurance');
+    }).select('_id notifications liabilityInsurance subscription email profile createdAt');
 
     const now = new Date();
 
@@ -132,6 +136,50 @@ export async function runDailyNotificationCheck() {
           }
         } catch (e) {
           stats.errors++;
+        }
+
+        // 4. Check trial expiry
+        try {
+          if (user.subscription?.status === 'trial' && user.subscription?.trialEndsAt) {
+            const trialEnd = new Date(user.subscription.trialEndsAt);
+            const daysRemaining = Math.ceil((trialEnd - now) / (1000 * 60 * 60 * 24));
+
+            if (daysRemaining === 2) {
+              await triggerTrialEndingSoon(user._id, { trialEndsAt: trialEnd, daysRemaining });
+              stats.remindersSent++;
+            } else if (daysRemaining === 1) {
+              await triggerTrialEndingTomorrow(user._id, { trialEndsAt: trialEnd });
+              stats.remindersSent++;
+            } else if (daysRemaining <= 0) {
+              // Mark expired (passive auth check also does this, but do it proactively)
+              await User.updateOne(
+                { _id: user._id, 'subscription.status': 'trial' },
+                { $set: { 'subscription.status': 'expired' } }
+              );
+              await triggerTrialEnded(user._id);
+              stats.remindersSent++;
+            }
+          }
+        } catch (e) {
+          stats.errors++;
+          console.error(`[DailyNotif] Trial check error for user ${user._id}:`, e.message);
+        }
+
+        // 5. Non-paid user check-in — every ~75 days for free + expired users
+        try {
+          const nonPayingStatuses = ['free', 'expired', 'canceled'];
+          if (nonPayingStatuses.includes(user.subscription?.status) && user.createdAt) {
+            const daysSinceRegistration = Math.floor((now - new Date(user.createdAt)) / (1000 * 60 * 60 * 24));
+            // Fire on day 75, 150, 225, 300, 375... — every ~2.5 months
+            // Skip if too new or if not on a 75-day boundary (±0 days)
+            if (daysSinceRegistration >= 75 && daysSinceRegistration % 75 === 0) {
+              await triggerNonPaidCheckIn(user._id, { daysSinceRegistration });
+              stats.remindersSent++;
+            }
+          }
+        } catch (e) {
+          stats.errors++;
+          console.error(`[DailyNotif] Check-in error for user ${user._id}:`, e.message);
         }
 
       } catch (userErr) {

--- a/server/src/models/Notification.js
+++ b/server/src/models/Notification.js
@@ -14,7 +14,7 @@ const notificationSchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ['credential_expiring', 'ce_reminder', 'course_completed', 'system', 'welcome', 'info', 'badge_earned', 'referral', 'supervision'],
+    enum: ['credential_expiring', 'ce_reminder', 'course_completed', 'system', 'welcome', 'info', 'badge_earned', 'referral', 'supervision', 'trial'],
     required: true
   },
   title: {

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -95,7 +95,14 @@ const userSchema = new mongoose.Schema({
     // Payment failure tracking
     paymentFailedAt: { type: Date },
     paymentFailureCount: { type: Number, default: 0 },
-    paymentRecoveredAt: { type: Date }
+    paymentRecoveredAt: { type: Date },
+
+    // Trial conversion email tracking — prevents double-sending
+    trialEmailsSent: {
+      type: [String],
+      default: []
+      // Possible values: 'ending_soon', 'ending_tomorrow', 'ended'
+    }
   },
   
   // Hardship Pause System (VIP perk)

--- a/server/src/services/notificationTriggerService.js
+++ b/server/src/services/notificationTriggerService.js
@@ -480,6 +480,177 @@ export async function triggerWeeklyDigest(userId, { credentials, recentCompletio
   }
 }
 
+// ─── Trial Conversion Triggers ───────────────────────────────────────────────
+
+export async function triggerTrialEndingSoon(userId, { trialEndsAt, daysRemaining }) {
+  try {
+    const user = await User.findById(userId);
+    if (!user) return;
+    if (user.subscription?.trialEmailsSent?.includes('ending_soon')) return;
+
+    const name = getUserName(user);
+    const friendlyDate = new Date(trialEndsAt).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+
+    await createInAppNotification(userId, {
+      type: 'trial',
+      title: `Your trial ends in ${daysRemaining} days`,
+      message: `Pick a plan to keep your CE tracking, courses, and credential management active after ${friendlyDate}.`,
+      urgency: 'warning',
+      link: '/subscription.html'
+    });
+
+    if (shouldSendEmail(user, 'email.trial')) {
+      await sendNotificationEmail(user.email, `Your CounselorReady trial ends ${friendlyDate}`, `
+        <h2 style="color:#2D4A3E;margin-top:0;">Your trial ends in ${daysRemaining} days, ${name}</h2>
+        <p>Your 7-day free trial of CounselorReady ends on <strong>${friendlyDate}</strong>. Pick a plan now to keep your courses, credential tracking, and CE certificate library active without interruption.</p>
+        <table style="width:100%;border-collapse:collapse;margin:20px 0;">
+          <tr>
+            <td style="padding:14px;background:#FBF7F0;border-radius:8px;">
+              <strong style="color:#6b1d34;">Starter — $19.99/mo</strong><br/>
+              <span style="color:#666;font-size:14px;">CE tracking + course library</span>
+            </td>
+          </tr>
+          <tr><td style="height:8px;"></td></tr>
+          <tr>
+            <td style="padding:14px;background:#FBF7F0;border-radius:8px;border:2px solid #4A7C59;">
+              <strong style="color:#6b1d34;">Professional — $29.99/mo</strong> <span style="color:#4A7C59;font-size:12px;font-weight:bold;">MOST POPULAR</span><br/>
+              <span style="color:#666;font-size:14px;">Everything in Starter + Researched-N-Ready CE</span>
+            </td>
+          </tr>
+          <tr><td style="height:8px;"></td></tr>
+          <tr>
+            <td style="padding:14px;background:#FBF7F0;border-radius:8px;">
+              <strong style="color:#6b1d34;">VIP — $49.99/mo</strong><br/>
+              <span style="color:#666;font-size:14px;">Everything + multi-state tracking + hardship pause</span>
+            </td>
+          </tr>
+        </table>
+        <div style="text-align:center;margin:24px 0;">
+          <a href="${BASE_URL}/subscription.html" style="background:#6b1d34;color:#fff;padding:14px 28px;text-decoration:none;border-radius:6px;font-weight:bold;">Choose Your Plan</a>
+        </div>
+        <p style="font-size:13px;color:#666;text-align:center;">Questions? Reply to this email — we read every one.</p>
+      `);
+    }
+
+    user.subscription.trialEmailsSent = [...(user.subscription.trialEmailsSent || []), 'ending_soon'];
+    await user.save();
+  } catch (err) {
+    console.error('[NotifTrigger] triggerTrialEndingSoon error:', err.message);
+  }
+}
+
+export async function triggerTrialEndingTomorrow(userId, { trialEndsAt }) {
+  try {
+    const user = await User.findById(userId);
+    if (!user) return;
+    if (user.subscription?.trialEmailsSent?.includes('ending_tomorrow')) return;
+
+    const name = getUserName(user);
+
+    await createInAppNotification(userId, {
+      type: 'trial',
+      title: 'Your trial ends tomorrow',
+      message: 'Pick a plan today to avoid losing access to your courses and credential tracking.',
+      urgency: 'urgent',
+      link: '/subscription.html'
+    });
+
+    if (shouldSendEmail(user, 'email.trial')) {
+      await sendNotificationEmail(user.email, 'Your CounselorReady trial ends tomorrow', `
+        <h2 style="color:#6b1d34;margin-top:0;">${name}, your trial ends tomorrow</h2>
+        <p>Tomorrow your CounselorReady free trial ends. After that, you'll lose access to:</p>
+        <ul style="line-height:1.8;color:#444;">
+          <li>Your CE course progress and certificates</li>
+          <li>Credential tracking for your license</li>
+          <li>Researched-N-Ready CE library</li>
+          <li>State board renewal monitoring</li>
+        </ul>
+        <p>Pick any plan and keep everything you've built so far.</p>
+        <div style="text-align:center;margin:24px 0;">
+          <a href="${BASE_URL}/subscription.html" style="background:#6b1d34;color:#fff;padding:14px 28px;text-decoration:none;border-radius:6px;font-weight:bold;">Choose Your Plan</a>
+        </div>
+      `);
+    }
+
+    user.subscription.trialEmailsSent = [...(user.subscription.trialEmailsSent || []), 'ending_tomorrow'];
+    await user.save();
+  } catch (err) {
+    console.error('[NotifTrigger] triggerTrialEndingTomorrow error:', err.message);
+  }
+}
+
+export async function triggerTrialEnded(userId) {
+  try {
+    const user = await User.findById(userId);
+    if (!user) return;
+    if (user.subscription?.trialEmailsSent?.includes('ended')) return;
+
+    const name = getUserName(user);
+
+    await createInAppNotification(userId, {
+      type: 'trial',
+      title: 'Your trial has ended',
+      message: 'Pick a plan to restore access to your courses and credential tracking.',
+      urgency: 'warning',
+      link: '/subscription.html'
+    });
+
+    if (shouldSendEmail(user, 'email.trial')) {
+      await sendNotificationEmail(user.email, 'Your CounselorReady trial has ended', `
+        <h2 style="color:#2D4A3E;margin-top:0;">Trial ended — your account is on hold, ${name}</h2>
+        <p>Your 7-day free trial has ended. Your account is preserved, but premium features are paused until you pick a plan.</p>
+        <p><strong>Your data is safe.</strong> Course progress, completed CE hours, and credential records are all still here.</p>
+        <p>Pick a plan whenever you're ready — your account picks right back up where you left off.</p>
+        <div style="text-align:center;margin:24px 0;">
+          <a href="${BASE_URL}/subscription.html" style="background:#6b1d34;color:#fff;padding:14px 28px;text-decoration:none;border-radius:6px;font-weight:bold;">Restore Access</a>
+        </div>
+        <p style="font-size:13px;color:#666;text-align:center;">Have feedback about your trial? Reply to this email — we'd love to hear what worked and what didn't.</p>
+      `);
+    }
+
+    user.subscription.trialEmailsSent = [...(user.subscription.trialEmailsSent || []), 'ended'];
+    await user.save();
+  } catch (err) {
+    console.error('[NotifTrigger] triggerTrialEnded error:', err.message);
+  }
+}
+
+export async function triggerNonPaidCheckIn(userId, { daysSinceRegistration }) {
+  try {
+    const user = await User.findById(userId);
+    if (!user) return;
+
+    const name = getUserName(user);
+
+    await createInAppNotification(userId, {
+      type: 'info',
+      title: 'How are your CE hours looking?',
+      message: 'Your renewal is coming. Take a quick look at where your hours stand and what you still need.',
+      urgency: 'info',
+      link: '/credentials.html'
+    });
+
+    if (shouldSendEmail(user, 'email.checkIn')) {
+      await sendNotificationEmail(user.email, 'Renewal coming up — where do your CE hours stand?', `
+        <h2 style="color:#2D4A3E;margin-top:0;">Quick check-in, ${name}</h2>
+        <p>It's been a while since we last connected. Your license renewal is coming up sooner than you think — here's a 30-second prompt to make sure you're on track.</p>
+        <p><strong>Three things worth doing today:</strong></p>
+        <ul style="line-height:1.8;color:#444;">
+          <li>Open your CounselorReady dashboard and confirm your renewal date is correct.</li>
+          <li>Check how many CE hours you've earned vs. how many your state requires.</li>
+          <li>Pick one course for this month — even one hour now beats scrambling at renewal time.</li>
+        </ul>
+        <div style="text-align:center;margin:24px 0;">
+          <a href="${BASE_URL}/dashboard.html" style="background:#6b1d34;color:#fff;padding:14px 28px;text-decoration:none;border-radius:6px;font-weight:bold;">Check My Status</a>
+        </div>
+        <p style="font-size:13px;color:#666;text-align:center;">Not ready to commit to a paid plan? That's fine — your free account will always be here when you need it.</p>
+      `);
+    }
+  } catch (err) {
+    console.error('[NotifTrigger] triggerNonPaidCheckIn error:', err.message);
+  }
+}
+
 export default {
   shouldSendEmail,
   shouldSendSms,
@@ -492,5 +663,9 @@ export default {
   triggerCredentialExpiring,
   triggerInsuranceExpiring,
   triggerNewCourseAnnouncement,
-  triggerWeeklyDigest
+  triggerWeeklyDigest,
+  triggerTrialEndingSoon,
+  triggerTrialEndingTomorrow,
+  triggerTrialEnded,
+  triggerNonPaidCheckIn
 };


### PR DESCRIPTION
## Summary
This PR implements a comprehensive trial-to-paid conversion notification system and non-paid user engagement reminders. It adds four new notification triggers that fire at critical moments in the user lifecycle: when trials are ending soon, ending tomorrow, have ended, and periodic check-ins for free/expired users.

## Key Changes

- **New Trial Conversion Triggers** (`notificationTriggerService.js`):
  - `triggerTrialEndingSoon()` — Fires 2 days before trial expiry with plan options
  - `triggerTrialEndingTomorrow()` — Urgent reminder 1 day before expiry
  - `triggerTrialEnded()` — Notification after trial expires, reassuring users their data is safe
  - `triggerNonPaidCheckIn()` — Periodic engagement reminder for free/expired users (every ~75 days)

- **Trial Email Tracking** (`User.js`):
  - Added `subscription.trialEmailsSent` array to prevent duplicate notifications
  - Tracks which trial emails have been sent: `'ending_soon'`, `'ending_tomorrow'`, `'ended'`

- **Daily Notification Job** (`dailyNotificationCheck.js`):
  - Integrated trial expiry checks into existing daily notification loop
  - Calculates days remaining and triggers appropriate notifications based on thresholds
  - Proactively marks trials as expired when `daysRemaining <= 0`
  - Implements non-paid user check-in logic on 75-day boundaries (days 75, 150, 225, etc.)

- **Cron Scheduling** (`index.js`):
  - Added daily cron job at 10 AM ET to run `runDailyNotificationCheck()`
  - Complements existing 9 AM CE deadline reminder job

- **Notification Types** (`Notification.js`):
  - Added `'trial'` to notification type enum to support trial-specific notifications

## Implementation Details

- All notifications include both in-app and email components with consistent styling
- Email templates feature pricing tables, clear CTAs, and reassuring messaging
- Trial emails are only sent once per milestone (tracked via `trialEmailsSent`)
- Non-paid check-in emails are sent on a predictable schedule without duplicate prevention, allowing periodic re-engagement
- Error handling and logging included for all new triggers
- User data is fetched with minimal fields (`_id`, `notifications`, `liabilityInsurance`, `subscription`, `email`, `profile`, `createdAt`) for efficiency

https://claude.ai/code/session_01W2b9MYhaSgLd6MqjeSFfh3