### PR TITLE
Add audit disclaimer to onboarding welcome page

### DIFF
--- a/client/public/welcome.html
+++ b/client/public/welcome.html
@@ -62,9 +62,14 @@
           <span class="text-burgundy-800">Counselor</span><span class="text-hunter-600">Ready</span>
         </span>
       </div>
-      <a href="/dashboard.html" class="text-forest-600 hover:text-forest-800 text-sm font-medium">
-        Skip to Dashboard →
-      </a>
+      <div style="text-align:right">
+        <a href="/dashboard.html" class="text-forest-600 hover:text-forest-800 text-sm font-medium">
+          Skip to Dashboard →
+        </a>
+        <p style="font-size:10px;color:#A67F2D;max-width:220px;margin-top:4px;line-height:1.3">
+          Skipping credential setup means we cannot advocate on your behalf in the event of a board audit.
+        </p>
+      </div>
     </div>
   </header>
 
@@ -128,6 +133,9 @@
                 Enter <code class="bg-white px-1.5 py-0.5 rounded text-burgundy-700 font-semibold text-xs">PRELICENSED</code>
                 in the license field. Certificates will reflect your status at completion and cannot be changed retroactively &mdash;
                 update your license number as soon as you're licensed.
+              </p>
+              <p class="text-sm text-burgundy-800 font-semibold mt-3" style="border-top:1px solid #fde68a;padding-top:8px">
+                ⚠ If you skip this step, CounselorReady cannot advocate on your behalf in the event of a board audit. We strongly recommend completing this before starting any courses.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds a small gold-text disclaimer beneath the "Skip to Dashboard" header link, warning that skipping credential setup means CounselorReady cannot advocate in a board audit
- Adds the same warning (bold, with yellow top border) inside the "Why we need this" callout in Step 1 (Add Your First Credential)

## Files changed
- `client/public/welcome.html` — 11 insertions, 3 deletions (1 file)

https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGadCifEz3rAgdZ2pDD1uT)_