### PR TITLE
phase1-followup: add CR-610 diagnostic script

### DIFF
--- a/tools/compare-cr610-seeds.cjs
+++ b/tools/compare-cr610-seeds.cjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * compare-cr610-seeds.cjs — static comparison of both CR-610 seed files
+ *
+ * Reads each seed file as text, extracts the `const CR610 = { ... }` object
+ * literal by tracking brace depth (string- and template-literal aware),
+ * evaluates the literal in a clean vm sandbox, then walks modules and
+ * computes per-block word counts using the same logic as the
+ * InteractiveCourse pre-save hook.
+ *
+ * Compares results against the known DB state (recorded inline below from
+ * `tools/inspect-course.cjs` output on 2026-05-18).
+ *
+ * Read-only. No DB. No edits to any seed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SEEDS = [
+  'server/src/scripts/seedCR610-Unretiring_the_Self_Retirement_Identity_Depression_and_Reinvention-23574words.js',
+  'server/src/scripts/seedGeriatricSeries-AllFive-CR610-CR614-89027words.js',
+];
+
+// Frozen snapshot of what's currently in the `interactivecourses` collection
+// for slug `unretiring-the-self-identity-purpose-depression-older-adults`.
+const DB_STATE = {
+  totalWords: 7225,
+  storedWordCount: 7274,
+  modules: [
+    { title_starts: 'Module 1: The Closed Library',
+      blockTypes: ['sectionDivider', 'text', 'knowledgeCheck', 'text'],
+      blockWords: [0, 1994, 0, 1013],
+      total: 3007 },
+    { title_starts: 'Module 2: Reopening the Doors',
+      blockTypes: ['sectionDivider', 'text', 'knowledgeCheck', 'text'],
+      blockWords: [0, 1918, 0, 523],
+      total: 2441 },
+    { title_starts: 'Module 3: New Hours, New Catalog',
+      blockTypes: ['sectionDivider', 'text', 'knowledgeCheck', 'text', 'quiz'],
+      blockWords: [0, 1624, 0, 153, 0],
+      total: 1777 },
+  ],
+};
+
+function wcOf(s) {
+  if (typeof s !== 'string' || !s) return 0;
+  const plain = s.replace(/]+>/g, ' ').replace(/&\w+;/g, ' ').trim();
+  return plain ? plain.split(/\s+/).filter(w => w.length > 0).length : 0;
+}
+
+function extractCR610(source) {
+  const marker = source.indexOf('const CR610');
+  if (marker < 0) return null;
+  let i = source.indexOf('{', marker);
+  if (i < 0) return null;
+  const start = i;
+  let depth = 0, inStr = null, inTpl = false, esc = false;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\') { esc = true; continue; }
+    if (inStr) { if (c === inStr) inStr = null; continue; }
+    if (inTpl) { if (c === '`') inTpl = false; continue; }
+    if (c === '"' || c === "'") { inStr = c; continue; }
+    if (c === '`') { inTpl = true; continue; }
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) return source.slice(start, i + 1); }
+  }
+  return null;
+}
+
+function analyzeSeed(seedPath) {
+  const absPath = path.join(process.cwd(), seedPath);
+  if (!fs.existsSync(absPath)) return { error: `not found: ${seedPath}` };
+  const src = fs.readFileSync(absPath, 'utf8');
+  const objText = extractCR610(src);
+  if (!objText) return { error: 'CR610 object literal not found' };
+
+  let obj;
+  try {
+    obj = vm.runInNewContext('(' + objText + ')', {}, { timeout: 2000 });
+  } catch (e) {
+    return { error: `eval failed: ${e.message}` };
+  }
+
+  const modules = Array.isArray(obj.modules) ? obj.modules : [];
+  const out = { title: obj.title, ceHours: obj.ceHours, modules: [], total: 0 };
+  for (const m of modules) {
+    const blocks = Array.isArray(m.contentBlocks) ? m.contentBlocks : [];
+    const mInfo = { title: m.title || '', blockCount: blocks.length, blocks: [], total: 0 };
+    for (const b of blocks) {
+      const text = b.textContent || b.content || b.html || b.body || '';
+      const wc = wcOf(text);
+      mInfo.blocks.push({ type: b.type || '(no-type)', wc });
+      mInfo.total += wc;
+    }
+    out.modules.push(mInfo);
+    out.total += mInfo.total;
+  }
+  return out;
+}
+
+function pad(s, n) { s = String(s); return s.length >= n ? s : s + ' '.repeat(n - s.length); }
+
+console.log('=== DB state (frozen snapshot) ===');
+console.log(`stored wordCount: ${DB_STATE.storedWordCount}`);
+console.log(`canonical total: ${DB_STATE.totalWords}`);
+for (let i = 0; i < DB_STATE.modules.length; i++) {
+  const m = DB_STATE.modules[i];
+  console.log(`  module ${i}: ${m.title_starts}  total=${m.total}  blocks=${m.blockTypes.join(',')} wc=${m.blockWords.join(',')}`);
+}
+
+for (const seedPath of SEEDS) {
+  console.log(`\n=== Seed: ${seedPath} ===`);
+  const r = analyzeSeed(seedPath);
+  if (r.error) { console.log(`  ERROR: ${r.error}`); continue; }
+  console.log(`title: ${r.title}`);
+  console.log(`ceHours: ${r.ceHours}`);
+  console.log(`modules: ${r.modules.length}`);
+  console.log(`canonical total words: ${r.total}`);
+  for (let mi = 0; mi < r.modules.length; mi++) {
+    const m = r.modules[mi];
+    console.log(`  module[${mi}] "${m.title.slice(0, 70)}"`);
+    console.log(`    blocks: ${m.blockCount}    canonical total: ${m.total}`);
+    for (let bi = 0; bi < m.blocks.length; bi++) {
+      const b = m.blocks[bi];
+      console.log(`      [${bi}] ${pad(b.type, 18)} wc=${b.wc}`);
+    }
+  }
+}
+
+console.log('\n=== Verdict ===');
+console.log('Whichever seed total ≈ 7225 is the seed that matches the live DB.');
+console.log('The other seed contains the missing content.');
+console.log('Compare module-by-module block totals to confirm.');

--- a/tools/inspect-course.cjs
+++ b/tools/inspect-course.cjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * inspect-course.cjs — CR-610 word-count diagnostic
+ *
+ * Read-only inspection of a single course in `interactivecourses`.
+ * Surfaces blocks whose text lives in fields the pre-save hook does
+ * not read (canonical: textContent | content | html | body).
+ *
+ * Usage:   node tools/inspect-course.cjs <slug>
+ * Default slug: unretiring-the-self-identity-purpose-depression-older-adults
+ * Env:     MONGODB_URI (required), AUDIT_COLLECTION (optional)
+ * Exit:    0 ok, 2 bad invocation or DB error
+ */
+
+const DEFAULT_SLUG = 'unretiring-the-self-identity-purpose-depression-older-adults';
+const slug = process.argv[2] || DEFAULT_SLUG;
+const MONGODB_URI      = process.env.MONGODB_URI;
+const AUDIT_COLLECTION = process.env.AUDIT_COLLECTION || 'interactivecourses';
+
+if (!MONGODB_URI) {
+  console.error('inspect-course: MONGODB_URI is not set. Aborting.');
+  process.exit(2);
+}
+
+let MongoClient;
+try { ({ MongoClient } = require('mongodb')); }
+catch {
+  try { ({ MongoClient } = require('mongoose/node_modules/mongodb')); }
+  catch { console.error('inspect-course: cannot load mongodb driver.'); process.exit(2); }
+}
+
+const CANONICAL_FIELDS = ['textContent', 'content', 'html', 'body'];
+
+function wcOf(s) {
+  if (typeof s !== 'string' || !s) return 0;
+  const plain = s.replace(/<[^>]+>/g, ' ').replace(/&\w+;/g, ' ').trim();
+  return plain ? plain.split(/\s+/).filter(w => w.length > 0).length : 0;
+}
+function truncate(s, n) {
+  const flat = String(s).replace(/\s+/g, ' ').trim();
+  return flat.length <= n ? flat : flat.slice(0, n) + '…';
+}
+function stringFields(b) {
+  return Object.keys(b || {}).filter(k => typeof b[k] === 'string' && b[k].length > 0);
+}
+function canonicalWc(b) {
+  for (const f of CANONICAL_FIELDS) if (typeof b[f] === 'string' && b[f]) return wcOf(b[f]);
+  return 0;
+}
+function fullWc(b) {
+  return stringFields(b).reduce((t, k) => t + wcOf(b[k]), 0);
+}
+function longestField(b) {
+  let best = null, bestLen = -1;
+  for (const k of stringFields(b)) if (b[k].length > bestLen) { best = k; bestLen = b[k].length; }
+  return best;
+}
+
+function printContainers(containers, label) {
+  let cTotal = 0, fTotal = 0;
+  const suspects = [];
+  containers.forEach((c, ci) => {
+    console.log('');
+    console.log(`${label} [${ci}]: ${c.title || '(untitled)'}`);
+    if (c.subtitle) console.log(`  subtitle: ${c.subtitle}`);
+    const blocks = Array.isArray(c.contentBlocks) ? c.contentBlocks : [];
+    console.log(`  contentBlocks: ${blocks.length}`);
+    let sc = 0, sf = 0;
+    blocks.forEach((b, bi) => {
+      const cw = canonicalWc(b), fw = fullWc(b);
+      sc += cw; sf += fw;
+      const fields = stringFields(b);
+      const longest = longestField(b);
+      console.log(`    [${bi}] type=${b.type || '(none)'}  canonical=${cw}  full=${fw}`);
+      console.log(`         fields: ${fields.join(', ') || '(none)'}`);
+      if (longest) console.log(`         longest(${longest}): ${truncate(b[longest], 80)}`);
+      if (cw === 0 && fw > 0) suspects.push({ container: ci, block: bi, type: b.type, fields, fullWc: fw });
+    });
+    console.log(`  subtotal canonical=${sc}  full=${sf}`);
+    cTotal += sc; fTotal += sf;
+  });
+  return { cTotal, fTotal, suspects };
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI, {
+    serverSelectionTimeoutMS: 10000, connectTimeoutMS: 10000,
+  });
+  try {
+    await client.connect();
+    const course = await client.db().collection(AUDIT_COLLECTION).findOne({ slug });
+    if (!course) {
+      console.error(`inspect-course: no document with slug=${slug} in ${AUDIT_COLLECTION}`);
+      process.exit(2);
+    }
+    const ce = Number(course.ceHours || 0);
+    const wc = Number(course.wordCount || 0);
+    const floor = Math.floor(ce * 6000);
+
+    console.log('=== Course header ===');
+    console.log(`title:       ${course.title || '(untitled)'}`);
+    console.log(`slug:        ${course.slug || ''}`);
+    console.log(`courseCode:  ${course.courseCode || ''}`);
+    console.log(`status:      ${course.status || '(unset)'}`);
+    console.log(`ceHours:     ${ce}`);
+    console.log(`wordCount:   ${wc}`);
+    console.log(`acepFloor:   ${floor}  (ceHours x 6000)`);
+    console.log(`shortfall:   ${floor - wc}`);
+
+    console.log('');
+    console.log('=== Top-level shape ===');
+    const sections = Array.isArray(course.sections) ? course.sections : null;
+    const modules  = Array.isArray(course.modules)  ? course.modules  : null;
+    const refs     = Array.isArray(course.references) ? course.references : null;
+    const aqs      = course.assessment && Array.isArray(course.assessment.questions) ? course.assessment.questions : null;
+    console.log(`sections:              ${sections ? `present, length=${sections.length}` : 'absent'}`);
+    console.log(`modules:               ${modules  ? `present, length=${modules.length}`  : 'absent'}`);
+    console.log(`references:            ${refs     ? `present, length=${refs.length}`     : 'absent'}`);
+    console.log(`assessment.questions:  ${aqs      ? `present, length=${aqs.length}`      : 'absent'}`);
+
+    let canonicalTotal = 0, fullTotal = 0;
+    const allSuspects = [];
+    if (sections && sections.length) {
+      console.log('');
+      console.log('=== Per-container breakdown: sections ===');
+      const r = printContainers(sections, 'section');
+      canonicalTotal += r.cTotal; fullTotal += r.fTotal; allSuspects.push(...r.suspects);
+    }
+    if (modules && modules.length) {
+      console.log('');
+      console.log('=== Per-container breakdown: modules ===');
+      const r = printContainers(modules, 'module');
+      canonicalTotal += r.cTotal; fullTotal += r.fTotal; allSuspects.push(...r.suspects);
+    }
+
+    console.log('');
+    console.log('=== Word-count reconciliation ===');
+    console.log(`canonical (textContent|content|html|body):  ${canonicalTotal}`);
+    console.log(`all string fields:                          ${fullTotal}`);
+    console.log(`stored wordCount:                           ${wc}`);
+    console.log(`acep floor:                                 ${floor}`);
+    console.log(`diff (full - canonical):                    ${fullTotal - canonicalTotal}`);
+
+    console.log('');
+    console.log('=== Suspect blocks (canonical=0, full>0) ===');
+    if (allSuspects.length === 0) console.log('(none)');
+    else allSuspects.forEach(s =>
+      console.log(`  container=${s.container} block=${s.block} type=${s.type} fullWc=${s.fullWc} fields=${s.fields.join(',')}`));
+
+    process.exit(0);
+  } catch (err) {
+    console.error(`inspect-course: ${err.message}`);
+    process.exit(2);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+main();


### PR DESCRIPTION
Read-only inspection tool for investigating wordCount discrepancies on a single course. Prints per-block field map + canonical vs full word counts to surface blocks whose text lives in fields the pre-save hook doesn't read.

Not part of any workflow — invoked manually:
  node tools/inspect-course.cjs <slug>

Default slug: unretiring-the-self-identity-purpose-depression-older-adults