### PR TITLE
Retry enrollment on purchase-success page

### DIFF
--- a/client/public/purchase-success.html
+++ b/client/public/purchase-success.html
@@ -76,10 +76,23 @@
         }
         const token = localStorage.getItem('token');
         if (token && course._id) {
-          await fetch(`${API_URL}/api/interactive-courses/${course._id}/enroll`, {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${token}` }
-          });
+          // Retry enrollment — webhook may not have fired yet
+          for (let attempt = 0; attempt < 3; attempt++) {
+            try {
+              const enrollRes = await fetch(`${API_URL}/api/interactive-courses/${course._id}/enroll`, {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${token}`,
+                  'Content-Type': 'application/json'
+                }
+              });
+              const enrollData = await enrollRes.json();
+              if (enrollRes.ok || enrollData.message === 'Already enrolled') break;
+              if (attempt < 2) await new Promise(r => setTimeout(r, 2000));
+            } catch (e) {
+              if (attempt < 2) await new Promise(r => setTimeout(r, 2000));
+            }
+          }
         }
         showSuccess();
       } catch (err) {


### PR DESCRIPTION
## Summary

When a user lands on `purchase-success.html`, the Stripe webhook that grants course access may not have fired yet. The page previously did a single fire-and-forget `POST /enroll`, which could fail in that race window, leaving the user un-enrolled.

This replaces the single call with a retry pattern: up to 3 attempts with a 2-second delay between them, breaking early on success or an "Already enrolled" response.

## Changes

`client/public/purchase-success.html` (enroll block, ~lines 78-83):

```diff
-          await fetch(`${API_URL}/api/interactive-courses/${course._id}/enroll`, {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${token}` }
-          });
+          // Retry enrollment — webhook may not have fired yet
+          for (let attempt = 0; attempt < 3; attempt++) {
+            try {
+              const enrollRes = await fetch(`${API_URL}/api/interactive-courses/${course._id}/enroll`, {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${token}`,
+                  'Content-Type': 'application/json'
+                }
+              });
+              const enrollData = await enrollRes.json();
+              if (enrollRes.ok || enrollData.message === 'Already enrolled') break;
+              if (attempt < 2) await new Promise(r => setTimeout(r, 2000));
+            } catch (e) {
+              if (attempt < 2) await new Promise(r => setTimeout(r, 2000));
+            }
+          }
```

## Note

The code snippet in the task prompt was truncated at `await new Promise(r => setTime`. I completed it as `setTimeout(r, 2000)` per the stated "2-second delay between attempts," and added a matching `catch` (also delaying) so a thrown fetch error still retries.

## Verification

- `git diff --stat`: **1 file changed, 17 insertions(+), 4 deletions(-)**
- Only `client/public/purchase-success.html` touched

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_