### PR TITLE
ip203: Fix deprecated Navy hex #34495E → #284157 in root-level snapshots

### DIFF
--- a/CourseBuilder.jsx
+++ b/CourseBuilder.jsx
@@ -15,7 +15,7 @@ const C = {
   burgundy: "#6B1D34", burgundyLight: "#8B2D4A", burgundyFaded: "rgba(107,29,52,0.08)",
   green: "#4A7C59", greenLight: "#5A9469", greenFaded: "rgba(74,124,89,0.08)",
   gold: "#D4A855", goldLight: "#E0BC72", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#34495E", navyLight: "#4A6278",
+  navy: "#284157", navyLight: "#4A6278",
   bg: "#FAFAF8", card: "#FFFFFF",
   border: "#E8E4DF", borderLight: "#F0EDE8",
   text: "#2C2C2C", textMuted: "#6B7280", textLight: "#9CA3AF",

--- a/NarrationPanel.jsx
+++ b/NarrationPanel.jsx
@@ -6,7 +6,7 @@ import { useState, useRef, useEffect } from "react";
 
 const C = {
   burgundy: "#6B1D34", green: "#4A7C59", gold: "#D4A855",
-  navy: "#34495E", text: "#2C2C2C", textMuted: "#6B7280",
+  navy: "#284157", text: "#2C2C2C", textMuted: "#6B7280",
   border: "#E8E4DF", card: "#FFFFFF", bg: "#FAFAF8",
   danger: "#DC2626",
 };

--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,7 @@ export const C = {
   burgundy: "#6B1D34", burgundyLight: "#8B2D4A", burgundyFaded: "rgba(107,29,52,0.08)",
   green: "#4A7C59", greenLight: "#5A9469", greenFaded: "rgba(74,124,89,0.08)",
   gold: "#D4A855", goldLight: "#E0BC72", goldFaded: "rgba(212,168,85,0.12)",
-  navy: "#34495E", navyLight: "#4A6278",
+  navy: "#284157", navyLight: "#4A6278",
   bg: "#FAFAF8", card: "#FFFFFF",
   border: "#E8E4DF", borderLight: "#F0EDE8",
   text: "#2C2C2C", textMuted: "#6B7280", textLight: "#9CA3AF",


### PR DESCRIPTION
## Summary
ip203: correct deprecated Navy hex `#34495E` → `#284157` in three root-level duplicate snapshots that still defined the old color.

## Files changed (3, not 4)
- `constants.js` (root)            navy: `#34495E` → `#284157`
- `NarrationPanel.jsx` (root)      navy: `#34495E` → `#284157`
- `CourseBuilder.jsx` (root)       navy: `#34495E` → `#284157`

The task listed a 4th file — `client/src/components/course-builder/constants.js` — whose trailing comment was to be flipped from `(NOT #284157)` to `(NOT #34495E)`. That comment was already corrected by commit 780fbed and required no edit.

## Protected files left untouched (verified)
These intentionally reference `#34495E` so the platform can detect the deprecated color:
- `server/src/scripts/validateSeed.js`
- `server/src/utils/contentValidator.js`
- `server/src/scripts/diagnoseEnforcement.js`
- `server/src/scripts/seedCR501-DBT_Foundations_Clinical_Applications-FULL.js` (migration-note comment)
- `client/public/css/design-tokens.css` (commented-out QA audit selector)

`grep -l "#34495E"` on those five files after the edit returned all five — confirms zero collateral damage to the deprecation tooling.

## Branch policy note
Task prompt said "push to main". Per CLAUDE.md branch policy condition 1 (single-file rule), a 3-file change disqualifies direct-to-main, so this went to a feature branch + draft PR per user direction.

## Test plan
- [x] `grep -rni "#34495E"` after edit shows only the 5 protected files
- [x] All 4 named navy defs now read `#284157`
- [x] `git diff --stat` = 3 files / 3 insertions / 3 deletions
- [ ] Manual: confirm no visual regression in CourseBuilder / NarrationPanel admin views (these root snapshots are duplicates — STEP 5 investigates whether they're imported anywhere)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vKJQBxGQ6RMvyLgvkBwxa)_