### PR TITLE
Handle legacy email verification tokens without expiry field

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -511,7 +511,10 @@ router.post('/verify-email', async (req, res) => {
     
     const user = await User.findOne({
       emailVerificationToken: tokenHash,
-      emailVerificationExpires: { $gt: Date.now() }
+      $or: [
+        { emailVerificationExpires: { $gt: Date.now() } },
+        { emailVerificationExpires: { $exists: false } }
+      ]
     });
     
     if (!user) {


### PR DESCRIPTION
Match tokens that are either non-expired (new 24h window) OR have no emailVerificationExpires field at all (issued before the expiry change), so pending pre-existing verification links keep working.