### PR TITLE
Remove index from timestamp field in ToolClick schema

### DIFF
--- a/server/src/models/ToolClick.js
+++ b/server/src/models/ToolClick.js
@@ -29,7 +29,7 @@ const toolClickSchema = new mongoose.Schema({
   referrer: { type: String },
   ip: { type: String },
   userAgent: { type: String },
-  timestamp: { type: Date, default: Date.now, index: true }
+  timestamp: { type: Date, default: Date.now }
 }, {
   timestamps: false
 });


### PR DESCRIPTION
## Summary
Removed the database index from the `timestamp` field in the ToolClick schema to reduce index overhead and storage requirements.

## Changes
- Removed `index: true` from the `timestamp` field definition in the ToolClick model
- The field retains its `Date` type with `Date.now` as the default value

## Details
The timestamp field is still automatically populated with the current date/time when a document is created, but queries on this field will no longer benefit from index acceleration. This change may be appropriate if timestamp-based queries are infrequent or if the index overhead outweighs the performance benefits for this particular collection.

https://claude.ai/code/session_013BJqp5bmmfUXqGSmEfQySr