### PR TITLE
Fix admin/users search and select for profile.name path

### DIFF
--- a/server/src/routes/announcements.js
+++ b/server/src/routes/announcements.js
@@ -410,7 +410,7 @@ router.get('/admin/users', protect, requireAdmin, async (req, res) => {
     
     if (search) {
       query.$or = [
-        { name: { $regex: search, $options: 'i' } },
+        { 'profile.name': { $regex: search, $options: 'i' } },
         { email: { $regex: search, $options: 'i' } }
       ];
     }
@@ -420,7 +420,7 @@ router.get('/admin/users', protect, requireAdmin, async (req, res) => {
     }
     
     let users = await User.find(query)
-      .select('name email subscription.plan primaryState createdAt')
+      .select('profile.name email subscription.plan primaryState createdAt')
       .sort({ createdAt: -1 })
       .limit(parseInt(limit));
     
@@ -430,7 +430,15 @@ router.get('/admin/users', protect, requireAdmin, async (req, res) => {
       users = users.filter(u => userIdsInState.some(id => id.toString() === u._id.toString()));
     }
     
-    res.json({ users });
+    const normalized = users.map(u => ({
+      _id: u._id,
+      name: u.profile?.name || '',
+      email: u.email,
+      plan: u.subscription?.plan,
+      primaryState: u.primaryState
+    }));
+
+    res.json({ users: normalized });
   } catch (error) {
     console.error('Get users error:', error);
     res.status(500).json({ error: 'Failed to get users' });


### PR DESCRIPTION
name lives at profile.name on the User schema, not top-level. The search regex, the select projection, and the response now use the correct nested path, and the response is normalized so the compose modal To field receives a flat name field.

https://claude.ai/code/session_01DMdSmkkYhkZAhSdNdhAWVK