### PR TITLE
Fix compose modal To-field autocomplete dropdown clipping

### DIFF
--- a/client/public/admin-messages.html
+++ b/client/public/admin-messages.html
@@ -414,7 +414,7 @@
 
   <!-- Compose Message Modal -->
   <div id="composeModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden">
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
+    <div class="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col">
       <div class="p-6 border-b border-stone-200">
         <div class="flex items-center justify-between">
           <h2 class="text-xl font-semibold text-forest-900">Compose Message</h2>
@@ -426,13 +426,14 @@
         </div>
       </div>
       
+      <div class="overflow-y-auto flex-1">
       <form id="composeForm" class="p-6 space-y-5">
         <!-- To Field with Autocomplete -->
         <div>
           <label class="block text-sm font-medium text-forest-700 mb-2">To *</label>
           <div class="relative">
             <input type="text" id="toField" placeholder="Start typing a name or email..." autocomplete="off" class="w-full px-4 py-3 border border-stone-300 rounded-xl focus:ring-2 focus:ring-burgundy-500 focus:border-burgundy-500 outline-none">
-            <div id="autocompleteResults" class="absolute top-full left-0 right-0 bg-white border border-stone-300 rounded-xl mt-1 shadow-lg z-10 hidden max-h-60 overflow-y-auto"></div>
+            <div id="autocompleteResults" class="fixed bg-white border border-stone-300 rounded-xl mt-1 shadow-lg z-[200] hidden max-h-60 overflow-y-auto w-full max-w-lg"></div>
           </div>
           <div id="selectedRecipients" class="flex flex-wrap gap-2 mt-2"></div>
         </div>
@@ -499,6 +500,7 @@
           </button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 
@@ -805,6 +807,10 @@
       }
       
       container.classList.remove('hidden');
+      const rect = document.getElementById('toField').getBoundingClientRect();
+      container.style.top = (rect.bottom + 4) + 'px';
+      container.style.left = rect.left + 'px';
+      container.style.width = rect.width + 'px';
     }
 
     function selectRecipient(id, name, email) {


### PR DESCRIPTION
The dropdown was hidden because the modal container's overflow-y-auto clipped the absolutely-positioned results. Switch the modal to a flex column with the form in a scrollable child, and position the dropdown with fixed coordinates so it escapes the scroll/stacking context.

https://claude.ai/code/session_01DMdSmkkYhkZAhSdNdhAWVK