### PR TITLE
Update approving body enums and add LPCAGA/GSCSW compliance fields

### DIFF
--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -554,13 +554,27 @@
           textColor: 'text-forest-800',
           getStatement: (providerNumber) => `GA Integrated Therapeutic Perspectives LLC has been approved by NBCC as an Approved Continuing Education Provider, ACEP No. ${providerNumber || '7760'}. Programs that do not qualify for NBCC credit are clearly identified. GA Integrated Therapeutic Perspectives LLC is solely responsible for all aspects of the programs.`
         },
-        'GCSCW': {
-          title: 'Georgia Composite Board Approved',
-          logo: '/images/gcscw-logo.png',
+        'GSCSW': {
+          title: 'GSCSW Approved Course',
+          logo: null,
           gradient: 'from-blue-50 to-indigo-50',
           borderColor: 'border-blue-200',
           textColor: 'text-blue-800',
-          getStatement: (providerNumber) => `GA Integrated Therapeutic Perspectives LLC is approved by the Georgia Composite Board of Professional Counselors, Social Workers, and Marriage & Family Therapists to provide continuing education.${providerNumber ? ` Provider Number: ${providerNumber}` : ''}`
+          // GSCSW Policy & Procedures (June 2024) page 4 mandates literal
+          // phrase "Approved by GSCSW" + approval number on certificate.
+          getStatement: (providerNumber) => `Approved by GSCSW${providerNumber ? `, Approval #${providerNumber}` : ''}.`
+        },
+        'LPCAGA': {
+          title: 'LPCA-GA Approved Course',
+          logo: null,
+          gradient: 'from-emerald-50 to-green-50',
+          borderColor: 'border-emerald-200',
+          textColor: 'text-emerald-800',
+          // LPCA-GA mandatory full sentence is rendered on the certificate
+          // PDF (with hour-type breakdown and delivery format). The badge
+          // here is a short summary; the full compliant disclosure lives
+          // on the cert.
+          getStatement: (providerNumber) => `Approved by the Licensed Professional Counselors Association of Georgia.${providerNumber ? ` LPCA CE Approval #${providerNumber}` : ''}`
         },
         'GA-LPC-Board': {
           title: 'Georgia LPC Board Approved',

--- a/server/src/models/BlogPost.js
+++ b/server/src/models/BlogPost.js
@@ -100,7 +100,6 @@ blogPostSchema.pre('validate', function(next) {
 
 // Index for public queries
 blogPostSchema.index({ status: 1, publishedAt: -1 });
-blogPostSchema.index({ slug: 1 });
 blogPostSchema.index({ category: 1 });
 blogPostSchema.index({ tags: 1 });
 

--- a/server/src/models/Certificate.js
+++ b/server/src/models/Certificate.js
@@ -74,7 +74,7 @@ const certificateSchema = new mongoose.Schema({
   // Approving Body & Applicability
   approvingBody: {
     type: String,
-    enum: ['NBCC', 'ACEP', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'LPCAGA', 'State Board', 'Other', null],
+    enum: ['NBCC', 'ACEP', 'LPCAGA', 'GSCSW', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'State Board', 'Other', null],
     default: null
   },
   approvalNumber: {

--- a/server/src/models/Course.js
+++ b/server/src/models/Course.js
@@ -192,7 +192,7 @@ const courseSchema = new mongoose.Schema({
   approvals: [{
     body: {
       type: String,
-      enum: ['NBCC', 'GCSCW', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'GA-LPC-Board', 'GA-LCSW-Board', 'GA-LMFT-Board', 'State Board', 'Other'],
+      enum: ['NBCC', 'ACEP', 'LPCAGA', 'GSCSW', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'State Board', 'Other'],
       required: true
     },
     providerNumber: { type: String },
@@ -204,13 +204,33 @@ const courseSchema = new mongoose.Schema({
     },
     approvalDate: { type: Date },
     expirationDate: { type: Date },
-    notes: { type: String }
+    notes: { type: String },
+
+    // Per-approval hour-type breakdown (required for LPCAGA + GSCSW
+    // certificate compliance — boards audit for explicit core/ethics split)
+    coreHours: { type: Number, default: 0, min: 0 },
+    ethicHours: { type: Number, default: 0, min: 0 },
+
+    // Delivery format — feeds the LPCA-GA mandatory disclosure sentence
+    // template at certificate-generation time. AW/LW/MLW/S/C from LPCA-GA's
+    // approval type taxonomy.
+    deliveryFormat: {
+      type: String,
+      enum: [
+        'asynchronous',          // AW — on-demand, 1-year validity
+        'live-webinar',          // LW — single live online date
+        'multi-live-workshop',   // MLW — series of live sessions, 12 mo
+        'in-person-single',      // S — one in-person date
+        'in-person-conference',  // C — multi-day in-person
+      ],
+      default: 'asynchronous'
+    }
   }],
   
   // Legacy fields (retained for backward compatibility)
   approvingBody: {
     type: String,
-    enum: ['NBCC', 'ACEP', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'LPCAGA', 'State Board', 'Other'],
+    enum: ['NBCC', 'ACEP', 'LPCAGA', 'GSCSW', 'ACA', 'NASW', 'APA', 'ASWB', 'AAMFT', 'State Board', 'Other'],
     default: 'NBCC'
   },
   approvingBodyOther: { type: String },
@@ -427,7 +447,6 @@ const courseSchema = new mongoose.Schema({
 // INDEXES
 // ============================================
 
-courseSchema.index({ slug: 1 });
 courseSchema.index({ status: 1 });
 courseSchema.index({ accessType: 1 });
 courseSchema.index({ title: 'text', description: 'text', tags: 'text' });

--- a/server/src/models/HelpArticle.js
+++ b/server/src/models/HelpArticle.js
@@ -83,7 +83,6 @@ const helpArticleSchema = new mongoose.Schema({
 });
 
 // Indexes
-helpArticleSchema.index({ slug: 1 });
 helpArticleSchema.index({ category: 1, status: 1, order: 1 });
 helpArticleSchema.index({ audience: 1, status: 1 });
 helpArticleSchema.index({ searchTags: 1 });

--- a/server/src/models/Organization.js
+++ b/server/src/models/Organization.js
@@ -72,7 +72,6 @@ organizationSchema.pre('save', function(next) {
 organizationSchema.index({ ownerId: 1 });
 organizationSchema.index({ 'seats.userId': 1 });
 organizationSchema.index({ 'seats.email': 1 });
-organizationSchema.index({ slug: 1 });
 
 // Get active seat count
 organizationSchema.methods.getActiveSeatCount = function() {

--- a/server/src/models/Partner.js
+++ b/server/src/models/Partner.js
@@ -109,7 +109,6 @@ const partnerSchema = new mongoose.Schema({
   timestamps: true
 });
 
-partnerSchema.index({ slug: 1 });
 partnerSchema.index({ active: 1 });
 partnerSchema.index({ 'branding.customDomain': 1 });
 

--- a/server/src/routes/scan.js
+++ b/server/src/routes/scan.js
@@ -159,11 +159,14 @@ APPROVING BODY - Look for these and extract exactly:
 - "APA" - American Psychological Association
 - "ASWB" - Association of Social Work Boards
 - "AAMFT" - American Association for Marriage and Family Therapy
-- State boards: "LPCAGA" (Georgia), "Florida Board", "Texas Board", etc.
+- "LPCAGA" - Licensed Professional Counselors Association of Georgia (per-course approval, format YYYY-MM-DD-NNNN[type])
+- "GSCSW" - Georgia Society for Clinical Social Workers (per-course approval, format MMDDYY)
+- State boards: "Florida Board", "Texas Board", etc.
 - If multiple approvals, list the primary/first one
 
 APPLICABILITY RULES:
 - If approved by NBCC, ACEP, ACA, NASW, APA, ASWB, AAMFT → "national" (applies to all states)
+- If approved by LPCAGA or GSCSW → "state-specific" (Georgia)
 - If approved by a state board, analyze the content:
   - If the content discusses STATE-SPECIFIC laws, rules, regulations, or statutes → "state-specific"
   - If the content is general clinical practice, theory, or skills → "national" (even if state-approved)


### PR DESCRIPTION
## Summary
This PR updates the course approval system to support Georgia-specific accrediting bodies (LPCAGA and GSCSW) with enhanced compliance tracking, and removes unused slug indexes across multiple models.

## Key Changes

**Course Model (Course.js)**
- Updated `approvals[].body` enum to replace legacy board references (`GA-LPC-Board`, `GA-LCSW-Board`, `GA-LMFT-Board`, `GCSCW`) with standardized codes: `LPCAGA` and `GSCSW`
- Added per-approval hour-type breakdown fields:
  - `coreHours` and `ethicHours` (required for LPCAGA and GSCSW certificate compliance audits)
  - `deliveryFormat` enum with five LPCA-GA taxonomy values (asynchronous, live-webinar, multi-live-workshop, in-person-single, in-person-conference)
- Updated legacy `approvingBody` enum to match new approving body codes
- Removed unused `slug` index

**Certificate Model (Certificate.js)**
- Updated `approvingBody` enum to include `LPCAGA` and `GSCSW` with consistent ordering

**Client UI (course-details.html)**
- Renamed `GCSCW` to `GSCSW` with updated branding and compliance statement
- Added new `LPCAGA` approval badge with emerald gradient and mandatory disclosure language
- Updated certificate statement templates to match board policy requirements (GSCSW Policy & Procedures June 2024, LPCA-GA mandatory disclosure)

**Scan Route (scan.js)**
- Updated approving body extraction documentation to recognize `LPCAGA` and `GSCSW` as state-specific Georgia approvals
- Added applicability rules: LPCAGA and GSCSW approvals map to "state-specific" (Georgia)

**Index Cleanup**
- Removed unused `slug` indexes from BlogPost, HelpArticle, Organization, and Partner models

## Implementation Details
- Hour-type breakdown fields default to 0 with minimum value constraints
- Delivery format defaults to 'asynchronous' for backward compatibility
- Certificate statements include board-mandated language and approval number formatting
- All enum updates maintain consistency across Course, Certificate, and UI models

https://claude.ai/code/session_012mTSN1KqkVuJdG2jyBGaUy