### PR TITLE
Use CLIENT_URL for Stripe checkout and password-reset redirects

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -371,7 +371,7 @@ router.post('/forgot-password', async (req, res) => {
     user.passwordResetExpires = Date.now() + 3600000;
     await user.save();
     
-    const resetUrl = `https://counselorready.com/reset-password.html?token=${resetToken}`;
+    const resetUrl = `${process.env.CLIENT_URL || 'https://counselorready.com'}/reset-password.html?token=${resetToken}`;
     
     await resend.emails.send({
       from: 'CounselorReady <noreply@counselorready.com>',

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -613,8 +613,8 @@ router.post('/create-course-checkout', protect, async (req, res) => {
         quantity: 1
       }],
       mode: 'payment',
-      success_url: `https://counselorready.com/course-success.html?session_id={CHECKOUT_SESSION_ID}&courseId=${course._id.toString()}`,
-      cancel_url: 'https://counselorready.com/catalog.html',
+      success_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/checkout-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug || ''}&name=${encodeURIComponent(course.title || '')}`,
+      cancel_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/course-details.html?slug=${course.slug || ''}&cancelled=true`,
       metadata: {
         type: 'course_purchase',
         courseId: course._id.toString(),


### PR DESCRIPTION
## Summary

Three redirect URLs were hardcoded to `https://counselorready.com`, and the course-checkout success URL pointed at a page that doesn't exist (`course-success.html`). This routes them through `process.env.CLIENT_URL` (falling back to the production domain) and fixes the success/cancel destinations.

## Changes (3 lines)

**`server/src/routes/payments.js`** — `create-course-checkout` endpoint (lines 616–617):
- `success_url` now targets the existing `checkout-success.html` with `slug` + `name` params instead of the missing `course-success.html?...&courseId=...`
- `cancel_url` returns to `course-details.html?slug=...&cancelled=true` instead of `catalog.html`
- both now use `${process.env.CLIENT_URL || 'https://counselorready.com'}`

**`server/src/routes/auth.js`** — `forgot-password` handler (line 374):
- reset URL now uses `${process.env.CLIENT_URL || 'https://counselorready.com'}`

## Scope

Both files are protected; only the three named lines were changed. The Stripe webhook handler and all auth logic are untouched.

```
 server/src/routes/auth.js     | 2 +-
 server/src/routes/payments.js | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

## Related

The new `success_url` target (`checkout-success.html`) is the page touched in #468 and the enroll-retry page family in #467 — this aligns the Stripe redirect with pages that actually exist.

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_