### PR TITLE
Fix login: add 2FA challenge step, wire remember-me to token lifetime, strip debug logs

### DIFF
--- a/client/public/login.html
+++ b/client/public/login.html
@@ -126,6 +126,41 @@
           <p class="text-red-700 text-sm" id="errorText"></p>
         </div>
 
+        <!-- 2FA Challenge Step (hidden until backend requests it) -->
+        <div id="twoFactorStep" class="hidden space-y-5 mt-2">
+          <div class="text-center">
+            <h2 class="font-display text-2xl font-semibold text-burgundy-900 mb-2">Two-Step Verification</h2>
+            <p class="text-forest-600 text-sm" id="twoFactorMessage">Enter the 6-digit code from your authenticator app, or a backup code.</p>
+          </div>
+          <div>
+            <label for="twoFactorCode" class="block text-sm font-medium text-forest-700 mb-2">Verification code</label>
+            <input
+              type="text"
+              id="twoFactorCode"
+              inputmode="text"
+              autocomplete="one-time-code"
+              placeholder="123456 or XXXX-XXXX"
+              class="w-full px-4 py-3 border border-forest-200 rounded-xl focus:ring-2 focus:ring-burgundy-500 focus:border-burgundy-500 transition-all outline-none text-center tracking-widest"
+            >
+          </div>
+          <button
+            type="button"
+            id="verifyBtn"
+            class="w-full bg-gradient-to-r from-burgundy-800 to-burgundy-700 hover:from-burgundy-900 hover:to-burgundy-800 text-white font-semibold py-3 px-4 rounded-xl transition-all shadow-md hover:shadow-lg"
+          >
+            Verify &amp; Sign In
+          </button>
+          <button
+            type="button"
+            id="backToLogin"
+            class="block w-full text-center text-sm text-burgundy-700 hover:text-burgundy-800 font-medium"
+          >
+            ← Back to login
+          </button>
+        </div>
+
+        <!-- Alt actions (hidden during 2FA challenge) -->
+        <div id="altActions">
         <!-- Divider -->
         <div class="relative my-8">
           <div class="absolute inset-0 flex items-center">
@@ -143,6 +178,7 @@
         >
           Create an Account
         </a>
+        </div><!-- /altActions -->
 
       </div>
 
@@ -177,6 +213,14 @@
       const form = document.getElementById('loginForm');
       const errorMessage = document.getElementById('errorMessage');
       const errorText = document.getElementById('errorText');
+      const twoFactorStep = document.getElementById('twoFactorStep');
+      const altActions = document.getElementById('altActions');
+      let challengeToken = null;
+
+      function showError(msg) {
+        errorText.textContent = msg;
+        errorMessage.classList.remove('hidden');
+      }
 
       if (!form) {
         console.error('Login form not found');
@@ -204,31 +248,36 @@
         `;
 
         try {
-          console.log('Attempting login to:', `${API_URL}/api/auth/login`);
-          
+          const remember = document.getElementById('remember').checked;
           const response = await fetch(`${API_URL}/api/auth/login`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ email, password }),
+            body: JSON.stringify({ email, password, remember }),
           });
 
-          console.log('Response status:', response.status);
           const data = await response.json();
-          console.log('Response data:', data);
 
-          if (response.ok) {
-            // Store token
+          if (response.ok && data.requiresTwoFactor) {
+            // 2FA enabled — show the challenge step instead of issuing a token.
+            challengeToken = data.challengeToken;
+            if (data.message) document.getElementById('twoFactorMessage').textContent = data.message;
+            errorMessage.classList.add('hidden');
+            form.classList.add('hidden');
+            if (altActions) altActions.classList.add('hidden');
+            twoFactorStep.classList.remove('hidden');
+            const codeInput = document.getElementById('twoFactorCode');
+            codeInput.value = '';
+            codeInput.focus();
+          } else if (response.ok && data.token) {
+            // Standard login — token issued.
             localStorage.setItem('token', data.token);
             localStorage.setItem('user', JSON.stringify(data.user));
-            
-            // Redirect to dashboard
             window.location.href = '/dashboard.html';
           } else {
             // Show error
-            errorText.textContent = data.error || data.message || 'Invalid email or password.';
-            errorMessage.classList.remove('hidden');
+            showError(data.error || data.message || 'Invalid email or password.');
           }
         } catch (error) {
           console.error('Login error:', error);
@@ -239,6 +288,56 @@
         // Re-enable button
         submitBtn.disabled = false;
         submitBtn.innerHTML = 'Sign In';
+      });
+
+      // ── 2FA challenge verification ──
+      const verifyBtn = document.getElementById('verifyBtn');
+      const codeInput = document.getElementById('twoFactorCode');
+      const backToLogin = document.getElementById('backToLogin');
+
+      async function verifyTwoFactor() {
+        const code = (codeInput.value || '').trim();
+        if (!code) { showError('Enter your verification code.'); return; }
+
+        errorMessage.classList.add('hidden');
+        verifyBtn.disabled = true;
+        const original = verifyBtn.innerHTML;
+        verifyBtn.innerHTML = 'Verifying…';
+
+        try {
+          const response = await fetch(`${API_URL}/api/auth/login/verify-2fa`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ challengeToken, code, remember: document.getElementById('remember').checked }),
+          });
+          const data = await response.json();
+
+          if (response.ok && data.token) {
+            localStorage.setItem('token', data.token);
+            localStorage.setItem('user', JSON.stringify(data.user));
+            window.location.href = '/dashboard.html';
+            return;
+          }
+          showError(data.error || 'Invalid code. Please try again.');
+        } catch (err) {
+          console.error('2FA verify error:', err);
+          showError('Unable to connect to server. Please try again.');
+        }
+
+        verifyBtn.disabled = false;
+        verifyBtn.innerHTML = original;
+      }
+
+      if (verifyBtn) verifyBtn.addEventListener('click', verifyTwoFactor);
+      if (codeInput) codeInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); verifyTwoFactor(); }
+      });
+      if (backToLogin) backToLogin.addEventListener('click', () => {
+        challengeToken = null;
+        twoFactorStep.classList.add('hidden');
+        errorMessage.classList.add('hidden');
+        form.classList.remove('hidden');
+        if (altActions) altActions.classList.remove('hidden');
       });
     });
   </script>

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -104,12 +104,19 @@ export const optionalAuth = async (req, res, next) => {
   }
 };
 
-// Generate JWT token
-export const generateToken = (userId) => {
+// Generate JWT token.
+// `remember` is optional: when explicitly true the session is long-lived (30d),
+// when explicitly false it is short-lived (1d). When omitted (undefined) the
+// behavior is unchanged from before — JWT_EXPIRES_IN or the 7d default — so
+// existing callers (2FA verify, admin impersonation) are unaffected.
+export const generateToken = (userId, remember) => {
+  let expiresIn = process.env.JWT_EXPIRES_IN || '7d';
+  if (remember === true) expiresIn = '30d';
+  else if (remember === false) expiresIn = '1d';
   return jwt.sign(
     { id: userId },
     process.env.JWT_SECRET,
-    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+    { expiresIn }
   );
 };
 

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -203,7 +203,7 @@ router.post('/register', async (req, res) => {
 // Login
 router.post('/login', async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const { email, password, remember } = req.body;
     
     if (!email || !password) {
       return res.status(400).json({ error: 'Email and password are required' });
@@ -239,7 +239,7 @@ router.post('/login', async (req, res) => {
       });
     }
 
-    const token = generateToken(user._id);
+    const token = generateToken(user._id, !!remember);
 
     try {
       if (global.posthog) {
@@ -277,7 +277,7 @@ router.post('/login', async (req, res) => {
 // XXXX-XXXX backup code. Returns the full JWT on success.
 router.post('/login/verify-2fa', async (req, res) => {
   try {
-    const { challengeToken, code } = req.body;
+    const { challengeToken, code, remember } = req.body;
 
     if (!challengeToken || !code) {
       return res.status(400).json({ error: 'challengeToken and code are required' });
@@ -318,7 +318,7 @@ router.post('/login/verify-2fa', async (req, res) => {
       return res.status(401).json({ error: 'Invalid code' });
     }
 
-    const token = generateToken(user._id);
+    const token = generateToken(user._id, !!remember);
 
     // Log login activity
     logActivity(ACTIVITY_TYPES.USER_LOGIN, { twoFactor: usedBackup ? 'backup' : 'totp' }, {


### PR DESCRIPTION
## Summary
Atomic 3-file change shipping frontend + backend together to avoid version skew.

- `client/public/login.html` — adds the missing 2FA challenge step (shown when `requiresTwoFactor` returned), passes `remember` in both `/api/auth/login` and `/api/auth/login/verify-2fa` bodies, strips debug `console.log` calls that previously logged token/user payloads.
- `server/src/routes/auth.js` — accepts optional `remember` on login and verify-2fa, forwards it to `generateToken`. Register auto-login and admin impersonation paths intentionally unchanged.
- `server/src/middleware/auth.js` — `generateToken(userId, remember?)`. `true` → 30d, `false` → 1d, `undefined` → unchanged default (`JWT_EXPIRES_IN` or 7d) so existing bare callers keep current behavior.

## Backward-compat verification
```
server/src/routes/adminUsers.js:502:    const token = generateToken(user._id);          # impersonation — bare
server/src/routes/auth.js:164:          const token = generateToken(user._id);          # register — bare
server/src/routes/auth.js:242:          const token = generateToken(user._id, !!remember);  # login
server/src/routes/auth.js:321:          const token = generateToken(user._id, !!remember);  # verify-2fa
```

## Validation
- `node --check` passes for both server files and extracted login.html inline JS.
- `npm run build` in `client/` succeeds (vite 5.4.21, 2310 modules, no errors).
- `console.log` count in login.html: 0. `console.error` count: 3 (error diagnostics retained).

## Deploy reminder
Backend changed — Render must redeploy the web service, not just the static site.

## Branch deviation
Task prompt requested commit to `main`. Session policy and CLAUDE.md branch policy (multi-file change, >10 lines, touches files marked "do not touch without explicit naming") both require a feature branch, so this landed on `claude/great-ramanujan-MkPsg` for review-then-merge.

## Test plan
- [ ] Sign in without 2FA, remember unchecked → ~1d token
- [ ] Sign in without 2FA, remember checked → ~30d token
- [ ] Sign in with 2FA enabled → 2FA step appears, code accepted, token issued; remember flag respected
- [ ] Back-to-login button restores email/password form
- [ ] Register and admin impersonation token lifetimes unchanged (still 7d / `JWT_EXPIRES_IN`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6DDSuSiUYe6fKJCRWtnWt)_