### PR TITLE
fix(legal): transparent contact info on Terms, Privacy, Refund pages

### DIFF
--- a/client/public/privacy.html
+++ b/client/public/privacy.html
@@ -124,7 +124,7 @@
           <li>Opt out of marketing communications</li>
           <li>Withdraw consent where applicable</li>
         </ul>
-        <p class="mt-4">To exercise these rights, contact us at <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="b3c0c6c3c3dcc1c7f3d0dcc6ddc0d6dfdcc1c1d6d2d7ca9dd0dcde">[email&#160;protected]</a>.</p>
+        <p class="mt-4">To exercise these rights, contact us at <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a>.</p>
       </section>
 
       <section>
@@ -158,7 +158,7 @@
 
       <section>
         <h2 class="font-display text-2xl font-semibold text-burgundy-800 mb-4">11. California Privacy Rights (CCPA)</h2>
-        <p>California residents have additional rights under the CCPA, including the right to know what personal information we collect, request deletion, and opt out of sales (we do not sell personal information). To exercise these rights, contact us at <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="b7c4c2c7c7d8c5c3f7d4d8c2d9c4d2dbd8c5c5d2d6d3ce99d4d8da">[email&#160;protected]</a>.</p>
+        <p>California residents have additional rights under the CCPA, including the right to know what personal information we collect, request deletion, and opt out of sales (we do not sell personal information). To exercise these rights, contact us at <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a>.</p>
       </section>
 
       <section>
@@ -170,8 +170,11 @@
         <h2 class="font-display text-2xl font-semibold text-burgundy-800 mb-4">13. Contact Us</h2>
         <p>For questions or concerns about this Privacy Policy or our data practices, contact us at:</p>
         <p class="mt-2">
-          <strong>Ga Integrated Therapeutic Perspectives LLC</strong><br>
-          Email: <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="44373134342b36300427272e2931282b3636212527332a6a272b29">[email&#160;protected]</a>
+          <strong>GA Integrated Therapeutic Perspectives LLC</strong><br>
+          PO Box 1417<br>
+          Hinesville, GA 31310<br>
+          Email: <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a><br>
+          Phone: <a href="tel:+16786644003" class="text-burgundy-700 underline">(678) 664-4003</a>
         </p>
       </section>
 

--- a/client/public/refund-policy.html
+++ b/client/public/refund-policy.html
@@ -114,7 +114,7 @@
         <h2 class="font-display text-2xl font-semibold text-burgundy-800 mb-4">6. How to Request a Refund</h2>
         <p>To request a refund:</p>
         <ol class="list-decimal list-inside mt-2 space-y-1 ml-4">
-          <li>Email us at <a href="/cdn-cgi/l/email-protection#097a7c7979667b7d496a667c677a6c65667b7b6c686d70276a6664" class="text-burgundy-700 underline"><span class="__cf_email__" data-cfemail="abd8dedbdbc4d9dfebc8c4dec5d8cec7c4d9d9cecacfd285c8c4c6">[email&#160;protected]</span></a></li>
+          <li>Email us at <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a></li>
           <li>Include your account email and reason for the refund</li>
           <li>We will verify eligibility and process within 5-7 business days</li>
           <li>Refunds are issued to the original payment method</li>
@@ -136,8 +136,11 @@
         <h2 class="font-display text-2xl font-semibold text-burgundy-800 mb-4">8. Contact</h2>
         <p>Questions about our refund policy? Contact us:</p>
         <p class="mt-2">
-          <strong>Ga Integrated Therapeutic Perspectives LLC</strong><br>
-          Email: <a href="/cdn-cgi/l/email-protection#ec9f999c9c839e98ac8f8399829f8980839e9e898d8895c28f8381" class="text-burgundy-700 underline"><span class="__cf_email__" data-cfemail="90e3e5e0e0ffe2e4d0f3ffe5fee3f5fcffe2e2f5f1f4e9bef3fffd">[email&#160;protected]</span></a>
+          <strong>GA Integrated Therapeutic Perspectives LLC</strong><br>
+          PO Box 1417<br>
+          Hinesville, GA 31310<br>
+          Email: <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a><br>
+          Phone: <a href="tel:+16786644003" class="text-burgundy-700 underline">(678) 664-4003</a>
         </p>
       </section>
 

--- a/client/public/terms.html
+++ b/client/public/terms.html
@@ -138,10 +138,13 @@
 
       <section>
         <h2 class="font-display text-2xl font-semibold text-burgundy-800 mb-4">16. Contact</h2>
-        <p>For questions about these Terms, contact us at:</p>
+        <p>For questions about these Terms or other legal matters, contact us at:</p>
         <p class="mt-2">
-          <strong>Ga Integrated Therapeutic Perspectives LLC</strong><br>
-          Email: <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="a6d5d3d6d6c9d4d2e6c5c9d3c8d5c3cac9d4d4c3c7c2df88c5c9cb">[email&#160;protected]</a>
+          <strong>GA Integrated Therapeutic Perspectives LLC</strong><br>
+          PO Box 1417<br>
+          Hinesville, GA 31310<br>
+          Email: <a href="mailto:legal@counselorready.com" class="text-burgundy-700 underline">legal@counselorready.com</a><br>
+          Phone: <a href="tel:+16786644003" class="text-burgundy-700 underline">(678) 664-4003</a>
         </p>
       </section>
 


### PR DESCRIPTION
PROBLEM
Cloudflare Email Address Obfuscation was baked into source files at some point - terms.html (1), privacy.html (3), refund-policy.html (2) all show literal '[email protected]' placeholders linking to the broken /cdn-cgi/l/email-protection endpoint. Legal pages were effectively unreachable, exposing the platform to CCPA, GDPR, and NBCC complaint resolution compliance gaps.

SOLUTION
Replace all 6 obfuscated email links with plain mailto: links to a new legal@counselorready.com address. Add full legal entity disclosure (mailing address + phone) to each Contact section per legal-page best practices and regulator expectations.

Entity contact info now displayed on all three pages:
  GA Integrated Therapeutic Perspectives LLC
  PO Box 1417, Hinesville, GA 31310
  legal@counselorready.com  /  (678) 664-4003

complaint-resolution.html and ada-accommodations.html already had clean plain mailto: + phone - left untouched.
admin-users.html is an internal admin tool - left untouched.

NOTE FOR KE: legal@counselorready.com forwarding rule needs to be set up in Resend / DNS before this ships if not already configured. Otherwise, regulator notices will bounce.