### PR TITLE
Expand server/.env.example with all referenced env vars

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,41 +1,53 @@
 # ===================================
 # CounselorReady Server - Environment Variables
-# Copy to .env and fill in your values
+# Copy to .env and fill in your values. Do NOT commit your real .env.
 # ===================================
 
-# --- Core ---
-NODE_ENV=development
-PORT=5000
-CLIENT_URL=http://localhost:5173
-FRONTEND_URL=http://localhost:5173
-API_URL=http://localhost:5000
-PLATFORM_URL=https://counselorready.com
+# --- Core / App URLs ---
+NODE_ENV=development                                                      # development | production
+PORT=5000                                                                 # Port the API server listens on
+CLIENT_URL=http://localhost:5173                                          # Frontend origin (CORS, email links, Stripe redirects)
+FRONTEND_URL=http://localhost:5173                                        # Legacy alias for CLIENT_URL (some modules read this)
+API_URL=http://localhost:5000                                             # Public base URL of this API server
+PLATFORM_URL=https://counselorready.com                                   # Canonical production platform URL
+PUBLIC_APP_URL=https://counselorready.com                                 # Public app URL used in generated links
+PRIMARY_DOMAIN=counselorready.com                                         # Bare primary domain (no scheme)
+BASE_URL=https://counselorready.com                                       # Generic base URL fallback for absolute links
 
 # --- Database ---
-MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/counselorready
+MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/counselorready   # Primary MongoDB connection string
+# MONGO_URI=                                                              # Optional fallback alias; code uses MONGODB_URI || MONGO_URI
 
 # --- Authentication ---
-JWT_SECRET=your-jwt-secret-here
-JWT_EXPIRES_IN=7d
+JWT_SECRET=your_jwt_secret_here                                           # Secret used to sign auth JWTs
+JWT_EXPIRES_IN=7d                                                         # JWT lifetime (e.g. 7d, 24h)
+
+# --- Google OAuth (Calendar integration) ---
+GOOGLE_CLIENT_ID=your_google_client_id_here                              # Google OAuth client ID for Calendar connect
+GOOGLE_CLIENT_SECRET=your_google_client_secret_here                      # Google OAuth client secret
+GOOGLE_REDIRECT_URI=http://localhost:5000/api/google-calendar/callback   # OAuth redirect/callback URL
 
 # --- Stripe Payments ---
-STRIPE_SECRET_KEY=sk_test_...
-STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_PRICE_STARTER=price_...
-STRIPE_PRICE_PROFESSIONAL=price_...
-STRIPE_PRICE_VIP=price_...
+STRIPE_SECRET_KEY=sk_test_your_key_here                                  # Stripe secret API key
+# STRIPE_SECRET=                                                         # Optional fallback alias; code uses STRIPE_SECRET_KEY || STRIPE_SECRET
+STRIPE_WEBHOOK_SECRET=whsec_your_secret_here                             # Signing secret for Stripe webhook verification
+STRIPE_PRICE_STARTER=price_your_id_here                                  # Stripe Price ID — Starter plan
+STRIPE_PRICE_PROFESSIONAL=price_your_id_here                            # Stripe Price ID — Professional plan
+STRIPE_PRICE_VIP=price_your_id_here                                      # Stripe Price ID — VIP plan
 
 # --- Cloudinary (Image/File CDN) ---
-CLOUDINARY_CLOUD_NAME=your-cloud-name
-CLOUDINARY_API_KEY=your-api-key
-CLOUDINARY_API_SECRET=your-api-secret
+CLOUDINARY_CLOUD_NAME=your_cloud_name_here                              # Cloudinary cloud name
+CLOUDINARY_API_KEY=your_api_key_here                                    # Cloudinary API key
+CLOUDINARY_API_SECRET=your_api_secret_here                              # Cloudinary API secret
 
 # --- Email (Resend) ---
-RESEND_API_KEY=re_...
-FROM_EMAIL=noreply@counselorready.com
-ADMIN_EMAIL=admin@counselorready.com
-ADMIN_NOTIFICATION_EMAIL=admin@counselorready.com
-ADMIN_NOTIFICATION_EMAILS=admin@counselorready.com
+RESEND_API_KEY=re_your_key_here                                         # Resend API key for transactional email
+RESEND_WEBHOOK_SECRET=your_webhook_secret_here                          # Signing secret for Resend inbound webhooks
+FROM_EMAIL=noreply@counselorready.com                                   # Default "from" address for outbound email
+ADMIN_EMAIL=admin@counselorready.com                                    # Primary admin contact address
+ADMIN_ALERT_EMAIL=admin@counselorready.com                              # Address for system/error alert emails
+ADMIN_NOTIFICATION_EMAIL=admin@counselorready.com                       # Recipient for admin activity notifications
+ADMIN_NOTIFICATION_EMAILS=admin@counselorready.com                      # Comma-separated additional notification recipients
 # Comma-separated activity types to SKIP email notifications for (leave empty to notify on all)
 # Available types: user_registered, user_login, user_enrolled, payment_succeeded, payment_failed,
 #   course_started, course_completed, course_failed, quiz_passed, quiz_failed,
@@ -43,42 +55,64 @@ ADMIN_NOTIFICATION_EMAILS=admin@counselorready.com
 # ADMIN_NOTIFY_DISABLED_TYPES=user_login,lesson_completed
 
 # --- AI (Anthropic Claude) ---
-ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_API_KEY=sk-ant-your_key_here                                  # Anthropic API key for AI course generation
+ANTHROPIC_MODEL=claude-sonnet-4-20250514                                # Default Claude model ID
+
+# --- Analytics (PostHog) ---
+POSTHOG_API_KEY=phc_your_key_here                                       # PostHog project API key for server-side events
+
+# --- Stock Images (Pexels) ---
+PEXELS_API_KEY=your_pexels_api_key_here                                 # Pexels API key for course image search
 
 # --- CE Broker (Optional) ---
-# CE_BROKER_API_KEY=
-# CE_BROKER_PROVIDER_ID=
-# CE_BROKER_SANDBOX=true
+# CE_BROKER_API_KEY=your_key_here                                       # CE Broker API key
+# CE_BROKER_PROVIDER_ID=your_provider_id_here                           # CE Broker provider/approval ID
+# CE_BROKER_SANDBOX=true                                                # Use CE Broker sandbox environment
 
 # --- Twilio SMS (Optional) ---
-# TWILIO_ACCOUNT_SID=
-# TWILIO_AUTH_TOKEN=
-# TWILIO_PHONE_NUMBER=
+# TWILIO_ACCOUNT_SID=your_sid_here                                      # Twilio account SID
+# TWILIO_AUTH_TOKEN=your_token_here                                     # Twilio auth token
+# TWILIO_PHONE_NUMBER=+15551234567                                      # Twilio sending phone number
+# ADMIN_PHONE=+15551234567                                              # Admin phone for critical SMS alerts
 
 # --- LTI Integration (Optional) ---
-# LTI_CONSUMER_KEY=
-# LTI_CONSUMER_SECRET=
+# LTI_CONSUMER_KEY=your_key_here                                        # LTI consumer key
+# LTI_CONSUMER_SECRET=your_secret_here                                  # LTI consumer secret
 
 # --- xAPI (Optional) ---
-# XAPI_ENDPOINT=
-# XAPI_USERNAME=
-# XAPI_PASSWORD=
+# XAPI_ENDPOINT=https://lrs.example.com/xapi/                           # xAPI LRS endpoint
+# XAPI_USERNAME=your_username_here                                      # xAPI basic-auth username
+# XAPI_PASSWORD=your_password_here                                      # xAPI basic-auth password
 
-# --- Narration/TTS (Optional) ---
-# NARRATION_PROVIDER=elevenlabs
-# ELEVENLABS_API_KEY=
-# ELEVENLABS_VOICE_ID=
-# ELEVENLABS_MODEL_ID=
-# OPENAI_API_KEY=
-# OPENAI_TTS_MODEL=tts-1
-# OPENAI_TTS_VOICE=alloy
+# --- Narration / TTS (Optional) ---
+# NARRATION_PROVIDER=elevenlabs                                         # TTS provider: elevenlabs | openai | polly
+# ELEVENLABS_API_KEY=your_key_here                                      # ElevenLabs API key
+# ELEVENLABS_VOICE_ID=your_voice_id_here                                # ElevenLabs voice ID
+# ELEVENLABS_MODEL_ID=eleven_multilingual_v2                            # ElevenLabs model ID
+# OPENAI_API_KEY=sk-your_key_here                                       # OpenAI API key (for OpenAI TTS)
+# OPENAI_TTS_MODEL=tts-1                                                # OpenAI TTS model
+# OPENAI_TTS_VOICE=alloy                                                # OpenAI TTS voice
+# AWS_POLLY_VOICE=Joanna                                                # AWS Polly voice name (when using Polly TTS)
 
-# --- R2 Storage (Optional - for video hosting) ---
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_REGION=auto
+# --- Object Storage (Cloudflare R2 / AWS S3, for video & file hosting) ---
+# AWS_ACCESS_KEY_ID=your_key_here                                       # S3/R2-compatible access key ID
+# AWS_SECRET_ACCESS_KEY=your_secret_here                                # S3/R2-compatible secret access key
+# AWS_REGION=auto                                                       # Region (use "auto" for R2)
+# R2_ACCOUNT_ID=your_account_id_here                                    # Cloudflare R2 account ID
+# R2_ACCESS_KEY_ID=your_key_here                                        # R2 access key ID
+# R2_SECRET_ACCESS_KEY=your_secret_here                                 # R2 secret access key
+# R2_BUCKET_NAME=counselorready-media                                   # R2 bucket name
+# R2_PUBLIC_URL=https://media.counselorready.com                        # Public base URL for R2-hosted assets
 
 # --- Misc ---
-# BASE_URL=https://counselorready.com
-# CROSSREF_MAILTO=your-email@example.com
+# CROSSREF_MAILTO=your_email@example.com                                # Contact email for Crossref API "polite pool"
+
+# ===================================
+# Script & Test-only variables (NOT required for running the server)
+# Used by CLI scripts in server/src/scripts and test/smoke utilities.
+# ===================================
+# DRY_RUN=true                                                          # Scripts: preview changes without writing
+# COURSE_SLUG=example-course                                            # Scripts: target a specific course by slug
+# MIN_WPCE=6000                                                         # Scripts: words-per-CE-hour threshold override
+# TEST_EMAIL=test@example.com                                           # Smoke/cert tests: login email
+# TEST_PASSWORD=your_test_password_here                                 # Smoke/cert tests: login password


### PR DESCRIPTION
## Summary

Documents every `process.env.*` variable referenced across `server/src/` in `server/.env.example`, grouped by category with placeholder values and short descriptions.

- Audited `server/src/` for all `process.env.*` usages → **68 unique vars** (no bracket-notation access found).
- **Preserved every entry** from the existing file — including `ADMIN_NOTIFICATION_EMAIL`, `ADMIN_NOTIFICATION_EMAILS`, and `ADMIN_NOTIFY_DISABLED_TYPES`, which are documented but not currently referenced in code.
- **Added 23 previously-undocumented vars**, including:
  - Google OAuth / Calendar: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
  - Analytics / images: `POSTHOG_API_KEY`, `PEXELS_API_KEY`
  - Object storage: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_PUBLIC_URL`
  - Email/admin: `RESEND_WEBHOOK_SECRET`, `ADMIN_ALERT_EMAIL`, `ADMIN_PHONE`
  - URLs: `PUBLIC_APP_URL`, `PRIMARY_DOMAIN`
  - TTS: `AWS_POLLY_VOICE`

## Notes / judgment calls

- **Aliases, not duplicates:** `MONGO_URI` and `STRIPE_SECRET` are only read as `||` fallbacks in scripts (`MONGODB_URI || MONGO_URI`, `STRIPE_SECRET_KEY || STRIPE_SECRET`), so they're commented as aliases rather than listed as standalone required vars.
- **Script/test-only vars** (`DRY_RUN`, `COURSE_SLUG`, `MIN_WPCE`, `TEST_EMAIL`, `TEST_PASSWORD`) are segregated into their own section so they aren't mistaken for runtime config.
- Optional integrations (CE Broker, Twilio, LTI, xAPI, TTS, R2) remain commented-out, matching the original file's convention.
- All placeholders use `your_*_here` style — **no real secrets**.

## Verification

```
USED-in-code vars MISSING from .env.example: (none) — all 68 documented
```

Only `server/.env.example` changed (1 file, +87 −53).

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_