### PR TITLE
fix: credential card cleanup — vertical line, icon fallbacks, layout

### DIFF
--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -74,28 +74,32 @@
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <div class="stat-card flex flex-col items-start gap-2">
             <div style="width:48px;height:48px;border-radius:50%;background:#6B1D34;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                <i class="ti ti-rosette-discount-check" style="color:#fff;font-size:22px"></i>
+                <!-- shield-check -->
+                <svg width="22" height="22" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M12 3L4 7v5c0 5 3.6 9.3 8 10.3C16.4 21.3 20 17 20 12V7L12 3z"/><path d="M9 12l2 2 4-4"/></svg>
             </div>
             <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="activeCredentialsCount">-</div>
             <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Active Credentials</div>
         </div>
         <div class="stat-card flex flex-col items-start gap-2">
             <div style="width:48px;height:48px;border-radius:50%;background:#4A7C59;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                <i class="ti ti-clock-hour-3" style="color:#fff;font-size:22px"></i>
+                <!-- clock -->
+                <svg width="22" height="22" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
             </div>
             <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="ceHoursLogged">-</div>
             <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">CE Hours Logged</div>
         </div>
         <div class="stat-card flex flex-col items-start gap-2">
             <div style="width:48px;height:48px;border-radius:50%;background:#284157;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                <i class="ti ti-certificate" style="color:#fff;font-size:22px"></i>
+                <!-- certificate / ribbon document -->
+                <svg width="22" height="22" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M14 3H6a2 2 0 00-2 2v14a2 2 0 002 2h12a2 2 0 002-2V9l-6-6z"/><path d="M14 3v6h6"/><circle cx="12" cy="15" r="2"/><path d="M10 20v-1.5a2 2 0 014 0V20"/></svg>
             </div>
             <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="certificatesCount">-</div>
             <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Certificates</div>
         </div>
         <div class="stat-card flex flex-col items-start gap-2">
             <div style="width:48px;height:48px;border-radius:50%;background:#A67F2D;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                <i class="ti ti-alert-triangle" style="color:#fff;font-size:22px"></i>
+                <!-- warning triangle -->
+                <svg width="22" height="22" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/></svg>
             </div>
             <div class="text-2xl font-bold font-display" style="color:#6B1D34" id="renewalsCount">-</div>
             <div class="text-xs font-semibold uppercase tracking-wide" style="color:#78716c">Renewals &lt; 1yr</div>
@@ -126,7 +130,7 @@
             <!-- Credentials Tab -->
             <div id="content-licenses" class="tab-content">
                 <div id="credLoading" class="text-center py-12"><div style="width:36px;height:36px;border:3px solid #e7e5e4;border-top-color:#6B1D34;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 12px"></div><p class="text-stone-400 text-sm">Loading credentials...</p></div>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5" id="credentialsGrid"></div>
+                <div id="credentialsGrid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:20px"></div>
             </div>
 
             <!-- CE Certificates Tab -->
@@ -529,54 +533,48 @@
         // "Find courses" button for urgent/critical
         const findCoursesBtn=(isCritical||isUrgent)?`<a href="/courses.html" class="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg mt-2" style="background:#E0ECE3;color:#2D4C37;text-decoration:none"><i class="ti ti-search"></i>Find courses</a>`:'';
 
-        return`<div class="cred-card" style="border-top:3px solid ${topBorder};padding-top:17px">
-          <div class="flex items-start justify-between mb-3">
-            <div class="flex items-start gap-3">
-              <!-- 64px progress ring -->
-              <div class="relative flex-shrink-0" style="width:64px;height:64px">
-                <svg width="64" height="64" viewBox="0 0 64 64">
-                  <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="#E7E5E4" stroke-width="5"/>
-                  <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="${ringColor}" stroke-width="5"
-                    stroke-dasharray="${circ.toFixed(2)}" stroke-dashoffset="${offset.toFixed(2)}" class="progress-ring-circle"/>
-                </svg>
-                <div class="absolute inset-0 flex flex-col items-center justify-center">
-                  <span style="font-size:13px;font-weight:700;line-height:1;color:${ringColor}">${pct}%</span>
-                  <span style="font-size:9px;color:#a8a29e;line-height:1;margin-top:2px">complete</span>
-                </div>
-              </div>
-              <div class="min-w-0">
-                <div class="flex items-center gap-1.5 mb-0.5">
-                  <i class="ti ${typeIcon}" style="color:#6B1D34;font-size:14px"></i>
-                  <h3 class="font-display font-bold text-lg leading-tight" style="color:#6B1D34">${esc(name)}</h3>
-                </div>
-                ${issuer?'<div class="text-xs" style="color:#78716c">'+esc(issuer)+'</div>':''}
-                ${licNum?'<div class="text-xs font-medium" style="color:#284157">'+esc(licNum)+'</div>':''}
-                <span style="background:${badgeBg};color:${badgeColor};font-size:11px;font-weight:700;padding:2px 9px;border-radius:20px;display:inline-block;margin-top:4px">${badgeText}</span>
+        return`<div class="cred-card" style="border-top:3px solid ${topBorder};padding-top:17px;display:flex;flex-direction:column">
+          <!-- Header: progress ring + name block -->
+          <div class="flex items-start gap-3 mb-3">
+            <!-- 64px progress ring -->
+            <div class="relative flex-shrink-0" style="width:64px;height:64px">
+              <svg width="64" height="64" viewBox="0 0 64 64">
+                <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="#E7E5E4" stroke-width="5"/>
+                <circle cx="${CX}" cy="${CY}" r="${R}" fill="none" stroke="${ringColor}" stroke-width="5"
+                  stroke-dasharray="${circ.toFixed(2)}" stroke-dashoffset="${offset.toFixed(2)}" class="progress-ring-circle"/>
+              </svg>
+              <div class="absolute inset-0 flex flex-col items-center justify-center">
+                <span style="font-size:13px;font-weight:700;line-height:1;color:${ringColor}">${pct}%</span>
+                <span style="font-size:9px;color:#a8a29e;line-height:1;margin-top:2px">complete</span>
               </div>
             </div>
-            <!-- Days badge + actions -->
-            <div class="flex flex-col items-end gap-2 flex-shrink-0">
-              <div class="flex items-center gap-1 text-xs font-semibold" style="color:${daysColor}">
-                <i class="ti ti-calendar" style="font-size:13px"></i>
-                ${daysLabel}
-              </div>
-              <button class="log-ceu-btn" onclick="openLogModal('${c._id}','${esc(name)}')"><i class="ti ti-plus" style="font-size:11px"></i> Log CEU</button>
+            <div style="min-width:0;flex:1">
+              <h3 class="font-display font-bold text-lg" style="color:#6B1D34;line-height:1.25;word-break:break-word">${esc(name)}</h3>
+              ${issuer?'<div class="text-xs mt-0.5" style="color:#78716c">'+esc(issuer)+'</div>':''}
+              ${licNum?'<div class="text-xs font-medium" style="color:#284157">'+esc(licNum)+'</div>':''}
+              <span style="background:${badgeBg};color:${badgeColor};font-size:11px;font-weight:700;padding:2px 9px;border-radius:20px;display:inline-block;margin-top:5px">${badgeText}</span>
             </div>
           </div>
-          <div class="text-xs mb-1 flex items-center gap-1.5" style="color:#78716c">
-            <i class="ti ti-calendar-event" style="font-size:12px"></i>
-            Expires ${expDate}
-          </div>
-          <div class="border-t border-stone-100 pt-3">
+          <!-- Expiry line -->
+          <div class="text-xs mb-3" style="color:#78716c">Expires ${expDate}</div>
+          <!-- Hours bar -->
+          <div class="border-t border-stone-100 pt-3 mb-3">
             <div class="flex justify-between text-xs mb-1.5">
               <span style="color:#284157;font-weight:700">${e} hrs logged</span>
               <span style="color:#78716c">${r} required</span>
             </div>
             <div class="w-full rounded-full" style="background:#e7e5e4;height:5px">
-              <div class="rounded-full progress-ring-circle" style="width:${Math.min(100,pct)}%;height:5px;background:${ringColor}"></div>
+              <div class="rounded-full" style="width:${Math.min(100,pct)}%;height:5px;background:${ringColor};transition:width .5s ease"></div>
             </div>
             ${pillsHtml}
-            ${findCoursesBtn}
+          </div>
+          <!-- Footer: days badge left, actions right -->
+          <div class="flex items-center justify-between mt-auto pt-2 border-t border-stone-100">
+            <div class="text-xs font-semibold" style="color:${daysColor}">${daysLabel}</div>
+            <div class="flex items-center gap-2">
+              ${findCoursesBtn}
+              <button class="log-ceu-btn" onclick="openLogModal('${c._id}','${esc(name)}')">+ Log CEU</button>
+            </div>
           </div>
         </div>`;
       }).join('')+`


### PR DESCRIPTION
## Three fixes in one file

### 1. Vertical line removed
The progress bar `div` had `class="rounded-full progress-ring-circle"` — the `.progress-ring-circle` CSS rule applies `transform:rotate(-90deg)`, which rotated the 5px-tall horizontal bar 90° into a vertical line cutting through the card. Fixed by removing that class; the bar's own `transition:width .5s ease` is inlined instead.

### 2. Stat card icons — inline SVG fallback
The Tabler Icons CDN link is correct and kept in `<head>` for other icon usages in the page. The four stat card circles now use inline SVGs (no CDN dependency) so they always render:
- Burgundy circle: shield with checkmark (Active Credentials)
- Green circle: clock (CE Hours Logged)
- Navy circle: document with ribbon (Certificates)
- Gold circle: warning triangle (Renewals < 1yr)

### 3. Credential card layout de-cramped
- Grid: fixed `grid-cols-3` → `minmax(320px, 1fr)` auto-fill
- Removed top-right column that squeezed days badge and Log CEU button next to the name
- New footer row: days label flush left, "Find courses" + "Log CEU" flush right
- Credential name: `word-break:break-word`, no truncation

## Visual hierarchy top-to-bottom (per card)
1. **3px urgency top border** (green / gold / red)
2. **Header row**: 64px progress ring (% + "complete") | credential name (wraps) + issuer + license # + status badge
3. **Expiry line**: "Expires Mon DD, YYYY" in secondary text
4. **Divider** then hours bar: "X hrs logged" ←→ "Y required", 5px progress fill
5. **Category pills** (if requirements exist): ethics=pink, general/core=green, other=blue
6. **Divider** then **footer**: days-remaining label | [Find courses] [+ Log CEU]

1 file changed, +40 / -42.

https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT)_