### PR TITLE
Remove payment access check from certificate generation endpoint

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -879,20 +879,6 @@ router.post('/:id/certificate', protect, async (req, res) => {
       return res.status(404).json({ success: false, error: 'User not found' });
     }
 
-    // Payment / access check — free courses always allowed; paid courses require purchase, subscription, or admin
-    if (course.accessType !== 'free') {
-      const hasPurchased = user.purchasedCourses && user.purchasedCourses.some(id => id.toString() === course._id.toString());
-      const hasSubscription = user.subscription && (user.subscription.status === 'active' || user.subscription.status === 'lifetime');
-      const isAdmin = user.role === 'admin';
-      if (!hasPurchased && !hasSubscription && !isAdmin) {
-        return res.status(403).json({
-          success: false,
-          code: 'PAYMENT_REQUIRED',
-          message: 'Please complete your purchase to receive your certificate.'
-        });
-      }
-    }
-
     // Check if certificate already exists
     let certificate = await Certificate.findOne({
       userId: req.user._id,


### PR DESCRIPTION
## Summary
Removed the payment/access validation logic from the certificate generation endpoint. Users can now generate certificates regardless of their course access status (free, paid, subscription, or admin).

## Changes
- Removed payment and access verification check from the POST `/:id/certificate` endpoint
- This check previously validated that users had either:
  - Purchased the course
  - Had an active/lifetime subscription
  - Were administrators
  - Or the course was free

## Notes
This change allows any authenticated user to generate a certificate for any course without verifying purchase or access rights. Consider whether additional authorization checks should be implemented elsewhere or if this represents an intentional policy change to certificate issuance.

https://claude.ai/code/session_01YP6pdM27Fia5reMbPaabWm