### PR TITLE
Add graceful shutdown handling on SIGTERM/SIGINT

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -388,7 +388,7 @@ const startServer = async () => {
   const phKey = process.env.POSTHOG_API_KEY || 'phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb';
   global.posthog = new PostHog(phKey, { host: 'https://us.i.posthog.com' });
   console.log('PostHog analytics initialized');
-  app.listen(PORT, () => {
+  const server = app.listen(PORT, () => {
     console.log(`
 ╔════════════════════════════════════════════════════╗
 ║                                                    ║
@@ -406,6 +406,26 @@ const startServer = async () => {
 ╚════════════════════════════════════════════════════╝
     `);
   });
+
+  // Graceful shutdown — let in-flight requests finish on SIGTERM/SIGINT
+  const shutdown = async (signal) => {
+    console.log(`\n${signal} received — shutting down gracefully...`);
+    server.close(() => {
+      console.log('HTTP server closed');
+      mongoose.connection.close(false).then(() => {
+        console.log('MongoDB connection closed');
+        process.exit(0);
+      });
+    });
+    // Force exit after 10 seconds if graceful shutdown hangs
+    setTimeout(() => {
+      console.error('Forced shutdown after timeout');
+      process.exit(1);
+    }, 10000);
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
 };
 
 startServer().catch(err => {


### PR DESCRIPTION
## Summary

Adds graceful shutdown handling to the server so deploys/restarts (Render sends `SIGTERM`) let in-flight requests finish instead of dropping connections.

## Change (`server/src/index.js`, inside `startServer`)

- `app.listen(PORT, …)` → `const server = app.listen(PORT, …)` to capture the server reference. Banner callback unchanged.
- On `SIGTERM`/`SIGINT`: `server.close()` to stop accepting new connections and drain in-flight ones, then close the MongoDB connection and `process.exit(0)`.
- Safety net: forced `process.exit(1)` after a 10s timeout if shutdown hangs.

`mongoose` was already imported — no new dependency or import.

## Integrity

Protected-file rules respected — surgical addition only:
- 72 `app.use` mounts intact
- `interactiveCourseRoutes.js` import intact
- No existing line removed except the `app.listen` → `const server = app.listen` edit

1 file changed, +21 −1.

https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCAcqKpNskiSBrmLTfahAy)_