### PR TITLE
fix: route-integrity drift — manifest is source of truth, detect forgotten mounts

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,14 +1,16 @@
 /**
  * CounselorReady API Server — index.js
  * ═══════════════════════════════════════════════════════════════
- * CRITICAL: This file is the single source of truth for all API
- * route registrations. DO NOT rewrite this file without including
- * ALL routes listed in the REQUIRED_ROUTES array below.
+ * CRITICAL: This file is the canonical place where API routes are
+ * MOUNTED. The declared set lives in ./routeManifest.js (ROUTE_MANIFEST).
+ * The boot-time verifyRoutes() cross-checks the two and reports any
+ * declared-but-not-mounted (forgotten app.use) or import-broken routers.
  *
  * If you are an AI assistant (Claude Code or otherwise):
  *   - NEVER remove or comment out any import or app.use() line
  *   - NEVER rewrite this file from scratch
  *   - Only ADD new routes — never subtract existing ones
+ *   - When adding a route: add the app.use here AND an entry in routeManifest.js
  *   - The startup integrity check will catch regressions
  *
  * Last verified: 2026-03-25 — 37 route mounts, all confirmed
@@ -93,9 +95,18 @@ import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
 import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
 import { runHardshipPauseResume } from './jobs/hardshipPauseResume.js';
 
+import { ROUTE_MANIFEST } from './routeManifest.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const app = express();
+
+// Mount recorder — records every '/api/...' path passed to app.use so
+// verifyRoutes() can detect routers that were imported but never mounted.
+// Must be installed BEFORE any app.use() calls below.
+const __mountedApiPaths = new Set();
+const __origUse = app.use.bind(app);
+app.use = (...args) => { if (typeof args[0] === 'string' && args[0].startsWith('/api')) __mountedApiPaths.add(args[0]); return __origUse(...args); };
 
 // ═══════════════════════════════════════════════════════════════
 // MIDDLEWARE
@@ -163,7 +174,7 @@ app.get('/health', async (req, res) => {
       mongodb: dbStatus[dbState] || 'unknown',
       environment: process.env.NODE_ENV || 'development',
       version: '1.0.0',
-      requiredRoutes: REQUIRED_ROUTES.length
+      requiredRoutes: ROUTE_MANIFEST.length
     });
   } catch (error) {
     res.status(500).json({ status: 'error', error: error.message });
@@ -237,65 +248,61 @@ app.use('/templates', express.static(path.join(__dirname, 'templates')));
 // Runs on every startup. Catches regressions from file overwrites.
 // ═══════════════════════════════════════════════════════════════
 
-const REQUIRED_ROUTES = {
-  '/api/auth':                authRoutes,
-  '/api/interactive-courses': interactiveCourseRoutes,
-  '/api/courses':             coursesRoutes,
-  '/api/admin':               adminRoutes,
-  '/api/users':               usersRoutes,
-  '/api/certificates':        certificatesRoutes,
-  '/api/credentials':         credentialsRoutes,
-  '/api/payments':            paymentsRoutes,
-  '/api/analytics':           analyticsRoutes,
-  '/api/announcements':       announcementsRoutes,
-  '/api/notifications':       notificationsRoutes,
-  '/api/gamification':        gamificationRoutes,
-  '/api/referrals':           referralsRoutes,
-  '/api/rewards':             rewardsRoutes,
-  '/api/board-alerts':        boardAlertsRoutes,
-  '/api/ce-planner':          cePlannerRoutes,
-  '/api/scan':                scanRoutes,
-  '/api/help':                helpRoutes,
-  '/api/course-builder':      courseBuilderRoutes,
-  '/api/research-ready':      researchReadyRoutes,
-  '/api/tools':               toolsRoutes,
-  '/api/partners':            partnersRoutes,
-  '/api/recommendations':     recommendationsRoutes,
-  '/api/images':              imageUploadRoutes,
-  '/api/admin/courses':       bulkUploadRoutes,
-  '/api/admin/course-mgmt':   adminCoursesRoutes,
-  '/api/admin/rewards':       adminRewardsRoutes,
-  '/api/blog':                blogRoutes,
-  '/api/tool-analytics':      toolAnalyticsRoutes,
-  '/api/security':            securityRoutes,
-};
-
 function verifyRoutes() {
-  let passed = 0;
-  let failed = 0;
-  const errors = [];
+  try {
+    const brokenImports = [];
+    const notMounted = [];
+    const manifestPaths = new Set();
 
-  Object.entries(REQUIRED_ROUTES).forEach(([path, router]) => {
-    if (!router || typeof router !== 'function') {
-      errors.push(path);
-      failed++;
-    } else {
-      passed++;
+    for (const entry of ROUTE_MANIFEST) {
+      const [path, router, label] = entry;
+      manifestPaths.add(path);
+      if (!router || typeof router !== 'function') {
+        brokenImports.push({ path, label });
+      }
+      if (!__mountedApiPaths.has(path)) {
+        notMounted.push({ path, label });
+      }
     }
-  });
 
-  if (failed > 0) {
-    console.error('');
-    console.error('╔══════════════════════════════════════════════════╗');
-    console.error('║  ❌ ROUTE INTEGRITY CHECK FAILED                ║');
-    console.error('╚══════════════════════════════════════════════════╝');
-    errors.forEach(p => console.error(`  ✗ ${p} — import is undefined/broken`));
-    console.error(`  ${passed} passed, ${failed} FAILED`);
-    console.error('');
-  } else {
-    console.log(`✅ Route integrity: ${passed}/${Object.keys(REQUIRED_ROUTES).length} required routes verified`);
+    const untracked = [];
+    for (const path of __mountedApiPaths) {
+      if (path === '/api/payments/webhook') continue; // raw-body parser, not a router
+      if (!manifestPaths.has(path)) untracked.push(path);
+    }
+
+    if (brokenImports.length > 0 || notMounted.length > 0) {
+      console.error('');
+      console.error('╔══════════════════════════════════════════════════╗');
+      console.error('║  ❌ ROUTE INTEGRITY CHECK FAILED                ║');
+      console.error('╚══════════════════════════════════════════════════╝');
+      if (brokenImports.length > 0) {
+        console.error(`  Broken imports (router is not a function): ${brokenImports.length}`);
+        brokenImports.forEach(({ path, label }) => console.error(`    ✗ ${path}  [${label}]`));
+      }
+      if (notMounted.length > 0) {
+        console.error(`  Declared but NOT MOUNTED (forgotten app.use): ${notMounted.length}`);
+        notMounted.forEach(({ path, label }) => console.error(`    ✗ ${path}  [${label}]`));
+      }
+      console.error('');
+    } else {
+      console.log(`✅ Route integrity: ${ROUTE_MANIFEST.length} routes declared, all mounted & valid`);
+    }
+
+    if (untracked.length > 0) {
+      console.warn(`⚠️  Route integrity: ${untracked.length} mounted path(s) not in manifest (drift):`);
+      untracked.forEach(p => console.warn(`    • ${p}`));
+    }
+  } catch (err) {
+    console.error('Route integrity check threw — continuing boot:', err && err.message ? err.message : err);
   }
 }
+
+// Run the integrity check now — all top-level app.use(...) mounts above
+// have already been registered (and recorded by __mountedApiPaths) by the
+// time module evaluation reaches this line. Doing it here (rather than
+// inside startServer) ensures it runs even if connectDB later exits.
+verifyRoutes();
 
 // ═══════════════════════════════════════════════════════════════
 // ERROR HANDLING
@@ -362,7 +369,6 @@ const startServer = async () => {
     );
   }, { timezone: 'America/New_York' });
   console.log('Hardship pause auto-resume cron scheduled (daily 8 AM ET)');
-  verifyRoutes();
   // PostHog server-side analytics
   const phKey = process.env.POSTHOG_API_KEY || 'phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb';
   global.posthog = new PostHog(phKey, { host: 'https://us.i.posthog.com' });
@@ -378,7 +384,7 @@ const startServer = async () => {
 ║   MongoDB: Connected                               ║
 ║   Scheduler: Active                                ║
 ║   Board Monitor: Active                            ║
-║   Routes: ${String(Object.keys(REQUIRED_ROUTES).length).padEnd(2)} required, verified               ║
+║   Routes: ${String(ROUTE_MANIFEST.length).padEnd(2)} declared, verified               ║
 ║                                                    ║
 ║   Health: http://localhost:${PORT}/health              ║
 ║                                                    ║

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -1,27 +1,31 @@
 /**
  * CounselorReady Route Manifest
  * ═══════════════════════════════
- * SINGLE SOURCE OF TRUTH for all route registrations.
- * 
- * WHY THIS EXISTS:
- * Routes were being lost every time index.js was edited — imports would
- * get dropped, features would silently break. This manifest file ensures
- * that ALL routes survive any edit to index.js. 
- * 
- * index.js just calls: mountAllRoutes(app)
- * 
+ * SINGLE SOURCE OF TRUTH for declared API route registrations.
+ *
+ * NOTE — mountAllRoutes() is NOT currently used. index.js mounts manually.
+ * The manifest is consumed by verifyRoutes() in index.js as the declared
+ * set, which is cross-checked against the paths actually mounted at boot.
+ *
+ * If anyone ever adopts mountAllRoutes() to replace the manual mounts,
+ * sub-paths (e.g. '/api/admin/stats') MUST precede catch-alls
+ * (e.g. '/api/admin') in this array — otherwise the catch-all is
+ * registered first and Express will shadow the sub-paths.
+ *
  * TO ADD A NEW ROUTE:
- * 1. Create the route file in server/src/routes/
- * 2. Add it to the ROUTE_MANIFEST array below
- * 3. That's it. It auto-mounts on next deploy.
- * 
- * DO NOT mount routes directly in index.js — add them here instead.
+ *   1. Create the route file in server/src/routes/
+ *   2. Add an import + an entry to ROUTE_MANIFEST below
+ *   3. Add the matching app.use(...) to index.js
+ *   4. Boot the server — the integrity check will confirm everything mounts.
  */
 
 import authRoutes from './routes/auth.js';
 import interactiveCourseRoutes from './routes/interactiveCourseRoutes.js';
 import coursesRoutes from './routes/courses.js';
 import adminRoutes from './routes/admin.js';
+import adminAuditRoutes from './routes/adminAudit.js';
+import adminCoursesRoutes from './routes/adminCourses.js';
+import adminUsersRoutes from './routes/adminUsers.js';
 import usersRoutes from './routes/users.js';
 import certificatesRoutes from './routes/certificates.js';
 import credentialsRoutes from './routes/credentials.js';
@@ -71,10 +75,13 @@ import auditKitRoutes from './routes/auditKit.js';
 import uploadsRoutes from './routes/uploads.js';
 
 /**
- * Route Manifest — add new routes here.
+ * Route Manifest — declared route registrations.
  * Format: [mountPath, routeHandler, label]
+ *
+ * Ordering rule: all '/api/admin/<subpath>' entries MUST appear before
+ * the bare '/api/admin' catch-all entries. Sub-paths first, catch-alls last.
  */
-const ROUTE_MANIFEST = [
+export const ROUTE_MANIFEST = [
   // ── Core ──
   ['/api/auth',                  authRoutes,                'Auth'],
   ['/api/interactive-courses',   interactiveCourseRoutes,   'Interactive Courses (full pipeline)'],
@@ -85,13 +92,18 @@ const ROUTE_MANIFEST = [
   ['/api/payments',              paymentsRoutes,            'Payments'],
   ['/api/notifications',         notificationsRoutes,       'Notifications'],
 
-  // ── Admin ──
-  ['/api/admin',                 adminRoutes,               'Admin (includes courses/users/AI/stripe/coupons)'],
-  ['/api/admin/courses',         bulkUploadRoutes,          'Bulk Upload'],
+  // ── Admin sub-paths (MUST come before the '/api/admin' catch-alls) ──
   ['/api/admin/stats',           adminStatsRoutes,          'Admin Stats'],
-  ['/api/admin/rewards',         adminRewardsRoutes,        'Admin Rewards'],
   ['/api/admin/stripe',          adminStripeRoutes,         'Admin Stripe'],
   ['/api/admin/coupons',         adminCouponsRoutes,        'Admin Coupons'],
+  ['/api/admin/audit',           adminAuditRoutes,          'Admin Audit'],
+  ['/api/admin/courses',         bulkUploadRoutes,          'Admin Bulk Upload'],
+  ['/api/admin/rewards',         adminRewardsRoutes,        'Admin Rewards'],
+
+  // ── Admin catch-alls (stacked on '/api/admin') ──
+  ['/api/admin',                 adminRoutes,               'Admin (core)'],
+  ['/api/admin',                 adminCoursesRoutes,        'Admin Courses (catch-all stack)'],
+  ['/api/admin',                 adminUsersRoutes,          'Admin Users (catch-all stack)'],
 
   // ── Features ──
   ['/api/gamification',          gamificationRoutes,        'Gamification / Achievements'],
@@ -139,6 +151,10 @@ const ROUTE_MANIFEST = [
 
 /**
  * Mount all routes and log the manifest on startup.
+ *
+ * NOTE: This function is NOT currently used by index.js. index.js mounts
+ * manually. If adopting mountAllRoutes(), sub-paths MUST precede catch-alls
+ * in ROUTE_MANIFEST or they will be shadowed.
  */
 export function mountAllRoutes(app) {
   let mounted = 0;


### PR DESCRIPTION
## Why

Three disagreeing route lists let a router-imported-but-never-mounted bug ship recently. Before this PR:

- `index.js` `REQUIRED_ROUTES` — 30 stale entries, one of which (`/api/admin/course-mgmt`) wasn't mounted anywhere, and `verifyRoutes()` only checked that each listed router was a function. It did **not** check whether anything was actually mounted, so the forgotten-`app.use` bug class was undetectable.
- `routeManifest.js` `ROUTE_MANIFEST` — not exported, missing `adminAudit`/`adminCourses`/`adminUsers`, and the `'/api/admin'` catch-all sat **before** `'/api/admin/stats'`/`stripe`/`coupons` (would shadow sub-paths if `mountAllRoutes()` were ever adopted).
- The actual `app.use()` block — 53 distinct API mount paths (54 mounts incl. the `/api/payments/webhook` raw-body parser; `/api/admin` is intentionally triple-stacked).

## What

**`routeManifest.js`** is now the single source of truth.

- `export const ROUTE_MANIFEST` (was a private const)
- Added missing imports: `adminAuditRoutes`, `adminCoursesRoutes`, `adminUsersRoutes`
- Added missing entries so every `app.use('/api/...')` in `index.js` has a matching declaration
- Moved every `'/api/admin/<subpath>'` entry **before** the three `'/api/admin'` catch-all entries — sub-paths first, catch-alls last
- Header comment now states `mountAllRoutes()` is currently unused and documents the sub-path-first ordering rule for any future adoption

**`server/src/index.js`** integrity check now actually detects forgotten mounts.

- New mount recorder installed immediately after `const app = express()`, **before** any `app.use(...)` — captures every `/api/...` mount path into `__mountedApiPaths`
- `import { ROUTE_MANIFEST } from './routeManifest.js'`
- Stale `REQUIRED_ROUTES` object deleted entirely
- `verifyRoutes()` rewritten (wrapped in try/catch so it can never crash boot):
  - **brokenImports** — manifest router not a function
  - **notMounted** — declared in manifest but never recorded by the mount recorder (the forgotten-`app.use` bug class)
  - **untracked** — recorded path missing from manifest (warn-only drift signal; excludes `/api/payments/webhook`, which is a raw-body parser, not a router)
- `verifyRoutes()` now runs at module top-level after the mount block (it does not depend on the DB, so it should not be gated behind `connectDB()` succeeding)
- Health JSON `requiredRoutes` and the startup banner `Routes:` line now use `ROUTE_MANIFEST.length`

## Untouched per task scope

- No `app.use(...)` mount line or order in `index.js` changed
- `interactiveCourseRoutes.js` not opened
- `mountAllRoutes()` body unchanged (only its surrounding comment + the `export` keyword)

## Verification

```
$ grep -n "export const ROUTE_MANIFEST\|REQUIRED_ROUTES\|__mountedApiPaths\|import { ROUTE_MANIFEST" server/src/index.js server/src/routeManifest.js
server/src/index.js:98:import { ROUTE_MANIFEST } from './routeManifest.js';
server/src/index.js:107:const __mountedApiPaths = new Set();
server/src/index.js:109:app.use = (...args) => { if (typeof args[0] === 'string' && args[0].startsWith('/api')) __mountedApiPaths.add(args[0]); return __origUse(...args); };
server/src/index.js:263:      if (!__mountedApiPaths.has(path)) {
server/src/index.js:269:    for (const path of __mountedApiPaths) {
server/src/routeManifest.js:84:export const ROUTE_MANIFEST = [
```

`REQUIRED_ROUTES` appears 0 times.

```
$ node --check server/src/index.js && echo "index.js syntax OK"
index.js syntax OK
$ node --check server/src/routeManifest.js && echo "manifest syntax OK"
manifest syntax OK
```

Admin ordering in the manifest — sub-paths precede catch-alls:

```
$ grep -nE "'/api/admin" server/src/routeManifest.js
 96:  ['/api/admin/stats',           adminStatsRoutes,          'Admin Stats'],
 97:  ['/api/admin/stripe',          adminStripeRoutes,         'Admin Stripe'],
 98:  ['/api/admin/coupons',         adminCouponsRoutes,        'Admin Coupons'],
 99:  ['/api/admin/audit',           adminAuditRoutes,          'Admin Audit'],
100:  ['/api/admin/courses',         bulkUploadRoutes,          'Admin Bulk Upload'],
101:  ['/api/admin/rewards',         adminRewardsRoutes,        'Admin Rewards'],
104:  ['/api/admin',                 adminRoutes,               'Admin (core)'],
105:  ['/api/admin',                 adminCoursesRoutes,        'Admin Courses (catch-all stack)'],
106:  ['/api/admin',                 adminUsersRoutes,          'Admin Users (catch-all stack)'],
```

Boot output (Mongo intentionally unreachable to prove the check runs at top-level, not gated behind `connectDB`):

```
$ cd server && RESEND_API_KEY=re_test_dummy MONGODB_URI="mongodb://127.0.0.1:1/nope" \
    timeout 25 node src/index.js 2>&1 | grep -iE "route integrity|not mounted|integrity check failed|drift|untracked"
✅ Route integrity: 54 routes declared, all mounted & valid
```

54 declared, all mounted, no drift.

## Test plan

- [x] `node --check` both files
- [x] Boot prints the success line with N ≥ 50
- [x] No `notMounted` entries (which would indicate a real forgotten `app.use` in `index.js`)
- [x] No `untracked` drift warnings
- [ ] Sanity-check on a downstream deploy: confirm health endpoint reports `requiredRoutes: 54`

---
_Generated by [Claude Code](https://claude.ai/code/session_016enXbzHe3uRtYznTBC3pi3)_