### PR TITLE
Auto-switch credentials tab based on URL hash

### DIFF
--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -983,6 +983,14 @@
 
     // ── Init ──
     loadAll();
+
+    // Handle hash-based tab switching (e.g. #planning from ce-planner redirect)
+    if (location.hash) {
+      const tab = location.hash.replace('#', '');
+      if (document.getElementById('tab-' + tab)) {
+        switchTab(tab);
+      }
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Reads `location.hash` on page init and calls `switchTab()` if a matching tab button exists
- Enables `/credentials.html#planning` to auto-open the Planning tab (used by the `ce-planner.html` redirect landed in #483)
- Also works for `#certifications`, `#licenses`, or any future hash-linked tab

## Change

```diff
+    // Handle hash-based tab switching (e.g. #planning from ce-planner redirect)
+    if (location.hash) {
+      const tab = location.hash.replace('#', '');
+      if (document.getElementById('tab-' + tab)) {
+        switchTab(tab);
+      }
+    }
```

One file changed, 8 lines added.

https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT)_