### PR TITLE
Fix doConfirm() callback never firing (Publish/Delete silently no-op)

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -740,7 +740,7 @@
       document.getElementById('confirmModal').style.display = 'flex';
     }
     function closeConfirm() { document.getElementById('confirmModal').style.display = 'none'; pendingFn = null; }
-    function doConfirm() { closeConfirm(); if (pendingFn) pendingFn(); }
+    function doConfirm() { const fn = pendingFn; closeConfirm(); if (fn) fn(); }
 
     function showToast(msg, bg = '#6b1d34') {
       const el = document.getElementById('toastMsg');


### PR DESCRIPTION
## Summary
One-line fix. `closeConfirm()` sets `pendingFn = null`, so the prior:

```js
function doConfirm() { closeConfirm(); if (pendingFn) pendingFn(); }
```

was guaranteed to skip the callback — by the time `if (pendingFn)` was checked, it was already null. Every Publish / Unpublish / Delete confirmation was silently a no-op: the modal closed and the user thought the action had succeeded. This pairs with the diagnostic surface in #426 (which would have shown an error if the request had actually been made — it never was).

## Fix

```js
function doConfirm() { const fn = pendingFn; closeConfirm(); if (fn) fn(); }
```

Capture `pendingFn` into a local before `closeConfirm()` nulls it.

## Diff scope
- One file changed: `client/public/admin-courses.html`
- 1 insertion, 1 deletion (same line)
- Parses OK

## Test plan
- [ ] Open `/admin-courses.html`, click Publish on a draft course → confirm the toggle actually fires a PATCH request (Network tab) and the toast appears
- [ ] Same for Unpublish on a published course
- [ ] Same for Delete on a course
- [ ] Same for the bulk Publish / Unpublish buttons


---
_Generated by [Claude Code](https://claude.ai/code/session_017gQY27MLjbCd1sVtuzkdfw)_