### PR TITLE
Redirect to login on expired token (protected pages only)

### DIFF
--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -239,7 +239,19 @@
 
   if (T) {
     fetch(`${API}/api/auth/me`, { headers: { Authorization: `Bearer ${T}` } })
-      .then(r => { if (!r.ok) throw 0; return r.json(); })
+      .then(r => {
+        if (r.status === 401) {
+          localStorage.removeItem('token');
+          localStorage.removeItem('user');
+          const pub = ['/', '/landing.html', '/courses.html', '/course-details.html', '/login.html', '/register.html', '/verify-email.html', '/reset-password.html', '/forgot-password.html', '/blog.html'];
+          if (!pub.includes(location.pathname)) {
+            location.href = '/login.html?redirect=' + encodeURIComponent(location.pathname + location.search);
+          }
+          throw 0;
+        }
+        if (!r.ok) throw 0;
+        return r.json();
+      })
       .then(d => {
         const u = d.user || d;
         const f = u.profile?.firstName || u.firstName || '';


### PR DESCRIPTION
## Summary

Handles expired/invalid auth tokens in the shared nav loader. When `GET /api/auth/me` returns **401**, the stale `token`/`user` are cleared from `localStorage`, and:

- On a **protected page** (dashboard, credentials, settings, etc.) → redirect to `/login.html?redirect=<current path+query>` so the user returns after logging in.
- On a **public page** (in the allowlist: `/`, landing, courses, course-details, login, register, verify-email, reset-password, forgot-password, blog) → just clear the token and stay on the page.

The login page already consumes the `redirect` param (added in PR #451).

## Scope

Single, surgical change: **only** the `.then(r => …)` handler immediately after the `fetch(\`${API}/api/auth/me\`…)` call in `client/public/shared/nav-footer.js`. The visually identical `.then` on the notifications fetch a few lines below is intentionally left untouched.

## Verification

- `node --check client/public/shared/nav-footer.js` → passes.
- Exact-count check: 1 `r.status === 401` handler, 1 `/api/auth/me` fetch, the notifications `.then(r => { if (!r.ok) throw 0; … })` one-liner remains unchanged.
- Diff: +13 / −1, one file.

```js
.then(r => {
  if (r.status === 401) {
    localStorage.removeItem('token');
    localStorage.removeItem('user');
    const pub = ['/', '/landing.html', '/courses.html', '/course-details.html', '/login.html', '/register.html', '/verify-email.html', '/reset-password.html', '/forgot-password.html', '/blog.html'];
    if (!pub.includes(location.pathname)) {
      location.href = '/login.html?redirect=' + encodeURIComponent(location.pathname + location.search);
    }
    throw 0;
  }
  if (!r.ok) throw 0;
  return r.json();
})
```

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_