### PR TITLE
Add NBCC and ACA reference taxonomies for course content mapping

### DIFF
--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -363,6 +363,20 @@ const CourseSchema = new mongoose.Schema({
       'Wellness and Prevention'
     ]
   }],
+
+  // ACA Code of Ethics — subsection-level tagging.
+  // Format: section letter A-I + dot + subsection number (e.g. 'A.1', 'B.6').
+  // Section-level rollup is computed in code:
+  //   course.acaCodeSections.map(s => s.split('.')[0])
+  // Powers the platform's content-overlap-prevention feature
+  // (showing users courses that don't repeat content they've already covered).
+  // Full mapping of subsection → topic is in
+  // server/src/reference-taxonomies/aca-code-sections.js
+  acaCodeSections: [{
+    type: String,
+    match: /^[A-I]\.\d+$/
+  }],
+
   accessType: {
     type: String,
     enum: ['free', 'subscription', 'purchase'],

--- a/server/src/reference-taxonomies/aca-code-sections.js
+++ b/server/src/reference-taxonomies/aca-code-sections.js
@@ -1,0 +1,70 @@
+/**
+ * ACA Code of Ethics (2014) — Reference Taxonomy
+ *
+ * Maps the InteractiveCourse.acaCodeSections[] schema's subsection codes
+ * to their section-level rollup and topic descriptions.
+ *
+ * Schema stores compact subsection codes like 'A.1', 'B.6', 'F.4'.
+ * Use these helpers when computing section-level rollups, related-section
+ * detection for overlap prevention, or rendering audit reports.
+ */
+
+export const ACA_SECTIONS = [
+  { letter: 'A', name: 'The Counseling Relationship' },
+  { letter: 'B', name: 'Confidentiality and Privacy' },
+  { letter: 'C', name: 'Professional Responsibility' },
+  { letter: 'D', name: 'Relationships With Other Professionals' },
+  { letter: 'E', name: 'Evaluation, Assessment, and Interpretation' },
+  { letter: 'F', name: 'Supervision, Training, and Teaching' },
+  { letter: 'G', name: 'Research and Publication' },
+  { letter: 'H', name: 'Distance Counseling, Technology, and Social Media' },
+  { letter: 'I', name: 'Resolving Ethical Issues' }
+];
+
+/**
+ * Common subsections within each section. Not exhaustive — schema accepts
+ * any A.N through I.N format, this object documents the typical ones.
+ */
+export const ACA_SUBSECTIONS = {
+  'A': ['A.1', 'A.2', 'A.3', 'A.4', 'A.5', 'A.6', 'A.7', 'A.8', 'A.9', 'A.10', 'A.11', 'A.12'],
+  'B': ['B.1', 'B.2', 'B.3', 'B.4', 'B.5', 'B.6', 'B.7'],
+  'C': ['C.1', 'C.2', 'C.3', 'C.4', 'C.5', 'C.6', 'C.7'],
+  'D': ['D.1', 'D.2'],
+  'E': ['E.1', 'E.2', 'E.3', 'E.4', 'E.5', 'E.6', 'E.7', 'E.8', 'E.9', 'E.10', 'E.11', 'E.12', 'E.13'],
+  'F': ['F.1', 'F.2', 'F.3', 'F.4', 'F.5', 'F.6', 'F.7', 'F.8', 'F.9', 'F.10', 'F.11'],
+  'G': ['G.1', 'G.2', 'G.3', 'G.4', 'G.5'],
+  'H': ['H.1', 'H.2', 'H.3', 'H.4', 'H.5', 'H.6'],
+  'I': ['I.1', 'I.2']
+};
+
+/**
+ * Get the section-level rollup for a subsection code.
+ * @param {string} subsection - e.g. 'A.1', 'B.6'
+ * @returns {string} Section letter (e.g. 'A', 'B')
+ */
+export const sectionLetter = (subsection) => {
+  if (typeof subsection !== 'string') return '';
+  return subsection.split('.')[0];
+};
+
+/**
+ * Get the section topic name for a subsection code.
+ * @param {string} subsection - e.g. 'A.1'
+ * @returns {string|null}
+ */
+export const sectionName = (subsection) => {
+  const letter = sectionLetter(subsection);
+  const section = ACA_SECTIONS.find(s => s.letter === letter);
+  return section ? section.name : null;
+};
+
+/**
+ * Roll up an array of subsection codes to their unique section letters.
+ * @param {string[]} subsections
+ * @returns {string[]} Unique section letters, sorted
+ */
+export const rollupToSections = (subsections) => {
+  if (!Array.isArray(subsections)) return [];
+  const letters = new Set(subsections.map(sectionLetter).filter(Boolean));
+  return Array.from(letters).sort();
+};

--- a/server/src/reference-taxonomies/nbcc-content-areas.js
+++ b/server/src/reference-taxonomies/nbcc-content-areas.js
@@ -1,0 +1,109 @@
+/**
+ * NBCC Content Areas — Reference Taxonomy
+ *
+ * Maps the InteractiveCourse.nbccContentAreas[] schema's abbreviated
+ * names to NBCC's official Section G content area names from the
+ * NBCC Provider Policy.
+ *
+ * The schema stores the abbreviated `code` for compact UI display.
+ * Use `officialName(code)` when generating certificates, audit reports,
+ * or any artifact that needs NBCC's exact official wording.
+ *
+ * Related-area logic powers the platform's content-overlap-prevention
+ * feature (preventing users from taking courses that repeat content
+ * they've already covered).
+ */
+
+export const NBCC_CONTENT_AREAS = [
+  {
+    code: 'Counseling Theory/Practice',
+    officialName: 'Counseling Theory/Practice and the Counseling Relationship',
+    description: 'Theoretical foundations of counseling and the therapeutic relationship. Covers counseling theories, counselor-client dynamics, helping skills, and evidence-based practice.',
+    relatedAreas: ['Group Dynamics', 'Professional Identity']
+  },
+  {
+    code: 'Human Growth and Development',
+    officialName: 'Human Growth and Development',
+    description: 'Lifespan development, learning theories, personality development, biopsychosocial factors influencing client behavior.',
+    relatedAreas: ['Wellness and Prevention']
+  },
+  {
+    code: 'Social and Cultural Foundations',
+    officialName: 'Social and Cultural Foundations',
+    description: 'Multicultural counseling, social and cultural diversity, intersectionality, equity, and social justice in counseling practice.',
+    relatedAreas: ['Professional Identity', 'Wellness and Prevention']
+  },
+  {
+    code: 'Group Dynamics',
+    officialName: 'Group Dynamics and Counseling',
+    description: 'Group counseling theory and practice, group facilitation, group process, group ethics.',
+    relatedAreas: ['Counseling Theory/Practice']
+  },
+  {
+    code: 'Career Development',
+    officialName: 'Career Development and Counseling',
+    description: 'Career theories, career assessment, career counseling techniques, employment trends.',
+    relatedAreas: ['Assessment', 'Human Growth and Development']
+  },
+  {
+    code: 'Assessment',
+    officialName: 'Assessment',
+    description: 'Psychological and behavioral assessment, testing principles, diagnostic skills, assessment ethics.',
+    relatedAreas: ['Career Development', 'Research/Program Evaluation']
+  },
+  {
+    code: 'Research/Program Evaluation',
+    officialName: 'Research and Program Evaluation',
+    description: 'Research methodology, program evaluation, evidence-based practice, statistical literacy.',
+    relatedAreas: ['Assessment']
+  },
+  {
+    code: 'Professional Identity',
+    officialName: 'Counselor Professional Identity and Practice Issues',
+    description: 'Professional ethics, legal issues, scope of practice, professional development, supervision, advocacy.',
+    relatedAreas: ['Counseling Theory/Practice', 'Social and Cultural Foundations']
+  },
+  {
+    code: 'Wellness and Prevention',
+    officialName: 'Wellness and Prevention',
+    description: 'Wellness models, prevention programming, mental health promotion, self-care, vicarious trauma.',
+    relatedAreas: ['Human Growth and Development', 'Social and Cultural Foundations']
+  }
+];
+
+/**
+ * Get the official long-form NBCC name for an abbreviated code.
+ * @param {string} code - The abbreviated name as stored in InteractiveCourse.nbccContentAreas
+ * @returns {string} Official NBCC Provider Policy name, or the code itself if unmatched
+ */
+export const officialName = (code) => {
+  const area = NBCC_CONTENT_AREAS.find(a => a.code === code);
+  return area ? area.officialName : code;
+};
+
+/**
+ * Get the description for an area code.
+ * @param {string} code
+ * @returns {string|null}
+ */
+export const description = (code) => {
+  const area = NBCC_CONTENT_AREAS.find(a => a.code === code);
+  return area ? area.description : null;
+};
+
+/**
+ * Get codes for areas related to the given code (for overlap detection
+ * and recommendation logic).
+ * @param {string} code
+ * @returns {string[]}
+ */
+export const relatedAreas = (code) => {
+  const area = NBCC_CONTENT_AREAS.find(a => a.code === code);
+  return area ? area.relatedAreas : [];
+};
+
+/**
+ * All valid codes (matches the InteractiveCourse.nbccContentAreas enum).
+ * @returns {string[]}
+ */
+export const allCodes = () => NBCC_CONTENT_AREAS.map(a => a.code);


### PR DESCRIPTION
## Summary
This PR introduces two reference taxonomy modules to support content area and ethics code mapping for interactive courses. These taxonomies enable the platform to track course coverage against NBCC content areas and ACA Code of Ethics sections, powering content-overlap-prevention features and audit reporting.

## Key Changes

- **Added `nbcc-content-areas.js`**: Reference taxonomy mapping NBCC's 9 official content areas with:
  - Abbreviated codes for compact UI display
  - Official long-form names for certificates and audit reports
  - Descriptions of each content area
  - Related-area relationships for overlap detection logic

- **Added `aca-code-sections.js`**: Reference taxonomy for ACA Code of Ethics (2014) with:
  - 9 sections (A–I) with official names
  - Common subsection listings (A.1–I.2 format)
  - Helper functions for section-level rollup and name lookup
  - Support for subsection-to-section mapping

- **Updated `InteractiveCourse.js` schema**: Added `acaCodeSections` field to store ACA Code of Ethics subsection tags (format: `[A-I]\.\d+`), with documentation linking to the reference taxonomy

## Implementation Details

- Both taxonomies export a data structure plus utility functions (`officialName()`, `description()`, `relatedAreas()`, `sectionName()`, `rollupToSections()`, etc.) for common lookup and transformation operations
- The NBCC taxonomy's `relatedAreas` field powers content-overlap-prevention by identifying courses that cover similar topics
- ACA subsection codes are stored compactly in the schema; section-level rollup is computed in application code via simple string splitting
- Full documentation in module headers explains the relationship between schema storage and reference taxonomy usage

https://claude.ai/code/session_01F1vnfgugtUUXLv5UQp3K8m