### PR TITLE
Add rate limiting to API and auth routes

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -20,6 +20,7 @@
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import path from 'path';
@@ -196,6 +197,24 @@ app.get('/health', async (req, res) => {
 // NEVER REMOVE ANY LINE. ONLY ADD.
 // ═══════════════════════════════════════════════════════════════
 
+const globalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' }
+});
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many authentication attempts, please try again later' }
+});
+
+app.use('/api/', globalLimiter);
+app.use('/api/auth', authLimiter);
 app.use('/api/auth', authRoutes);
 app.use('/api/interactive-courses', interactiveCourseRoutes);
 app.use('/api/courses', coursesRoutes);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -107,6 +107,7 @@ import { ROUTE_MANIFEST } from './routeManifest.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const app = express();
+app.set('trust proxy', 1);
 app.use(helmet({ contentSecurityPolicy: false }));
 
 // Mount recorder — records every '/api/...' path passed to app.use so
@@ -199,7 +200,7 @@ app.get('/health', async (req, res) => {
 
 const globalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 300,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' }
@@ -207,7 +208,7 @@ const globalLimiter = rateLimit({
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 10,
+  max: 15,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many authentication attempts, please try again later' }


### PR DESCRIPTION
## Summary

Adds `express-rate-limit` to `server/src/index.js` to protect API and authentication endpoints from abuse / brute-force.

- **`trust proxy`** — `app.set('trust proxy', 1)` so the limiter keys on the real client IP behind Render's proxy (rather than bucketing all traffic under the proxy IP).
- **Global limiter** — `300` requests per 15 min per IP, applied to `/api/` before all route mounts.
- **Auth limiter** — `15` requests per 15 min per IP, applied to `/api/auth` immediately before the existing `authRoutes` mount so it runs first.
- Both use `standardHeaders: true` / `legacyHeaders: false` and return a JSON `{ error: ... }` message on limit.
- `express-rate-limit` was already a declared dependency (`^7.1.5` in `server/package.json`); no new dependency added.

```diff
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';

 const app = express();
+app.set('trust proxy', 1);
 app.use(helmet({ contentSecurityPolicy: false }));

@@ API ROUTE REGISTRATION
+const globalLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 300, standardHeaders: true, legacyHeaders: false, message: { error: 'Too many requests, please try again later' } });
+const authLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 15, standardHeaders: true, legacyHeaders: false, message: { error: 'Too many authentication attempts, please try again later' } });
+app.use('/api/', globalLimiter);
+app.use('/api/auth', authLimiter);
 app.use('/api/auth', authRoutes);
```

`git diff --stat` vs `main`: 1 file changed, 22 insertions(+). No existing line removed.

## Notes

- Limits were tuned up from the initial 100/10 to **300/15** to avoid tripping `429`s during normal authenticated browsing (a single page load fires many `/api/` calls).
- `trust proxy` is set to `1` (one hop) to match Render's single reverse proxy in front of the app.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_