### PR TITLE
Add PostHog analytics for paywall and section completion events

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3820,6 +3820,12 @@ function loadCourse(data) {
         msgEl.textContent = 'This course requires a subscription. Subscribe for unlimited access to all courses and CE tracking.';
       }
     }
+    if (window.posthog) {
+      posthog.capture('paywall_hit', {
+        course_slug: crSlugOrId(),
+        reason: course._freeHoursExhausted ? 'free_hours_exhausted' : 'subscription_required'
+      });
+    }
     return; // Don't render stripped content
   }
 
@@ -7085,6 +7091,15 @@ function crSyncSection(sectionIndex) {
       timeSpent: 0
     })
   }).catch(() => {});
+
+  if (isComplete && window.posthog) {
+    posthog.capture('section_completed', {
+      course_slug: id,
+      course_title: course?.title,
+      section_index: sectionIndex,
+      section_title: section?.title || section?.sectionTitle || ''
+    });
+  }
 }
 
 function restoreProgress() {


### PR DESCRIPTION
## Summary
Adds PostHog event tracking to capture two key user interactions in the interactive course player:
1. When users hit the course paywall (subscription required or free hours exhausted)
2. When users complete a course section

## Changes
- **Paywall event tracking**: Captures `paywall_hit` event with course slug and reason (free hours exhausted vs subscription required) when content is gated
- **Section completion tracking**: Captures `section_completed` event with course slug, title, section index, and section title when a section is marked complete

## Implementation Details
- Both events are only captured if `window.posthog` is available (graceful degradation)
- Paywall tracking occurs in the content gating logic after the paywall message is set
- Section completion tracking occurs after progress is saved to the database
- Events include relevant context (course/section identifiers and metadata) for analytics segmentation

https://claude.ai/code/session_01Y26CvWsTwXrUnkfQNVkqg7