### PR TITLE
Wire 5 unmounted routes in index.js and routeManifest

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -76,6 +76,11 @@ import legacyVaultRoutes from './routes/legacyVault.js';
 import groupLicensesRoutes from './routes/groupLicenses.js';
 import scholarlyArticlesRoutes from './routes/scholarlyArticles.js';
 import adminStatsRoutes from './routes/adminStats.js';
+import adminStripeRoutes from './routes/adminStripe.js';
+import adminCouponsRoutes from './routes/adminCoupons.js';
+import organizationsRoutes from './routes/organizations.js';
+import auditKitRoutes from './routes/auditKit.js';
+import uploadsRoutes from './routes/uploads.js';
 
 // ═══════════════════════════════════════════════════════════════
 // SERVICE IMPORTS
@@ -174,6 +179,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/interactive-courses', interactiveCourseRoutes);
 app.use('/api/courses', coursesRoutes);
 app.use('/api/admin/stats', adminStatsRoutes);
+app.use('/api/admin/stripe', adminStripeRoutes);
+app.use('/api/admin/coupons', adminCouponsRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/admin/audit', adminAuditRoutes);
 app.use('/api/users', usersRoutes);
@@ -219,6 +226,9 @@ app.use('/api/insurance-credentials', insuranceCredentialsRoutes);
 app.use('/api/legacy-vault', legacyVaultRoutes);
 app.use('/api/group-licenses', groupLicensesRoutes);
 app.use('/api/scholarly-articles', scholarlyArticlesRoutes);
+app.use('/api/organizations', organizationsRoutes);
+app.use('/api/audit-kit', auditKitRoutes);
+app.use('/api/uploads', uploadsRoutes);
 
 app.use('/templates', express.static(path.join(__dirname, 'templates')));
 

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -64,6 +64,11 @@ import groupLicensesRoutes from './routes/groupLicenses.js';
 import scholarlyArticlesRoutes from './routes/scholarlyArticles.js';
 import toolRoutes from './routes/toolRoutes.js';
 import toolAnalyticsRoutes from './routes/toolAnalytics.js';
+import adminStripeRoutes from './routes/adminStripe.js';
+import adminCouponsRoutes from './routes/adminCoupons.js';
+import organizationsRoutes from './routes/organizations.js';
+import auditKitRoutes from './routes/auditKit.js';
+import uploadsRoutes from './routes/uploads.js';
 
 /**
  * Route Manifest — add new routes here.
@@ -85,6 +90,8 @@ const ROUTE_MANIFEST = [
   ['/api/admin/courses',         bulkUploadRoutes,          'Bulk Upload'],
   ['/api/admin/stats',           adminStatsRoutes,          'Admin Stats'],
   ['/api/admin/rewards',         adminRewardsRoutes,        'Admin Rewards'],
+  ['/api/admin/stripe',          adminStripeRoutes,         'Admin Stripe'],
+  ['/api/admin/coupons',         adminCouponsRoutes,        'Admin Coupons'],
 
   // ── Features ──
   ['/api/gamification',          gamificationRoutes,        'Gamification / Achievements'],
@@ -125,6 +132,9 @@ const ROUTE_MANIFEST = [
   ['/api/scholarly-articles',    scholarlyArticlesRoutes,   'Scholarly Articles'],
   ['/api/tool-actions',          toolRoutes,                'Tool Actions'],
   ['/api/tool-analytics',        toolAnalyticsRoutes,       'Tool Analytics'],
+  ['/api/organizations',         organizationsRoutes,       'Organizations'],
+  ['/api/audit-kit',             auditKitRoutes,            'Audit Kit'],
+  ['/api/uploads',               uploadsRoutes,             'Uploads'],
 ];
 
 /**


### PR DESCRIPTION
## Summary

Five route files existed in `server/src/routes/` but were never imported or mounted in `server/src/index.js`, so their endpoints 404'd despite the frontend calling them. This PR wires them up.

| File | Mount path |
|---|---|
| `adminStripe.js`   | `/api/admin/stripe`   |
| `adminCoupons.js`  | `/api/admin/coupons`  |
| `organizations.js` | `/api/organizations`  |
| `auditKit.js`      | `/api/audit-kit`      |
| `uploads.js`       | `/api/uploads`        |

### Order-critical detail
The two `/api/admin/*` mounts are registered **before** the generic `app.use('/api/admin', adminRoutes)` catch-all so they aren't shadowed by Express's prefix-matching:

```
app.use('/api/admin/stats',   adminStatsRoutes);
app.use('/api/admin/stripe',  adminStripeRoutes);   // new
app.use('/api/admin/coupons', adminCouponsRoutes);  // new
app.use('/api/admin',         adminRoutes);
```

The other three mounts are appended after the last existing mount line. `routeManifest.js` receives the same 5 entries in matching format to stay in sync.

### Scope
- No router-file internals were modified — only imports + mounts in `index.js` and a manifest entry per route.
- `interactiveCourseRoutes.js` and its import were not touched.
- Diff: 2 files changed, 20 insertions(+), 0 deletions.

## Verification

```
$ grep -nE "adminStripeRoutes|adminCouponsRoutes|organizationsRoutes|auditKitRoutes|uploadsRoutes" server/src/index.js
79:import adminStripeRoutes from './routes/adminStripe.js';
80:import adminCouponsRoutes from './routes/adminCoupons.js';
81:import organizationsRoutes from './routes/organizations.js';
82:import auditKitRoutes from './routes/auditKit.js';
83:import uploadsRoutes from './routes/uploads.js';
182:app.use('/api/admin/stripe', adminStripeRoutes);
183:app.use('/api/admin/coupons', adminCouponsRoutes);
229:app.use('/api/organizations', organizationsRoutes);
230:app.use('/api/audit-kit', auditKitRoutes);
231:app.use('/api/uploads', uploadsRoutes);
```
10 hits — 5 imports + 5 mounts.

```
$ grep -nE "app.use\('/api/admin" server/src/index.js
181:app.use('/api/admin/stats', adminStatsRoutes);
182:app.use('/api/admin/stripe', adminStripeRoutes);
183:app.use('/api/admin/coupons', adminCouponsRoutes);
184:app.use('/api/admin', adminRoutes);
185:app.use('/api/admin/audit', adminAuditRoutes);
201:app.use('/api/admin', adminCoursesRoutes);
202:app.use('/api/admin/courses', bulkUploadRoutes);
222:app.use('/api/admin', adminUsersRoutes);
223:app.use('/api/admin/rewards', adminRewardsRoutes);
```
`stripe` and `coupons` are on lines 182–183, before the `/api/admin` catch-all on line 184. ✅

```
$ for r in adminStripe adminCoupons organizations auditKit uploads; do
    node -e "import('./routes/$r.js').then(()=>console.log('$r OK')).catch(e=>{console.error('$r FAIL:',e.message);process.exit(1)})"
  done
adminStripe OK
adminCoupons OK
organizations OK
auditKit OK
uploads OK
```
All 5 modules load cleanly.

## Test plan

- [ ] Deploy and confirm `/api/admin/stripe`, `/api/admin/coupons`, `/api/organizations`, `/api/audit-kit`, `/api/uploads` no longer 404
- [ ] Confirm the existing `/api/admin/*` endpoints handled by `adminRoutes` still resolve (catch-all still works for paths other than `stripe`/`coupons`)
- [ ] Confirm startup integrity check log still shows the same required-routes count (REQUIRED_ROUTES wasn't expanded — these 5 weren't in it before either)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk6vgCXCkmSeWzaJJYJyTq)_