### PR TITLE
Fix publish for InteractiveCourse drafts (frontend tag + backend dual-collection)

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -398,7 +398,14 @@
           });
           if (r.ok) {
             const d = await r.json();
-            courses = (d.courses || []).map(c => ({ ...c, _source: 'courses' }));
+            // Use _collection from backend to correctly identify InteractiveCourse docs.
+            // Without this, draft InteractiveCourses (not returned by /api/interactive-courses
+            // which filters to published only) keep _source:'courses' and route to the wrong
+            // publish endpoint, returning 404.
+            courses = (d.courses || []).map(c => ({
+              ...c,
+              _source: c._collection === 'interactivecourses' ? 'interactivecourses' : 'courses'
+            }));
           }
         } catch(e) {}
 

--- a/server/src/routes/adminCourses.js
+++ b/server/src/routes/adminCourses.js
@@ -1305,21 +1305,43 @@ router.put('/courses/:courseId', protect, adminOnly, async (req, res) => {
 });
 
 // @route   PATCH /api/admin/courses/:courseId/publish
-// @desc    Publish or unpublish a course
+// @desc    Publish or unpublish a course (handles both Course and InteractiveCourse)
 // @access  Admin only
 router.patch('/courses/:courseId/publish', protect, adminOnly, async (req, res) => {
   try {
     const { publish } = req.body;
-    
-    const course = await Course.findById(req.params.courseId);
-    
-    if (!course) {
-      return res.status(404).json({ error: 'Course not found' });
+    const courseId = req.params.courseId;
+    const newStatus = publish ? 'published' : 'draft';
+    const newPublishedAt = publish ? new Date() : null;
+
+    // Try legacy Course collection first
+    let course = await Course.findById(courseId).lean();
+    let collection = 'courses';
+
+    if (course) {
+      // Use updateOne to avoid full-document validation on save (protects against
+      // nested subdoc required-field errors in old lesson data)
+      await Course.updateOne(
+        { _id: courseId },
+        { $set: { status: newStatus, publishedAt: newPublishedAt } }
+      );
+    } else {
+      // Fall back to InteractiveCourse (Architecture A) collection
+      course = await InteractiveCourse.findById(courseId).lean();
+      if (!course) {
+        return res.status(404).json({ error: 'Course not found' });
+      }
+      await InteractiveCourse.updateOne(
+        { _id: courseId },
+        { $set: { status: newStatus, publishedAt: newPublishedAt } }
+      );
+      collection = 'interactivecourses';
     }
-    
-    course.status = publish ? 'published' : 'draft';
-    course.publishedAt = publish ? new Date() : null;
-    await course.save();
+
+    // Return refreshed doc
+    const updated = collection === 'interactivecourses'
+      ? await InteractiveCourse.findById(courseId).lean()
+      : await Course.findById(courseId).lean();
 
     // Send new course announcement when publishing
     if (publish) {
@@ -1334,7 +1356,7 @@ router.patch('/courses/:courseId/publish', protect, adminOnly, async (req, res) 
 
     res.json({
       success: true,
-      course,
+      course: updated,
       message: publish ? 'Course published' : 'Course unpublished'
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
Two combining bugs prevented draft InteractiveCourses from publishing via the admin panel. Fixed both at the seam where they crossed.

### Bug 1 — frontend tag mismatch (`client/public/admin-courses.html`, ~line 401)
`loadCourses()` unconditionally stamped `_source:'courses'` on every row returned from `GET /api/admin/courses`, even though that endpoint returns **both** legacy `Course` docs and `InteractiveCourse` docs (tagged with `_collection` by the backend at line 1071–1072 of `adminCourses.js`). Drafts don't surface from `GET /api/interactive-courses` (published-only), so they only entered the UI via the admin endpoint — and kept the wrong tag. Clicking Publish then routed to the legacy `/api/admin/courses/:id/publish`, which couldn't find the doc.

Fix: derive `_source` from `_collection`:
```js
_source: c._collection === 'interactivecourses' ? 'interactivecourses' : 'courses'
```

### Bug 2 — backend single-collection lookup + validation-on-save (`server/src/routes/adminCourses.js`, ~line 1310)
The legacy `PATCH /courses/:courseId/publish` route only looked up the `Course` collection, so any InteractiveCourse ID arriving here (from this frontend or older admin tooling) hit `404 Course not found`. It also used `.save()`, which runs full-document validation — older seeded courses with incomplete nested subdoc data were failing publish for unrelated reasons.

Fix:
- Try `Course.findById` first; on miss fall back to `InteractiveCourse.findById`
- Use `updateOne({ $set })` on both branches to bypass subdoc validation
- Return the refreshed `.lean()` doc in the response

`InteractiveCourse` was already imported at the top of the file (line 18) — no new imports needed.

## Diff scope
- 2 files changed, 41 insertions(+), 12 deletions(-)
- HTML parses OK; `node --check server/src/routes/adminCourses.js` passes

## Test plan
- [ ] Open `/admin-courses.html`, find a draft InteractiveCourse, click Publish → toast shows "✓ Published", badge flips to green
- [ ] Same for a legacy Course (if any remain)
- [ ] Click Unpublish on a published InteractiveCourse → status returns to draft
- [ ] Bulk publish across a mixed set (legacy + interactive) → all succeed
- [ ] Confirm `triggerNewCourseAnnouncement` still fires on publish (Resend email arrives)


---
_Generated by [Claude Code](https://claude.ai/code/session_017gQY27MLjbCd1sVtuzkdfw)_