### PR TITLE
fix: gate admin alerts on DB error, help hero bg, drop redundant refe…

### DIFF
--- a/client/public/help.html
+++ b/client/public/help.html
@@ -48,7 +48,7 @@
   <script src="/shared/nav-footer.js"></script>
 
   <main>
-    <section id="heroSection" class="py-14" style="background: #F5F5DC;">
+    <section id="heroSection" class="py-14" style="background: #F8F7F4;">
       <div class="max-w-4xl mx-auto px-6 text-center">
         <h1 class="font-display text-3xl font-semibold mb-3" style="color: #6b1d34;">Help Center</h1>
         <p class="text-base mb-8" style="color: #284157;">Search our knowledge base or browse by category</p>

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -314,7 +314,7 @@ const userSchema = new mongoose.Schema({
   }],
 
   // ─── REWARDS: REFERRAL ───
-  referralCode: { type: String, unique: true, sparse: true, index: true },
+  referralCode: { type: String, unique: true, sparse: true },
   referredBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
 
   // ─── REWARDS: CARECREDITS ───

--- a/server/src/services/activityTrackingService.js
+++ b/server/src/services/activityTrackingService.js
@@ -101,7 +101,7 @@ export async function logActivity(type, data, options = {}) {
         }
         sendAdminAlertIfEnabled(prefs, type, { userName, userEmail, ...data });
       })
-      .catch(() => sendAdminAlert(type, { userName, userEmail, ...data })); // fallback on DB error
+      .catch(() => {}); // swallow DB error — do not send ungated alert
   }
 
   return activity;


### PR DESCRIPTION
…rralCode index

- activityTrackingService: swallow DB error in logActivity rather than bypassing per-event admin preferences with an ungated alert.
- help.html: hero background #F5F5DC → #F8F7F4 to match platform tone.
- User.js: remove redundant `index: true` on referralCode (already indexed via `unique: true, sparse: true`).