### PR TITLE
Fix purchasedCourses access check to read pc.courseId

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -91,7 +91,7 @@ async function gateContent(courseObj, user) {
 
   // Individual purchase → full content
   const hasPurchased = user.purchasedCourses?.some(
-    id => id.toString() === courseObj._id.toString()
+    pc => pc.courseId?.toString() === courseObj._id.toString()
   );
   if (hasPurchased) return courseObj;
 
@@ -359,7 +359,7 @@ router.post('/:id/enroll', protect, async (req, res) => {
     const isAdmin = user.role === 'admin';
     const isFree = course.accessType === 'free';
     const hasPurchased = user.purchasedCourses?.some(
-      id => id.toString() === course._id.toString()
+      pc => pc.courseId?.toString() === course._id.toString()
     );
 
     let accessGranted = false;


### PR DESCRIPTION
## Summary

`user.purchasedCourses` contains objects `{ courseId, slug, purchasedAt, amount, stripeSessionId }`, not plain ObjectIds. Two `hasPurchased` checks in `server/src/routes/interactiveCourseRoutes.js` treated each element as an ObjectId via `id.toString()`, so the comparison never matched — purchasers were denied full content / enrollment access.

This aligns both checks with the correct pattern already used in `payments.js:1069` and the User model's `hasAccessTo` method.

## Changes

Two surgical line edits only:

- **`gateContent()` (~line 93)** — individual-purchase content gate
- **enroll endpoint (~line 361)** — purchase access check

```diff
   const hasPurchased = user.purchasedCourses?.some(
-    id => id.toString() === courseObj._id.toString()
+    pc => pc.courseId?.toString() === courseObj._id.toString()
   );
```

```diff
     const hasPurchased = user.purchasedCourses?.some(
-      id => id.toString() === course._id.toString()
+      pc => pc.courseId?.toString() === course._id.toString()
     );
```

## Verification

- `git diff --stat`: **1 file changed, 2 insertions(+), 2 deletions(-)**
- Line count: **1578** lines (≥ 1518 protected-file floor)
- No other code touched — protected file scope respected

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_