### PR TITLE
Remove leftover client/vercel.json

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,7 +1,0 @@
-{
-  "cleanUrls": false,
-  "rewrites": [
-    { "source": "/tools/:path*", "destination": "/tools/:path*" },
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
-}


### PR DESCRIPTION
## Summary

Deletes `client/vercel.json` — an inert leftover Vercel SPA-rewrite config. CounselorReady deploys on **Render only**, which uses `client/public/_redirects` for SPA/route handling and ignores `vercel.json` entirely.

```diff
diff --git a/client/vercel.json b/client/vercel.json
deleted file mode 100644
--- a/client/vercel.json
+++ /dev/null
@@ -1,7 +0,0 @@
-{
-  "cleanUrls": false,
-  "rewrites": [
-    { "source": "/tools/:path*", "destination": "/tools/:path*" },
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
-}
```

`git diff --stat` vs `main`: 1 file changed, 7 deletions(-).

## Verification
- Searched the repo for references to `vercel.json` / `vercel` — **none found** (no build script, config, or doc depends on it).
- Render reads `client/public/_redirects`, not `vercel.json`, so there is no deploy impact.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_