### PR TITLE
Add dynamic SEO meta to course-details; OG tags to courses catalog

### DIFF
--- a/client/public/course-details.html
+++ b/client/public/course-details.html
@@ -444,6 +444,27 @@
       
       // Set page title
       document.title = `${currentCourse.title} - CounselorReady`;
+
+      // Dynamic SEO meta tags
+      const ceHours = currentCourse.ceHours || currentCourse.ceuHours || '';
+      const seoDesc = currentCourse.description
+        ? currentCourse.description.substring(0, 155) + (currentCourse.description.length > 155 ? '...' : '')
+        : `${ceHours} CE hour${ceHours !== 1 ? 's' : ''} — NBCC-approved continuing education course for licensed counselors.`;
+
+      function setMeta(name, content, property) {
+        const attr = property ? 'property' : 'name';
+        const val = property || name;
+        let el = document.querySelector(`meta[${attr}="${val}"]`);
+        if (!el) { el = document.createElement('meta'); el.setAttribute(attr, val); document.head.appendChild(el); }
+        el.setAttribute('content', content);
+      }
+
+      setMeta('description', seoDesc);
+      setMeta(null, currentCourse.title + ' — CounselorReady CE Course', 'og:title');
+      setMeta(null, seoDesc, 'og:description');
+      setMeta(null, 'article', 'og:type');
+      setMeta(null, window.location.href, 'og:url');
+      if (currentCourse.thumbnail) setMeta(null, currentCourse.thumbnail, 'og:image');
       
       // Basic info
       document.getElementById('courseTitle').textContent = currentCourse.title;

--- a/client/public/courses.html
+++ b/client/public/courses.html
@@ -6,6 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Courses - CounselorReady</title>
   <meta name="description" content="Browse NBCC-approved continuing education courses for licensed counselors. Earn CE hours online at your own pace.">
+  <meta property="og:title" content="CE Courses for Counselors — CounselorReady">
+  <meta property="og:description" content="NBCC-approved continuing education courses. Earn CE hours online at your own pace.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://counselorready.com/courses.html">
   <link rel="stylesheet" href="/css/design-tokens.css">
   <link rel="stylesheet" href="/css/typography.css">
   <script src="https://cdn.tailwindcss.com/3.4.17"></script>


### PR DESCRIPTION
## Summary

Adds SEO/Open Graph metadata to the course pages.

### `course-details.html` (dynamic)
After `document.title` is set, a block now creates-or-updates meta tags from the loaded course object: `description` (course description truncated to 155 chars, or a CE-hours fallback), plus `og:title`, `og:description`, `og:type=article`, `og:url`, and `og:image` (only if a thumbnail exists). Uses a small idempotent `setMeta()` helper that updates an existing tag or appends a new one.

### `courses.html` (static catalog)
Added `og:title`, `og:description`, `og:type`, `og:url`.

## Deviation from the literal request (confirmed with maintainer)

The task asked to also add a `meta description` to `courses.html`. That page **already has** a `meta description` (added by merged PR #492) with nearly identical text — the task's wording only differs by a trailing "with CounselorReady." Adding it verbatim would have produced **two** `<meta name="description">` tags (invalid/duplicate SEO). Per maintainer direction, I **kept the existing description** and added only the 4 missing OG tags. The `course-details.html` dynamic block is implemented exactly as specified.

## Verification

- `course-details.html`: extracted the inline `<script>` and ran `node --check` → parses cleanly; 6 `setMeta(...)` calls + 1 definition present.
- `courses.html`: exactly **1** `meta description` (no duplicate) and **4** `og:*` tags.
- Diff: 2 files, +25 / −0.

https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYyGoXHHxVfDmakpksn3ys)_