### PR TITLE
Schedule certificate self-heal cron job (every 6 hours)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -105,6 +105,7 @@ import cron from 'node-cron';
 import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
 import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
 import { runHardshipPauseResume } from './jobs/hardshipPauseResume.js';
+import { runCertificateSelfHeal } from './jobs/certificateSelfHeal.js';
 
 import { ROUTE_MANIFEST } from './routeManifest.js';
 
@@ -413,6 +414,14 @@ const startServer = async () => {
     );
   }, { timezone: 'America/New_York' });
   logger.info('Hardship pause auto-resume cron scheduled (daily 8 AM ET)');
+
+  // Certificate self-heal — every 6 hours
+  cron.schedule('0 */6 * * *', () => {
+    runCertificateSelfHeal().catch(err =>
+      console.error('Certificate self-heal error:', err.message)
+    );
+  }, { timezone: 'America/New_York' });
+  logger.info('Certificate self-heal cron scheduled (every 6 hours)');
   // PostHog server-side analytics
   const phKey = process.env.POSTHOG_API_KEY || 'phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb';
   global.posthog = new PostHog(phKey, { host: 'https://us.i.posthog.com' });


### PR DESCRIPTION
## Summary

Wires up the `certificateSelfHeal` job in `server/src/index.js`, mirroring the existing hardship pause auto-resume cron wiring:

1. Adds `import { runCertificateSelfHeal } from './jobs/certificateSelfHeal.js';` immediately after the `runHardshipPauseResume` import.
2. Adds a cron schedule (`0 */6 * * *`, every 6 hours, `America/New_York`) immediately after the hardship-pause log line.

## Verification

`grep -n "certificateSelfHeal\|self-heal" server/src/index.js`:
```
108:import { runCertificateSelfHeal } from './jobs/certificateSelfHeal.js';
418:  // Certificate self-heal — every 6 hours
421:      console.error('Certificate self-heal error:', err.message)
424:  logger.info('Certificate self-heal cron scheduled (every 6 hours)');
```

`git diff --stat`: `1 file changed, 9 insertions(+)` — only `server/src/index.js` touched, no deletions.

`node --check src/index.js`: passes.

Confirmed the imported job file exists (`server/src/jobs/certificateSelfHeal.js`) and exports `runCertificateSelfHeal`.

## Note on branching

The task prompts requested committing directly to `main`. Per CLAUDE.md, `server/src/index.js` is a **protected file**, and the direct-to-main exception (condition 4) excludes any change touching a protected file. The change was therefore committed to the feature branch `claude/festive-rubin-BVmS5` and opened as this draft PR instead of pushed to main.

https://claude.ai/code/session_014EUVH2iCSzdzKvCre1JBDX

---
_Generated by [Claude Code](https://claude.ai/code/session_014EUVH2iCSzdzKvCre1JBDX)_