### PR TITLE
Show success/cancel banner on subscription Stripe redirect

### DIFF
--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -331,6 +331,26 @@
         return;
       }
 
+    // Handle Stripe redirect params
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('success') === 'true') {
+      const banner = document.createElement('div');
+      banner.className = 'mb-6 p-4 bg-hunter-50 border border-hunter-200 rounded-xl text-hunter-700 text-sm font-medium text-center';
+      banner.textContent = 'Your subscription is now active! Welcome aboard.';
+      const main = document.querySelector('main') || document.querySelector('.max-w-4xl') || document.body.firstElementChild;
+      if (main) main.prepend(banner);
+      // Clean URL
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+    if (urlParams.get('canceled') === 'true') {
+      const banner = document.createElement('div');
+      banner.className = 'mb-6 p-4 bg-burgundy-50 border border-burgundy-200 rounded-xl text-burgundy-700 text-sm font-medium text-center';
+      banner.textContent = 'Checkout was canceled. No charges were made.';
+      const main = document.querySelector('main') || document.querySelector('.max-w-4xl') || document.body.firstElementChild;
+      if (main) main.prepend(banner);
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+
       await
     await loadSubscription();
       await loadBillingHistory();


### PR DESCRIPTION
## Summary

After Stripe subscription checkout, `payments.js` redirects back to `subscription.html?success=true` (or `?canceled=true`), but the page never surfaced either outcome to the user. This adds a banner that reads those redirect params, shows a confirmation/cancellation message, and cleans the URL.

## Change

Purely additive (20 lines) at the start of `init()` in `client/public/subscription.html` — after the `API_URL`/token setup and before `loadSubscription()`:

- `?success=true` → hunter-green banner: "Your subscription is now active! Welcome aboard."
- `?canceled=true` → burgundy banner: "Checkout was canceled. No charges were made."
- both call `window.history.replaceState(...)` to strip the query string.

`init()` runs on `DOMContentLoaded`, so the DOM is ready when the banner is prepended.

## Notes

- The success/cancel param names match what `create-checkout-session` sets as its `success_url`/`cancel_url` in `payments.js`.
- A pre-existing dangling `await` on the line below the insertion point was left untouched (out of scope).

```
 client/public/subscription.html | 20 ++++++++++++++++++++
 1 file changed, 20 insertions(+)
```

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_