### PR TITLE
Remove admin Courses tab redirect to /admin-courses.html

### DIFF
--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -266,12 +266,6 @@
           document.getElementById('adminMob')?.classList.remove('hidden');
           const ml = document.getElementById('menuAdminLink');
           if (ml) ml.style.display = 'flex';
-          // Point "Courses" nav tab to admin course management for admins
-          document.querySelectorAll('a.cr-nav-tab, a[href="/courses.html"]').forEach(a => {
-            if (a.textContent.trim() === 'Courses') {
-              a.href = '/admin-courses.html';
-            }
-          });
         }
 
         localStorage.setItem('user', JSON.stringify(u));


### PR DESCRIPTION
## Summary
- Removed the 6-line block in `client/public/shared/nav-footer.js` that silently rewrote the shared-nav "Courses" tab to `/admin-courses.html` for admin users.
- "Courses" now points to `/courses.html` for everyone, matching the link definition at line 22.
- Admin-badge logic (`adminBadge`, `adminMob`, `menuAdminLink`) inside the same `if (u.role === 'admin' || u.isAdmin)` block is preserved. Admins still reach course management via the admin sidebar.

## Verification
`grep -n "admin-courses.html" client/public/shared/nav-footer.js` → ZERO results.

`grep -n "menuAdminLink\|adminBadge\|label: 'Courses', href: '/courses.html'"` → still shows:
```
22:    { label: 'Courses', href: '/courses.html' },
104:        <a href="/admin.html" id="adminBadge" ...>
128:        <a href="/admin.html" id="menuAdminLink" ...>
264:          document.getElementById('adminBadge')?.classList.remove('hidden');
265:          document.getElementById('adminBadge')?.classList.add('flex');
267:          const ml = document.getElementById('menuAdminLink');
```

`node -e "require('fs').readFileSync(...)"` → reads OK.

`git diff --stat main` → 1 file changed, 6 deletions(-), 0 insertions.

## Test plan
- [ ] Log in as a non-admin user; confirm "Courses" tab in shared nav points to `/courses.html`.
- [ ] Log in as an admin user; confirm "Courses" tab in shared nav now also points to `/courses.html` (no longer hijacked to `/admin-courses.html`).
- [ ] Confirm admin badge still appears and `menuAdminLink` still shows "Admin Panel" linking to `/admin.html`.
- [ ] Confirm admins can still reach course management via the admin sidebar.

https://claude.ai/code/session_01CaNyyA738m7XoPPr5RwEy4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaNyyA738m7XoPPr5RwEy4)_