### PR TITLE
Honor safe redirect param after login

### DIFF
--- a/client/public/login.html
+++ b/client/public/login.html
@@ -276,7 +276,7 @@
             localStorage.setItem('user', JSON.stringify(data.user));
             const params = new URLSearchParams(window.location.search);
             const redirect = params.get('redirect');
-            window.location.href = (redirect && redirect.startsWith('/')) ? redirect : '/dashboard.html';
+            window.location.href = (redirect && redirect.startsWith('/') && !redirect.startsWith('//')) ? redirect : '/dashboard.html';
           } else {
             // Show error
             showError(data.error || data.message || 'Invalid email or password.');
@@ -319,7 +319,7 @@
             localStorage.setItem('user', JSON.stringify(data.user));
             const params = new URLSearchParams(window.location.search);
             const redirect = params.get('redirect');
-            window.location.href = (redirect && redirect.startsWith('/')) ? redirect : '/dashboard.html';
+            window.location.href = (redirect && redirect.startsWith('/') && !redirect.startsWith('//')) ? redirect : '/dashboard.html';
             return;
           }
           showError(data.error || 'Invalid code. Please try again.');

--- a/client/public/login.html
+++ b/client/public/login.html
@@ -274,7 +274,9 @@
             // Standard login — token issued.
             localStorage.setItem('token', data.token);
             localStorage.setItem('user', JSON.stringify(data.user));
-            window.location.href = '/dashboard.html';
+            const params = new URLSearchParams(window.location.search);
+            const redirect = params.get('redirect');
+            window.location.href = (redirect && redirect.startsWith('/')) ? redirect : '/dashboard.html';
           } else {
             // Show error
             showError(data.error || data.message || 'Invalid email or password.');
@@ -315,7 +317,9 @@
           if (response.ok && data.token) {
             localStorage.setItem('token', data.token);
             localStorage.setItem('user', JSON.stringify(data.user));
-            window.location.href = '/dashboard.html';
+            const params = new URLSearchParams(window.location.search);
+            const redirect = params.get('redirect');
+            window.location.href = (redirect && redirect.startsWith('/')) ? redirect : '/dashboard.html';
             return;
           }
           showError(data.error || 'Invalid code. Please try again.');


### PR DESCRIPTION
## Summary

After a successful login, redirect to a `redirect` query param when present instead of always going to `/dashboard.html`. Applied at both post-login redirect points in `client/public/login.html`:

- **Standard login success** (token issued)
- **2FA verification success**

Each now uses:

```js
const params = new URLSearchParams(window.location.search);
const redirect = params.get('redirect');
window.location.href = (redirect && redirect.startsWith('/') && !redirect.startsWith('//')) ? redirect : '/dashboard.html';
```

The guard only allows **relative, non-protocol-relative** paths, preventing open-redirect attacks:
- `?redirect=https://evil.com` → fails (`startsWith('/')` false) → falls back to `/dashboard.html`
- `?redirect=//evil.com` → fails (`startsWith('//')` true) → falls back to `/dashboard.html`
- `?redirect=/dashboard.html?tab=ce` → allowed (legitimate relative path)

`git diff --stat` vs `main`: 1 file changed, 8 insertions(+), 2 deletions(-). Only `client/public/login.html` touched.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_