### PR TITLE
Harden CORS origin allowlist + add helmet security headers

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -19,6 +19,7 @@
 
 import express from 'express';
 import cors from 'cors';
+import helmet from 'helmet';
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import path from 'path';
@@ -105,6 +106,7 @@ import { ROUTE_MANIFEST } from './routeManifest.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const app = express();
+app.use(helmet({ contentSecurityPolicy: false }));
 
 // Mount recorder — records every '/api/...' path passed to app.use so
 // verifyRoutes() can detect routers that were imported but never mounted.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -121,6 +121,8 @@ const allowedOrigins = [
   'http://localhost:5173',
   'http://localhost:3000',
   'http://127.0.0.1:5173',
+  'https://counselorready.com',
+  'https://www.counselorready.com',
   process.env.CLIENT_URL
 ].filter(Boolean);
 
@@ -131,7 +133,7 @@ app.use(cors({
       callback(null, true);
     } else {
       console.log('Blocked by CORS:', origin);
-      callback(null, true);
+      callback(null, false);
     }
   },
   credentials: true,


### PR DESCRIPTION
## Summary

Two security-hardening changes to `server/src/index.js`.

### 1. Enforce CORS origin allowlist
- **Added hardcoded allowed origins** (`https://counselorready.com`, `https://www.counselorready.com`) before the `process.env.CLIENT_URL` entry, so CORS works even if the env var is ever unset.
- **Block unknown origins** — the `else` branch now calls `callback(null, false)` instead of `callback(null, true)`. Previously every origin was allowed through and the "Blocked by CORS" log was informational only.

```diff
 const allowedOrigins = [
   'http://localhost:5173',
   'http://localhost:3000',
   'http://127.0.0.1:5173',
+  'https://counselorready.com',
+  'https://www.counselorready.com',
   process.env.CLIENT_URL
 ].filter(Boolean);

@@ app.use(cors({
       callback(null, true);
     } else {
       console.log('Blocked by CORS:', origin);
-      callback(null, true);
+      callback(null, false);
     }
```

### 2. Add helmet security headers
- Mounts `helmet` immediately after app creation, before any other middleware.
- `contentSecurityPolicy: false` is intentional — CSP is already handled by the client `_headers` file. This enables helmet's other defaults (HSTS, X-Content-Type-Options, X-DNS-Prefetch-Control, etc.).
- `helmet` was already a declared dependency (`^7.1.0` in `server/package.json`); no new dependency added.

```diff
 import express from 'express';
 import cors from 'cors';
+import helmet from 'helmet';
 import mongoose from 'mongoose';

@@
 const app = express();
+app.use(helmet({ contentSecurityPolicy: false }));
```

`git diff --stat`: 1 file changed, 5 insertions(+), 1 deletion(-).

## ⚠️ Deploy heads-up

This changes runtime behavior: origins not in the list are now genuinely blocked (previously all were allowed). Before merging, verify on Render:
- **`CLIENT_URL`** — if set to anything other than the apex/www (trailing slash, `*.onrender.com`, preview domain), it must match exactly. The two hardcoded entries cover apex + www regardless.
- **Partner domains** — partner traffic uses `X-Partner-*` headers, not separate origins, so it should be unaffected; double-check any cross-origin embeds.
- **helmet HSTS** — `Strict-Transport-Security` is now sent on all responses; confirm the production domain is fully HTTPS (it is) before merging.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_