### PR TITLE
Wire up CE logs and course progress in data export

### DIFF
--- a/server/src/services/dataExportService.js
+++ b/server/src/services/dataExportService.js
@@ -1,20 +1,20 @@
 import { Resend } from 'resend';
+import mongoose from 'mongoose';
 import UserCredential from '../models/UserCredential.js';
 import Certificate from '../models/Certificate.js';
-// TODO: model not found — CELog
-// TODO: model not found — InteractiveCourseProgress
+import { CourseProgress } from '../models/InteractiveCourse.js';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 async function compileUserData(user) {
   const userId = user._id;
 
-  const [credentials, certificates] = await Promise.all([
+  const [credentials, certificates, courseProgress, ceLogs] = await Promise.all([
     UserCredential.find({ userId }).lean(),
     Certificate.find({ userId }).lean(),
+    CourseProgress.find({ userId }).lean(),
+    mongoose.connection.collection('celogs').find({ user: userId }).toArray(),
   ]);
-  const ceLogs = []; // TODO: model not found — CELog
-  const courseProgress = []; // TODO: model not found — InteractiveCourseProgress
 
   return {
     exportedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Resolves the two TODOs in `dataExportService.js` so the user data export actually includes CE logs and interactive-course progress (previously hardcoded to empty arrays).

## Changes

- Import `CourseProgress` (mongoose model `InteractiveCourseProgress`, exported from `models/InteractiveCourse.js`) and `mongoose`.
- Fold both new queries into the existing `Promise.all`:
  - `CourseProgress.find({ userId }).lean()` — keyed on `userId` (matches the schema's `{ userId, courseId }` index).
  - `mongoose.connection.collection('celogs').find({ user: userId }).toArray()` — raw query against the `celogs` collection (no Mongoose model exists for it).
- Removed the 4 TODO comments and the 2 standalone empty-array consts.

## Note on the `celogs` user key

The CE-log query keys on **`user`**, not `userId`. Verified against the only writers of that collection:
- `server/src/scripts/reimportCompletions.cjs:161` → `user: user._id`
- `server/src/migrateTalentLMS.js:509` → `user: userId`

Using `{ userId }` there would have silently returned zero CE logs for every user. Stored as `ObjectId` on both sides, so the match types line up.

```diff
 import { Resend } from 'resend';
+import mongoose from 'mongoose';
 import UserCredential from '../models/UserCredential.js';
 import Certificate from '../models/Certificate.js';
-// TODO: model not found — CELog
-// TODO: model not found — InteractiveCourseProgress
+import { CourseProgress } from '../models/InteractiveCourse.js';
@@
-  const [credentials, certificates] = await Promise.all([
+  const [credentials, certificates, courseProgress, ceLogs] = await Promise.all([
     UserCredential.find({ userId }).lean(),
     Certificate.find({ userId }).lean(),
+    CourseProgress.find({ userId }).lean(),
+    mongoose.connection.collection('celogs').find({ user: userId }).toArray(),
   ]);
-  const ceLogs = []; // TODO: model not found — CELog
-  const courseProgress = []; // TODO: model not found — InteractiveCourseProgress
```

1 file changed, +5 −5.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_