### PR TITLE
Add API versioning middleware (/api/v1 → /api rewrite)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,6 +26,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { requestId } from './middleware/requestId.js';
+import { apiVersioning } from './middleware/apiVersioning.js';
 
 dotenv.config();
 
@@ -160,6 +161,8 @@ if (process.env.NODE_ENV !== 'production') {
   });
 }
 
+app.use(apiVersioning);
+
 // ═══════════════════════════════════════════════════════════════
 // DATABASE
 // ═══════════════════════════════════════════════════════════════
@@ -189,6 +192,7 @@ app.get('/health', async (req, res) => {
       mongodb: dbStatus[dbState] || 'unknown',
       environment: process.env.NODE_ENV || 'development',
       version: '1.0.0',
+      apiVersions: ['v1'],
       requiredRoutes: ROUTE_MANIFEST.length
     });
   } catch (error) {

--- a/server/src/middleware/apiVersioning.js
+++ b/server/src/middleware/apiVersioning.js
@@ -1,0 +1,16 @@
+/**
+ * API Versioning Middleware
+ *
+ * Rewrites /api/v1/* requests to /api/* so they hit existing route mounts.
+ * This lets both /api/courses and /api/v1/courses work simultaneously.
+ *
+ * - Existing frontend pages keep using /api/ (no changes needed)
+ * - New integrations and partners use /api/v1/
+ * - When v2 is needed, mount v2-specific handlers separately
+ */
+export const apiVersioning = (req, res, next) => {
+  if (req.path.startsWith('/api/v1/')) {
+    req.url = req.url.replace('/api/v1/', '/api/');
+  }
+  next();
+};


### PR DESCRIPTION
## Summary

Introduces a lightweight API versioning shim so `/api/v1/*` requests resolve against the existing `/api/*` route mounts — no existing route paths change.

- New `server/src/middleware/apiVersioning.js` — rewrites `req.url` from `/api/v1/` to `/api/` so versioned requests hit the existing mounts. Both `/api/courses` and `/api/v1/courses` work simultaneously.
- Mounted in `server/src/index.js` after the body parsers and dev logger, before the first API route mount.
- `/health` now reports `apiVersions: ['v1']`.

## Notes on placement

- This branch's `index.js` has no rate limiters; the first API route mount is `app.use('/api/auth', authRoutes)`. The middleware is mounted just before that block and after the `express.json`/`express.urlencoded` parsers and the dev request logger — satisfying "after body parsers and other middleware, before API route mounts."
- `app.use(apiVersioning)` passes a function (not a string path), so the boot-time `__mountedApiPaths` recorder and `verifyRoutes()` are unaffected — no route-manifest drift.

## Verification

- `node --check` passes on both `index.js` and the new middleware.
- All 56 `app.use('/api...')` mounts preserved; no path changes.
- Diff is purely additive: +20 lines across 2 files.

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_