### PR TITLE
fix: import InteractiveCourse model correctly in 4 more files (follow-up to #437)

### DIFF
--- a/server/src/middleware/quotaEnforcement.js
+++ b/server/src/middleware/quotaEnforcement.js
@@ -5,7 +5,7 @@
  */
 import Partner from '../models/Partner.js';
 import User from '../models/User.js';
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 import { PLAN_LIMITS } from '../utils/planLimits.js';
 
 /**

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -11,7 +11,7 @@ import Stripe from 'stripe';
 import { Resend } from 'resend';
 import Partner from '../models/Partner.js';
 import User from '../models/User.js';
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 import { protect, requireAdmin, requirePartnerAdmin } from '../middleware/auth.js';
 import { enforceCourseQuota, enforceUserQuota, enforceCustomDomainFeature, enforceBulkUploadFeature, getPartnerUsage } from '../middleware/quotaEnforcement.js';
 import { PARTNER_PLANS, getPlanLimits } from '../utils/planLimits.js';

--- a/server/src/scripts/bulkRegenerateBadCerts.js
+++ b/server/src/scripts/bulkRegenerateBadCerts.js
@@ -15,7 +15,7 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 // Import models directly — standalone scripts don't auto-register
 import Certificate from '../models/Certificate.js';
 import User from '../models/User.js';
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 import certificateService from '../services/certificateService.js';
 
 // Also import Course.js for legacy certs

--- a/server/src/scripts/patchMissingSlugs.js
+++ b/server/src/scripts/patchMissingSlugs.js
@@ -24,7 +24,7 @@ const __dirname = path.dirname(__filename);
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
 
 const WRITE = process.argv.includes('--write');
 


### PR DESCRIPTION
## Summary
Follow-up to #437. The same `InteractiveCourse` default-import bug exists in 4 more files. Same one-line fix in each.

The model file `server/src/models/InteractiveCourse.js` exports:
```js
export { Course, CourseProgress, ContentInteraction };
export default { Course, CourseProgress, ContentInteraction };
```
…so a default import binds the name to the **object**, not the Mongoose model — and calls like `InteractiveCourse.findOne(...)` / `.create(...)` / `.countDocuments(...)` throw `is not a function` at runtime.

I grep'd each of these files and verified every usage of `InteractiveCourse` calls a model method **directly on the imported binding** (none use the `.Course.x` indirection), so all four are real runtime bugs:

| File | Broken calls | Notes |
| --- | ---:| --- |
| `server/src/routes/partners.js` | 22 | All partner CRUD/listing routes |
| `server/src/middleware/quotaEnforcement.js` | 2 | Quota check used by partner routes |
| `server/src/scripts/bulkRegenerateBadCerts.js` | 1 | Standalone script |
| `server/src/scripts/patchMissingSlugs.js` | 3 | Standalone script |

## Diff
One line per file, identical fix:
```diff
-import InteractiveCourse from '../models/InteractiveCourse.js';
+import { Course as InteractiveCourse } from '../models/InteractiveCourse.js';
```

Stat:
```
server/src/middleware/quotaEnforcement.js    | 2 +-
server/src/routes/partners.js                | 2 +-
server/src/scripts/bulkRegenerateBadCerts.js | 2 +-
server/src/scripts/patchMissingSlugs.js      | 2 +-
4 files changed, 4 insertions(+), 4 deletions(-)
```

## Verification
- `node --check` passes on all 4 files.
- `grep -c "{ Course as InteractiveCourse }"` returns 1 in each.

## Scope notes
- Pattern matches `adminCourses.js` and most other consumers of this model.
- No behavior change beyond making the previously-broken code paths actually execute.
- Does NOT touch `server/src/models/InteractiveCourse.js` (protected) or any unrelated file.
- Independent of #437 — different files, no merge conflict.

## Test plan
- [ ] Partner routes: GET `/api/partners`, GET `/api/partners/:id/courses`, POST `/api/partners/:id/courses` succeed (instead of 500).
- [ ] Quota middleware passes courseCount enforcement on a partner request without throwing.
- [ ] Scripts can be invoked without immediate "is not a function" errors (full execution out of scope here — flag-gated already).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LL8gGLDJTQ7oL4hmUPG9sp)_