### PR TITLE
Refactor: Move tierFromLifetime to rewardsService

### DIFF
--- a/server/src/routes/rewards.js
+++ b/server/src/routes/rewards.js
@@ -19,6 +19,8 @@ const stripe = process.env.STRIPE_SECRET_KEY ? new Stripe(process.env.STRIPE_SEC
 import emailService from '../services/emailService.js';
 const { sendRedemptionConfirmation, sendRedemptionAdminAlert } = emailService;
 
+import { tierFromLifetime } from '../services/rewardsService.js';
+
 const router = express.Router();
 
 // ─────────────────────────────────────────────────────────────────
@@ -259,17 +261,6 @@ router.get('/referrals', protect, async (req, res) => {
     return res.status(500).json({ error: 'server_error' });
   }
 });
-
-// ─────────────────────────────────────────────────────────────────
-// Tier calculation — keep in sync with v1.0 §3.1
-// ─────────────────────────────────────────────────────────────────
-// TODO: replace with `import { tierFromLifetime } from '../services/rewardsService.js'` to prevent drift (see PR for v2.2 tier rename)
-function tierFromLifetime(lifetime) {
-  if (lifetime >= 1500) return { name: 'Seasoned', color: 'gold', multiplier: 2.0, nextThreshold: null };
-  if (lifetime >= 750)  return { name: 'Skilled',      color: 'navy', multiplier: 1.5, nextThreshold: 1500 };
-  if (lifetime >= 250)  return { name: 'Proficient',    color: 'hunter', multiplier: 1.25, nextThreshold: 750 };
-  return                       { name: 'Capable',    color: 'green', multiplier: 1.0, nextThreshold: 250 };
-}
 
 // ─────────────────────────────────────────────────────────────────
 // POST /api/rewards/redeem


### PR DESCRIPTION
## Summary
Consolidates the tier calculation logic by moving the `tierFromLifetime` function from the rewards route handler to the centralized `rewardsService` module, eliminating code duplication and reducing maintenance burden.

## Changes
- Removed the `tierFromLifetime` function definition from `server/src/routes/rewards.js`
- Added import statement to use `tierFromLifetime` from `../services/rewardsService.js`
- Removed the TODO comment that flagged this refactoring task

## Details
This change resolves the TODO comment that was previously in the code, which explicitly called for moving this function to prevent drift between implementations. By importing from a single source of truth in the rewardsService module, we ensure the tier calculation logic remains consistent across the codebase and simplifies future maintenance.

https://claude.ai/code/session_01QHAWtt4D18Lp2VUX3nfJ98