### PR TITLE
Hash backup codes with bcrypt for enhanced security

### DIFF
--- a/server/src/routes/security.js
+++ b/server/src/routes/security.js
@@ -6,6 +6,7 @@ import {
   generate2FASetup,
   verify2FACode,
   generateBackupCodes,
+  hashBackupCodes,
 } from '../services/twoFactorService.js';
 import { hashToken } from '../middleware/sessionTracking.js';
 
@@ -50,15 +51,17 @@ router.post('/2fa/verify', protect, async (req, res) => {
     const valid = verify2FACode(user.twoFactorSecret, code);
     if (!valid) return res.status(400).json({ error: 'Invalid code' });
 
-    const backupCodes = generateBackupCodes();
+    const plaintextBackupCodes = generateBackupCodes();
+    const hashedBackupCodes = await hashBackupCodes(plaintextBackupCodes);
     user.twoFactorEnabled     = true;
     user.twoFactorEnabledAt   = new Date();
-    user.twoFactorBackupCodes = backupCodes;
+    user.twoFactorBackupCodes = hashedBackupCodes;
     await user.save();
 
+    // Return PLAINTEXT codes once — user saves them now or never sees them again
     return res.json({
       enabled: true,
-      backupCodes,
+      backupCodes: plaintextBackupCodes,
     });
   } catch (err) {
     console.error('[2fa/verify] error:', err);

--- a/server/src/services/twoFactorService.js
+++ b/server/src/services/twoFactorService.js
@@ -1,6 +1,7 @@
 import speakeasy from 'speakeasy';
 import qrcode from 'qrcode';
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 
 const ISSUER = 'CounselorReady';
 
@@ -39,8 +40,20 @@ export function generateBackupCodes() {
   return codes;
 }
 
-export function verifyBackupCode(storedCodes, submitted) {
-  if (!Array.isArray(storedCodes) || !submitted) return -1;
+// Hash a list of plaintext codes with bcrypt cost 12
+export async function hashBackupCodes(plaintextCodes) {
+  const salt = await bcrypt.genSalt(12);
+  return Promise.all(plaintextCodes.map(c => bcrypt.hash(c.toUpperCase(), salt)));
+}
+
+// Verify a submitted backup code against bcrypt-hashed stored codes.
+// Returns the index of the matched code (for one-time consumption), or -1.
+export async function verifyBackupCode(storedHashes, submitted) {
+  if (!Array.isArray(storedHashes) || !submitted) return -1;
   const normalized = String(submitted).trim().toUpperCase();
-  return storedCodes.findIndex(c => c === normalized);
+  for (let i = 0; i < storedHashes.length; i++) {
+    const match = await bcrypt.compare(normalized, storedHashes[i]);
+    if (match) return i;
+  }
+  return -1;
 }


### PR DESCRIPTION
## Summary
This PR enhances the security of two-factor authentication backup codes by storing them as bcrypt hashes instead of plaintext. This ensures that even if the database is compromised, backup codes cannot be directly used without cracking the hashes.

## Key Changes
- Added bcrypt hashing for backup codes with cost factor 12
- Created `hashBackupCodes()` function to hash plaintext codes before storage
- Updated `verifyBackupCode()` to perform constant-time comparison against bcrypt hashes instead of direct string matching
- Modified the 2FA verification endpoint to hash backup codes before saving to the database
- Ensured plaintext codes are returned to the user only once during setup (with a clarifying comment)

## Implementation Details
- Backup codes are normalized to uppercase before hashing and verification
- The `verifyBackupCode()` function now uses `bcrypt.compare()` for secure comparison, preventing timing attacks
- Both `hashBackupCodes()` and `verifyBackupCode()` are now async functions to accommodate bcrypt operations
- A single salt is generated and reused for all codes in a batch to optimize performance while maintaining security

https://claude.ai/code/session_01KFbDaNGCVFQE4cAMLw51zb