### PR TITLE
feat(viewer): optional hero banner image on section dividers

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -4622,6 +4622,17 @@ function renderBlock(block, index) {
 
 // ─── SECTION DIVIDER ───
 function renderSectionDivider(wrap, block) {
+  if (typeof block.bannerImage === 'string' && block.bannerImage) {
+    wrap.innerHTML = `<div class="cr-section-divider has-banner">
+      <img class="cr-section-divider-banner" src="${esc(block.bannerImage)}" alt="${esc(block.bannerAlt || block.title || '')}">
+      <div class="cr-section-divider-banner-overlay"></div>
+      <div class="cr-section-divider-inner">
+        <div class="cr-section-divider-number">${block.sectionNumber || ''}</div>
+        <div><h2>${esc(block.title || '')}</h2>${block.subtitle ? '<p>' + esc(block.subtitle) + '</p>' : ''}</div>
+      </div>
+    </div>`;
+    return wrap;
+  }
   wrap.innerHTML = `<div class="cr-section-divider">
     <div class="cr-section-divider-number">${block.sectionNumber || ''}</div>
     <div>


### PR DESCRIPTION
## Summary

Adds optional hero-banner-image support to section dividers in the static course viewer. When a `sectionDivider` block includes a non-empty `block.bannerImage` string, the divider renders as a full-width background image with overlay (the "richer course" look) using the CSS hooks that landed in #415. When `bannerImage` is absent, the existing markup is rendered byte-for-byte unchanged — full backward compatibility.

## Scope

- **Only file touched:** `client/public/interactive-course.html`
- **Only function touched:** `renderSectionDivider` (~line 4624)
- **Edit type:** purely additive — new `if (block.bannerImage)` branch added above the existing markup, which is preserved verbatim.
- No CSS changes (uses existing `#415` hooks at lines 3155–3191).
- No other render function touched. No scrollspy code touched. No backend file touched.

## Verification

```
wc -l client/public/interactive-course.html
  7911 before  →  7922 after   (+11, additive only)

grep -c "function render" client/public/interactive-course.html
  33 before  →  33 after       (no functions added/removed)

grep -n "has-banner|block.bannerImage|cr-section-divider-banner"
  CSS hooks at 3155, 3166, 3174, 3180, 3190, 3191  (untouched, from #415)
  New code at 4625-4628                             (inside renderSectionDivider)

node -e "require('fs').readFileSync('client/public/interactive-course.html','utf8'); console.log('reads OK')"
  reads OK
```

`git diff --stat main` = exactly 1 file changed, 11 insertions, 0 deletions.

## Behavior

```js
// With banner:
{ type: 'sectionDivider', sectionNumber: '02', title: 'Assessment',
  bannerImage: '/img/hero.jpg', bannerAlt: 'Therapist consultation' }
// → .cr-section-divider.has-banner with img + overlay + inner

// Without banner (existing courses):
{ type: 'sectionDivider', sectionNumber: '02', title: 'Assessment' }
// → identical markup to current production
```

`bannerAlt` falls back to `block.title` then `''` for accessibility. All text is escaped via the existing `esc()` helper.

## Test plan

- [ ] Existing courses (no `bannerImage`) render section dividers identically to production
- [ ] A course with `bannerImage` set renders the banner variant with overlay and white text
- [ ] `bannerAlt` falls back to title when omitted
- [ ] Empty-string `bannerImage` falls through to the legacy renderer
- [ ] No regression in any other block type


---
_Generated by [Claude Code](https://claude.ai/code/session_018BLMnKEpW1kkPMLcSajYRD)_