### PR TITLE
Add CLIENT_URL fallback to purchase-course redirect URLs

### DIFF
--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -1107,8 +1107,8 @@ router.post('/purchase-course', protect, async (req, res) => {
         userId: user._id.toString(),
         slug: course.slug
       },
-      success_url: req.body.successUrl || `${process.env.CLIENT_URL}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
-      cancel_url: `${process.env.CLIENT_URL}/course-details.html?slug=${course.slug}&cancelled=true`
+      success_url: req.body.successUrl || `${process.env.CLIENT_URL || 'https://counselorready.com'}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
+      cancel_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/course-details.html?slug=${course.slug}&cancelled=true`
     };
 
     // Add discount if coupon code provided


### PR DESCRIPTION
## Summary

The `POST /api/payments/purchase-course` endpoint built its Stripe `success_url`/`cancel_url` from `process.env.CLIENT_URL` with no fallback. If that env var is ever unset, the redirect URLs become `undefined/purchase-success.html...`, breaking the post-checkout redirect. This adds the same `|| 'https://counselorready.com'` fallback already used everywhere else in the file (e.g. `create-checkout-session`).

## Change

`server/src/routes/payments.js` (purchase-course endpoint, lines 1110–1111):

```diff
-      success_url: req.body.successUrl || `${process.env.CLIENT_URL}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
-      cancel_url: `${process.env.CLIENT_URL}/course-details.html?slug=${course.slug}&cancelled=true`
+      success_url: req.body.successUrl || `${process.env.CLIENT_URL || 'https://counselorready.com'}/purchase-success.html?session_id={CHECKOUT_SESSION_ID}&slug=${course.slug}`,
+      cancel_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/course-details.html?slug=${course.slug}&cancelled=true`
```

## Verification

- `git diff --stat`: **1 file changed, 2 insertions(+), 2 deletions(-)**
- Only the two specified lines changed; the webhook handler and all other logic untouched.

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_