### PR TITLE
fix(nav-footer): defer injection until DOMContentLoaded if divs not yet parsed

### DIFF
--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -198,11 +198,21 @@
   </footer>`;
 
   // ── INJECT ────────────────────────────────────────────────
-  const headerEl = document.getElementById('cr-header');
-  const footerEl = document.getElementById('cr-footer');
+  // Inject immediately if divs already exist; otherwise defer until DOM is
+  // parsed. This makes the script tag's position in the page irrelevant —
+  // <head>, top of <body>, or before the divs in <body> all work.
+  function crInject() {
+    const headerEl = document.getElementById('cr-header');
+    const footerEl = document.getElementById('cr-footer');
+    if (headerEl) headerEl.innerHTML = headerHTML;
+    if (footerEl) footerEl.innerHTML = footerHTML;
+  }
 
-  if (headerEl) headerEl.innerHTML = headerHTML;
-  if (footerEl) footerEl.innerHTML = footerHTML;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', crInject);
+  } else {
+    crInject();
+  }
 
   // ── SHARED FUNCTIONS (global) ─────────────────────────────
   window.toggleCRDropdown = function (id) {


### PR DESCRIPTION
## Summary

Fixes header/footer not rendering on all 71 static HTML pages.

**Root cause:** Every page places `<script src="/shared/nav-footer.js">` *before* `<div id="cr-header">` and `<div id="cr-footer">`. The IIFE ran immediately on script load, queried for elements that didn't exist yet, returned `null`, and silently skipped both injections.

**Fix:** Wrap the inject block in a `crInject()` function. If `document.readyState === 'loading'`, defer to `DOMContentLoaded`; otherwise inject immediately. Single-file fix — none of the 71 HTML pages need to be touched.

**No behavior change** when the divs are already present at script load — same code path. Only adds the fallback for the case where they aren't yet.

## Verification gates (all passed)

- Gate 1 — `grep -n "function crInject\|DOMContentLoaded"` → 2 matches (L204, L212)
- Gate 2 — `grep -c "headerEl.innerHTML = headerHTML"` → 1 (no duplicate)
- Gate 3 — `node --check` → silent (syntax OK)
- Gate 4 — `git diff --stat` → 1 file changed, 14 insertions(+), 4 deletions(-)

## Test plan

- [ ] Load any page that includes `nav-footer.js` (e.g. landing.html) and confirm header + footer render
- [ ] Confirm pages where the script tag is already after the divs still render correctly (regression check)
- [ ] Spot-check admin-users.html and a course-details page

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsC3gbM1ow6kR6HEcRerSa)_