### PR TITLE
fix(fileUpload): import InteractiveCourse model correctly

### DIFF
--- a/server/src/routes/fileUpload.js
+++ b/server/src/routes/fileUpload.js
@@ -11,7 +11,7 @@ import multer from 'multer';
 import cloudinary from 'cloudinary';
 import { Readable } from 'stream';
 import { protect, adminOnly as requireAdmin } from '../middleware/auth.js';
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
`server/src/routes/fileUpload.js` imports the `InteractiveCourse` Mongoose model with a default import, but the model file's default export is **an object** `{ Course, CourseProgress, ContentInteraction }`, not the model. So `InteractiveCourse.findByIdAndUpdate(...)` on line 185 throws **`findByIdAndUpdate is not a function`** at runtime.

This breaks the `PUT /api/files/resources/:id` endpoint that saves a course's `resources[]` array. The React builder's `SupplementsManager` calls it, so saving supplements in the React builder fails with a 500.

(The static `admin-course-editor.html` Supplements tab from #436 is **not** affected — it saves via `PUT /api/admin/courses/:id`, which imports the model correctly via `adminCourses.js`.)

Fix: use the named import with alias — the pattern already used by `adminCourses.js` and other consumers.

## Diff
```diff
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
```

## Scope
- 1 file, +1/-1.
- `node --check` passes.

## Same-bug-pattern occurrences (NOT in this PR)
Verified all four below default-import the model AND call `.find` / `.create` / `.findByIdAndUpdate` / `.countDocuments` / `.updateOne` directly on the imported binding (none use `.Course.x`), so all four have the same runtime bug:
- `server/src/routes/partners.js` (22 broken calls)
- `server/src/middleware/quotaEnforcement.js` (2 broken calls)
- `server/src/scripts/bulkRegenerateBadCerts.js` (1)
- `server/src/scripts/patchMissingSlugs.js` (3)

Follow-up PR fixing those is being opened separately.

## Test plan
- [ ] `node --check server/src/routes/fileUpload.js` → OK.
- [ ] In the React course builder, open SupplementsManager → add a supplement → Save → returns 200, `course.resources[]` persists; reloading the course shows it.
- [ ] Static editor (`admin-course-editor.html`) Supplements tab still works (unchanged path).
