### PR TITLE
Fix Chart.js CDN and syntax error in ce-planner.html

### DIFF
--- a/client/public/admin-analytics.html
+++ b/client/public/admin-analytics.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/css/typography.css">
   <script src="https://cdn.tailwindcss.com/3.4.17"></script>
   <script src="/js/tailwind-config.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 
   <link rel="stylesheet" href="/lib/fontawesome/css/all.min.css">
   <style>

--- a/client/public/ce-planner.html
+++ b/client/public/ce-planner.html
@@ -295,7 +295,6 @@
     }
 
     function printPlan(){window.print();}
-    }
 
     function esc(s){if(!s)return'';return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
     loadPlan();


### PR DESCRIPTION
## Summary
Fixes two issues in client-facing HTML files: updates the Chart.js CDN source to a stable versioned URL and removes a stray closing brace that was causing a syntax error.

## Changes
- **admin-analytics.html**: Updated Chart.js CDN from the generic jsdelivr endpoint to a specific versioned URL (`4.4.1`) on cdnjs.cloudflare.com for better stability and version pinning
- **ce-planner.html**: Removed extraneous closing brace (`}`) after the `printPlan()` function that was breaking the script block

## Details
The Chart.js update ensures the analytics page uses a pinned, stable version rather than relying on the latest version from jsdelivr, reducing the risk of unexpected breaking changes. The syntax error in ce-planner.html was preventing the script from executing properly and has been corrected.

https://claude.ai/code/session_01JZ3GNnY6vQ1GAt2VkWXC9k