### PR TITLE
feat(email): Resend webhook for open/click tracking

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -59,6 +59,7 @@ import rewardsRoutes from './routes/rewards.js';
 import boardAlertsRoutes from './routes/boardAlerts.js';
 import boardSourcesRoutes from './routes/boardSources.js';
 import googleCalendarRoutes from './routes/googleCalendar.js';
+import resendWebhookRoutes from './routes/webhooksResend.js';
 import cePlannerRoutes from './routes/cePlanner.js';
 import imageUploadRoutes from './routes/imageUpload.js';
 import fileUploadRoutes from './routes/fileUpload.js';
@@ -139,6 +140,7 @@ app.use(cors({
 }));
 
 app.use('/api/payments/webhook', express.raw({ type: 'application/json' }));
+app.use('/api/webhooks/resend', express.raw({ type: 'application/json' }));
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
@@ -226,6 +228,7 @@ app.use('/api/rewards', rewardsRoutes);
 app.use('/api/board-alerts', boardAlertsRoutes);
 app.use('/api/board-sources', boardSourcesRoutes);
 app.use('/api/google-calendar', googleCalendarRoutes);
+app.use('/api/webhooks/resend', resendWebhookRoutes);
 app.use('/api/ce-planner', cePlannerRoutes);
 app.use('/api/images', imageUploadRoutes);
 app.use('/api/files', fileUploadRoutes);

--- a/server/src/models/EmailEvent.js
+++ b/server/src/models/EmailEvent.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * EmailEvent
+ * Stores delivery/engagement events received from Resend webhooks
+ * (sent, delivered, opened, clicked, bounced, complained, delivery_delayed).
+ * Used to compute open/click rates and feed engagement analytics.
+ */
+import mongoose from 'mongoose';
+
+const emailEventSchema = new mongoose.Schema(
+  {
+    messageId: { type: String, index: true },
+    type: { type: String, required: true },
+    email: { type: String, index: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    subject: { type: String, default: null },
+    clickUrl: { type: String, default: null },
+    eventAt: { type: Date, default: Date.now },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+emailEventSchema.index({ type: 1, eventAt: -1 });
+emailEventSchema.index({ email: 1, type: 1 });
+
+const EmailEvent = mongoose.model('EmailEvent', emailEventSchema);
+
+export default EmailEvent;

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -50,6 +50,7 @@ import referralsRoutes from './routes/referrals.js';
 import boardAlertsRoutes from './routes/boardAlerts.js';
 import boardSourcesRoutes from './routes/boardSources.js';
 import googleCalendarRoutes from './routes/googleCalendar.js';
+import resendWebhookRoutes from './routes/webhooksResend.js';
 import cePlannerRoutes from './routes/cePlanner.js';
 import imageUploadRoutes from './routes/imageUpload.js';
 import fileUploadRoutes from './routes/fileUpload.js';
@@ -117,6 +118,7 @@ export const ROUTE_MANIFEST = [
   ['/api/board-alerts',          boardAlertsRoutes,         'Board Alerts'],
   ['/api/board-sources',         boardSourcesRoutes,        'Board Sources (admin monitor mgmt)'],
   ['/api/google-calendar',       googleCalendarRoutes,      'Google Calendar (OAuth + sync)'],
+  ['/api/webhooks/resend',       resendWebhookRoutes,       'Resend email webhook (open/click tracking)'],
   ['/api/ce-planner',            cePlannerRoutes,           'CE Planner'],
   ['/api/recommendations',       recommendationsRoutes,     'Recommendations'],
   ['/api/research-ready',        researchReadyRoutes,       'Researched & Ready'],

--- a/server/src/routes/webhooksResend.js
+++ b/server/src/routes/webhooksResend.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * Resend Email Webhook — verifies Svix signature, stores EmailEvent docs,
+ * forwards opens/clicks to PostHog. Mounted at /api/webhooks/resend.
+ * Raw body parser applied at app level in index.js (before express.json).
+ * Set RESEND_WEBHOOK_SECRET (the "whsec_..." value from the Resend dashboard).
+ */
+import express from 'express';
+import crypto from 'crypto';
+import EmailEvent from '../models/EmailEvent.js';
+import User from '../models/User.js';
+
+const router = express.Router();
+
+const TOLERANCE_SECONDS = 5 * 60;
+
+function verifySvixSignature(payload, headers, secret) {
+  const svixId = headers['svix-id'];
+  const svixTimestamp = headers['svix-timestamp'];
+  const svixSignature = headers['svix-signature'];
+  if (!svixId || !svixTimestamp || !svixSignature || !secret) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  const ts = parseInt(svixTimestamp, 10);
+  if (!Number.isFinite(ts) || Math.abs(now - ts) > TOLERANCE_SECONDS) return false;
+
+  const key = Buffer.from(secret.replace(/^whsec_/, ''), 'base64');
+  const signedContent = `${svixId}.${svixTimestamp}.${payload.toString('utf8')}`;
+  const expected = crypto.createHmac('sha256', key).update(signedContent).digest('base64');
+
+  return svixSignature.split(' ').some((entry) => {
+    const sig = entry.includes(',') ? entry.split(',')[1] : entry;
+    try {
+      const a = Buffer.from(sig);
+      const b = Buffer.from(expected);
+      return a.length === b.length && crypto.timingSafeEqual(a, b);
+    } catch {
+      return false;
+    }
+  });
+}
+
+router.post('/', async (req, res) => {
+  const secret = process.env.RESEND_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('[resend-webhook] RESEND_WEBHOOK_SECRET not set');
+    return res.status(503).json({ error: 'Webhook not configured' });
+  }
+
+  const raw = Buffer.isBuffer(req.body) ? req.body : Buffer.from(req.body || '');
+  if (!verifySvixSignature(raw, req.headers, secret)) {
+    return res.status(400).json({ error: 'Invalid signature' });
+  }
+
+  let evt;
+  try {
+    evt = JSON.parse(raw.toString('utf8'));
+  } catch {
+    return res.status(400).json({ error: 'Invalid JSON' });
+  }
+
+  res.json({ received: true });
+
+  try {
+    const type = String(evt.type || '').replace(/^email\./, '');
+    const data = evt.data || {};
+    const recipient = Array.isArray(data.to) ? data.to[0] : data.to || null;
+    const clickUrl = data.click?.link || null;
+    const eventAt = evt.created_at ? new Date(evt.created_at) : new Date();
+
+    let userId = null;
+    if (recipient) {
+      const user = await User.findOne({ email: recipient }).select('_id').lean();
+      if (user) userId = user._id;
+    }
+
+    await EmailEvent.create({
+      messageId: data.email_id || null,
+      type,
+      email: recipient,
+      userId,
+      subject: data.subject || null,
+      clickUrl,
+      eventAt,
+    });
+
+    if (global.posthog && (type === 'opened' || type === 'clicked')) {
+      global.posthog.capture({
+        distinctId: userId ? userId.toString() : recipient || 'unknown',
+        event: `email_${type}`,
+        properties: { messageId: data.email_id || null, subject: data.subject || null, clickUrl, recipient },
+      });
+    }
+  } catch (err) {
+    console.error('[resend-webhook] processing error:', err.message);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- New `EmailEvent` Mongoose model stores Resend lifecycle events (sent, delivered, opened, clicked, bounced, complained, delivery_delayed) with indexes on `messageId`, `email`, and `(type, eventAt)`.
- New `POST /api/webhooks/resend` route verifies the Svix signature (HMAC-SHA256, 5-min replay tolerance, timing-safe compare — no `svix` dependency added), persists each event as an `EmailEvent`, best-effort attributes by recipient email to a `User`, and forwards `opened` / `clicked` to PostHog when `global.posthog` is set.
- `server/src/index.js`: import added, raw-body parser mounted at `/api/webhooks/resend` (before `express.json`), router mounted after the existing `/api/google-calendar` mount.
- `server/src/routeManifest.js`: import + manifest entry added so the route-integrity check at boot validates the new mount.

Purely additive — 4 files, +140 lines, no edits to existing logic.

## Configuration
Set `RESEND_WEBHOOK_SECRET` (the `whsec_...` value from the Resend dashboard) in the API environment. Without it, the endpoint returns 503 and logs `[resend-webhook] RESEND_WEBHOOK_SECRET not set`. Point the Resend webhook at `https://<api-host>/api/webhooks/resend`.

## Verify locally
- `node --check` clean on all four files (`EmailEvent.js`, `webhooksResend.js`, `index.js`, `routeManifest.js`)
- `grep` confirms: index.js has 3 hits (import + raw-body + router mount), routeManifest.js has 2 hits (import + manifest row)

## Test plan
- [ ] Set `RESEND_WEBHOOK_SECRET` in staging, configure the Resend webhook to point at `/api/webhooks/resend`, send a test email and verify `EmailEvent` docs land for `delivered`/`opened` and PostHog receives `email_opened` / `email_clicked` events.
- [ ] Boot the server and confirm route-integrity check passes with `/api/webhooks/resend` listed as mounted.
- [ ] Send a forged request with a bad/missing signature and confirm 400 response.
- [ ] Boot without `RESEND_WEBHOOK_SECRET` and confirm 503 + the expected error log.

Opened as draft per request — do not merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZbspfePVkusGLyS8o9bDh)_