### PR TITLE
feat: certificate cards — responsive grid with colored top borders

### DIFF
--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -136,7 +136,7 @@
             <!-- CE Certificates Tab -->
             <div id="content-certifications" class="tab-content hidden">
                 <div id="certLoading" class="text-center py-12"><div style="width:36px;height:36px;border:3px solid #e7e5e4;border-top-color:#6B1D34;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 12px"></div><p class="text-stone-400 text-sm">Loading certificates...</p></div>
-                <div id="certificatesGrid" class="space-y-3"></div>
+                <div id="certificatesGrid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:12px"></div>
             </div>
 
             <!-- CE Planning Tab -->
@@ -601,20 +601,30 @@
         const cat=c.category||'General';
         const provider=c.provider||'CounselorReady';
         const nbcc=c.nbccApproved;
-        return`<div class="bg-white rounded-xl border border-stone-200 p-4 flex items-center gap-4 hover:border-hunter-300 transition-colors">
-          <div style="width:44px;height:44px;border-radius:10px;background:#E0ECE3;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-            <svg class="w-5 h-5" style="color:#4A7C59" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+
+        // Top border color by content type
+        const area=(c.contentArea||c.type||cat||'').toLowerCase();
+        let topBorder='#4A7C59';
+        if(area.includes('ethics'))topBorder='#6B1D34';
+        else if(area.includes('supervis')||area.includes('telehealth'))topBorder='#284157';
+
+        // Category badge colors
+        let catBg='#E0ECE3',catColor='#2D4C37';
+        if(area.includes('ethics')){catBg='#FAE8EB';catColor='#6B1D34';}
+        else if(area.includes('supervis')||area.includes('telehealth')){catBg='#EEF2F5';catColor='#284157';}
+
+        return`<div style="background:#fff;border-radius:12px;border:0.5px solid #e7e5e4;border-top:3px solid ${topBorder};padding:1rem;display:flex;flex-direction:column">
+          <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
+            <span style="background:${catBg};color:${catColor};font-size:11px;font-weight:600;padding:2px 9px;border-radius:20px">${esc(cat)}</span>
+            <span style="background:#FFF8E1;color:#876520;font-size:11px;font-weight:700;padding:2px 9px;border-radius:20px">${hrs} CE</span>
+            ${nbcc?'<span style="background:#E0ECE3;color:#2D4C37;font-size:11px;font-weight:600;padding:2px 9px;border-radius:20px">NBCC</span>':''}
           </div>
-          <div class="flex-1 min-w-0">
-            <p class="text-sm font-semibold truncate" style="color:#6B1D34">${esc(c.title||'Certificate')}</p>
-            <p class="text-xs" style="color:#78716c">${esc(provider)} &middot; ${date}</p>
+          <p style="font-size:13px;font-weight:500;color:#284157;margin:8px 0 0;line-height:1.4;word-break:break-word">${esc(c.title||'Certificate')}</p>
+          <p style="font-size:11px;color:#78716c;margin:4px 0 0">${esc(provider)}${date?' &middot; '+date:''}</p>
+          <div style="margin-top:10px;display:flex;align-items:center;gap:12px">
+            ${c.certificateNumber?`<a href="/api/certificates/${c._id}/download" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#4A7C59;text-decoration:none"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a>`:''}
+            <a href="/interactive-course.html?cert=${c._id}" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#284157;text-decoration:none"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>View</a>
           </div>
-          <div class="flex items-center gap-2 flex-shrink-0">
-            <span style="background:#FFF8E1;color:#876520;font-size:11px;font-weight:700;padding:3px 10px;border-radius:20px">${hrs} CE</span>
-            <span style="background:#FAE8EB;color:#6B1D34;font-size:11px;font-weight:600;padding:3px 10px;border-radius:20px">${esc(cat)}</span>
-            ${nbcc?'<span style="background:#E0ECE3;color:#2D4C37;font-size:11px;font-weight:600;padding:3px 10px;border-radius:20px">NBCC</span>':''}
-          </div>
-          ${c.certificateNumber?'<a href="/api/certificates/'+c._id+'/download" class="text-xs font-semibold" style="color:#4A7C59;white-space:nowrap">Download</a>':''}
         </div>`;
       }).join('');
     }


### PR DESCRIPTION
## Summary

- Switches `certificatesGrid` container from `space-y-3` list to CSS grid (`auto-fill, minmax(280px, 1fr), gap 12px`)
- Vertical card layout (top to bottom): badges row → title → provider/date → action row
- 3px colored top border derived from `contentArea` → `type` → `category`:
  - `ethics` → `#6B1D34` (burgundy)
  - `supervision` / `telehealth` → `#284157` (navy)
  - default → `#4A7C59` (hunter green)
- Category badge color matches top border
- Action row uses inline SVGs (no CDN dependency, consistent with fix from #487): arrow-down for Download, eye for View
- Download href preserves existing `/api/certificates/:id/download`

## Scope

Only `renderCertificates` and its container div changed. Licenses tab and CE Planning tab untouched.

1 file changed, +23 / -13.

https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT)_