### PR TITLE
Fix admin detection and autocomplete dropdown in New Message modal

### DIFF
--- a/client/public/messages.html
+++ b/client/public/messages.html
@@ -138,7 +138,7 @@
           <label class="block text-sm font-medium text-forest-700 mb-2">To *</label>
           <div class="relative">
             <input type="text" id="toField" placeholder="Start typing a name or email..." autocomplete="off" class="w-full px-4 py-3 border border-stone-300 rounded-xl focus:ring-2 focus:ring-burgundy-500 focus:border-burgundy-500 outline-none">
-            <div id="autocompleteResults" class="absolute top-full left-0 right-0 bg-white border border-stone-300 rounded-xl mt-1 shadow-lg z-10 hidden max-h-60 overflow-y-auto"></div>
+            <div id="autocompleteResults" class="fixed bg-white border border-stone-300 rounded-xl mt-1 shadow-lg z-[200] hidden max-h-60 overflow-y-auto w-full max-w-lg"></div>
           </div>
           <div id="selectedRecipients" class="flex flex-wrap gap-2 mt-2"></div>
         </div>
@@ -229,13 +229,14 @@
           headers: { 'Authorization': `Bearer ${token}` }
         });
         const data = await response.json();
-        if (data.role === 'admin') {
+        const me = data.user || data;
+        if (me.role === 'admin') {
           isAdmin = true;
           document.getElementById('adminToField').classList.remove('hidden');
           setupAdminAutocomplete();
         }
         // Set user initial
-        const initial = (data.name || data.email || '?').substring(0, 1).toUpperCase();
+        const initial = (me.profile?.name || me.email || '?').substring(0, 1).toUpperCase();
         document.getElementById('userInitial').textContent = initial;
       } catch (err) {
         console.log('Could not check admin status');
@@ -287,6 +288,10 @@
         `).join('');
       }
       container.classList.remove('hidden');
+      const rect = document.getElementById('toField').getBoundingClientRect();
+      container.style.top = (rect.bottom + 4) + 'px';
+      container.style.left = rect.left + 'px';
+      container.style.width = rect.width + 'px';
     }
 
     function selectRecipient(id, name, email) {


### PR DESCRIPTION
Three small fixes in `client/public/messages.html` (single file):

**Change 1 — `/api/auth/me` parsing in `checkAdminStatus()`**
Now reads `const me = data.user || data;`, checks `me.role`, and derives the user initial from `me.profile?.name || me.email`.

**Change 2 — Autocomplete dropdown clipping**
`#autocompleteResults` switched from `absolute` to `fixed` positioning with `z-[200]` and `w-full max-w-lg`, so it is no longer clipped by the modal's `overflow-y-auto`.

**Change 3 — Dropdown positioning**
In `renderAutocomplete()`, after un-hiding the container, position it under the `#toField` input using `getBoundingClientRect()`.

Verification (`grep -n 'data.user\|autocompleteResults\|rect.bottom'`):
```
141: <div id="autocompleteResults" class="fixed bg-white border border-stone-300 rounded-xl mt-1 shadow-lg z-[200] hidden max-h-60 overflow-y-auto w-full max-w-lg"></div>
232: const me = data.user || data;
253: setTimeout(() => document.getElementById('autocompleteResults').classList.add('hidden'), 200);
259: document.getElementById('autocompleteResults').classList.add('hidden');
267: renderAutocomplete(data.users || []);
274: const container = document.getElementById('autocompleteResults');
292: container.style.top = (rect.bottom + 4) + 'px';
302: document.getElementById('autocompleteResults').classList.add('hidden');
```

`git diff --stat`: 1 file changed, 8 insertions(+), 3 deletions(-)

https://claude.ai/code/session_01PEjVHuh9QpUCjEQLBeyhjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEjVHuh9QpUCjEQLBeyhjR)_