### PR TITLE
fix(model): backfill missing block/section order in pre('save') + one-off script

### DIFF
--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -455,6 +455,12 @@ const CourseSchema = new mongoose.Schema({
 //   • section.title and block.title/subtitle — section headers (metadata)
 //   • course.description, tags, targetAudience, instructor — catalog metadata
 CourseSchema.pre('save', function(next) {
+  (this.sections || []).forEach((sec, si) => {
+    if (sec.order === undefined || sec.order === null) sec.order = si;
+    (sec.contentBlocks || []).forEach((blk, bi) => {
+      if (blk && (blk.order === undefined || blk.order === null)) blk.order = bi;
+    });
+  });
   this.totalEstimatedTime = this.sections.reduce((sum, s) => sum + (s.estimatedTime || 15), 0);
   this.totalContentBlocks = this.sections.reduce((sum, s) => sum + s.contentBlocks.length, 0);
   this.totalQuizQuestions = this.sections.reduce((sum, s) => sum + (s.quizQuestions?.length || 0), 0)

--- a/server/src/scripts/backfillBlockOrder.js
+++ b/server/src/scripts/backfillBlockOrder.js
@@ -1,0 +1,91 @@
+/**
+ * Backfill the required `order` field on content blocks (and sections, if missing)
+ * so course.save() passes validation.
+ *
+ * Root cause: the InteractiveCourse schema marks `contentBlocks[].order` (and
+ * `sections[].order`) as required, but several seed scripts never set them. The
+ * admin editor's Save All Changes calls course.save(), which validates the whole
+ * document and fails on every block missing `order` — surfacing as a 500.
+ *
+ * This sets each block's `order` to its index within its section (and each
+ * section's `order` to its index) ONLY where missing. Idempotent: re-running
+ * changes nothing once fixed. It re-validates before saving and refuses to save
+ * if anything is still invalid (so it can never write a still-broken doc).
+ *
+ * Run on the Render shell (working dir ~/project/src/server):
+ *     node src/scripts/backfillBlockOrder.js CR-501          # one course by code
+ *     node src/scripts/backfillBlockOrder.js <mongoId>       # one course by _id
+ *     node src/scripts/backfillBlockOrder.js --all           # every course missing order
+ *     node src/scripts/backfillBlockOrder.js --all --dry     # report only, no writes
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('❌ No MONGODB_URI environment variable set'); process.exit(1); }
+
+const args = process.argv.slice(2);
+const DRY = args.includes('--dry');
+const ALL = args.includes('--all');
+const target = args.find(a => !a.startsWith('--'));
+
+function backfillOrders(course) {
+  let changed = 0;
+  (course.sections || []).forEach((sec, si) => {
+    if (sec.order === undefined || sec.order === null) { sec.order = si; changed++; }
+    (sec.contentBlocks || []).forEach((blk, bi) => {
+      if (blk.order === undefined || blk.order === null) { blk.order = bi; changed++; }
+    });
+  });
+  return changed;
+}
+
+function remainingErrors(course) {
+  const err = course.validateSync();
+  if (!err) return [];
+  return Object.entries(err.errors).map(([p, e]) => `${p} (${e.kind})`);
+}
+
+(async () => {
+  await mongoose.connect(MONGODB_URI);
+  console.log(DRY ? 'Connected (DRY RUN — no writes).\n' : 'Connected.\n');
+
+  let query = {};
+  if (target) query = mongoose.isValidObjectId(target) ? { _id: target } : { courseCode: target };
+  else if (!ALL) { console.error('Specify a course code/_id, or --all.'); await mongoose.disconnect(); process.exit(1); }
+
+  const courses = await Course.find(query);
+  if (!courses.length) { console.log('No courses matched.'); await mongoose.disconnect(); return; }
+
+  let fixed = 0, stillBad = 0;
+  for (const c of courses) {
+    const label = `${c.courseCode || '(no code)'} — "${(c.title || '').slice(0, 60)}" [${c._id}]`;
+    const before = remainingErrors(c).length;
+    const changed = backfillOrders(c);
+    const after = remainingErrors(c);
+
+    if (changed === 0 && before === 0) { console.log(`✓ ${label} — already valid, nothing to do`); continue; }
+
+    console.log(`• ${label}`);
+    console.log(`    set ${changed} missing order field(s); validation errors ${before} -> ${after.length}`);
+
+    if (after.length) {
+      stillBad++;
+      console.log(`    ⚠ STILL INVALID after backfill — NOT saving. Remaining:`);
+      after.slice(0, 20).forEach(e => console.log(`        - ${e}`));
+      if (after.length > 20) console.log(`        ...and ${after.length - 20} more`);
+      console.log(`      (Some other required/enum field is wrong — run diagnoseCourseValidation.js for detail.)`);
+      continue;
+    }
+
+    if (DRY) { console.log(`    (dry run) would save — now valid`); fixed++; continue; }
+    c.updatedAt = new Date();
+    await c.save();          // passes validation now
+    console.log(`    ✓ saved — course is now valid`);
+    fixed++;
+  }
+
+  console.log('\n────────────────────────────────────────');
+  console.log(`${courses.length} checked · ${fixed} ${DRY ? 'would be fixed' : 'fixed'} · ${stillBad} still invalid (other fields)`);
+  await mongoose.disconnect();
+})().catch(async (e) => { console.error('Fatal:', e); try { await mongoose.disconnect(); } catch {} process.exit(1); });


### PR DESCRIPTION
## Summary
Course saves were 500-ing with `Path "order" is required` whenever the editor's "Save All Changes" went through `course.save()`. Several seed scripts built courses without `sections[].order` or `contentBlocks[].order` set, but the schema marks both as required, so `validateSync` blew up on every existing doc.

Two parts:

### 1. Schema fix (`server/src/models/InteractiveCourse.js`)
Inserted **6 lines** at the top of the existing `CourseSchema.pre('save')` hook — before the `totalEstimatedTime = ...` line. Fills in any missing `order` to the field's index within its parent.

```js
(this.sections || []).forEach((sec, si) => {
  if (sec.order === undefined || sec.order === null) sec.order = si;
  (sec.contentBlocks || []).forEach((blk, bi) => {
    if (blk && (blk.order === undefined || blk.order === null)) blk.order = bi;
  });
});
```

- Idempotent: only touches `undefined`/`null`.
- **No enum modified.** **No `required:` flag modified.**
- Runs ahead of the existing aggregate calculations, so every save going forward writes a valid doc.

### 2. One-off backfill script (`server/src/scripts/backfillBlockOrder.js`, new)
For docs that haven't yet been re-saved through the editor. Dry-runnable, revalidates after backfilling, refuses to save if any unrelated validation error remains.

```
node src/scripts/backfillBlockOrder.js CR-501          # one course by code
node src/scripts/backfillBlockOrder.js <mongoId>       # one course by _id
node src/scripts/backfillBlockOrder.js --all           # every course missing order
node src/scripts/backfillBlockOrder.js --all --dry     # report only
```

## Verify
```
$ node --check server/src/models/InteractiveCourse.js
$ node --check server/src/scripts/backfillBlockOrder.js
$ grep -c "blk.order = bi" server/src/models/InteractiveCourse.js
1
```

Diff stat:
```
server/src/models/InteractiveCourse.js |  6 ++++++
server/src/scripts/backfillBlockOrder.js | 91 ++++++++++++++++++++++++++++++++
2 files changed, 97 insertions(+)
```

After merge:
```
git fetch origin
git show origin/main:server/src/models/InteractiveCourse.js | grep -c "blk.order = bi"   # MUST be 1
```

## Scope notes
Touches only the two files in the task. No enum touched (per the "PROTECTED ENUM" rule in CLAUDE.md). No `required:` flag touched. The pre-save hook gains 6 lines at the top; the rest of the hook is unchanged.

## Test plan
- [ ] `course.save()` on an existing doc with missing `order` no longer throws — completes and persists `order` index-fill.
- [ ] Admin editor "Save All Changes" on a previously-broken course returns 200.
- [ ] Re-running the backfill script on a now-fixed course reports "already valid, nothing to do" (idempotency).
- [ ] `--dry` writes nothing.
- [ ] Script aborts cleanly if `MONGODB_URI` is unset.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LL8gGLDJTQ7oL4hmUPG9sp)_