### PR TITLE
Add cr-gtag.js to all client/public HTML pages

### DIFF
--- a/client/public/404.html
+++ b/client/public/404.html
@@ -12,6 +12,7 @@
     a { display:inline-block; padding:0.75rem 2rem; background:linear-gradient(to right,#355E3B,#4A7C59); color:#fff; text-decoration:none; border-radius:0.5rem; font-weight:600; }
     a:hover { opacity:0.9; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
   <div class="box">

--- a/client/public/about.html
+++ b/client/public/about.html
@@ -21,6 +21,7 @@
       font-family: 'Source Serif Pro', Georgia, serif;
     }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 text-gray-900 antialiased">
   

--- a/client/public/achievements.html
+++ b/client/public/achievements.html
@@ -33,6 +33,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/ada-accommodations.html
+++ b/client/public/ada-accommodations.html
@@ -18,6 +18,7 @@
     body { background:#F8F7F4; font-family:'Lato',system-ui,sans-serif; }
     .font-display { font-family:'Cormorant Garamond',Georgia,serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-analytics.html
+++ b/client/public/admin-analytics.html
@@ -31,6 +31,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-blog.html
+++ b/client/public/admin-blog.html
@@ -32,6 +32,7 @@
     .toast { animation: slideIn 0.3s ease-out; }
     @keyframes slideIn { from { transform: translateY(-20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/client/public/admin-bulk-upload.html
+++ b/client/public/admin-bulk-upload.html
@@ -26,6 +26,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-coupons.html
+++ b/client/public/admin-coupons.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-course-editor.html
+++ b/client/public/admin-course-editor.html
@@ -39,6 +39,7 @@
     .toast.success { background:#2E7D4F; color:#fff; }
     .toast.error { background:#C0392B; color:#fff; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-course-links.html
+++ b/client/public/admin-course-links.html
@@ -46,6 +46,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/admin-course-preview.html
+++ b/client/public/admin-course-preview.html
@@ -32,6 +32,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -17,6 +17,7 @@
     body { font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-credentials.html
+++ b/client/public/admin-credentials.html
@@ -33,6 +33,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50">
 

--- a/client/public/admin-funnel.html
+++ b/client/public/admin-funnel.html
@@ -29,6 +29,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-hardship.html
+++ b/client/public/admin-hardship.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-health.html
+++ b/client/public/admin-health.html
@@ -29,6 +29,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/client/public/admin-help-articles.html
+++ b/client/public/admin-help-articles.html
@@ -34,6 +34,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-help.html
+++ b/client/public/admin-help.html
@@ -28,6 +28,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-import.html
+++ b/client/public/admin-import.html
@@ -26,6 +26,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen" style="font-family: 'Lato', system-ui, sans-serif;">
 

--- a/client/public/admin-integrations.html
+++ b/client/public/admin-integrations.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-messages.html
+++ b/client/public/admin-messages.html
@@ -29,6 +29,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-migration.html
+++ b/client/public/admin-migration.html
@@ -28,6 +28,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-partners.html
+++ b/client/public/admin-partners.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-quick-links.html
+++ b/client/public/admin-quick-links.html
@@ -37,6 +37,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-stripe.html
+++ b/client/public/admin-stripe.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-tool-analytics.html
+++ b/client/public/admin-tool-analytics.html
@@ -25,6 +25,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .bar-fill { transition: width 0.6s ease; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-users.html
+++ b/client/public/admin-users.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/admin-video-upload.html
+++ b/client/public/admin-video-upload.html
@@ -42,6 +42,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50">
 

--- a/client/public/admin.html
+++ b/client/public/admin.html
@@ -29,6 +29,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/audit-kit.html
+++ b/client/public/audit-kit.html
@@ -23,6 +23,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/audit.html
+++ b/client/public/audit.html
@@ -31,6 +31,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   

--- a/client/public/blog-post.html
+++ b/client/public/blog-post.html
@@ -47,6 +47,7 @@
     /* Checkbox styling for checklists */
     .prose input[type="checkbox"] { margin-right: 0.5rem; accent-color: #6B1D34; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-cream min-h-screen">
 

--- a/client/public/blog.html
+++ b/client/public/blog.html
@@ -40,6 +40,7 @@
   <style>
     body { font-family: 'Lato', sans-serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-cream min-h-screen">
 

--- a/client/public/board-alerts.html
+++ b/client/public/board-alerts.html
@@ -38,6 +38,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/ce-planner.html
+++ b/client/public/ce-planner.html
@@ -30,6 +30,7 @@
     .rec-link{display:flex;align-items:center;justify-content:space-between;padding:12px;border-radius:8px;text-decoration:none;transition:background .15s}
     .rec-link:hover{opacity:.85}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/certificates.html
+++ b/client/public/certificates.html
@@ -33,6 +33,7 @@
         input[type="text"], select { font-family: 'Lato', sans-serif; }
         input:focus, select:focus { outline:none;ring:2px;border-color:#6B1D34; }
     </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/checkout-success.html
+++ b/client/public/checkout-success.html
@@ -51,6 +51,7 @@
       background: linear-gradient(135deg, #6B1D34 0%, #8B2542 100%);
     }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen flex flex-col">
 

--- a/client/public/complaint-resolution.html
+++ b/client/public/complaint-resolution.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   
   <style>body{background:#F8F7F4;font-family:'Lato',system-ui,sans-serif}.font-display{font-family:'Cormorant Garamond',Georgia,serif}</style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   <header class="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50" style="border-color:#d5e1d7">

--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   

--- a/client/public/course-player-unified.html
+++ b/client/public/course-player-unified.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
 <html><head><script>
 window.location.replace('/interactive-course.html' + window.location.search);
-</script></head><body></body></html>
+</script><script src="/js/cr-gtag.js"></script>
+</head><body></body></html>

--- a/client/public/course-player.html
+++ b/client/public/course-player.html
@@ -8,6 +8,7 @@
   const slug = params.get('slug');
   window.location.replace('/interactive-course.html' + (slug ? '?slug=' + slug : ''));
 </script>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <script src="/js/footer.js"></script><body></body>
 </html>

--- a/client/public/courses-unified.html
+++ b/client/public/courses-unified.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <script>window.location.replace('/courses.html');</script>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <script src="/js/footer.js"></script><body></body>
 </html>

--- a/client/public/courses.html
+++ b/client/public/courses.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   

--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -40,6 +40,7 @@
         .ce-bar-fill { height:100%;border-radius:4px;background:#4A7C59; }
         .ce-bar-fill.overage { background:#6B1D34; }
     </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -35,6 +35,7 @@
     .resume-btn{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:6px;font-size:11px;font-weight:600;text-decoration:none;transition:all .15s;flex-shrink:0}
     .resume-btn:hover{opacity:.85}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/forgot-password.html
+++ b/client/public/forgot-password.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen flex flex-col">
   

--- a/client/public/group-licenses.html
+++ b/client/public/group-licenses.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/help.html
+++ b/client/public/help.html
@@ -41,6 +41,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   <div id="cr-header"></div>

--- a/client/public/home-redirect.html
+++ b/client/public/home-redirect.html
@@ -3,6 +3,7 @@
 <head>
 <meta http-equiv="refresh" content="0;url=/landing.html">
 <link rel="canonical" href="https://counselorready.com/landing.html">
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body></body>
 </html>

--- a/client/public/insurance-tracker.html
+++ b/client/public/insurance-tracker.html
@@ -31,6 +31,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/interactive-course-legacy.html
+++ b/client/public/interactive-course-legacy.html
@@ -117,6 +117,7 @@
     .high-contrast-mode .prose * { color: #000 !important; }
     .high-contrast-mode * { border-color: #333 !important; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-slate-50 font-sans min-h-screen">
   

--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1738,6 +1738,7 @@ body.cr-has-timer .cr-glossary-btn { bottom: 220px; }
     person_profiles: 'identified_only'
   });
 </script>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body data-text-size="medium" data-line-spacing="normal" data-dyslexia="false" data-high-contrast="false" data-dark-mode="false" data-reduced-motion="false" data-enhanced-focus="false" data-reading-guide="false">
 

--- a/client/public/interactive-courses.html
+++ b/client/public/interactive-courses.html
@@ -14,6 +14,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <script src="/js/footer.js"></script><body>
 

--- a/client/public/landing.html
+++ b/client/public/landing.html
@@ -54,6 +54,7 @@
       transform: translateY(-4px);
     }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 text-gray-900 antialiased">
   

--- a/client/public/legacy-vault.html
+++ b/client/public/legacy-vault.html
@@ -29,6 +29,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/login.html
+++ b/client/public/login.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen flex flex-col">
   

--- a/client/public/messages.html
+++ b/client/public/messages.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   <!-- Header -->

--- a/client/public/mockup-dashboard.html
+++ b/client/public/mockup-dashboard.html
@@ -35,6 +35,7 @@
     .resume-btn{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:6px;font-size:11px;font-weight:600;text-decoration:none;transition:all .15s;flex-shrink:0}
     .resume-btn:hover{opacity:.85}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/non-discrimination.html
+++ b/client/public/non-discrimination.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   
   <style>body{background:#F8F7F4;font-family:'Lato',system-ui,sans-serif}.font-display{font-family:'Cormorant Garamond',Georgia,serif}</style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   <header class="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50" style="border-color:#d5e1d7">

--- a/client/public/organization.html
+++ b/client/public/organization.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/partner-dashboard.html
+++ b/client/public/partner-dashboard.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/privacy.html
+++ b/client/public/privacy.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/purchase-success.html
+++ b/client/public/purchase-success.html
@@ -16,6 +16,7 @@
     body { font-family: 'Source Sans 3', sans-serif; background: #F8F7F4; }
     h1, h2 { font-family: 'Merriweather', serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen flex items-center justify-center p-4">
   <div id="loadingState" class="text-center">

--- a/client/public/recommendations.html
+++ b/client/public/recommendations.html
@@ -27,6 +27,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/referrals.html
+++ b/client/public/referrals.html
@@ -32,6 +32,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen">
 

--- a/client/public/refund-policy.html
+++ b/client/public/refund-policy.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/register.html
+++ b/client/public/register.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen flex flex-col">
   

--- a/client/public/research-ready-about.html
+++ b/client/public/research-ready-about.html
@@ -57,6 +57,7 @@ p{font-size:16px;margin-bottom:14px;color:#3D2B1A}
 
 @media(max-width:520px){.get-grid{grid-template-columns:1fr}.hero-title{font-size:26px}.page{padding:24px 16px 36px}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/research-ready-posttest.html
+++ b/client/public/research-ready-posttest.html
@@ -154,6 +154,7 @@
     .hidden{display:none!important}
     @media(max-width:640px){.page{padding:1rem 1rem 3rem}.stepper{gap:4px;flex-wrap:wrap}.step-line{width:16px}.content-reader{padding:16px 18px}.question-card{padding:14px 16px}}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
   <div class="wg-strip wg-top"></div>

--- a/client/public/research-ready.html
+++ b/client/public/research-ready.html
@@ -171,6 +171,7 @@
 
     @media(max-width:640px){.page{padding:1rem 1rem 6rem}.hero{padding:1.5rem}.hero h1{font-size:1.3rem}.search-wrap{flex-direction:column}.btn-search{padding:10px}.hour-selector{gap:6px}.hour-pill{min-width:70px;padding:8px 12px}.ac-footer{flex-direction:column;align-items:flex-start}}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
   <div class="wg-strip wg-top"></div>

--- a/client/public/reset-password.html
+++ b/client/public/reset-password.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen flex flex-col">
   

--- a/client/public/settings.html
+++ b/client/public/settings.html
@@ -451,6 +451,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -26,6 +26,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
   

--- a/client/public/supervision.html
+++ b/client/public/supervision.html
@@ -28,6 +28,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/terms.html
+++ b/client/public/terms.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/tools/consent-generator.html
+++ b/client/public/tools/consent-generator.html
@@ -64,6 +64,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.row{flex-direction:column;gap:0}.wiz-body{padding:20px 18px}.wiz-footer{padding:12px 18px}}
 @media print{.hdr,.wiz-card,.output-actions,.privacy,.footer{display:none !important}.output{box-shadow:none;border:1px solid #ccc}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/tools/diagnostic-helper.html
+++ b/client/public/tools/diagnostic-helper.html
@@ -71,6 +71,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.row{flex-direction:column;gap:0}}
 @media print{.hdr,.disc,.card,.btn,.output-actions,.privacy,.footer{display:none!important}.output,.output-hdr,.output-body{box-shadow:none}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/tools/hold-guide.html
+++ b/client/public/tools/hold-guide.html
@@ -769,6 +769,7 @@ textarea.wiz-input { resize: vertical; line-height: 1.6; min-height: 80px; }
   .assembled-body { padding: 16px; }
 }
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/tools/index.html
+++ b/client/public/tools/index.html
@@ -81,6 +81,7 @@ body{font-family:'Lato','Segoe UI',sans-serif;background:var(--stone);color:#2A2
   .tools-grid{grid-template-columns:1fr}
 }
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/tools/note-writer.html
+++ b/client/public/tools/note-writer.html
@@ -135,6 +135,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 .tool-footer{background:var(--navy-deep);color:rgba(255,255,255,.5);text-align:center;padding:18px;font-size:11px;line-height:1.6;margin-top:20px}
 .tool-footer a{color:rgba(255,255,255,.6);text-decoration:none}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 

--- a/client/public/tools/safety-plan.html
+++ b/client/public/tools/safety-plan.html
@@ -53,6 +53,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.entry-row{flex-direction:column}.entry-row .del{width:100%;height:auto;padding:4px}}
 @media print{.hdr,.crisis-bar,.btn,.output-actions,.privacy,.footer,.step{display:none!important}.output{box-shadow:none;border:1px solid #ccc}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/tools/sliding-scale.html
+++ b/client/public/tools/sliding-scale.html
@@ -52,6 +52,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.row{flex-direction:column;gap:0}}
 @media print{.hdr,.card,.output-actions,.privacy,.ehr-note,.footer{display:none!important}.output{box-shadow:none;border:1px solid #ccc}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/tools/startup-checklist.html
+++ b/client/public/tools/startup-checklist.html
@@ -53,6 +53,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 .privacy{text-align:center;font-size:11px;color:#aaa;margin-top:16px;line-height:1.5}
 .footer{text-align:center;padding:20px;font-size:12px;color:#999;line-height:1.7;margin-top:20px;background:var(--navy-deep);border-radius:12px}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/tools/superbill.html
+++ b/client/public/tools/superbill.html
@@ -55,6 +55,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.row{flex-direction:column;gap:0}.svc-row{flex-wrap:wrap}}
 @media print{.hdr,.card,.output-actions,.privacy,.footer{display:none!important}.output{box-shadow:none;border:1px solid #ccc}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/tools/treatment-plan.html
+++ b/client/public/tools/treatment-plan.html
@@ -72,6 +72,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 @media(max-width:600px){.row{flex-direction:column;gap:0}}
 @media print{.hdr,.actions,.output-actions,.privacy,.footer,.ce-pitch,.card:not(.output){display:none!important}.output{box-shadow:none;border:1px solid #ccc}.output-hdr{-webkit-print-color-adjust:exact;print-color-adjust:exact}}
 </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body>
 <div class="hdr">

--- a/client/public/update-content.html
+++ b/client/public/update-content.html
@@ -23,6 +23,7 @@
     .nav-link:hover{color:#6B1D34;background:#FDF5F7}
     .nav-link.active{color:#6B1D34;background:#FDF5F7;font-weight:600;border-bottom:2px solid #6B1D34}
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen flex items-center justify-center p-6" style="background:#F8F7F4">
 

--- a/client/public/verify-email.html
+++ b/client/public/verify-email.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.tailwindcss.com/3.4.17"></script>
   <script src="/js/tailwind-config.js"></script>
 
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="min-h-screen bg-stone-50 flex items-center justify-center p-4" style="background:#F8F7F4">
   <div class="max-w-md w-full">

--- a/client/public/verify.html
+++ b/client/public/verify.html
@@ -17,6 +17,7 @@
     body{background:#F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
     .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 min-h-screen">
 

--- a/client/public/welcome.html
+++ b/client/public/welcome.html
@@ -22,6 +22,7 @@
     .step-card.completed .step-number { background: #34503d; }
     .progress-line { height: 4px; transition: width 0.5s ease; }
   </style>
+<script src="/js/cr-gtag.js"></script>
 </head>
 <body class="bg-stone-50 text-gray-900 antialiased min-h-screen">
 


### PR DESCRIPTION
Inserts <script src="/js/cr-gtag.js"></script> before </head> in every static HTML page under client/public/ (89 files, including tools/), per the script's documented "every page <head>" deployment.

Done via:
  find client/public -name "*.html" -exec sed -i \
    's|</head>|<script src="/js/cr-gtag.js"></script>\n</head>|' {} \;

The sed pattern also matched </head> embedded inside JS print-popup strings in 7 tools/*.html files (safety-plan, treatment-plan, diagnostic-helper, consent-generator, hold-guide, sliding-scale, superbill). Those spurious in-string injections were reverted so the print helpers' string literals stay intact; each of those 7 files still gets exactly one legitimate insertion in its real <head>.

https://claude.ai/code/session_01PCsnQ4nQvRa38AP6yYZ94a