### PR TITLE
Add email verification token expiration

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -257,6 +257,7 @@ const userSchema = new mongoose.Schema({
   // Metadata
   emailVerified: { type: Boolean, default: false },
   emailVerificationToken: { type: String },
+  emailVerificationExpires: { type: Date },
   passwordResetToken: { type: String },
   passwordResetExpires: { type: Date },
   role: {

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -81,7 +81,8 @@ router.post('/register', async (req, res) => {
       },
       ...(partnerId && { partnerId }),
       emailVerified: false,
-      emailVerificationToken: verificationTokenHash
+      emailVerificationToken: verificationTokenHash,
+      emailVerificationExpires: Date.now() + 24 * 60 * 60 * 1000,
     });
     
     // Log activity for admin notification
@@ -508,7 +509,10 @@ router.post('/verify-email', async (req, res) => {
     
     const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
     
-    const user = await User.findOne({ emailVerificationToken: tokenHash });
+    const user = await User.findOne({
+      emailVerificationToken: tokenHash,
+      emailVerificationExpires: { $gt: Date.now() }
+    });
     
     if (!user) {
       return res.status(400).json({ error: 'Invalid or expired verification link' });
@@ -547,6 +551,7 @@ router.post('/resend-verification', protect, async (req, res) => {
     const verificationTokenHash = crypto.createHash('sha256').update(verificationToken).digest('hex');
     
     user.emailVerificationToken = verificationTokenHash;
+    user.emailVerificationExpires = Date.now() + 24 * 60 * 60 * 1000;
     await user.save();
     
     const verifyUrl = `${process.env.CLIENT_URL || 'https://counselorready.com'}/verify-email.html?token=${verificationToken}`;


### PR DESCRIPTION
## Summary
Implement email verification token expiration to improve security by ensuring verification links are only valid for 24 hours.

## Changes
- **User model**: Added `emailVerificationExpires` field (Date type) to track token expiration
- **Registration endpoint**: Set token expiration to 24 hours when creating new user accounts
- **Email verification endpoint**: Updated query to check both token validity and expiration time before allowing verification
- **Resend verification endpoint**: Reset expiration to 24 hours when resending verification emails

## Implementation Details
- Expiration is set to `Date.now() + 24 * 60 * 60 * 1000` (24 hours in milliseconds)
- Verification query uses MongoDB `$gt` operator to ensure `emailVerificationExpires` is greater than current time
- Invalid or expired tokens now return the same error message: "Invalid or expired verification link"

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys