### PR TITLE
Staggered enrollment cap by subscription tier

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -4108,6 +4108,15 @@ function loadCourse(data) {
               const msgEl = document.getElementById('crGateMsg');
               if (msgEl) msgEl.textContent = d.message || 'A subscription is required to access this course.';
             }
+          } else if (d.code === 'ENROLLMENT_LIMIT_REACHED') {
+            const gateEl = document.getElementById('crGateSubscription');
+            if (gateEl) {
+              gateEl.style.display = 'flex';
+              const msgEl = document.getElementById('crGateMsg');
+              if (msgEl) msgEl.textContent = d.error || 'Finish a course in progress before enrolling in another.';
+              const ctaEl = gateEl.querySelector('a[href]');
+              if (ctaEl) { ctaEl.href = '/dashboard.html'; ctaEl.textContent = 'Go to My Courses'; }
+            }
           }
         });
       }

--- a/server/src/routes/courses.js
+++ b/server/src/routes/courses.js
@@ -408,6 +408,33 @@ router.post('/:id/enroll', protect, async (req, res) => {
       return res.status(400).json({ error: 'Already enrolled in this course' });
     }
     
+    // Enrollment cap — staggered by subscription tier:
+    //   free    → 1 active course at a time
+    //   trial   → 1 active course at a time
+    //   active / lifetime → unlimited
+    const subStatus = req.user.subscription?.status;
+    const enrollCap = subStatus === 'active' || subStatus === 'lifetime'
+      ? Infinity
+      : 1;  // free and trial = 1 active course at a time
+
+    if (enrollCap !== Infinity) {
+      const activeEnrollments = await UserCourseProgress.countDocuments({
+        userId: req.user._id,
+        status: { $in: ['not_started', 'in_progress'] }
+      });
+      if (activeEnrollments >= enrollCap) {
+        const capMsg = enrollCap === 1
+          ? 'Free accounts can only have 1 course in progress at a time. Finish it before enrolling in another.'
+          : `You have ${enrollCap} courses in progress. Finish one before enrolling in another.`;
+        return res.status(403).json({
+          error: capMsg,
+          code: 'ENROLLMENT_LIMIT_REACHED',
+          activeEnrollments,
+          cap: enrollCap
+        });
+      }
+    }
+
     // Check access requirements based on subscription tier
     if (!req.user.canAccessCourse(course)) {
       // Determine what tier is needed


### PR DESCRIPTION
## Summary

- Backend: enforce 1 active enrollment for free/trial users in `POST /api/courses/:id/enroll`; active and lifetime subscribers remain uncapped. Returns 403 with `code: 'ENROLLMENT_LIMIT_REACHED'` when the cap is hit.
- Frontend: the static viewer's auto-enroll 403 handler now recognizes `ENROLLMENT_LIMIT_REACHED` and reuses the subscription gate with the server-supplied message and a "Go to My Courses" CTA pointing at `/dashboard.html`.

Two files touched, additive only (+36 lines):
- `server/src/routes/courses.js` — gate added just before `canAccessCourse` check.
- `client/public/interactive-course.html` — extra `else if` branch in the auto-enroll 403 handler.

## Test plan

- [ ] Free user with 0 active enrollments can enroll in a course.
- [ ] Free user with 1 active enrollment hits 403 `ENROLLMENT_LIMIT_REACHED` on second enroll attempt.
- [ ] Trial user behaves the same as free.
- [ ] Active subscriber can enroll in multiple courses with no cap.
- [ ] Lifetime subscriber can enroll in multiple courses with no cap.
- [ ] Auto-enroll flow in `interactive-course.html` shows the gate with the cap message and "Go to My Courses" CTA when a capped user opens a second course.
- [ ] `courses.html` alert fallback still fires on unknown codes (unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q355cSErF4mFwE1btmT3Hn)_