### PR TITLE
Move /user/my-courses route above /:id wildcard

### DIFF
--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -266,6 +266,40 @@ router.get('/slug/:slug', optionalAuth, async (req, res) => {
 });
 
 /**
+ * GET /api/interactive-courses/user/my-courses
+ * Get all courses user is enrolled in with progress
+ */
+router.get('/user/my-courses', protect, async (req, res) => {
+  try {
+    const { status } = req.query;
+
+    const query = { userId: req.user._id };
+    if (status) query.status = status;
+
+    const progressList = await CourseProgress.find(query)
+      .populate('courseId', 'title slug description thumbnail ceHours totalEstimatedTime')
+      .sort({ lastAccessedAt: -1 });
+
+    const courses = progressList.map(p => ({
+      course: p.courseId,
+      progress: p.overallProgress,
+      status: p.status,
+      currentSection: p.currentSectionIndex,
+      totalTimeSpent: p.totalTimeSpent,
+      enrolledAt: p.enrolledAt,
+      lastAccessedAt: p.lastAccessedAt,
+      completedAt: p.completedAt,
+      certificateId: p.certificateId
+    }));
+
+    res.json({ success: true, data: courses });
+  } catch (error) {
+    console.error('Error fetching user courses:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch courses' });
+  }
+});
+
+/**
  * GET /api/interactive-courses/:id
  * Get course details by ID — content gated by auth/subscription
  */
@@ -1469,40 +1503,6 @@ router.post('/:id/progress/interaction', protect, async (req, res) => {
   } catch (error) {
     console.error('Error logging interaction:', error);
     res.status(500).json({ success: false, error: 'Failed to log interaction' });
-  }
-});
-
-/**
- * GET /api/interactive-courses/user/my-courses
- * Get all courses user is enrolled in with progress
- */
-router.get('/user/my-courses', protect, async (req, res) => {
-  try {
-    const { status } = req.query;
-
-    const query = { userId: req.user._id };
-    if (status) query.status = status;
-
-    const progressList = await CourseProgress.find(query)
-      .populate('courseId', 'title slug description thumbnail ceHours totalEstimatedTime')
-      .sort({ lastAccessedAt: -1 });
-
-    const courses = progressList.map(p => ({
-      course: p.courseId,
-      progress: p.overallProgress,
-      status: p.status,
-      currentSection: p.currentSectionIndex,
-      totalTimeSpent: p.totalTimeSpent,
-      enrolledAt: p.enrolledAt,
-      lastAccessedAt: p.lastAccessedAt,
-      completedAt: p.completedAt,
-      certificateId: p.certificateId
-    }));
-
-    res.json({ success: true, data: courses });
-  } catch (error) {
-    console.error('Error fetching user courses:', error);
-    res.status(500).json({ success: false, error: 'Failed to fetch courses' });
   }
 });
 


### PR DESCRIPTION
## Summary

Express matches routes in registration order. In `server/src/routes/interactiveCourseRoutes.js`, the wildcard `GET /:id` (line 272) was registered before `GET /user/my-courses` (line 1479), so the wildcard captured `user` as an `:id` and the my-courses handler was unreachable.

This PR relocates the `/user/my-courses` handler so it's registered **before** `/:id`. It is a **pure move** — the comment + handler block is byte-for-byte identical, only its position changed.

## Verification

`grep -n "my-courses\|'/:id'" server/src/routes/interactiveCourseRoutes.js`:
```
269: * GET /api/interactive-courses/user/my-courses
272:router.get('/user/my-courses', protect, async (req, res) => {
306:router.get('/:id', optionalAuth, async (req, res) => {
```
`/user/my-courses` (272) is now **lower** than `/:id` (306). ✓

`wc -l`: **1594** — unchanged (move only, no net change). ✓

`node --check`: passes. ✓

`git diff --stat`: `1 file changed, 34 insertions(+), 34 deletions(-)` — only this file, identical block relocated. ✓

## Protected-file compliance

`interactiveCourseRoutes.js` is a protected file. This change is move-only / additive — no rewrite, no inline `mongoose.model()`, no removed routes or functions, line count preserved above the 1518 minimum.

https://claude.ai/code/session_014EUVH2iCSzdzKvCre1JBDX

---
_Generated by [Claude Code](https://claude.ai/code/session_014EUVH2iCSzdzKvCre1JBDX)_