### PR TITLE
fix(admin): correct Course Editor link on admin hub

### DIFF
--- a/client/public/admin.html
+++ b/client/public/admin.html
@@ -222,7 +222,7 @@
           </div>
           <p class="text-sm text-stone-500">Preview interactive courses as a learner would experience them before publishing.</p>
         </a>
-        <a href="/admin-course-edit.html" class="admin-card bg-white rounded-xl border border-stone-200 p-5 block">
+        <a href="/admin-course-editor.html" class="admin-card bg-white rounded-xl border border-stone-200 p-5 block">
           <div class="flex items-center gap-3 mb-2">
             <i class="fas fa-edit text-forest-600"></i>
             <h3 class="font-semibold text-stone-800">Course Editor</h3>


### PR DESCRIPTION
## Summary
- The Course Editor card on `/admin.html` linked to `/admin-course-edit.html`, which returns 404.
- The real file is `admin-course-editor.html` (matches the naming convention of every other card on the page).
- One-line href change in `client/public/admin.html`.

## Diff
```diff
-        <a href="/admin-course-edit.html" class="admin-card bg-white rounded-xl border border-stone-200 p-5 block">
+        <a href="/admin-course-editor.html" class="admin-card bg-white rounded-xl border border-stone-200 p-5 block">
```

## Verify
```
$ grep -n 'admin-course-edit' client/public/admin.html
225:        <a href="/admin-course-editor.html" class="admin-card bg-white rounded-xl border border-stone-200 p-5 block">
```
Only `admin-course-editor.html` remains — the broken link is gone.

## Test plan
- [ ] Visit `/admin.html` and click the Course Editor card → loads `/admin-course-editor.html` (no 404).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LL8gGLDJTQ7oL4hmUPG9sp)_