### PR TITLE
Add meta descriptions and OG tags to 9 tool pages

### DIFF
--- a/client/public/tools/consent-generator.html
+++ b/client/public/tools/consent-generator.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Informed Consent Generator — CounselorReady</title>
+<meta name="description" content="Free informed consent form generator for therapists. Create customized consent documents for your practice including telehealth provisions.">
+<meta property="og:title" content="Informed Consent Generator — CounselorReady">
+<meta property="og:description" content="Generate customized informed consent forms for your counseling practice. Free tool.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--green-light:#5A9469;--green-deep:#345640;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/diagnostic-helper.html
+++ b/client/public/tools/diagnostic-helper.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Diagnostic Impressions Helper — CounselorReady</title>
+<meta name="description" content="Free diagnostic assessment helper for clinicians. Explore DSM-5 criteria with differential diagnosis support and clinical decision trees.">
+<meta property="og:title" content="Diagnostic Helper — CounselorReady">
+<meta property="og:description" content="Explore DSM-5 criteria with differential diagnosis support. Free clinical decision tool.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--green-light:#5A9469;--green-deep:#345640;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/hold-guide.html
+++ b/client/public/tools/hold-guide.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>State Involuntary Hold Guide — CounselorReady</title>
+<meta name="description" content="Free involuntary hold reference guide for clinicians. State-by-state criteria, timelines, and procedures for emergency psychiatric holds.">
+<meta property="og:title" content="Involuntary Hold Guide — CounselorReady">
+<meta property="og:description" content="State-by-state involuntary hold criteria, timelines, and procedures for mental health clinicians.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root {

--- a/client/public/tools/note-writer.html
+++ b/client/public/tools/note-writer.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Clinical Note Writer — CounselorReady</title>
+<meta name="description" content="Free AI-powered clinical note writer for therapists. Generate SOAP, DAP, and BIRP notes in seconds. No signup required.">
+<meta property="og:title" content="Free Clinical Note Writer — CounselorReady">
+<meta property="og:description" content="AI-powered clinical note writer for therapists. Generate SOAP, DAP, and BIRP notes in seconds.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/safety-plan.html
+++ b/client/public/tools/safety-plan.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Crisis Safety Plan Builder — CounselorReady</title>
+<meta name="description" content="Free safety plan builder for clinicians. Create collaborative crisis safety plans following the Stanley-Brown model.">
+<meta property="og:title" content="Safety Plan Builder — CounselorReady">
+<meta property="og:description" content="Build collaborative crisis safety plans with clients. Stanley-Brown model. Free for clinicians.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/sliding-scale.html
+++ b/client/public/tools/sliding-scale.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Sliding Scale Fee Calculator — CounselorReady</title>
+<meta name="description" content="Free sliding scale fee calculator for therapists in private practice. Set fair rates based on client income and household size.">
+<meta property="og:title" content="Sliding Scale Calculator — CounselorReady">
+<meta property="og:description" content="Calculate fair therapy rates based on client income. Free tool for counselors in private practice.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/startup-checklist.html
+++ b/client/public/tools/startup-checklist.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Private Practice Startup Checklist — CounselorReady</title>
+<meta name="description" content="Free private practice startup checklist for therapists. Step-by-step guide covering licensing, business setup, insurance paneling, and marketing.">
+<meta property="og:title" content="Practice Startup Checklist — CounselorReady">
+<meta property="og:description" content="Step-by-step private practice startup guide for therapists. Licensing, business setup, insurance, and marketing.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/superbill.html
+++ b/client/public/tools/superbill.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Superbill Generator — CounselorReady</title>
+<meta name="description" content="Free superbill generator for therapists. Create professional insurance reimbursement forms with CPT and ICD-10 codes.">
+<meta property="og:title" content="Superbill Generator — CounselorReady">
+<meta property="og:description" content="Generate professional superbills with CPT and ICD-10 codes. Free tool for therapists.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}

--- a/client/public/tools/treatment-plan.html
+++ b/client/public/tools/treatment-plan.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Treatment Plan Builder — CounselorReady</title>
+<meta name="description" content="Free treatment plan builder for therapists. Generate evidence-based treatment plans with goals, objectives, and interventions.">
+<meta property="og:title" content="Treatment Plan Builder — CounselorReady">
+<meta property="og:description" content="Generate evidence-based treatment plans with goals, objectives, and interventions. Free for clinicians.">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
 <style>
 :root{--burgundy:#6B1D34;--burgundy-light:#8B3A54;--burgundy-deep:#4A1224;--rose:#D0768A;--green:#4A7C59;--green-light:#5A9469;--green-deep:#345640;--gold:#D4A855;--navy:#284157;--navy-deep:#1A2D3D;--stone:#EDEADF;--cream:#F9F6EF}


### PR DESCRIPTION
## Summary

Adds SEO metadata to all 9 free clinical tool pages under `client/public/tools/`. For each page, a `meta description`, `og:title`, and `og:description` were inserted directly after the existing `<title>` tag (none had these before).

| Page | OG title |
|------|----------|
| `note-writer.html` | Free Clinical Note Writer — CounselorReady |
| `hold-guide.html` | Involuntary Hold Guide — CounselorReady |
| `sliding-scale.html` | Sliding Scale Calculator — CounselorReady |
| `superbill.html` | Superbill Generator — CounselorReady |
| `safety-plan.html` | Safety Plan Builder — CounselorReady |
| `treatment-plan.html` | Treatment Plan Builder — CounselorReady |
| `consent-generator.html` | Informed Consent Generator — CounselorReady |
| `diagnostic-helper.html` | Diagnostic Helper — CounselorReady |
| `startup-checklist.html` | Practice Startup Checklist — CounselorReady |

## Verification

- Every page has exactly **1** `meta description`, **1** `og:title`, **1** `og:description` (confirmed per file).
- Insert point verified against each page's real `<title>` line before editing.
- Diff: 9 files, **+27 / −0** (3 lines per page, additions only).

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_