### PR TITLE
Remove 4 duplicate Mongoose index declarations

### DIFF
--- a/server/src/models/Gamification.js
+++ b/server/src/models/Gamification.js
@@ -43,7 +43,6 @@ const gamificationSchema = new mongoose.Schema({
   timestamps: true
 });
 
-gamificationSchema.index({ userId: 1 }, { unique: true });
 gamificationSchema.index({ xp: -1 }); // for leaderboard
 
 // XP thresholds for levels

--- a/server/src/models/Referral.js
+++ b/server/src/models/Referral.js
@@ -174,7 +174,6 @@ referralSchema.methods.convertRegistrationCredit = function (referralEntryId) {
 };
 
 referralSchema.index({ referrerId: 1 }, { unique: true });
-referralSchema.index({ referralCode: 1 }, { unique: true });
 referralSchema.index({ 'referrals.referredEmail': 1 });
 referralSchema.index({ 'referrals.referredUserId': 1 });
 

--- a/server/src/models/ScholarlyArticle.js
+++ b/server/src/models/ScholarlyArticle.js
@@ -76,7 +76,6 @@ const scholarlyArticleSchema = new mongoose.Schema({
   timestamps: true
 });
 
-scholarlyArticleSchema.index({ doi: 1 });
 scholarlyArticleSchema.index({ title: 'text', journal: 'text' });
 
 // ============================================

--- a/server/src/models/Session.js
+++ b/server/src/models/Session.js
@@ -18,7 +18,7 @@ const sessionSchema = new mongoose.Schema({
   ip:       { type: String, default: '' },
   location: { type: String, default: '' },
   createdAt:  { type: Date, default: Date.now, index: true },
-  lastActive: { type: Date, default: Date.now, index: true },
+  lastActive: { type: Date, default: Date.now },
   revoked:   { type: Boolean, default: false },
   revokedAt: { type: Date,    default: null },
 }, { timestamps: false });


### PR DESCRIPTION
## Summary

Removes 4 duplicate Mongoose index declarations that were each producing a "Duplicate schema index" warning in the Render logs. In every case the field already had an index created another way; the redundant declaration is dropped while the effective index (and its options) is preserved.

| # | Field | Model | Removed | Index still created by |
|---|-------|-------|---------|------------------------|
| 1 | `userId` | `Gamification.js` | `gamificationSchema.index({ userId: 1 }, { unique: true })` | `unique: true` on the `userId` field def |
| 2 | `referralCode` | `Referral.js` | `referralSchema.index({ referralCode: 1 }, { unique: true })` | `unique: true` on the `referralCode` field def |
| 3 | `doi` | `ScholarlyArticle.js` | `scholarlyArticleSchema.index({ doi: 1 })` | `unique: true` on the `doi` field def |
| 4 | `lastActive` | `Session.js` | `index: true` on the field def | the TTL `sessionSchema.index({ lastActive: 1 }, { expireAfterSeconds: ... })` call — **kept** |

### Note on which side was removed
For #1–#3 the two declarations created an equivalent index, so the standalone `.index()` call was the redundant one to drop. For #4 they differed: the field-level `index: true` is a plain index, while the `.index()` call carries `expireAfterSeconds` (the 90-day TTL that expires old sessions). The `.index()` call **must** survive to preserve TTL behavior, so the field-level `index: true` is the one removed.

For #3, the field def is `unique` whereas the dropped `.index({ doi: 1 })` was non-unique — so the remaining index on `doi` stays **unique**, which is the stricter/correct constraint for a DOI.

## Verification

- `node --check` passes on all 4 model files.
- Confirmed each kept declaration is still present and each removed line is gone (grep counts).
- Diff: 4 files, **−4 / +1** (the +1 is the rewritten `lastActive` field line).

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_