### PR TITLE
Fix apostrophe-corrupted geriatric seed files (CR-610, CR-611)

### DIFF
--- a/server/src/scripts/seedCR610-Unretiring_the_Self_Retirement_Identity_Depression_and_Reinvention-23574words.js
+++ b/server/src/scripts/seedCR610-Unretiring_the_Self_Retirement_Identity_Depression_and_Reinvention-23574words.js
@@ -157,9 +157,8 @@ const COURSE = {
               options: [
               { text: "Autonomy vs. shame and doubt, focused on developing independence from caregivers", isCorrect: false },
               { text: "Generativity vs. stagnation, focused on contributing to future generations", isCorrect: false },
-              { text: "Integrity vs. despair, focused on accepting one", isCorrect: true },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Integrity vs. despair, focused on accepting one's life as it was actually lived", isCorrect: true },
+              { text: "Identity vs. role confusion, focused on establishing a coherent sense of self", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Erikson's eighth stage, integrity vs. despair, is the central psychosocial task of late life. Successful navigation yields a sense of meaning and acceptance of one's lived experience. Failed navigation yields despair — the sense that life was wasted and that it is too late to find meaning. This framework is particularly useful for understanding the existential dimensions of late-life depression."
             },
@@ -285,14 +284,10 @@ const COURSE = {
               question: "Life Review Therapy is grounded primarily in which theoretical framework?",
               type: "multipleChoice",
               options: [
-              { text: "Aaron Beck", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: "s integrity vs. despair stage and Robert Butler", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: " person-centered theory of unconditional positive regard", isCorrect: false },
-              { text: "Viktor Frankl", isCorrect: false }
+              { text: "Aaron Beck's cognitive model of depression", isCorrect: false },
+              { text: "Erik Erikson's integrity vs. despair stage and Robert Butler's life review concept", isCorrect: true },
+              { text: "Carl Rogers' person-centered theory of unconditional positive regard", isCorrect: false },
+              { text: "Viktor Frankl's logotherapy and existential philosophy", isCorrect: false }
             ], correctAnswer: 1,
               explanation: "Life Review Therapy draws from Erik Erikson's eighth psychosocial stage (integrity vs. despair) and Robert Butler's foundational work on therapeutic reminiscence. Butler proposed that life review — the natural process by which older adults reflect on and evaluate their lives — could be guided therapeutically to facilitate integration, resolve regrets, and promote a sense of meaning and acceptance. The approach was manualized by Barbara Haight and has strong empirical support for late-life depression."
             },
@@ -403,13 +398,10 @@ const COURSE = {
               question: "When working with an older adult client who has impaired decision-making capacity, the ethically appropriate default position is:",
               type: "multipleChoice",
               options: [
-              { text: "Transfer all decision-making authority to the client", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: "s safety", isCorrect: true },
-              { text: "Support the client", isCorrect: false },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Transfer all decision-making authority to the client's next of kin", isCorrect: false },
+              { text: "Pursue legal guardianship to ensure the client's safety", isCorrect: false },
+              { text: "Support the client's autonomous decision-making to the greatest extent possible using the least restrictive means available", isCorrect: true },
+              { text: "Defer all major decisions until the client is evaluated by a geriatric psychiatrist", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "The ethical default in working with cognitively impaired older adults is always to support autonomous decision-making to the greatest possible extent, using the least restrictive means. Capacity is situation-specific, not global. Supported decision-making frameworks, family involvement (with client consent), simplified communication, and repeated information provision should all be pursued before legal mechanisms like guardianship, which represents a significant restriction of civil rights and should be a last resort."
             },
@@ -420,7 +412,7 @@ const COURSE = {
               { text: "History of previous depressive episodes", isCorrect: false },
               { text: "Current medication list and potential depressogenic side effects", isCorrect: false },
               { text: "Family dynamics and caregiver involvement", isCorrect: false },
-              { text: "Beliefs about life", isCorrect: true }
+              { text: "Beliefs about life's purpose and framework for understanding suffering", isCorrect: true }
             ], correctAnswer: 3,
               explanation: "The spiritual domain of comprehensive geriatric assessment encompasses beliefs about meaning and purpose, religious and spiritual practices, existential concerns about mortality and legacy, and the client's framework for understanding suffering. This domain is often omitted from conventional psychiatric assessment but is profoundly important for older adults confronting their own mortality and seeking to understand the meaning of their lives."
             }
@@ -479,11 +471,9 @@ const COURSE = {
               type: "multipleChoice",
               options: [
               { text: "Generalized Anxiety Disorder with somatic features", isCorrect: false },
-              { text: "Early-onset Alzheimer", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Early-onset Alzheimer's disease", isCorrect: false },
+              { text: "Depression with psychotic features, which occurs at elevated rates in older adults", isCorrect: true },
+              { text: "Somatic Symptom Disorder", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Depression with psychotic features — particularly nihilistic delusions about physical decay, personal culpability, or family harm — occurs at higher rates in older adults than in younger populations. This is a psychiatric emergency requiring intensive treatment and should not be attributed to cognitive decline."
             },
@@ -494,7 +484,7 @@ const COURSE = {
               { text: "Financial wealth", isCorrect: false },
               { text: "Living in a urban rather than rural environment", isCorrect: false },
               { text: "Strong social support network and meaningful social connection", isCorrect: true },
-              { text: "Having adult children involved in the older adult", isCorrect: false }
+              { text: "Having adult children involved in the older adult's care", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Strong social support and meaningful social connection consistently emerge as the most robust protective factors against late-life depression across multiple research designs and populations. Subjective loneliness — feeling disconnected even in the presence of others — is a stronger predictor of adverse outcomes than objective social isolation."
             },
@@ -524,12 +514,9 @@ const COURSE = {
               question: "When working with an older Latino client experiencing depression, the clinician's awareness that familismo may affect treatment engagement MOST appropriately leads to:",
               type: "multipleChoice",
               options: [
-              { text: "Automatically involving family members in all treatment sessions without the client", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: ",
-                ", isCorrect: false },
-              { text: "s family will serve as an adequate substitute for professional treatment", isCorrect: false },
+              { text: "Automatically involving family members in all treatment sessions without the client's explicit consent", isCorrect: false },
+              { text: "Exploring with the client how family values and relationships factor into their depression and preferred support strategies", isCorrect: true },
+              { text: "Assuming the client's family will serve as an adequate substitute for professional treatment", isCorrect: false },
               { text: "Avoiding discussion of family dynamics to maintain a focus on individual cognitive and behavioral targets", isCorrect: false }
             ], correctAnswer: 1,
               explanation: "Familismo — the strong family orientation prevalent in many Latino cultures — can be both a protective resource and a barrier to individual treatment-seeking. The clinically appropriate response is to explore with the client how family relationships factor into their experience and preferences, neither automatically involving family without consent nor ignoring this central cultural value."
@@ -551,9 +538,8 @@ const COURSE = {
               options: [
               { text: "Osteoporosis without functional limitation", isCorrect: false },
               { text: "Managed hypertension with no cardiovascular events", isCorrect: false },
-              { text: "Cardiovascular disease, stroke, chronic pain, and Parkinson", isCorrect: true },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Cardiovascular disease, stroke, chronic pain, and Parkinson's disease", isCorrect: true },
+              { text: "Well-controlled type 2 diabetes without complications", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Conditions including cardiovascular disease, stroke, Parkinson's disease, and chronic pain are among those most strongly associated with late-life depression, through both inflammatory pathways and the psychological impact of functional limitation, loss of independence, and confrontation with mortality."
             },
@@ -583,10 +569,8 @@ const COURSE = {
               question: "In Meaning-Centered Psychotherapy for older adults, 'attitudinal values' refers to:",
               type: "multipleChoice",
               options: [
-              { text: "The client", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: "s attitude toward unavoidable suffering", isCorrect: false },
+              { text: "The client's positive attitudes toward treatment and clinician", isCorrect: false },
+              { text: "The freedom to choose one's attitude toward unavoidable suffering", isCorrect: true },
               { text: "Cognitive attitudes that maintain depressive episodes", isCorrect: false },
               { text: "Cultural values that shape the expression of distress", isCorrect: false }
             ], correctAnswer: 1,
@@ -596,13 +580,10 @@ const COURSE = {
               question: "A clinician who normalizes an older client's depression as 'just part of getting old' is demonstrating:",
               type: "multipleChoice",
               options: [
-              { text: "Culturally responsive care that honors the client", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: "s own self-understanding", isCorrect: true },
-              { text: "Ageism that normalizes pathology without adequate clinical assessment", isCorrect: false }
+              { text: "Culturally responsive care that honors the client's explanatory model", isCorrect: false },
+              { text: "Ageism that pathologizes normal aging without adequate clinical assessment", isCorrect: false },
+              { text: "Person-centered reflection of the client's own self-understanding", isCorrect: false },
+              { text: "Ageism that normalizes pathology without adequate clinical assessment", isCorrect: true }
             ], correctAnswer: 3,
               explanation: "Ageism — the implicit assumption that depression, sadness, and loss of interest are 'natural' in old age — is arguably the single greatest barrier to adequate geriatric mental health care. When a clinician normalizes clinical depression as aging, they fail to offer available, effective treatments to a client who is suffering unnecessarily. Depression is not a normal part of aging; it is a treatable condition at any age."
             },
@@ -612,10 +593,8 @@ const COURSE = {
               options: [
               { text: "Exclude family members entirely to protect client confidentiality", isCorrect: false },
               { text: "Involve family members in all decisions, as older adults with depression cannot make autonomous choices", isCorrect: false },
-              { text: "Establish explicit confidentiality agreements with the client, assess caregiver wellbeing and provide referrals when needed, and engage family as treatment allies with the client", isCorrect: true },
-              { text: ",
-                ", isCorrect: false },
-              { text: " perceptions as the primary clinical data source, as they are most reliable", isCorrect: false }
+              { text: "Establish explicit confidentiality agreements with the client, assess caregiver wellbeing and provide referrals when needed, and engage family as treatment allies with the client's informed consent", isCorrect: true },
+              { text: "Rely on family members' perceptions as the primary clinical data source, as they are most reliable", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Effective, ethical geriatric depression treatment requires clear confidentiality agreements with the client about what can be shared with family, active screening of family caregivers for their own depression and burnout, and engagement of family as informed treatment allies — all with the older adult's informed consent and in a manner that preserves their autonomy."
             }

--- a/server/src/scripts/seedCR611-The_Long_Goodbye_Dementia_Grief_Family_Systems-22650words.js
+++ b/server/src/scripts/seedCR611-The_Long_Goodbye_Dementia_Grief_Family_Systems-22650words.js
@@ -105,11 +105,9 @@ const COURSE = {
               type: "multipleChoice",
               options: [
               { text: "Frontotemporal dementia with behavioral variant presentation", isCorrect: false },
-              { text: "Early Alzheimer", isCorrect: true },
-              { text: ",
-                ", isCorrect: false },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Early Alzheimer's disease, in which recent episodic memory is impaired while older autobiographical memories are relatively preserved", isCorrect: true },
+              { text: "Lewy body dementia with fluctuating cognitive presentation", isCorrect: false },
+              { text: "Vascular dementia following a discrete stroke event", isCorrect: false }
             ], correctAnswer: 1,
               explanation: "Alzheimer's disease classically presents with an amnestic pattern that disproportionately affects recent episodic memory while leaving older autobiographical memories relatively intact in early stages. The hippocampus — where recent memories are encoded — is among the first regions affected. This is clinically important as it preserves access to life history, emotion-laden memories, and identity-relevant content that can be therapeutically utilized."
             },
@@ -117,13 +115,10 @@ const COURSE = {
               question: "A 58-year-old client is brought for evaluation because of dramatic personality changes — disinhibition, loss of empathy, and compulsive behaviors — while his memory appears relatively intact. This presentation is MOST suggestive of:",
               type: "multipleChoice",
               options: [
-              { text: "Early Alzheimer", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: ",
-                ", isCorrect: false }
+              { text: "Early Alzheimer's disease with atypical presentation", isCorrect: false },
+              { text: "Major Depressive Disorder with psychomotor features", isCorrect: false },
+              { text: "Frontotemporal dementia, behavioral variant", isCorrect: true },
+              { text: "Lewy body dementia with prominent psychiatric features", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "The behavioral variant of frontotemporal dementia (bvFTD) presents with personality change, disinhibition, loss of empathy, and compulsive behaviors — often with relatively preserved memory in early stages. It frequently affects adults between 45 and 65. This presentation challenges families who may attribute changes to psychological or moral causes before the neurological diagnosis is made."
             },
@@ -211,11 +206,9 @@ const COURSE = {
               type: "multipleChoice",
               options: [
               { text: "Uncertainty about the dementia diagnosis due to incomplete neurological evaluation", isCorrect: false },
-              { text: "The family", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: ",
-                ", isCorrect: false }
+              { text: "The family's uncertainty about how to distribute caregiving responsibilities", isCorrect: false },
+              { text: "The experience of grieving a person who is physically present but psychologically increasingly absent", isCorrect: true },
+              { text: "The ambiguity of prognosis and illness trajectory in neurocognitive disorders", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "Boss's ambiguous loss framework describes the experience of grief for someone who is physically present but psychologically absent — the paradigmatic experience of family members of people with dementia. There is no social ritual, no acknowledged mourning period, and no resolution — the person is still there, but the relationship as it existed is progressively lost. Naming this experience is itself therapeutically valuable for caregivers."
             },
@@ -311,13 +304,10 @@ const COURSE = {
               question: "Under what circumstances may a clinician appropriately share clinical information about a client with dementia with family members?",
               type: "multipleChoice",
               options: [
-              { text: "Any time a family member expresses genuine concern about the client", isCorrect: false },
-              { text: ",
-                ", isCorrect: false },
-              { text: ",
-                ", isCorrect: true },
-              { text: "s explicit consent (obtained while capacity existed), or when a specific legal exception applies such as mandatory reporting", isCorrect: false },
-              { text: "When the client", isCorrect: false }
+              { text: "Any time a family member expresses genuine concern about the client's welfare", isCorrect: false },
+              { text: "Whenever the clinician judges that information-sharing would improve care coordination", isCorrect: false },
+              { text: "Only with the client's explicit consent (obtained while capacity existed), or when a specific legal exception applies such as mandatory reporting", isCorrect: true },
+              { text: "When the client's cognitive impairment makes their confidentiality rights legally moot", isCorrect: false }
             ], correctAnswer: 2,
               explanation: "HIPAA confidentiality protections apply fully to persons with dementia. Information may be shared with family members only with the client's explicit informed consent (ideally obtained while capacity was intact), or when a specific legal exception applies — such as mandatory reporting of abuse or neglect. The person's cognitive impairment does not eliminate their privacy rights."
             },
@@ -326,8 +316,7 @@ const COURSE = {
               type: "multipleChoice",
               options: [
               { text: "Uncomplicated bereavement that resolves quickly because grief work was done during the illness", isCorrect: false },
-              { text: "A distinct clinical experience shaped by years of anticipatory mourning, potential relief, and exhaustion from caregiving — sometimes involving ", isCorrect: true },
-              { text: " requiring specific therapeutic support", isCorrect: false },
+              { text: "A distinct clinical experience shaped by years of anticipatory mourning, potential relief, and exhaustion from caregiving — sometimes involving 'second grief' requiring specific therapeutic support", isCorrect: true },
               { text: "A straightforward grief response identical to other bereavement experiences", isCorrect: false },
               { text: "Primarily focused on guilt and should be treated with CBT-based cognitive restructuring", isCorrect: false }
             ], correctAnswer: 1,
@@ -355,10 +344,10 @@ const COURSE = {
               { text: "90 to 95 percent", isCorrect: false }
             ], correctAnswer: 2, explanation: "Alzheimer's disease is the most common cause of dementia, accounting for 60–80% of cases." },
             { question: "The stepwise deterioration pattern — with abrupt declines following vascular events interspersed with relative stability — is MOST characteristic of:", type: "multipleChoice", options: [
-              { text: "Alzheimer", isCorrect: false },
-              { text: ", ", isCorrect: false },
-              { text: ", ", isCorrect: false },
-              { text: ", ", isCorrect: true }
+              { text: "Alzheimer's disease", isCorrect: false },
+              { text: "Frontotemporal dementia", isCorrect: false },
+              { text: "Lewy body dementia", isCorrect: false },
+              { text: "Vascular dementia", isCorrect: true }
             ], correctAnswer: 3, explanation: "Vascular dementia typically follows a stepwise pattern, with declines linked to discrete cerebrovascular events rather than the gradual progression of Alzheimer's disease." },
             { question: "A person with Lewy body dementia must be carefully monitored for adverse reactions to which category of medication?", type: "multipleChoice", options: [
               { text: "NSAIDs and blood thinners", isCorrect: false },
@@ -380,11 +369,11 @@ const COURSE = {
             ], correctAnswer: 1, explanation: "Validation Therapy, developed by Naomi Feil, involves entering the subjective world of the person with dementia and acknowledging the emotional truth of their experience, rather than correcting temporal or factual misperceptions. This approach reduces distress and conflict, particularly in moderate to late-stage dementia." },
             { question: "According to Boss's ambiguous loss framework, the grief of family members of people with dementia is particularly difficult because:", type: "multipleChoice", options: [
               { text: "The care recipient", isCorrect: false },
-              { text: "s", isCorrect: true },
-              { text: "There is no social ritual, acknowledged mourning period, or resolution — the person is physically present but psychologically increasingly absent", isCorrect: false },
+              { text: "s", isCorrect: false },
+              { text: "There is no social ritual, acknowledged mourning period, or resolution — the person is physically present but psychologically increasingly absent", isCorrect: true },
               { text: "Families are not entitled to grieve until the care recipient has died", isCorrect: false },
               { text: "The grief is primarily anticipatory and does not reflect actual loss", isCorrect: false }
-            ], correctAnswer: 1, explanation: "Ambiguous loss in dementia lacks the social recognition, ritual, and resolution of conventional bereavement. The care recipient is physically present while psychologically increasingly absent — creating grief that has no clear beginning, no clear end, and no social scripts for mourning." },
+            ], correctAnswer: 2, explanation: "Ambiguous loss in dementia lacks the social recognition, ritual, and resolution of conventional bereavement. The care recipient is physically present while psychologically increasingly absent — creating grief that has no clear beginning, no clear end, and no social scripts for mourning." },
             { question: "The REACH (Resources for Enhancing Alzheimer's Caregiver Health) intervention demonstrated effectiveness through:", type: "multipleChoice", options: [
               { text: "Pharmacological management of caregiver anxiety and depression", isCorrect: false },
               { text: "Institutionalization of care recipients to relieve caregiver burden", isCorrect: false },
@@ -398,10 +387,10 @@ const COURSE = {
               { text: "Respite care is only indicated when the caregiver has been formally diagnosed with depression", isCorrect: false }
             ], correctAnswer: 2, explanation: "Despite its documented benefits for caregiver wellbeing, respite care is dramatically underutilized due to caregiver guilt and financial and access barriers. Clinicians play an important role in normalizing respite as essential maintenance of the caregiver's capacity to continue providing care." },
             { question: "When a sibling conflict arises over caregiving responsibilities for a parent with dementia, the clinician's MOST appropriate role is:", type: "multipleChoice", options: [
-              { text: "Advocate for the caregiving sibling", isCorrect: false },
-              { text: ", ", isCorrect: true },
-              { text: ", ", isCorrect: false },
-              { text: ", ", isCorrect: false }
+              { text: "Advocate for the caregiving sibling's perspective, as they have greater clinical insight into the care situation", isCorrect: false },
+              { text: "Facilitate family communication and collaborative problem-solving while maintaining neutrality regarding family dynamics", isCorrect: true },
+              { text: "Remain uninvolved in family dynamics, limiting the clinical focus to the identified client", isCorrect: false },
+              { text: "Provide a formal clinical opinion about the appropriate distribution of caregiving responsibilities", isCorrect: false }
             ], correctAnswer: 1, explanation: "Sibling conflict over caregiving is extremely common and clinically significant. The clinician's appropriate role is to facilitate communication, validate the experiences of all parties, and support collaborative problem-solving — maintaining therapeutic neutrality rather than aligning with any particular sibling's perspective." },
             { question: "Hospice care is underutilized for persons with advanced dementia primarily because:", type: "multipleChoice", options: [
               { text: "Hospice is not legally permitted for non-cancer diagnoses", isCorrect: false },
@@ -431,7 +420,7 @@ const COURSE = {
               { text: "Defer all clinical intervention until cognitive decline is more advanced and the care situation is clearer", isCorrect: false },
               { text: "Focus exclusively on caregiver support for the spouse, as the person with dementia cannot benefit from psychotherapy", isCorrect: false },
               { text: "Individual and/or couples counseling addressing emotional processing of the diagnosis, advance care planning, identity maintenance, and communication — while the client still has sufficient capacity to meaningfully engage", isCorrect: true },
-              { text: "Pharmacological referral only, as psychotherapy cannot benefit persons with Alzheimer", isCorrect: false }
+              { text: "Pharmacological referral only, as psychotherapy cannot benefit persons with Alzheimer's disease", isCorrect: false }
             ], correctAnswer: 2, explanation: "Early-stage dementia is the optimal time for direct therapeutic engagement with the person with cognitive decline — while insight is relatively intact and capacity for meaningful participation in counseling, advance care planning, and identity-affirming work is preserved. Both individual and couples/family sessions are appropriate and beneficial." },
             { question: "What does 'second grief' refer to in the context of post-dementia bereavement?", type: "multipleChoice", options: [
               { text: "A second bereavement following the death of another family member", isCorrect: false },


### PR DESCRIPTION
## Summary

Fixes apostrophe-corrupted quiz options in the two geriatric seed files merged in PR #440. Both files were uploaded with contractions (`Alzheimer's`, `Erikson's`, `Frankl's`, `Beck's`, `Butler's`, etc.) terminating JS string literals early — the comma/space remainders became orphaned option entries.

### Severity before this PR

| File | Status | Symptom |
|---|---|---|
| `seedCR610-...-23574words.js` | **SyntaxError**, would not parse | Could not run, can't seed CR-610 |
| `seedCR611-...-22650words.js` | Parsed, but quiz broken | Multiple bare-comma `","` options across 4 questions; final exam Q6 marked wrong fragment as correct answer |

### What changed

- **CR-610**: replaced verbatim from author's clean paste (apostrophes properly contained within double-quoted strings).
- **CR-611**: replaced verbatim from author's clean paste, plus two minimal answer-key fixes that preserve all option text (no wordcount reduction per requirement):
  - **Final exam Q6** (Boss's ambiguous loss framework): `isCorrect: true` flipped from the orphan `"s"` fragment to the correct `"There is no social ritual..."` option; `correctAnswer` `1` → `2`. All 5 option strings preserved verbatim.
  - **Final exam Q14** (last option): completed from `"...persons with Alzheimer"` to `"...persons with Alzheimer's disease"`.

### Validation

```
$ node --check seedCR610-...-23574words.js   ✅
$ node --check seedCR611-...-22650words.js   ✅
```

No other files touched. No locked files modified. Branch is one commit off main.

## Test plan

- [ ] Render deploy succeeds (server-side scripts now parse)
- [ ] Run `node server/src/scripts/seedCR610-...-23574words.js` against staging — CR-610 course seeds without error
- [ ] Run `node server/src/scripts/seedCR611-...-22650words.js` against staging — CR-611 course seeds without error
- [ ] In CR-611 viewer, open final exam Q6 (ambiguous loss); confirm "no social ritual..." is the keyed correct answer
- [ ] In CR-611 viewer, confirm final exam Q14 last option reads "...with Alzheimer's disease"

https://claude.ai/code/session_01Ccc5KZ7tNQy9LAPYnPosj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ccc5KZ7tNQy9LAPYnPosj9)_