### PR TITLE
Add automated hardship pause resume job scheduled daily at 8 AM ET

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -75,6 +75,7 @@ import { initializeBoardMonitor } from './services/boardMonitorService.js';
 import cron from 'node-cron';
 import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
 import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
+import { runHardshipPauseResume } from './jobs/hardshipPauseResume.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -320,6 +321,14 @@ const startServer = async () => {
     runDailyNotificationCheck().catch(err => console.error('Daily notification check error:', err.message));
   }, { timezone: 'America/New_York' });
   console.log('Daily notification check cron scheduled (daily 10 AM ET)');
+
+  // Hardship pause auto-resume — daily at 8 AM ET
+  cron.schedule('0 8 * * *', () => {
+    runHardshipPauseResume().catch(err =>
+      console.error('Hardship pause resume error:', err.message)
+    );
+  }, { timezone: 'America/New_York' });
+  console.log('Hardship pause auto-resume cron scheduled (daily 8 AM ET)');
   verifyRoutes();
   app.listen(PORT, () => {
     console.log(`

--- a/server/src/jobs/hardshipPauseResume.js
+++ b/server/src/jobs/hardshipPauseResume.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+import User from '../models/User.js';
+
+/**
+ * Auto-resume hardship pauses whose pauseEndDate has passed.
+ * Scheduled via node-cron at 8 AM ET daily.
+ */
+export async function runHardshipPauseResume() {
+  console.log('[HardshipResume] Starting hardship pause auto-resume check...');
+  const stats = { checked: 0, resumed: 0, stripeFailures: 0, errors: 0 };
+
+  try {
+    const now = new Date();
+    const expiredPauses = await User.find({
+      'hardshipPause.isActive': true,
+      'hardshipPause.pauseEndDate': { $lte: now },
+    }).select('_id email hardshipPause subscription profile');
+
+    stats.checked = expiredPauses.length;
+    console.log(`[HardshipResume] Found ${stats.checked} expired pauses to resume`);
+
+    for (const user of expiredPauses) {
+      try {
+        // 1. Resume Stripe billing (same pattern as users.js manual resume)
+        if (user.subscription?.stripeSubscriptionId) {
+          try {
+            const Stripe = (await import('stripe')).default;
+            const stripe = process.env.STRIPE_SECRET_KEY
+              ? new Stripe(process.env.STRIPE_SECRET_KEY)
+              : null;
+            if (stripe) {
+              await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
+                pause_collection: ''
+              });
+              console.log(`[HardshipResume] Resumed Stripe sub ${user.subscription.stripeSubscriptionId} for user ${user._id}`);
+            }
+          } catch (stripeErr) {
+            console.error(`[HardshipResume] Stripe resume failed for user ${user._id}:`, stripeErr.message);
+            stats.stripeFailures++;
+            // Continue anyway — flip the DB flag so manual resume can retry Stripe
+          }
+        }
+
+        // 2. Flip the DB pause flags via existing instance method
+        await user.endHardshipPause();
+        stats.resumed++;
+        console.log(`[HardshipResume] Resumed user ${user._id} (${user.email})`);
+      } catch (userErr) {
+        console.error(`[HardshipResume] Failed to resume user ${user._id}:`, userErr.message);
+        stats.errors++;
+      }
+    }
+  } catch (err) {
+    console.error('[HardshipResume] Top-level error:', err);
+    stats.errors++;
+  }
+
+  console.log('[HardshipResume] Complete:', stats);
+  return stats;
+}


### PR DESCRIPTION
## Summary
This PR adds an automated job that automatically resumes hardship pauses for users whose pause end date has passed. The job runs daily at 8 AM ET via node-cron and handles both Stripe subscription resumption and database state updates.

## Key Changes
- **New job file** (`server/src/jobs/hardshipPauseResume.js`): Implements `runHardshipPauseResume()` function that:
  - Queries for users with active hardship pauses whose `pauseEndDate` has expired
  - Attempts to resume Stripe billing by clearing the `pause_collection` flag
  - Calls the existing `endHardshipPause()` instance method to update database state
  - Tracks statistics (checked, resumed, Stripe failures, errors) and logs results
  - Gracefully handles Stripe failures while still updating the database to allow manual retry

- **Updated server initialization** (`server/src/index.js`): 
  - Imports the new hardship pause resume job
  - Schedules the job to run daily at 8 AM ET using node-cron
  - Follows the same pattern as the existing daily notification check job

## Implementation Details
- The job uses MongoDB queries with `$lte` operator to find expired pauses efficiently
- Stripe resumption follows the same pattern as manual resume in the users controller
- Errors are logged but don't prevent processing of other users
- Stripe failures are tracked separately from database errors to distinguish between external and internal failures
- The job logs detailed information at each step for monitoring and debugging

https://claude.ai/code/session_01KFbDaNGCVFQE4cAMLw51zb