### PR TITLE
Fix broken internal links and remove dead script references

### DIFF
--- a/client/public/admin-courses.html
+++ b/client/public/admin-courses.html
@@ -39,7 +39,7 @@
           <a href="/dashboard.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">Dashboard</a>
           <a href="/courses.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">Courses</a>
           <a href="/credentials.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">Credentials</a>
-          <a href="/ce-tracker.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">CE</a>
+          <a href="/credentials.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">CE</a>
           <a href="/certificates.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">Certificates</a>
           <a href="/messages.html" class="px-3 py-1 rounded-full text-xs font-medium text-burgundy-200 hover:text-white hover:bg-burgundy-800 transition-colors">Messages</a>
         </nav>

--- a/client/public/admin-health.html
+++ b/client/public/admin-health.html
@@ -36,8 +36,6 @@
   <div id="cr-header"></div>
   <script src="/shared/nav-footer.js"></script>
 
-  <script src="/js/header.js"></script>
-
   <div class="max-w-7xl mx-auto px-6 py-8">
     <!-- Page Header -->
     <div class="mb-8">

--- a/client/public/admin-users.html
+++ b/client/public/admin-users.html
@@ -627,7 +627,7 @@
     </div>
   </div>
 
-  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+  <script>
     const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
     const token = localStorage.getItem('token');
     

--- a/client/public/checkout-success.html
+++ b/client/public/checkout-success.html
@@ -107,7 +107,7 @@
           </svg>
           Start Course Now
         </a>
-        <a href="/catalog.html"
+        <a href="/courses.html"
            class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-hunter-700 text-hunter-700 font-semibold hover:bg-hunter-700 hover:text-white transition-colors">
           Browse More Courses
         </a>

--- a/client/public/purchase-success.html
+++ b/client/public/purchase-success.html
@@ -54,7 +54,7 @@
       </div>
       <h2 class="text-lg font-bold text-red-800 mb-2">Something went wrong</h2>
       <p id="errorMessage" class="text-red-600 mb-4">We couldn't confirm your purchase.</p>
-      <a href="/catalog.html" class="inline-block bg-burgundy-800 hover:bg-burgundy-900 text-white font-semibold py-3 px-6 rounded-xl transition-colors">
+      <a href="/courses.html" class="inline-block bg-burgundy-800 hover:bg-burgundy-900 text-white font-semibold py-3 px-6 rounded-xl transition-colors">
         Back to Catalog
       </a>
     </div>

--- a/client/public/tools/note-writer.html
+++ b/client/public/tools/note-writer.html
@@ -619,7 +619,7 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 
 <div class="tool-footer">
   <strong style="color:rgba(255,255,255,.8)">Important:</strong> AI-generated notes are drafts. Review and edit before adding to any medical record. CounselorReady is not responsible for clinical decisions based on generated content.<br>
-  <span style="margin-top:6px;display:inline-block"><a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a> · <a href="/contact.html">Contact</a> · © 2026 GA Integrated Therapeutic Perspectives LLC. CounselorReady™ is a trademark of GAITP LLC.</span>
+  <span style="margin-top:6px;display:inline-block"><a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a> · <a href="/help.html">Contact</a> · © 2026 GA Integrated Therapeutic Perspectives LLC. CounselorReady™ is a trademark of GAITP LLC.</span>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary

Fixes six broken internal links / dead script references across static pages.

| # | File | Change |
|---|------|--------|
| 1 | `client/public/purchase-success.html` | `href="/catalog.html"` → `href="/courses.html"` |
| 2 | `client/public/checkout-success.html` | `href="/catalog.html"` → `href="/courses.html"` |
| 3 | `client/public/admin-courses.html` | CE nav link `href="/ce-tracker.html"` → `href="/credentials.html"` |
| 4 | `client/public/tools/note-writer.html` | footer `href="/contact.html"` → `href="/help.html"` (href only; surrounding markup untouched) |
| 5 | `client/public/admin-health.html` | removed `<script src="/js/header.js">` — the file does not exist |
| 6 | `client/public/admin-users.html` | removed the Cloudflare `email-decode.min.js` `<script>` tag — the site is on Render, not Cloudflare. The inline `<script>` that was concatenated on the same line is preserved. |

## Verification

- Confirmed destinations exist: `courses.html`, `credentials.html`, `help.html` all present in `client/public/`.
- Confirmed removed assets don't exist locally: `client/public/js/header.js` and `email-decode.min.js`.
- `git diff --stat`: **6 files changed, 5 insertions(+), 7 deletions(-)**

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_