### PR TITLE
Upgrade XP↔MMP bridge to v4 with earn/spend two-card layout

### DIFF
--- a/client/public/achievements.html
+++ b/client/public/achievements.html
@@ -107,11 +107,16 @@
 
 <!--
   ═══════════════════════════════════════════════════════════════
-  CounselorReady Achievements Page — XP↔MMP Bridge v3
+  CounselorReady Achievements Page — XP↔MMP Bridge v4
   Day 3.5 — May 7, 2026
 
   PLACEMENT: Drop into client/public/achievements.html DIRECTLY ABOVE
   the existing <div id="cr-mmp-widget" ...> block.
+
+  v4 changes from v3:
+    + "How you earn MMP" card (lists earn types and point values)
+    + 2-column desktop layout (earn | spend), stacks on mobile
+    + Footnote on each card
 
   STANDALONE: Self-contained CSS scoped to .cr-bridge-* prefix.
   REVERT: Delete this entire block.
@@ -166,10 +171,7 @@
       white-space: nowrap;
       box-shadow: 0 1px 3px rgba(212, 168, 85, 0.10);
     }
-    .cr-bridge-sparkle {
-      font-size: 14px;
-      line-height: 1;
-    }
+    .cr-bridge-sparkle { font-size: 14px; line-height: 1; }
 
     .cr-bridge-headline {
       font-family: 'Cormorant Garamond', Georgia, serif;
@@ -182,47 +184,47 @@
       max-width: 600px;
       padding: 0 16px;
     }
-    .cr-bridge-headline strong {
-      font-style: italic;
-      color: #4A7C59;
-    }
+    .cr-bridge-headline strong { font-style: italic; color: #4A7C59; }
 
     .cr-bridge-explainer {
       max-width: 580px;
-      margin: 0 auto 16px;
+      margin: 0 auto 20px;
       padding: 0 16px;
       text-align: center;
       font-size: 13.5px;
       line-height: 1.6;
       color: rgba(40, 65, 87, 0.78);
     }
-    .cr-bridge-explainer .cr-bridge-mmp {
-      color: #6B1D34;
-      font-weight: 700;
+    .cr-bridge-explainer .cr-bridge-mmp { color: #6B1D34; font-weight: 700; }
+    .cr-bridge-explainer .cr-bridge-xp { color: #4A7C59; font-weight: 700; }
+
+    .cr-bridge-cardgrid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      max-width: 760px;
+      margin: 0 auto 16px;
     }
-    .cr-bridge-explainer .cr-bridge-xp {
-      color: #4A7C59;
-      font-weight: 700;
+    @media (max-width: 640px) {
+      .cr-bridge-cardgrid { grid-template-columns: 1fr; }
     }
 
-    .cr-bridge-spendlist {
-      max-width: 460px;
-      margin: 0 auto 14px;
-      padding: 14px 18px;
+    .cr-bridge-card {
+      padding: 16px 18px 14px;
       background: linear-gradient(135deg, rgba(245, 245, 220, 0.55) 0%, rgba(255, 255, 255, 0.7) 100%);
       border: 1px solid rgba(212, 168, 85, 0.30);
       border-radius: 12px;
     }
-    .cr-bridge-spendlist-title {
+    .cr-bridge-card-title {
       font-size: 11px;
       letter-spacing: 0.10em;
       text-transform: uppercase;
       font-weight: 700;
       color: #8C6A1F;
       text-align: center;
-      margin-bottom: 10px;
+      margin-bottom: 12px;
     }
-    .cr-bridge-spend-row {
+    .cr-bridge-row {
       display: flex;
       align-items: center;
       gap: 10px;
@@ -231,34 +233,41 @@
       color: #284157;
       line-height: 1.4;
     }
-    .cr-bridge-spend-row + .cr-bridge-spend-row {
+    .cr-bridge-row + .cr-bridge-row {
       border-top: 1px dashed rgba(40, 65, 87, 0.10);
       margin-top: 4px;
       padding-top: 8px;
     }
-    .cr-bridge-spend-icon {
+    .cr-bridge-icon {
       flex-shrink: 0;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       background: rgba(212, 168, 85, 0.18);
       border-radius: 50%;
       color: #8C6A1F;
-      font-size: 11px;
+      font-size: 12px;
       font-weight: 700;
+      line-height: 1;
     }
-    .cr-bridge-spend-text {
-      flex: 1;
-    }
-    .cr-bridge-spend-text strong {
-      color: #6B1D34;
+    .cr-bridge-text { flex: 1; }
+    .cr-bridge-text strong { color: #6B1D34; }
+    .cr-bridge-text em { color: #4A7C59; font-style: normal; font-weight: 700; }
+    .cr-bridge-footnote {
+      margin-top: 10px;
+      padding-top: 8px;
+      border-top: 1px dashed rgba(40, 65, 87, 0.10);
+      font-size: 11px;
+      line-height: 1.5;
+      color: rgba(40, 65, 87, 0.6);
+      font-style: italic;
     }
 
     .cr-bridge-mission {
       max-width: 540px;
-      margin: 0 auto;
+      margin: 4px auto 0;
       padding: 0 16px;
       text-align: center;
       font-family: 'Cormorant Garamond', Georgia, serif;
@@ -272,7 +281,7 @@
       .cr-bridge-headline { font-size: 19px; }
       .cr-bridge-explainer { font-size: 13px; }
       .cr-bridge-mission { font-size: 14.5px; }
-      .cr-bridge-spend-row { font-size: 12.5px; }
+      .cr-bridge-row { font-size: 12.5px; }
     }
   </style>
 
@@ -290,23 +299,59 @@
   </h3>
 
   <p class="cr-bridge-explainer">
-    <span class="cr-bridge-xp">XP and Level above</span> map your daily journey &mdash; logins, streaks, sections, badges. <span class="cr-bridge-mmp">Mastery Mark Points below</span> are something different: a real, redeemable currency you earn for the moments that matter most &mdash; finishing courses, claiming certificates, submitting reflections, referring colleagues.
+    <span class="cr-bridge-xp">XP and Level above</span> map your daily journey &mdash; logins, streaks, sections, badges. <span class="cr-bridge-mmp">Mastery Mark Points below</span> are something different: a real, redeemable currency you earn for the moments that matter most.
   </p>
 
-  <div class="cr-bridge-spendlist">
-    <div class="cr-bridge-spendlist-title">What MMP can buy</div>
-    <div class="cr-bridge-spend-row">
-      <span class="cr-bridge-spend-icon">$</span>
-      <span class="cr-bridge-spend-text"><strong>$10 or $25 subscription credit</strong> &mdash; auto-applied to your next invoice</span>
+  <div class="cr-bridge-cardgrid">
+
+    <!-- HOW TO EARN -->
+    <div class="cr-bridge-card">
+      <div class="cr-bridge-card-title">How you earn MMP</div>
+
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">💭</span>
+        <span class="cr-bridge-text"><strong>+5 MMP</strong> &mdash; submit a reflection in any course</span>
+      </div>
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">🎓</span>
+        <span class="cr-bridge-text"><strong>+25 to +100 MMP</strong> &mdash; complete a course <em>(longer courses + subscribers earn more)</em></span>
+      </div>
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">📜</span>
+        <span class="cr-bridge-text"><strong>+25 MMP</strong> &mdash; claim your certificate</span>
+      </div>
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">🤝</span>
+        <span class="cr-bridge-text"><strong>up to +350 MMP</strong> &mdash; refer a colleague*</span>
+      </div>
+
+      <div class="cr-bridge-footnote">
+        *+50 MMP when they sign up &middot; +200 when they subscribe &middot; +100 more after 3 months
+      </div>
     </div>
-    <div class="cr-bridge-spend-row">
-      <span class="cr-bridge-spend-icon">🛍</span>
-      <span class="cr-bridge-spend-text"><strong>Amazon or DoorDash</strong> $25 gift cards</span>
+
+    <!-- WHAT MMP CAN BUY -->
+    <div class="cr-bridge-card">
+      <div class="cr-bridge-card-title">What MMP can buy</div>
+
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">$</span>
+        <span class="cr-bridge-text"><strong>$10 or $25 subscription credit</strong> &mdash; auto-applied to your next invoice</span>
+      </div>
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">🛍</span>
+        <span class="cr-bridge-text"><strong>$25 Amazon or DoorDash</strong> gift cards</span>
+      </div>
+      <div class="cr-bridge-row">
+        <span class="cr-bridge-icon">🌿</span>
+        <span class="cr-bridge-text"><strong>$25 spa gift cards</strong> &mdash; massage, retreats, and wellness at Georgia partner spas</span>
+      </div>
+
+      <div class="cr-bridge-footnote">
+        Redemption unlocks at 500 MMP &middot; spend any time after that
+      </div>
     </div>
-    <div class="cr-bridge-spend-row">
-      <span class="cr-bridge-spend-icon">🌿</span>
-      <span class="cr-bridge-spend-text"><strong>$25 spa gift cards</strong> &mdash; massage, retreats, and wellness at Georgia partner spas</span>
-    </div>
+
   </div>
 
   <p class="cr-bridge-mission">
@@ -314,7 +359,7 @@
   </p>
 </div>
 
-<!-- ═══ END XP↔MMP Bridge v3 ═══ -->
+<!-- ═══ END XP↔MMP Bridge v4 ═══ -->
 
 <div id="cr-mmp-widget" class="cr-mmp-root" style="display:none">
   <style>


### PR DESCRIPTION
Adds a "How you earn MMP" card alongside the existing "What MMP can buy" card, in a 2-column grid that stacks on mobile. Each card now carries a footnote (referral breakdown / 500-point redemption threshold). All styling stays scoped under .cr-bridge-* and the surrounding cr-mmp-widget is untouched.