### PR TITLE
Add two-factor authentication (2FA) support to login flow

### DIFF
--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -113,6 +113,28 @@ export const generateToken = (userId) => {
   );
 };
 
+// Short-lived JWT used between password verification and 2FA code submission.
+// 5-minute expiry. The 'purpose' claim distinguishes it from real auth tokens.
+export const generateChallengeToken = (userId) => {
+  return jwt.sign(
+    { id: userId, purpose: '2fa-challenge' },
+    process.env.JWT_SECRET,
+    { expiresIn: '5m' }
+  );
+};
+
+// Verify a 2FA challenge token. Returns userId on success, null otherwise.
+// Rejects tokens without the 2fa-challenge purpose claim.
+export const verifyChallengeToken = (token) => {
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    if (decoded?.purpose !== '2fa-challenge') return null;
+    return decoded.id;
+  } catch {
+    return null;
+  }
+};
+
 // Alias for admin middleware (used in course routes)
 export const admin = requireAdmin;
 export const adminOnly = requireAdmin;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -8,9 +8,15 @@ import crypto from 'crypto';
 import { Resend } from 'resend';
 import User from '../models/User.js';
 import Partner from '../models/Partner.js';
-import { protect, generateToken } from '../middleware/auth.js';
+import {
+  protect,
+  generateToken,
+  generateChallengeToken,
+  verifyChallengeToken,
+} from '../middleware/auth.js';
 import { sendPartnerWelcomeEmail } from './partners.js';
 import { logActivity, ACTIVITY_TYPES } from '../services/activityTrackingService.js';
+import { verify2FACode, verifyBackupCode } from '../services/twoFactorService.js';
 import Notification from '../models/Notification.js';
 import { sendRealtimeNotification } from './notifications.js';
 
@@ -173,12 +179,22 @@ router.post('/login', async (req, res) => {
     }
     
     user.lastLoginAt = new Date();
-    
+
     if (user.isTrialExpired()) {
       user.subscription.status = 'expired';
     }
-    
+
     await user.save();
+
+    // 2FA gate — if enabled, do not issue a full token yet.
+    if (user.twoFactorEnabled) {
+      const challengeToken = generateChallengeToken(user._id);
+      return res.json({
+        requiresTwoFactor: true,
+        challengeToken,
+        message: 'Enter the 6-digit code from your authenticator app, or a backup code.',
+      });
+    }
 
     const token = generateToken(user._id);
 
@@ -198,6 +214,75 @@ router.post('/login', async (req, res) => {
   } catch (error) {
     console.error('Login error:', error);
     res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+// POST /api/auth/login/verify-2fa
+// Accepts a challenge token and either a 6-digit TOTP code or an
+// XXXX-XXXX backup code. Returns the full JWT on success.
+router.post('/login/verify-2fa', async (req, res) => {
+  try {
+    const { challengeToken, code } = req.body;
+
+    if (!challengeToken || !code) {
+      return res.status(400).json({ error: 'challengeToken and code are required' });
+    }
+
+    const userId = verifyChallengeToken(challengeToken);
+    if (!userId) {
+      return res.status(401).json({ error: 'Challenge expired or invalid — please log in again' });
+    }
+
+    const user = await User.findById(userId).select('+twoFactorSecret +twoFactorBackupCodes');
+    if (!user || !user.twoFactorEnabled) {
+      return res.status(401).json({ error: 'Account not found or 2FA not enabled' });
+    }
+
+    const submitted = String(code).trim();
+    let success = false;
+    let usedBackup = false;
+
+    // Try TOTP first (6 digits)
+    if (/^\d{6}$/.test(submitted)) {
+      success = verify2FACode(user.twoFactorSecret, submitted);
+    }
+
+    // Fall back to backup code (XXXX-XXXX, case-insensitive)
+    if (!success && /^[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$/.test(submitted)) {
+      const idx = await verifyBackupCode(user.twoFactorBackupCodes, submitted);
+      if (idx >= 0) {
+        // One-time consumption — remove the used code
+        user.twoFactorBackupCodes.splice(idx, 1);
+        await user.save();
+        success = true;
+        usedBackup = true;
+      }
+    }
+
+    if (!success) {
+      return res.status(401).json({ error: 'Invalid code' });
+    }
+
+    const token = generateToken(user._id);
+
+    // Log login activity
+    logActivity(ACTIVITY_TYPES.USER_LOGIN, { twoFactor: usedBackup ? 'backup' : 'totp' }, {
+      notifyAdmin: false,
+      userId: user._id,
+      userName: user.profile?.firstName || '',
+      userEmail: user.email
+    }).catch(() => {});
+
+    return res.json({
+      message: 'Login successful',
+      token,
+      user: user.toJSON(),
+      backupCodeUsed: usedBackup,
+      backupCodesRemaining: usedBackup ? user.twoFactorBackupCodes.length : undefined,
+    });
+  } catch (err) {
+    console.error('[login/verify-2fa] error:', err);
+    return res.status(500).json({ error: '2FA verification failed' });
   }
 });
 


### PR DESCRIPTION
## Summary
Implements two-factor authentication (2FA) support for user login, allowing users with 2FA enabled to verify their identity using either a TOTP code from an authenticator app or a backup code before receiving a full authentication token.

## Key Changes
- **Login flow modification**: When a user with 2FA enabled logs in successfully, they now receive a short-lived challenge token instead of a full JWT, and are prompted to verify with a 2FA code
- **New 2FA verification endpoint** (`POST /api/auth/login/verify-2fa`): Accepts a challenge token and either a 6-digit TOTP code or a backup code (XXXX-XXXX format), validates it, and returns the full authentication token on success
- **Challenge token system**: Introduced `generateChallengeToken()` and `verifyChallengeToken()` functions in auth middleware that create and verify short-lived (5-minute) JWT tokens with a `2fa-challenge` purpose claim to bridge the gap between password verification and 2FA code submission
- **Backup code consumption**: Backup codes are one-time use only—when a backup code is used, it's removed from the user's account and the response indicates how many backup codes remain
- **Activity logging**: 2FA login attempts are logged with details about whether TOTP or a backup code was used
- **Service integration**: Integrated with `twoFactorService` functions (`verify2FACode`, `verifyBackupCode`) to handle code validation

## Implementation Details
- Challenge tokens expire after 5 minutes to limit the window for brute-force attacks
- TOTP codes are validated as exactly 6 digits; backup codes follow the XXXX-XXXX alphanumeric format
- The 2FA verification endpoint validates that the challenge token is legitimate and hasn't expired before processing the code
- Backup code indices are used to enable one-time consumption without exposing the actual codes in responses

https://claude.ai/code/session_01KFbDaNGCVFQE4cAMLw51zb