### PR TITLE
viewer: within-section scrollspy (sidebar sub-nav)

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3246,6 +3246,59 @@ body.cr-has-timer .cr-glossary-btn { bottom: 220px; }
 
 /* — END PHASE 4 — */
 
+
+/* ═══════════════════════════════════════════════════════════════
+   CREADY VIEWER — PHASE 5 WITHIN-SECTION SCROLLSPY
+   May 22, 2026
+   Nested sub-nav rendered under the active .cr-nav-item, listing
+   sub-headings inside the current section. Highlights whichever
+   anchor is currently on screen as the learner scrolls.
+   CSS uses only existing --cr-* tokens.
+   ═══════════════════════════════════════════════════════════════ */
+
+.cr-subnav {
+  list-style: none;
+  margin: 2px 0 8px;
+  padding: 0;
+  border-left: 1px solid var(--cr-border);
+  margin-left: 28px;
+}
+
+.cr-subnav-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-left: 2px solid transparent;
+  padding: 5px 10px 5px 12px;
+  margin-left: -1px;
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--cr-text-muted);
+  cursor: pointer;
+  transition: color var(--cr-transition), border-color var(--cr-transition), background var(--cr-transition);
+}
+
+.cr-subnav-item:hover {
+  color: var(--cr-burgundy);
+}
+
+.cr-subnav-item:focus-visible {
+  outline: 2px solid var(--cr-honey);
+  outline-offset: 1px;
+}
+
+.cr-subnav-item.active {
+  color: var(--cr-burgundy);
+  border-left-color: var(--cr-honey);
+  font-weight: 600;
+  background: var(--cr-tint-burg);
+}
+
+
+/* — END PHASE 5 — */
+
 </style>
 <!-- .docx parsing -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.6.0/mammoth.browser.min.js"></script>
@@ -4514,6 +4567,144 @@ function renderCurrentSection() {
   restoreHighlights();
   const _toolbar = document.getElementById('crToolbar');
   if (_toolbar) _toolbar.style.display = (section && !section._isOverview && currentView === 'section') ? 'flex' : 'none';
+}
+
+// ═══════════════════════════════════════════════════════════════
+// WITHIN-SECTION SCROLLSPY (Phase 5)
+// Builds a nested sub-nav under the active .cr-nav-item, listing
+// sub-headings (section dividers + h2/h3 inside text/imageText)
+// in the current section. An IntersectionObserver highlights the
+// heading nearest the top as the learner scrolls. Degrades to a
+// no-op when fewer than 2 anchors exist or required APIs are
+// unavailable. Pure additive — does not touch renderBlock,
+// renderSectionDivider, makeNavItem internals, or goToSection.
+// ═══════════════════════════════════════════════════════════════
+let _crSubnavObserver = null;
+
+function getSectionSubAnchors() {
+  const area = document.getElementById('crContentArea');
+  if (!area) return [];
+  const out = [];
+  const seen = new Set();
+  // (a) section dividers — already rendered by renderSectionDivider
+  area.querySelectorAll('.cr-section-divider').forEach(el => {
+    const h = el.querySelector('h1, h2, h3') || el;
+    const raw = (h.textContent || '').trim();
+    if (!raw || seen.has(el)) return;
+    seen.add(el);
+    out.push({ el: el, label: raw.length > 40 ? raw.slice(0, 38).trim() + '…' : raw });
+  });
+  // (b) h2/h3 inside text / imageText blocks
+  area.querySelectorAll('.cr-block[data-block-type="text"] h2, .cr-block[data-block-type="text"] h3, .cr-block[data-block-type="imageText"] h2, .cr-block[data-block-type="imageText"] h3').forEach(h => {
+    if (seen.has(h)) return;
+    const raw = (h.textContent || '').trim();
+    if (!raw) return;
+    seen.add(h);
+    out.push({ el: h, label: raw.length > 40 ? raw.slice(0, 38).trim() + '…' : raw });
+  });
+  // Preserve document order
+  out.sort((a, b) => {
+    if (a.el === b.el) return 0;
+    return (a.el.compareDocumentPosition(b.el) & Node.DOCUMENT_POSITION_FOLLOWING) ? -1 : 1;
+  });
+  return out;
+}
+
+function initSectionScrollspy() {
+  try {
+    // Tear down any previous observer to prevent leaks across re-renders
+    if (_crSubnavObserver && typeof _crSubnavObserver.disconnect === 'function') {
+      _crSubnavObserver.disconnect();
+    }
+    _crSubnavObserver = null;
+
+    // Remove any stale sub-nav from a prior render
+    document.querySelectorAll('.cr-subnav').forEach(n => n.remove());
+
+    if (typeof window === 'undefined' || typeof window.IntersectionObserver !== 'function') return;
+
+    const anchors = getSectionSubAnchors();
+    if (!anchors || anchors.length < 2) return; // short sections → no clutter
+
+    const activeNavBtn = document.querySelector('#crSectionNav .cr-nav-item.active');
+    if (!activeNavBtn) return;
+
+    // Tag each anchor so the observer callback can map back to the sub-item
+    anchors.forEach((a, i) => { a.el.dataset.crSubspyIdx = String(i); });
+
+    const reducedMotion = document.documentElement.getAttribute('data-reduced-motion') === 'true';
+    const scrollBehavior = reducedMotion ? 'auto' : 'smooth';
+
+    const nav = document.createElement('nav');
+    nav.setAttribute('aria-label', 'Within this section');
+    const ul = document.createElement('ul');
+    ul.className = 'cr-subnav';
+
+    anchors.forEach((a, i) => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'cr-subnav-item';
+      btn.textContent = a.label;
+      btn.setAttribute('data-cr-subspy-idx', String(i));
+      btn.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        try {
+          a.el.scrollIntoView({ behavior: scrollBehavior, block: 'start' });
+        } catch (_) {
+          a.el.scrollIntoView();
+        }
+      });
+      li.appendChild(btn);
+      ul.appendChild(li);
+    });
+    nav.appendChild(ul);
+
+    // Insert directly after the active section nav item so it nests visually
+    if (activeNavBtn.parentNode) {
+      activeNavBtn.parentNode.insertBefore(nav, activeNavBtn.nextSibling);
+    }
+
+    const items = ul.querySelectorAll('.cr-subnav-item');
+    const setActive = (idx) => {
+      items.forEach(it => {
+        const on = it.getAttribute('data-cr-subspy-idx') === String(idx);
+        it.classList.toggle('active', on);
+        if (on) it.setAttribute('aria-current', 'location');
+        else it.removeAttribute('aria-current');
+      });
+    };
+    setActive(0);
+
+    _crSubnavObserver = new IntersectionObserver((entries) => {
+      // Pick the visible entry closest to the top of the viewport
+      const visible = entries
+        .filter(e => e.isIntersecting)
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+      if (visible.length > 0) {
+        const idx = visible[0].target.dataset.crSubspyIdx;
+        if (idx != null) setActive(idx);
+      }
+    }, { rootMargin: '-10% 0px -80% 0px', threshold: 0 });
+
+    anchors.forEach(a => _crSubnavObserver.observe(a.el));
+  } catch (err) {
+    // Scrollspy is purely cosmetic — never let it break the viewer
+    try { console && console.warn && console.warn('[cr-subnav] init failed:', err); } catch (_) {}
+  }
+}
+
+// Wrap renderCurrentSection so the scrollspy rebuilds on every section
+// render without editing the function body. renderCurrentSection is a
+// top-level function declaration (sloppy mode) and is reassignable.
+if (typeof renderCurrentSection === 'function') {
+  const _origRenderCurrentSection = renderCurrentSection;
+  renderCurrentSection = function () {
+    const _ret = _origRenderCurrentSection.apply(this, arguments);
+    try { initSectionScrollspy(); } catch (_) {}
+    return _ret;
+  };
 }
 
 // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds a within-section scrollspy to the course viewer's sidebar. When inside a section, a nested sub-list of that section's sub-headings is rendered under the active `.cr-nav-item`, and an `IntersectionObserver` highlights whichever sub-heading is currently on screen as the learner scrolls.

Phase 4 (cosmetic polish) from this branch is already merged to main; this PR carries only commit `2bc0ceb`.

### What's added

CSS — appended inside the existing `<style>` block:
- `.cr-subnav` (indented, hairline left border)
- `.cr-subnav-item` (muted base, `--cr-text-muted`)
- `.cr-subnav-item:hover`, `:focus-visible`, `.active` (burgundy text + honey left accent bar + `--cr-tint-burg` background)
- All colors via existing `--cr-*` tokens; no `#34495E`.

JS — appended inside the existing main `<script>` block, immediately after `renderCurrentSection`:
- `getSectionSubAnchors()` — collects `.cr-section-divider` elements and `h2`/`h3` inside `.cr-block[data-block-type="text"|"imageText"]`, sorted by document order, labels truncated to ~40 chars.
- `initSectionScrollspy()` —
  - disconnects any prior observer (stored in module-scoped `_crSubnavObserver`) to prevent leaks across re-renders;
  - removes any stale `.cr-subnav` from a prior render;
  - returns a no-op if fewer than 2 anchors exist, or if `IntersectionObserver` is unavailable, or if no active nav button is found;
  - renders `<nav aria-label="Within this section"> > <ul class="cr-subnav">` directly after the active `.cr-nav-item` in `#crSectionNav`;
  - each `<button class="cr-subnav-item">` calls `scrollIntoView({ behavior: 'auto' | 'smooth', block: 'start' })`, choosing `'auto'` under `[data-reduced-motion="true"]`;
  - `IntersectionObserver` with `rootMargin: '-10% 0px -80% 0px'` highlights the anchor nearest the top, sets `.active` + `aria-current="location"`;
  - the whole function is wrapped in `try/catch` and logs via `console.warn` — scrollspy failures never break the viewer.
- Hook: `renderCurrentSection` is wrapped via reassignment **after** its declaration, so the body of `renderCurrentSection` is untouched.

### Protections honored

- No edits to `renderBlock`, `renderSectionDivider`, `makeNavItem` internals, `goToSection`, or the body of `renderCurrentSection`.
- No new `id` attributes added to blocks — the existing `.cr-block` divs and rendered `h2/h3` elements are the stable scroll anchors.
- No new libraries introduced.
- No backend file touched.
- Wrapper uses an anonymous function expression, so `grep -c "function render"` is unchanged (33 before/after).

### Verification (raw output)

```
wc -l client/public/interactive-course.html
  before: 7911
  after:  8102       (after ≥ before ✓)

grep -c "function render" client/public/interactive-course.html
  before: 33
  after:  33         (UNCHANGED ✓)

grep -n "cr-subnav|initSectionScrollspy|IntersectionObserver|getSectionSubAnchors" — all present (5 CSS selectors + getSectionSubAnchors definition + initSectionScrollspy definition + IntersectionObserver constructor call + wrapper call + several internal references)

node -e "require('fs').readFileSync('client/public/interactive-course.html','utf8'); console.log('file reads OK')"
  → file reads OK

git diff --stat (vs main): 1 file changed, 191 insertions(+)
```

## Test plan

- [ ] Inside a long section (≥2 sub-headings: section divider + text/imageText `h2`/`h3`), a nested sub-list appears under the active sidebar item.
- [ ] Scrolling the content area updates which sub-item shows the burgundy active state + honey left accent.
- [ ] Clicking a sub-item scrolls the matching anchor to the top (smooth, or instant under `[data-reduced-motion="true"]`).
- [ ] Short sections (<2 anchors) render NO sub-list — no clutter.
- [ ] Switching sections rebuilds the sub-list; no duplicate `.cr-subnav` in the DOM after multiple navigations (observer disconnected + stale node removed).
- [ ] Screen reader announces the "Within this section" landmark; active sub-item reports as `aria-current="location"`.
- [ ] No console errors when `IntersectionObserver` is stubbed unavailable in DevTools — the function returns early.
- [ ] Dark mode, high-contrast mode, reduced-motion mode all behave as expected (no hard-coded light colors; reduced motion uses `'auto'` scroll behavior).


---
_Generated by [Claude Code](https://claude.ai/code/session_012c4BM971wNURRgXaNhy3sT)_