### PR TITLE
Replace eggshell with stone token in hold-guide

### DIFF
--- a/client/public/tools/hold-guide.html
+++ b/client/public/tools/hold-guide.html
@@ -18,8 +18,7 @@
   --gold-warm: #C49A40;
   --navy: #284157;
   --navy-deep: #1A2D3D;
-  --eggshell: #F5F5DC;
-  --stone: #EDEADF;
+  --stone: #F8F7F4;
   --cream: #F9F6EF;
 }
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }


### PR DESCRIPTION
## Summary

Removes the `--eggshell` token from `client/public/tools/hold-guide.html` (eggshell is reserved for the course viewer content area only; all other pages use stone) and consolidates onto a single `--stone` token at `#F8F7F4`.

```diff
   --gold-warm: #C49A40;
   --navy: #284157;
   --navy-deep: #1A2D3D;
-  --eggshell: #F5F5DC;
-  --stone: #EDEADF;
+  --stone: #F8F7F4;
   --cream: #F9F6EF;
```

`git diff --stat` vs `main`: 1 file changed, 1 insertion(+), 2 deletions(-). Only `client/public/tools/hold-guide.html` touched.

## Notes on what the file actually contained (differed from the original ask)

The file already defined **both** tokens — `--eggshell: #F5F5DC` (unused — **zero** `var(--eggshell)` references) and `--stone: #EDEADF` (used for the page background). So a literal "rename `--eggshell` → `--stone`" would have produced two conflicting `--stone` declarations. Resolved per direction by:

1. Deleting the unused `--eggshell` line.
2. Pointing the existing `--stone` at `#F8F7F4`.

### ⚠️ Visual change
The page background (`body { background: var(--stone) }`) changes from `#EDEADF` → `#F8F7F4` — a lighter, less-warm stone. This is intended per the chosen resolution, but flagging it since it's a visible change to the tool page rather than a pure no-op token cleanup.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_