### PR TITLE
Add PostHog analytics events for auth, payments, certificates, course…

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -157,7 +157,22 @@ router.post('/register', async (req, res) => {
     }
 
     const token = generateToken(user._id);
-    
+
+    try {
+      if (global.posthog) {
+        global.posthog.capture({
+          distinctId: user._id.toString(),
+          event: 'user_registered',
+          properties: {
+            plan: user.subscription?.plan || 'free',
+            state: user.profile?.licenseState || '',
+            licenseType: user.profile?.licenseType || '',
+            referredBy: user.referredBy ? user.referredBy.toString() : null,
+            $set: { email: user.email, name: `${user.profile?.firstName || ''} ${user.profile?.lastName || ''}`.trim() }
+          }
+        });
+      }
+    } catch (phErr) { console.error('PostHog user_registered failed:', phErr); }
     res.status(201).json({
       message: 'Registration successful. Please check your email to verify your account.',
       token,
@@ -210,6 +225,18 @@ router.post('/login', async (req, res) => {
 
     const token = generateToken(user._id);
 
+    try {
+      if (global.posthog) {
+        global.posthog.capture({
+          distinctId: user._id.toString(),
+          event: 'user_logged_in',
+          properties: {
+            plan: user.subscription?.plan || 'free',
+            $set: { email: user.email }
+          }
+        });
+      }
+    } catch (phErr) { console.error('PostHog user_logged_in failed:', phErr); }
     // Log login activity (fire and forget)
     logActivity(ACTIVITY_TYPES.USER_LOGIN, {}, {
       notifyAdmin: false,

--- a/server/src/routes/certificates.js
+++ b/server/src/routes/certificates.js
@@ -199,6 +199,20 @@ function sendFile(res, fileBuffer, certificate, ext) {
     'Content-Length': fileBuffer.length,
     'Cache-Control': 'private, max-age=3600'
   });
+  try {
+    if (global.posthog) {
+      global.posthog.capture({
+        distinctId: (certificate.userId || certificate.user || 'unknown').toString(),
+        event: 'certificate_downloaded',
+        properties: {
+          certificateId: certificate._id?.toString() || '',
+          courseTitle: certificate.courseTitle || certificate.title || '',
+          ceHours: certificate.ceHours || 0,
+          fileType: contentType
+        }
+      });
+    }
+  } catch (phErr) { console.error('PostHog certificate_downloaded failed:', phErr); }
   return res.send(fileBuffer);
 }
 

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -1228,6 +1228,21 @@ router.put('/:id/progress/section/:sectionIndex', protect, async (req, res) => {
       sectionProgress.status = 'completed';
       sectionProgress.completedAt = sectionProgress.completedAt || new Date();
 
+      try {
+        if (global.posthog) {
+          global.posthog.capture({
+            distinctId: req.user._id.toString(),
+            event: 'section_completed',
+            properties: {
+              courseId: course._id.toString(),
+              courseTitle: course.title,
+              sectionIndex: parseInt(sectionIndex),
+              sectionTitle: section.title || `Section ${parseInt(sectionIndex) + 1}`,
+              timeSpentSeconds: sectionProgress.timeSpent || 0
+            }
+          });
+        }
+      } catch (phErr) { console.error('PostHog section_completed failed:', phErr); }
       // Log section completion (fire-and-forget)
       logActivity(ACTIVITY_TYPES.LESSON_COMPLETED, {
         courseId: course._id,

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -790,6 +790,19 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
               userEmail: subUser?.email || ''
             }).catch(() => {});
           }
+          try {
+            if (global.posthog) {
+              global.posthog.capture({
+                distinctId: userId.toString(),
+                event: 'subscription_activated',
+                properties: {
+                  plan: subscription.metadata?.plan || 'unknown',
+                  status: subscription.status,
+                  stripeSubscriptionId: subscription.id
+                }
+              });
+            }
+          } catch (phErr) { console.error('PostHog subscription_activated failed:', phErr); }
           console.log(`Subscription updated for user ${userId}: ${subscription.status}`);
         }
         break;
@@ -826,6 +839,18 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
             userName: canceledUser?.profile?.firstName || '',
             userEmail: canceledUser?.email || ''
           }).catch(() => {});
+          try {
+            if (global.posthog) {
+              global.posthog.capture({
+                distinctId: userId.toString(),
+                event: 'subscription_canceled',
+                properties: {
+                  plan: canceledPlan,
+                  stripeSubscriptionId: subscription.id
+                }
+              });
+            }
+          } catch (phErr) { console.error('PostHog subscription_canceled failed:', phErr); }
           console.log(`Subscription canceled for user ${userId}`);
         }
         break;


### PR DESCRIPTION
… progress

Insertion-only changes that capture user_registered, user_logged_in, subscription_activated, subscription_canceled, certificate_downloaded, and section_completed via the global PostHog client. All wrapped in try/catch with the same fire-and-forget pattern used in courseRoutes.