### PR TITLE
Skip /api/ (global rate limiter) in route drift check

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -311,6 +311,7 @@ function verifyRoutes() {
     const untracked = [];
     for (const path of __mountedApiPaths) {
       if (path === '/api/payments/webhook') continue; // raw-body parser, not a router
+      if (path === '/api/') continue; // global rate limiter, not a route handler
       if (!manifestPaths.has(path)) untracked.push(path);
     }
 


### PR DESCRIPTION
## Summary

Silences the harmless startup warning:

```
⚠️  Route integrity: 1 mounted path(s) not in manifest (drift):
    • /api/
```

`/api/` is where the **global rate limiter** is mounted (`app.use('/api/', globalLimiter)`). It's middleware, not a route handler, so it legitimately has no `ROUTE_MANIFEST` entry. The fix adds it to the existing skip list in `verifyRoutes()`'s drift loop — right next to the `'/api/payments/webhook'` exception that's there for the same reason (raw-body parser, not a router).

## ⚠️ Deviation from the literal request

The task asked to add this entry to `routeManifest.js`:

```js
['/api/', 'globalLimiter', 'middleware'],
```

I did **not** do that, because it would backfire. `verifyRoutes()` iterates every manifest entry and runs:

```js
const [path, router, label] = entry;
if (!router || typeof router !== 'function') {
  brokenImports.push({ path, label });   // string 'globalLimiter' is NOT a function
}
```

The string `'globalLimiter'` is not a function, so the entry would land in `brokenImports`, and a non-empty `brokenImports` flips the soft warning into a hard, scary **`❌ ROUTE INTEGRITY CHECK FAILED`** banner on every boot — louder than the warning it was meant to remove. `globalLimiter` is defined in `index.js` and isn't importable into `routeManifest.js`, so there's no clean manifest-only fix. Confirmed the alternative approach (skip `/api/` in the drift loop) with the maintainer before implementing.

## The change

```diff
     const untracked = [];
     for (const path of __mountedApiPaths) {
       if (path === '/api/payments/webhook') continue; // raw-body parser, not a router
+      if (path === '/api/') continue; // global rate limiter, not a route handler
       if (!manifestPaths.has(path)) untracked.push(path);
     }
```

## Protected-file note (`index.js`)

This is a targeted one-line addition inside `verifyRoutes()`. No import or `app.use()` removed or changed; `app.use` mount count unchanged (77); the `interactiveCourseRoutes` import still points at `./routes/interactiveCourseRoutes.js`. `node --check src/index.js` passes.

Diff: **+1 line, one file**.

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_