### PR TITLE
Add concurrent enrollment gate for free users

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -390,6 +390,22 @@ router.post('/:id/enroll', protect, async (req, res) => {
       });
     }
 
+    // Free-tier concurrent course limit: 1 active course at a time
+    if (!isAdmin && (subPlan === 'free' || !isActiveSub)) {
+      const activeCount = await CourseProgress.countDocuments({
+        userId: req.user._id,
+        status: { $in: ['not_started', 'in_progress'] }
+      });
+      if (activeCount >= 1) {
+        return res.status(403).json({
+          success: false,
+          error: 'Free plan allows one active course at a time.',
+          code: 'CONCURRENT_LIMIT',
+          message: 'Complete your current course before starting a new one, or subscribe for unlimited access.'
+        });
+      }
+    }
+
     // Create new enrollment
     progress = new CourseProgress({
       userId: req.user._id,


### PR DESCRIPTION
## Summary

Adds a concurrent enrollment gate to the `POST /:id/enroll` route in `server/src/routes/interactiveCourseRoutes.js`. Free-tier users (and any non-active subscription) are now limited to **one active course at a time**.

The new block is inserted immediately after the existing `if (!accessGranted)` return and before the `// Create new enrollment` comment. If a free user already has a `not_started` or `in_progress` course, enrollment returns `403` with code `CONCURRENT_LIMIT`.

```js
// Free-tier concurrent course limit: 1 active course at a time
if (!isAdmin && (subPlan === 'free' || !isActiveSub)) {
  const activeCount = await CourseProgress.countDocuments({
    userId: req.user._id,
    status: { $in: ['not_started', 'in_progress'] }
  });
  if (activeCount >= 1) {
    return res.status(403).json({
      success: false,
      error: 'Free plan allows one active course at a time.',
      code: 'CONCURRENT_LIMIT',
      message: 'Complete your current course before starting a new one, or subscribe for unlimited access.'
    });
  }
}
```

## Verification

- `node --check server/src/routes/interactiveCourseRoutes.js` → **SYNTAX OK**
- Line count: **1594** (above the 1518-line protected-file minimum)
- Single file changed, 16 insertions, no deletions — surrounding logic untouched
- Reuses existing in-scope variables: `isAdmin`, `subPlan`, `isActiveSub`, `CourseProgress`, `req.user._id`

https://claude.ai/code/session_01DMdSmkkYhkZAhSdNdhAWVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMdSmkkYhkZAhSdNdhAWVK)_