### PR TITLE
Fix subscription conversion tracking logic

### DIFF
--- a/client/public/js/cr-gtag.js
+++ b/client/public/js/cr-gtag.js
@@ -53,7 +53,7 @@ window.crTrackConversion = function(type, value, currency) {
   }
 
   // Subscription success — Stripe redirects to /subscription.html?success=true&session_id=...
-  if (path.includes('subscription') && (params.get('success') === 'true' || params.get('session_id'))) {
+  if (path.includes('subscription') && params.get('success') === 'true' && params.get('session_id')) {
     var plan = params.get('plan') || 'starter';
     var prices = { starter: 19.99, professional: 29.99, vip: 49.99, annual_vip: 299.99 };
     var value = prices[plan] || 19.99;


### PR DESCRIPTION
## Summary
Fixed the subscription success conversion tracking condition to require both success and session_id parameters to be present, rather than accepting either one.

## Key Changes
- Updated the conditional logic in `crTrackConversion()` to use AND (`&&`) instead of OR (`||`) when checking for `success` and `session_id` parameters
- Changed from `(params.get('success') === 'true' || params.get('session_id'))` to `params.get('success') === 'true' && params.get('session_id')`

## Implementation Details
This change ensures that conversion tracking only fires when both conditions are met:
1. The `success` parameter is explicitly set to `'true'`
2. A valid `session_id` parameter is present

This prevents false positive conversion events and ensures more accurate tracking of completed Stripe subscription transactions.

https://claude.ai/code/session_01M11zUXkPyG4vR3ikUfuqTL