### PR TITLE
Remove stray closing brace breaking CE planner inline script

### DIFF
--- a/client/public/ce-planner.html
+++ b/client/public/ce-planner.html
@@ -295,7 +295,6 @@
     }
 
     function printPlan(){window.print();}
-    }
 
     function esc(s){if(!s)return'';return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
     loadPlan();


### PR DESCRIPTION
## Summary

`client/public/ce-planner.html` had a stray closing brace `}` on line 298 — sitting on its own line between `function printPlan(){window.print();}` and `function esc(s){...}`. It had no matching opener, so it broke the inline `<script>` parse (extra `}` closed the surrounding scope prematurely). This deletes that one line.

## Diff

```diff
     function printPlan(){window.print();}
-    }
 
     function esc(s){if(!s)return'';return String(s).replace(/&/g,'&amp;')...}
```

## Verification

- **Brace balance** in the inline `<script>` block: **98 `{` / 98 `}` — balanced** (was imbalanced by the stray `}`).
- Extracted the inline script and ran `node --check` → parses cleanly.
- Lines 295–302 after the edit:
  ```
  295    }
  296
  297    function printPlan(){window.print();}
  298
  299    function esc(s){...}
  300    loadPlan();
  301  </script>
  302  </body>
  ```

Diff: 1 file, −1 line.

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_