### PR TITLE
Fix email verification request method and local API URL

### DIFF
--- a/client/public/verify-email.html
+++ b/client/public/verify-email.html
@@ -87,7 +87,7 @@
   </div>
 
   <script>
-    const API = 'https://api.counselorready.com/api/auth';
+    const API = (window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com') + '/api/auth';
 
     async function verifyEmail() {
       const params = new URLSearchParams(window.location.search);
@@ -100,7 +100,11 @@
       }
 
       try {
-        const res = await fetch(`${API}/verify-email?token=${token}`);
+        const res = await fetch(`${API}/verify-email`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token })
+        });
         const data = await res.json();
 
         document.getElementById('loading-state').classList.add('hidden');


### PR DESCRIPTION
## Summary

`verify-email.html` could never complete verification: it called the endpoint with a **GET** and a query-string token, but the server route is **`POST /verify-email`** reading `{ token }` from `req.body` (auth.js:501). The hardcoded API base also broke local development.

## Changes (2 spots in `client/public/verify-email.html`)

1. **API base URL** — derive from hostname so it works on localhost:
   ```diff
   - const API = 'https://api.counselorready.com/api/auth';
   + const API = (window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com') + '/api/auth';
   ```

2. **GET → POST** — match the server contract:
   ```diff
   - const res = await fetch(`${API}/verify-email?token=${token}`);
   + const res = await fetch(`${API}/verify-email`, {
   +   method: 'POST',
   +   headers: { 'Content-Type': 'application/json' },
   +   body: JSON.stringify({ token })
   + });
   ```

## Verification

Confirmed (read-only) the server route is `router.post('/verify-email', ...)` reading `const { token } = req.body` — so the POST + JSON body now matches.

```
 client/public/verify-email.html | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_