### PR TITLE
Visual upgrade: stat cards with icon circles + enhanced credential cards

### DIFF
--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -11,6 +11,7 @@
     <script src="/js/tailwind-config.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.6.0/dist/tabler-icons.min.css">
 
     <style>
         body { font-family: 'Lato', 'Helvetica Neue', Arial, sans-serif; background: #F8F7F4; margin: 0; }
@@ -71,21 +72,33 @@
 
     <!-- Stats Row -->
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <div class="stat-card">
-            <div class="text-xs font-semibold uppercase tracking-wide mb-1" style="color:#4A7C59">Active Credentials</div>
-            <div class="text-3xl font-bold font-display" style="color:#6B1D34" id="activeCredentialsCount">-</div>
+        <div class="stat-card flex flex-col items-start gap-2">
+            <div style="width:48px;height:48px;border-radius:50%;background:#6B1D34;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                <i class="ti ti-rosette-discount-check" style="color:#fff;font-size:22px"></i>
+            </div>
+            <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="activeCredentialsCount">-</div>
+            <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Active Credentials</div>
         </div>
-        <div class="stat-card">
-            <div class="text-xs font-semibold uppercase tracking-wide mb-1" style="color:#4A7C59">CE Hours Logged</div>
-            <div class="text-3xl font-bold font-display" style="color:#6B1D34" id="ceHoursLogged">-</div>
+        <div class="stat-card flex flex-col items-start gap-2">
+            <div style="width:48px;height:48px;border-radius:50%;background:#4A7C59;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                <i class="ti ti-clock-hour-3" style="color:#fff;font-size:22px"></i>
+            </div>
+            <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="ceHoursLogged">-</div>
+            <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">CE Hours Logged</div>
         </div>
-        <div class="stat-card">
-            <div class="text-xs font-semibold uppercase tracking-wide mb-1" style="color:#4A7C59">Certificates</div>
-            <div class="text-3xl font-bold font-display" style="color:#6B1D34" id="certificatesCount">-</div>
+        <div class="stat-card flex flex-col items-start gap-2">
+            <div style="width:48px;height:48px;border-radius:50%;background:#284157;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                <i class="ti ti-certificate" style="color:#fff;font-size:22px"></i>
+            </div>
+            <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="certificatesCount">-</div>
+            <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Certificates</div>
         </div>
-        <div class="stat-card">
-            <div class="text-xs font-semibold uppercase tracking-wide mb-1" style="color:#D4A855">Renewals &lt; 1yr</div>
-            <div class="text-3xl font-bold font-display" style="color:#6B1D34" id="renewalsCount">-</div>
+        <div class="stat-card flex flex-col items-start gap-2">
+            <div style="width:48px;height:48px;border-radius:50%;background:#A67F2D;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                <i class="ti ti-alert-triangle" style="color:#fff;font-size:22px"></i>
+            </div>
+            <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="renewalsCount">-</div>
+            <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Renewals &lt; 1yr</div>
         </div>
     </div>
 
@@ -437,7 +450,9 @@
       const totalHrs=allCredentials.reduce((s,c)=>s+(c.totalCEUsCompleted||0),0);
       document.getElementById('ceHoursLogged').textContent=totalHrs%1===0?totalHrs:totalHrs.toFixed(1);
       const renewals=allCredentials.filter(c=>{if(!c.expirationDate)return false;const d=Math.ceil((new Date(c.expirationDate)-now)/864e5);return d>0&&d<=365}).length;
-      document.getElementById('renewalsCount').textContent=renewals;
+      const renewalsEl=document.getElementById('renewalsCount');
+      renewalsEl.textContent=renewals;
+      renewalsEl.style.color=renewals>0?'#D4A855':'#6B1D34';
     }
 
     // ── Render Credentials ──
@@ -452,72 +467,122 @@
         const now=new Date();
         const e=c.totalCEUsCompleted||0, r=c.totalCEUsRequired||0;
         const pct=r>0?Math.min(100,Math.round(e/r*100)):0;
-        const circumference=2*Math.PI*22; // r=22
-        const offset=circumference-(pct/100)*circumference;
         const days=c.expirationDate?Math.ceil((new Date(c.expirationDate)-now)/864e5):null;
-        const daysColor=days===null?'#78716c':days<=0?'#DC2626':days<=180?'#A67F2D':'#4A7C59';
-        const daysLabel=days===null?'No expiration':days<=0?'EXPIRED':days+' days';
-        const statusBadge=days===null||days>365?'badge-active':days<=0?'badge-expiring':'badge-expiring';
-        const statusText=days===null||days>0?'Active':'Expired';
+
+        // Urgency bucket
+        const isExpired=days!==null&&days<=0;
+        const isCritical=days!==null&&days>0&&days<=30;
+        const isUrgent=days!==null&&days>30&&days<=90;
+        const isExpiring=days!==null&&days>90&&days<=365;
+        const isOnTrack=days===null||days>365;
+
+        // Top border + ring color
+        const ringColor=isExpired||isCritical?'#E24B4A':isUrgent||isExpiring?'#D4A855':'#4A7C59';
+        const topBorder=isExpired||isCritical?'#E24B4A':isUrgent||isExpiring?'#D4A855':'#4A7C59';
+
+        // Status badge
+        let badgeBg,badgeColor,badgeText;
+        if(isExpired){badgeBg='#FEE2E2';badgeColor='#991B1B';badgeText='Expired';}
+        else if(isCritical){badgeBg='#FEE2E2';badgeColor='#991B1B';badgeText=days+' days left';}
+        else if(isUrgent||isExpiring){badgeBg='#FFF8E1';badgeColor='#A67F2D';badgeText=days+' days left';}
+        else{badgeBg='#E0ECE3';badgeColor='#2D4C37';badgeText='Active';}
+
+        // Days badge in top-right
+        const daysLabel=days===null?'No exp.':isExpired?'EXPIRED':days+' days';
+        const daysColor=isExpired||isCritical?'#E24B4A':isUrgent||isExpiring?'#D4A855':'#4A7C59';
+
         const expDate=c.expirationDate?new Date(c.expirationDate).toLocaleDateString('en-US',{month:'short',day:'numeric',year:'numeric'}):'N/A';
 
-        // Name
+        // 64px progress ring (r=28, circumference≈175.9)
+        const R=28,CX=32,CY=32;
+        const circ=2*Math.PI*R;
+        const offset=circ-(pct/100)*circ;
+
+        // Name & meta
         const name=c.code||c.name||c.credentialType||'Credential';
         const issuer=c.issuingBody||'';
         const licNum=c.licenseNumber?'#'+c.licenseNumber:'';
 
-        // Requirements breakdown
-        let reqHtml='';
+        // Credential type icon
+        const credType=(c.credentialType||c.code||'').toUpperCase();
+        const isLicense=['LPC','LCSW','LMFT','LPCC','LAC','LAPC','LSW'].some(t=>credType.includes(t));
+        const typeIcon=isLicense?'ti-shield-check':'ti-award';
+
+        // Category pills
+        let pillsHtml='';
         if(c.requirements&&c.requirements.length){
-          reqHtml=c.requirements.map(rq=>{
+          pillsHtml='<div class="flex flex-wrap gap-1.5 mt-3">'+c.requirements.map(rq=>{
             const done=rq.hoursCompleted||0,need=rq.hoursRequired||0;
+            const cat=(rq.category||'').toLowerCase();
+            let bg,color;
+            if(cat==='ethics'||cat==='ethics & boundaries'){bg='#FDF5F7';color='#6B1D34';}
+            else if(cat==='total'||cat==='general'||cat==='core'){bg='#F2F7F4';color='#2D4C37';}
+            else{bg='#EEF2F5';color='#284157';}
             const met=done>=need;
-            return`<span style="color:#57534e">${esc(rq.category)}</span>
-              <div class="flex items-center gap-2">
-                <span style="color:#284157;font-weight:600">${done}/${need}</span>
-                ${met?'<svg class="w-3.5 h-3.5" style="color:#4A7C59" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>':'<span style="color:#DC2626;font-size:10px;font-weight:600">'+(need-done)+' left</span>'}
-              </div>`;
-          }).join('');
+            return`<span style="background:${bg};color:${color};font-size:11px;font-weight:600;padding:3px 9px;border-radius:20px;display:inline-flex;align-items:center;gap:4px">
+              ${esc(rq.category)}: ${done}/${need}
+              ${met?'<i class="ti ti-check" style="font-size:10px;color:#4A7C59"></i>':''}
+            </span>`;
+          }).join('')+'</div>';
         }
 
-        return`<div class="cred-card">
+        // "Find courses" button for urgent/critical
+        const findCoursesBtn=(isCritical||isUrgent)?`<a href="/courses.html" class="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg mt-2" style="background:#E0ECE3;color:#2D4C37;text-decoration:none"><i class="ti ti-search"></i>Find courses</a>`:'';
+
+        return`<div class="cred-card" style="border-top:3px solid ${topBorder};padding-top:17px">
           <div class="flex items-start justify-between mb-3">
-            <div class="flex items-center gap-3">
-              <div class="relative flex-shrink-0" style="width:52px;height:52px">
-                <svg width="52" height="52" viewBox="0 0 52 52">
-                  <circle cx="26" cy="26" r="22" fill="none" stroke="#E0ECE3" stroke-width="4"/>
-                  <circle cx="26" cy="26" r="22" fill="none" stroke="${pct>=100?'#4A7C59':pct>=50?'#D4A855':'#6B1D34'}" stroke-width="4"
-                    stroke-dasharray="${circumference}" stroke-dashoffset="${offset}" class="progress-ring-circle"/>
+            <div class="flex items-start gap-3">
+              <!-- 64px progress ring -->
+              <div class="relative flex-shrink-0" style="width:64px;height:64px">
+                <svg width="64" height="64" viewBox="0 0 64 64">
+                  <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="#E7E5E4" stroke-width="5"/>
+                  <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="${ringColor}" stroke-width="5"
+                    stroke-dasharray="${circ.toFixed(2)}" stroke-dashoffset="${offset.toFixed(2)}" class="progress-ring-circle"/>
                 </svg>
-                <span class="absolute inset-0 flex items-center justify-center text-xs font-bold" style="color:${pct>=100?'#4A7C59':pct>=50?'#D4A855':'#6B1D34'}">${pct}%</span>
+                <div class="absolute inset-0 flex flex-col items-center justify-center">
+                  <span style="font-size:13px;font-weight:700;line-height:1;color:${ringColor}">${pct}%</span>
+                  <span style="font-size:9px;color:#a8a29e;line-height:1;margin-top:2px">complete</span>
+                </div>
               </div>
-              <div>
-                <h3 class="font-display font-bold text-lg leading-tight" style="color:#6B1D34">${esc(name)}</h3>
-                ${issuer?'<div class="text-xs mt-0.5" style="color:#78716c">'+esc(issuer)+'</div>':''}
+              <div class="min-w-0">
+                <div class="flex items-center gap-1.5 mb-0.5">
+                  <i class="ti ${typeIcon}" style="color:#6B1D34;font-size:14px"></i>
+                  <h3 class="font-display font-bold text-lg leading-tight" style="color:#6B1D34">${esc(name)}</h3>
+                </div>
+                ${issuer?'<div class="text-xs" style="color:#78716c">'+esc(issuer)+'</div>':''}
                 ${licNum?'<div class="text-xs font-medium" style="color:#284157">'+esc(licNum)+'</div>':''}
+                <span style="background:${badgeBg};color:${badgeColor};font-size:11px;font-weight:700;padding:2px 9px;border-radius:20px;display:inline-block;margin-top:4px">${badgeText}</span>
               </div>
             </div>
-            <div class="flex flex-col items-end gap-1.5">
-              <span class="${statusBadge}">${statusText}</span>
-              <button class="log-ceu-btn" onclick="openLogModal('${c._id}','${esc(name)}')">Log CEU</button>
+            <!-- Days badge + actions -->
+            <div class="flex flex-col items-end gap-2 flex-shrink-0">
+              <div class="flex items-center gap-1 text-xs font-semibold" style="color:${daysColor}">
+                <i class="ti ti-calendar" style="font-size:13px"></i>
+                ${daysLabel}
+              </div>
+              <button class="log-ceu-btn" onclick="openLogModal('${c._id}','${esc(name)}')"><i class="ti ti-plus" style="font-size:11px"></i> Log CEU</button>
             </div>
           </div>
-          <div class="text-xs mb-3 flex items-center gap-1.5" style="color:#78716c">
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-            Expires ${expDate} <span style="color:${daysColor};font-weight:600">(${daysLabel})</span>
+          <div class="text-xs mb-1 flex items-center gap-1.5" style="color:#78716c">
+            <i class="ti ti-calendar-event" style="font-size:12px"></i>
+            Expires ${expDate}
           </div>
-          <div class="border-t border-stone-100 pt-3 space-y-2">
-            <div class="flex justify-between text-xs mb-1">
-              <span style="color:#284157;font-weight:700">${e}</span>
-              <span style="color:#78716c">/${r} CE hours</span>
+          <div class="border-t border-stone-100 pt-3">
+            <div class="flex justify-between text-xs mb-1.5">
+              <span style="color:#284157;font-weight:700">${e} hrs logged</span>
+              <span style="color:#78716c">${r} required</span>
             </div>
-            ${reqHtml?'<div class="flex items-center justify-between text-xs flex-wrap gap-y-1">'+reqHtml+'</div>':''}
+            <div class="w-full rounded-full" style="background:#e7e5e4;height:5px">
+              <div class="rounded-full progress-ring-circle" style="width:${Math.min(100,pct)}%;height:5px;background:${ringColor}"></div>
+            </div>
+            ${pillsHtml}
+            ${findCoursesBtn}
           </div>
         </div>`;
       }).join('')+`
         <div class="cred-card flex flex-col items-center justify-center text-center" style="border-style:dashed;border-color:#C2D9C8;cursor:pointer;min-height:180px" onclick="openAddModal()">
           <div style="width:40px;height:40px;border-radius:50%;background:#E0ECE3;display:flex;align-items:center;justify-content:center;margin:0 auto 10px">
-            <svg class="w-5 h-5" style="color:#4A7C59" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+            <i class="ti ti-plus" style="color:#4A7C59;font-size:20px"></i>
           </div>
           <p class="text-sm font-semibold" style="color:#4A7C59">Add Credential</p>
           <p class="text-xs mt-1" style="color:#a8a29e">License, certification, or NCC</p>


### PR DESCRIPTION
## Summary

- **Stat cards**: 48px brand-colored icon circles (burgundy `#6B1D34`, hunter green `#4A7C59`, navy `#284157`, gold `#A67F2D`) with white Tabler icons; numbers bumped to `text-2xl`; icon above number above label; renewals count turns gold when > 0. No gradients — white card background, stone border unchanged.
- **Credential cards**: 64px SVG progress ring (color = red for expired/critical, gold for urgent/expiring, green for on-track), 3px urgency-colored top border, credential-type icon (shield-check for state licenses, award for certs/NCC), inline status badge, category pills with color-coded backgrounds (ethics=pink/burgundy, total/general/core=green, other=light blue/navy), calendar+days badge in top-right, "Find courses" button on critical/urgent cards.
- **Tabler Icons CDN**: `@tabler/icons-webfont@3.6.0` added to `<head>`.

## Verification

- JS brace balance: **277 opens / 277 closes (delta 0)**
- Only `client/public/credentials.html` changed — 1 file, +117 / -52
- All existing functionality preserved (modals, sync, log CEU, scan)

https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT)_