### PR TITLE
Fix: align local tierFromLifetime() with v2.2 service names

### DIFF
--- a/server/src/routes/rewards.js
+++ b/server/src/routes/rewards.js
@@ -263,11 +263,12 @@ router.get('/referrals', protect, async (req, res) => {
 // ─────────────────────────────────────────────────────────────────
 // Tier calculation — keep in sync with v1.0 §3.1
 // ─────────────────────────────────────────────────────────────────
+// TODO: replace with `import { tierFromLifetime } from '../services/rewardsService.js'` to prevent drift (see PR for v2.2 tier rename)
 function tierFromLifetime(lifetime) {
-  if (lifetime >= 1500) return { name: 'Flourishing', color: 'gold', multiplier: 2.0, nextThreshold: null };
-  if (lifetime >= 750)  return { name: 'Rooted',      color: 'navy', multiplier: 1.5, nextThreshold: 1500 };
-  if (lifetime >= 250)  return { name: 'Grounded',    color: 'hunter', multiplier: 1.25, nextThreshold: 750 };
-  return                       { name: 'Seedling',    color: 'green', multiplier: 1.0, nextThreshold: 250 };
+  if (lifetime >= 1500) return { name: 'Seasoned', color: 'gold', multiplier: 2.0, nextThreshold: null };
+  if (lifetime >= 750)  return { name: 'Skilled',      color: 'navy', multiplier: 1.5, nextThreshold: 1500 };
+  if (lifetime >= 250)  return { name: 'Proficient',    color: 'hunter', multiplier: 1.25, nextThreshold: 750 };
+  return                       { name: 'Capable',    color: 'green', multiplier: 1.0, nextThreshold: 250 };
 }
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- routes/rewards.js (no other duplicates found via repo-wide grep)
- 4 string swaps: Flourishing→Seasoned, Rooted→Skilled, Grounded→Proficient, Seedling→Capable
- Thresholds/colors/multipliers/nextThreshold unchanged
- TODO comment added pointing to future consolidation with rewardsService.js