### PR TITLE
Include course modules in word count backfill

### DIFF
--- a/server/backfillWordCount.js
+++ b/server/backfillWordCount.js
@@ -165,7 +165,8 @@ async function main() {
 
   for (const course of courses) {
     let totalWc = 0;
-    for (const section of (course.sections || [])) {
+    const containers = [...(course.sections || []), ...(course.modules || [])];
+    for (const section of containers) {
       let sectionWc = 0;
       (section.contentBlocks || []).forEach(b => { sectionWc += countBlock(b); });
       totalWc += sectionWc;


### PR DESCRIPTION
## Summary
Updated the word count backfill script to process both course sections and modules when calculating total word counts.

## Changes
- Modified `server/backfillWordCount.js` to include `course.modules` in addition to `course.sections` when iterating through content containers
- Combined sections and modules into a single `containers` array for unified processing
- Maintains existing word count calculation logic for content blocks within each container

## Details
The backfill script previously only counted words in course sections. This change extends it to also process modules, ensuring comprehensive word count statistics across all course content types.

https://claude.ai/code/session_01PvxPGL4qChjhj4Z4EPcVxX