### PR TITLE
Add 90-day notification TTL and hide Blog (Admin) from public nav

### DIFF
--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -34,7 +34,6 @@
     { label: 'Referrals', href: '/referrals.html' },
     { label: 'Partner Portal', href: '/partner-dashboard.html' },
     { label: 'Legacy Vault', href: '/legacy-vault.html' },
-    { label: 'Blog (Admin)', href: '/admin-blog.html' },
   ];
 
   // ── POLICY LINKS (footer) ────────────────────────────────

--- a/server/src/models/Notification.js
+++ b/server/src/models/Notification.js
@@ -66,6 +66,9 @@ const notificationSchema = new mongoose.Schema({
 notificationSchema.index({ userId: 1, read: 1, createdAt: -1 });
 notificationSchema.index({ userId: 1, dismissed: 1 });
 
+// Auto-delete notifications older than 90 days
+notificationSchema.index({ createdAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 });
+
 // Get unread count for a user
 notificationSchema.statics.getUnreadCount = async function(userId) {
   return this.countDocuments({ userId, read: false, dismissed: false });


### PR DESCRIPTION
## Summary

Two small, independent changes:

### 1. Notification TTL (`server/src/models/Notification.js`)
Add a MongoDB TTL index on `createdAt` so notifications older than 90 days are auto-deleted by Mongo's background TTL monitor — no cron job needed. Added right after the existing index declarations.

```js
// Auto-delete notifications older than 90 days
notificationSchema.index({ createdAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 });
```

### 2. Hide "Blog (Admin)" from public nav (`client/public/shared/nav-footer.js`)
Remove `{ label: 'Blog (Admin)', href: '/admin-blog.html' }` from the public `secondaryLinks` array. The admin panel link is already provided separately and gated behind the admin role check, so blog admin doesn't belong in the public secondary links.

## Verification

- `node --check server/src/models/Notification.js` → **passes**
- `secondaryLinks` still contains all 6 other items: Researched-N-Ready, CE Planner, Achievements, Referrals, Partner Portal, Legacy Vault

```
 client/public/shared/nav-footer.js | 1 -
 server/src/models/Notification.js  | 3 +++
 2 files changed, 3 insertions(+), 1 deletion(-)
```

https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01No7awbQRmjnmyLe4rBWAjp)_