### PR TITLE
Show error banner when dashboard loadStats fails

### DIFF
--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -159,7 +159,17 @@
 
       // Courses completed
       if(pR?.ok){const p=await pR.json();const list=p.data||(Array.isArray(p)?p:[]);document.getElementById('coursesCompleted').textContent=list.filter(x=>x.status==='completed'||x.status==='certified').length;renderCourses(list);}
-    }catch(e){console.error('Dashboard loadStats error:',e);}}
+    }catch(e){
+    console.error('Dashboard loadStats error:',e);
+    const main = document.querySelector('main');
+    if (main) {
+      const banner = document.createElement('div');
+      banner.className = 'mb-6 p-4 rounded-xl text-center';
+      banner.style.cssText = 'background:#FDF5F7;border:1px solid #F5D0D6;color:#6B1D34';
+      banner.innerHTML = '<p class="text-sm font-medium">Unable to load your data right now. <button onclick="location.reload()" class="underline font-semibold">Try again</button></p>';
+      main.prepend(banner);
+    }
+  }}
 
     function credLabel(x){
       const generic=['state_license','national_cert','specialty_cert','training','custom','other'];


### PR DESCRIPTION
## Summary

Adds a visible error state to the dashboard. Previously, if `loadStats()` failed, the error was only logged to the console and the user saw a silently empty dashboard. Now the `catch` block also prepends an error banner to `<main>` with a **Try again** button that reloads the page.

## Scope

Patched **only** the `loadStats()` `catch` block in `client/public/dashboard.html`. The function-closing brace was preserved (the original line was `}catch(e){...}}` — catch close + function close).

```diff
-    }catch(e){console.error('Dashboard loadStats error:',e);}}
+    }catch(e){
+    console.error('Dashboard loadStats error:',e);
+    const main = document.querySelector('main');
+    if (main) {
+      const banner = document.createElement('div');
+      banner.className = 'mb-6 p-4 rounded-xl text-center';
+      banner.style.cssText = 'background:#FDF5F7;border:1px solid #F5D0D6;color:#6B1D34';
+      banner.innerHTML = '<p class="text-sm font-medium">Unable to load your data right now. <button onclick="location.reload()" class="underline font-semibold">Try again</button></p>';
+      main.prepend(banner);
+    }
+  }}
```

The banner uses the brand burgundy palette (`#6B1D34` / `#FDF5F7`), consistent with the rest of the platform.

## Verification

- Extracted the inline `<script>` and ran `node --check` → parses cleanly (function/brace structure intact).
- `loadStats` error log still present exactly once.
- Diff: 1 file, +11 / −1.

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_