### PR TITLE
Fix Quick Edit + Metadata saves for interactive courses (route both to /api/admin/courses)

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -902,10 +902,9 @@
 
     try {
       const course = allCourses.find(c => c._id === courseId);
-      const src = course?._source || 'interactivecourses';
-      const endpoint = src === 'courses'
-        ? `${API_URL}/api/admin/courses/${courseId}`
-        : `${API_URL}/api/interactive-courses/${courseId}`;
+      // Both course types use the admin PUT endpoint.
+      // PUT /api/interactive-courses/:id doesn't exist; /api/admin/courses/:id handles both.
+      const endpoint = `${API_URL}/api/admin/courses/${courseId}`;
       const r = await fetch(endpoint, {
         method: 'PUT',
         headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -983,9 +982,9 @@
     if (payload.status === 'draft') payload.isPublished = false;
 
     try {
-      const endpoint = qeSrc !== 'courses'
-        ? `${API_URL}/api/interactive-courses/${qeCourseId}`
-        : `${API_URL}/api/admin/courses/${qeCourseId}`;
+      // Both course types use the admin PUT endpoint.
+      // PUT /api/interactive-courses/:id doesn't exist; /api/admin/courses/:id handles both.
+      const endpoint = `${API_URL}/api/admin/courses/${qeCourseId}`;
       const r = await fetch(endpoint, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${localStorage.getItem('token')}` },


### PR DESCRIPTION
## Summary
Both `saveQuickEdit` and `saveMetadata` branched on `_source` and routed InteractiveCourse PUTs to `/api/interactive-courses/:id` — a route that **does not exist**. `PUT /api/admin/courses/:id` is the actual endpoint and already handles both `Course` and `InteractiveCourse` via an `InteractiveCourse.findById()` fallback inside `adminCourses.js`. Result: every Quick Edit save and every Metadata save on an interactive course was returning the wrong status / failing silently.

## Fix
Drop the branching in both save paths; always PUT to `/api/admin/courses/:id`.

- `saveQuickEdit` (~line 985): unconditional `/api/admin/courses/${qeCourseId}`
- `saveMetadata` (~line 904): unconditional `/api/admin/courses/${courseId}`

Per the task: `openQuickEdit` (GET to load the form) is untouched — that route exists and works.

## Diff scope
- One file changed: `client/public/admin-courses.html`
- 6 insertions, 7 deletions (the `qeSrc` and `src` branching expressions are gone; one-line endpoint + two-line comment per site)
- Parses OK

## Test plan
- [ ] Open `/admin-courses.html`, click ⚡ Quick Edit on an interactive course → change title/status → Save → toast shows ✓, card refreshes
- [ ] Same for a legacy Course (if any remain) — confirm save still works
- [ ] Click ✎ Edit metadata on an interactive course → toggle some NBCC areas → Save → toast shows ✓
- [ ] Same for a legacy Course
- [ ] Confirm `openQuickEdit` still loads the form correctly (GET unchanged)


---
_Generated by [Claude Code](https://claude.ai/code/session_017gQY27MLjbCd1sVtuzkdfw)_