### PR TITLE
TMH601: add Stage 4 clean-only restructure + clean→mkkycoyo sync script

### DIFF
--- a/server/src/scripts/patchTMH601_RestructureSections_CleanOnly.js
+++ b/server/src/scripts/patchTMH601_RestructureSections_CleanOnly.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * patchTMH601_RestructureSections_CleanOnly.js
+ * ───────────────────────────────────────────
+ * Stage 4 — single-slug variant. Runs the section restructure (§9 → §6) and
+ * §2/§11 dedup against the clean slug ONLY. The mkkycoyo slug is a different
+ * course with a different section structure; it gets handled separately via
+ * the sync script.
+ *
+ *   cd ~/project/src/server
+ *   node src/scripts/patchTMH601_RestructureSections_CleanOnly.js              # dry
+ *   APPLY=1 node src/scripts/patchTMH601_RestructureSections_CleanOnly.js      # write
+ */
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('❌ MONGODB_URI not found in env');
+  process.exit(1);
+}
+const APPLY = process.env.APPLY === '1';
+
+// Single slug only — mkkycoyo is handled by syncTMH601_CleanToMkkycoyo.js
+const TARGET_SLUGS = ['mastering-telemental-health'];
+
+function findSpecialPopulationsIndex(sections) {
+  return sections.findIndex(s =>
+    typeof s.title === 'string' && /special\s+populations/i.test(s.title)
+  );
+}
+
+function renumberSections(sections) {
+  let updates = 0;
+  sections.forEach((section, i) => {
+    const newNumber = i + 1;
+    if ('order' in section && section.order !== newNumber) {
+      section.order = newNumber;
+      updates++;
+    }
+    const divider = (section.contentBlocks || []).find(b => b.type === 'sectionDivider');
+    if (divider) {
+      if (divider.sectionNumber !== newNumber) {
+        divider.sectionNumber = newNumber;
+        updates++;
+      }
+      const newTitle = `Section ${newNumber}`;
+      if (divider.title !== newTitle) {
+        divider.title = newTitle;
+        updates++;
+      }
+    }
+  });
+  return updates;
+}
+
+function reorderSections(course) {
+  const sections = [...(course.sections || [])];
+  const popsIdx = findSpecialPopulationsIndex(sections);
+  if (popsIdx === 5) return { changed: false, popsFrom: 5, popsTo: 5 };
+  if (popsIdx < 0) return { changed: false, error: 'Special Populations section not found' };
+  const [popsSection] = sections.splice(popsIdx, 1);
+  sections.splice(5, 0, popsSection);
+  const renumberCount = renumberSections(sections);
+  course.sections = sections;
+  return { changed: true, popsFrom: popsIdx + 1, popsTo: 6, renumberOps: renumberCount };
+}
+
+const DEDUP_MARKER = 'cr-marker-s2-s11-interstate-dedup';
+
+function dedupS2InterstateContent(s2Section) {
+  if (!s2Section || !Array.isArray(s2Section.contentBlocks)) return { changed: false };
+  let changedBlocks = 0;
+  s2Section.contentBlocks.forEach(block => {
+    const field = block.content !== undefined ? 'content' : (block.textContent !== undefined ? 'textContent' : null);
+    if (!field) return;
+    const html = block[field] || '';
+    if (html.includes(DEDUP_MARKER)) return;
+    let modified = html;
+    let didModify = false;
+    const pA = /\s*<p>\s*Regarding telehealth practice specifically[\s\S]*?the state where the counselor maintains a license or physical office\.\s*<\/p>/;
+    if (pA.test(modified)) {
+      modified = modified.replace(
+        pA,
+        `\n<p><!--${DEDUP_MARKER}-->Regarding telehealth practice specifically, the Georgia Board has adopted regulations that largely align with the prevailing national framework. Georgia-licensed counselors may provide telehealth services to clients located within the state of Georgia without additional authorization beyond their existing LPC license. <strong>The jurisdictional question of which state's law governs when clients are physically located outside Georgia — including the client-location rule, the Counseling Compact, PSYPACT, and the full interstate framework — is covered in detail in §11 (Interstate Practice, Compacts, and Jurisdictional Navigation).</strong></p>`
+      );
+      didModify = true;
+    }
+    const pB = /\s*<p>\s*This client-location principle has profound implications[\s\S]*?disciplinary action by either or both state boards involved\.\s*<\/p>/;
+    if (pB.test(modified)) {
+      modified = modified.replace(pB, '');
+      didModify = true;
+    }
+    if (didModify) {
+      block[field] = modified;
+      changedBlocks++;
+    }
+  });
+  return { changed: changedBlocks > 0, blockEdits: changedBlocks };
+}
+
+async function main() {
+  console.log('═'.repeat(64));
+  console.log('  CR-TMH601 Stage 4 (CLEAN SLUG ONLY) — Restructure + §2/§11 Dedup');
+  console.log('  Mode:', APPLY ? 'APPLY' : 'DRY RUN');
+  console.log('═'.repeat(64));
+
+  await mongoose.connect(MONGODB_URI);
+  console.log('✓ Connected to MongoDB');
+  const db = mongoose.connection.db;
+  const collection = db.collection('interactivecourses');
+
+  for (const slug of TARGET_SLUGS) {
+    console.log(`\n── slug: ${slug}`);
+    const course = await collection.findOne({ slug });
+    if (!course) {
+      console.log('  (not found — skipping)');
+      continue;
+    }
+    console.log(`  Found: "${course.title}" (${course.sections?.length || 0} sections)`);
+
+    const reorderResult = reorderSections(course);
+    const s2Idx = (course.sections || []).findIndex(s =>
+      typeof s.title === 'string' && /Regulatory Landscape/i.test(s.title)
+    );
+    const dedupResult = s2Idx >= 0 ? dedupS2InterstateContent(course.sections[s2Idx]) : { changed: false };
+
+    if (reorderResult.changed) {
+      console.log(`  [reorder] Special Populations: §${reorderResult.popsFrom} → §${reorderResult.popsTo}`);
+      console.log(`  [reorder] sectionDivider/order updates: ${reorderResult.renumberOps}`);
+    } else if (reorderResult.error) {
+      console.log(`  [reorder] skipped: ${reorderResult.error}`);
+    } else {
+      console.log(`  [reorder] no-op — already in target order`);
+    }
+
+    if (dedupResult.changed) {
+      console.log(`  [dedup]   §2 interstate paragraphs replaced (${dedupResult.blockEdits} block edited)`);
+    } else {
+      console.log(`  [dedup]   no-op`);
+    }
+
+    if (reorderResult.changed) {
+      console.log('  New order:');
+      course.sections.forEach((s, i) => console.log(`    ${i + 1}. ${s.title}`));
+    }
+
+    if (!reorderResult.changed && !dedupResult.changed) {
+      console.log('  ✓ Nothing to do.');
+      continue;
+    }
+
+    if (!APPLY) {
+      console.log('  (dry run)');
+      continue;
+    }
+
+    const result = await collection.updateOne(
+      { slug },
+      { $set: { sections: course.sections, updatedAt: new Date() } }
+    );
+    console.log(`  ✓ Written. matched=${result.matchedCount} modified=${result.modifiedCount}`);
+  }
+
+  await mongoose.disconnect();
+  console.log('\n✓ Done.');
+}
+
+main().catch(err => {
+  console.error('❌ Error:', err);
+  process.exit(1);
+});

--- a/server/src/scripts/syncTMH601_CleanToMkkycoyo.js
+++ b/server/src/scripts/syncTMH601_CleanToMkkycoyo.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * syncTMH601_CleanToMkkycoyo.js
+ * ─────────────────────────────
+ * Copies the entire content of the clean slug into mkkycoyo. The mkkycoyo
+ * document retains its `_id` (mongo-enforced via $set), its `slug` (so the ad
+ * URL keeps working), and its `title` (the longer SEO-aligned ad-copy title).
+ * Everything else is overwritten by clean's values.
+ *
+ * Ke's instruction (June 2026): preserve slug + title; the rest can change.
+ * Test progress records and test certificates may be scrambled by the
+ * structural change in `sections`; that is accepted.
+ *
+ * SAFETY
+ * ──────
+ *   • Default mode is dry-run. APPLY=1 to write.
+ *   • Before writing, the current mkkycoyo doc is backed up to the
+ *     `interactivecourses_backups` collection with a timestamp. Restore is
+ *     possible if needed.
+ *   • Status fields. After sync, mkkycoyo inherits clean's `status` /
+ *     `isPublished` values. Clean is currently `draft` / `false`. The script
+ *     therefore FORCES `status='published'` and `isPublished=true` post-copy
+ *     so the public ad URL does not 404. Override with NO_FORCE_PUBLISH=1 to
+ *     leave them at clean's values.
+ *   • Idempotency: if mkkycoyo's content (sections, assessment, etc.) already
+ *     matches clean's, the script no-ops.
+ *
+ * RUN
+ * ───
+ *   cd ~/project/src/server
+ *   node src/scripts/syncTMH601_CleanToMkkycoyo.js                # dry run
+ *   APPLY=1 node src/scripts/syncTMH601_CleanToMkkycoyo.js        # write + backup
+ */
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import crypto from 'crypto';
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('❌ MONGODB_URI not found in env');
+  process.exit(1);
+}
+const APPLY = process.env.APPLY === '1';
+const NO_FORCE_PUBLISH = process.env.NO_FORCE_PUBLISH === '1';
+
+const MKKYCOYO_SLUG = 'mastering-telemental-health-an-essential-guide-to-a-compliant-virtual-healthcare-practice-in-georgia-mkkycoyo';
+const CLEAN_SLUG = 'mastering-telemental-health';
+
+// Fields that mkkycoyo KEEPS (never copied from clean). Note: `_id` is
+// preserved automatically by updateOne — $set cannot change _id. The longer
+// mkkycoyo title is SEO-aligned with the ad copy and stays.
+const PRESERVE_ON_MKKYCOYO = new Set(['_id', 'slug', 'title']);
+
+function contentHash(doc) {
+  // Hash everything except identity & timestamps so we can detect "already in sync"
+  const clone = { ...doc };
+  delete clone._id;
+  delete clone.slug;
+  delete clone.updatedAt;
+  delete clone.createdAt;
+  delete clone.__v;
+  delete clone.publishedAt;
+  delete clone.status;
+  delete clone.isPublished;
+  return crypto.createHash('sha256').update(JSON.stringify(clone)).digest('hex').slice(0, 16);
+}
+
+async function main() {
+  console.log('═'.repeat(64));
+  console.log('  CR-TMH601 SYNC — clean slug → mkkycoyo');
+  console.log('  Preserves: _id (mongo-enforced), slug, title');
+  console.log('  Mode:', APPLY ? 'APPLY (writes + backup)' : 'DRY RUN');
+  if (NO_FORCE_PUBLISH) console.log('  NO_FORCE_PUBLISH=1 — leaving status/isPublished as clean\'s values');
+  console.log('═'.repeat(64));
+
+  await mongoose.connect(MONGODB_URI);
+  console.log('✓ Connected to MongoDB');
+  const db = mongoose.connection.db;
+  const courses = db.collection('interactivecourses');
+
+  const mkky = await courses.findOne({ slug: MKKYCOYO_SLUG });
+  const clean = await courses.findOne({ slug: CLEAN_SLUG });
+
+  if (!mkky) { console.log('❌ mkkycoyo slug not found.'); await mongoose.disconnect(); return; }
+  if (!clean) { console.log('❌ clean slug not found.'); await mongoose.disconnect(); return; }
+
+  console.log(`\n  mkkycoyo (target):  _id=${mkky._id}  ${mkky.sections?.length || 0} sections, ${mkky.assessment?.questions?.length || 0} Qs`);
+  console.log(`  clean (source):     _id=${clean._id}  ${clean.sections?.length || 0} sections, ${clean.assessment?.questions?.length || 0} Qs`);
+
+  // Idempotency check
+  const mkkyHash = contentHash(mkky);
+  const cleanHash = contentHash(clean);
+  console.log(`\n  Content hashes (excl. identity & status): mkkycoyo=${mkkyHash}  clean=${cleanHash}`);
+  if (mkkyHash === cleanHash) {
+    console.log('  ✓ Content already in sync. Nothing to do.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  // Build the field-set for $set: everything from clean except _id and slug
+  const updateDoc = {};
+  for (const [key, value] of Object.entries(clean)) {
+    if (PRESERVE_ON_MKKYCOYO.has(key)) continue;
+    updateDoc[key] = value;
+  }
+  // Force-publish unless overridden
+  if (!NO_FORCE_PUBLISH) {
+    updateDoc.status = 'published';
+    updateDoc.isPublished = true;
+    if (!updateDoc.publishedAt) updateDoc.publishedAt = mkky.publishedAt || new Date();
+  }
+  updateDoc.updatedAt = new Date();
+
+  // Report what will change
+  console.log('\n  Fields to overwrite on mkkycoyo:');
+  const reportedKeys = Object.keys(updateDoc).sort();
+  reportedKeys.forEach(k => {
+    const oldVal = mkky[k];
+    const newVal = updateDoc[k];
+    let oldPreview = JSON.stringify(oldVal);
+    let newPreview = JSON.stringify(newVal);
+    if (oldPreview && oldPreview.length > 70) oldPreview = oldPreview.slice(0, 70) + '…';
+    if (newPreview && newPreview.length > 70) newPreview = newPreview.slice(0, 70) + '…';
+    const same = oldPreview === newPreview;
+    console.log(`    ${same ? ' ' : '≠'} ${k.padEnd(28)} mkky:${oldPreview}   →   clean:${newPreview}`);
+  });
+
+  console.log('\n  Fields PRESERVED on mkkycoyo:');
+  PRESERVE_ON_MKKYCOYO.forEach(k => {
+    console.log(`    • ${k.padEnd(28)} = ${JSON.stringify(mkky[k]).slice(0, 80)}`);
+  });
+
+  // Side-effect summary
+  console.log('\n  Side effects of sync:');
+  console.log(`    • mkkycoyo's existing progress records will reference sections whose _ids no longer exist (test data — per Ke\'s instruction)`);
+  console.log(`    • mkkycoyo's 2 issued certificates remain valid (PDFs are immutable)`);
+  console.log(`    • mkkycoyo's analytics object (enrollments / lastEnrollmentAt) and discountPrice / discountExpires will be ${clean.analytics ? 'overwritten' : 'removed'} unless present on clean`);
+  console.log(`    • Title preserved: "${mkky.title}"`);
+
+  if (!APPLY) {
+    console.log('\n  (dry run — no writes performed)');
+    await mongoose.disconnect();
+    return;
+  }
+
+  // ── BACKUP ──
+  console.log('\n  Writing pre-sync backup of mkkycoyo document …');
+  const backupCol = db.collection('interactivecourses_backups');
+  const backupDoc = {
+    backupAt: new Date(),
+    backupReason: 'pre-sync-clean-to-mkkycoyo',
+    originalSlug: mkky.slug,
+    originalId: mkky._id,
+    document: mkky,
+  };
+  const backupResult = await backupCol.insertOne(backupDoc);
+  console.log(`  ✓ Backup written. backup _id=${backupResult.insertedId}`);
+  console.log(`    To restore later:`);
+  console.log(`      const b = await db.collection('interactivecourses_backups').findOne({_id: ObjectId("${backupResult.insertedId}")});`);
+  console.log(`      await db.collection('interactivecourses').replaceOne({_id: b.originalId}, b.document);`);
+
+  // ── WRITE ──
+  console.log('\n  Applying sync …');
+  const result = await courses.updateOne(
+    { slug: MKKYCOYO_SLUG },
+    { $set: updateDoc }
+  );
+  console.log(`  ✓ Written. matched=${result.matchedCount} modified=${result.modifiedCount}`);
+
+  // ── VERIFY ──
+  const verify = await courses.findOne({ slug: MKKYCOYO_SLUG });
+  const verifyHash = contentHash(verify);
+  console.log(`\n  Verification:`);
+  console.log(`    mkkycoyo._id preserved:        ${String(verify._id) === String(mkky._id) ? '✓' : '✗ MISMATCH'}`);
+  console.log(`    mkkycoyo.slug preserved:       ${verify.slug === MKKYCOYO_SLUG ? '✓' : '✗ MISMATCH'}`);
+  console.log(`    content hash now matches clean: ${verifyHash === cleanHash ? '✓' : '✗ ' + verifyHash + ' vs ' + cleanHash}`);
+  console.log(`    sections:                       ${verify.sections?.length || 0}  (was ${mkky.sections?.length || 0}, clean ${clean.sections?.length || 0})`);
+  console.log(`    assessment Qs:                  ${verify.assessment?.questions?.length || 0}  (was ${mkky.assessment?.questions?.length || 0}, clean ${clean.assessment?.questions?.length || 0})`);
+  console.log(`    status:                         ${verify.status}  (mkky was ${mkky.status}, clean is ${clean.status})`);
+  console.log(`    isPublished:                    ${verify.isPublished}`);
+  console.log(`    title:                          "${verify.title}"`);
+
+  await mongoose.disconnect();
+  console.log('\n✓ Done.');
+}
+
+main().catch(err => {
+  console.error('❌ Error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## TMH601 Sync — Supplementary Patch (follow-up to 4-stage cleanup, #517)

Adds two more idempotent scripts to `server/src/scripts/`. **No other files touched. Scripts are NOT run here** — they connect to production MongoDB and are run by Ke on the Render shell.

### Files added (verbatim from Ke's uploads, md5-verified)
| Path | Lines | Purpose |
|---|---|---|
| `patchTMH601_RestructureSections_CleanOnly.js` | 179 | Stage 4 single-slug variant — same restructure (Special Populations → §6, dedup §2/§11) but targets only the `mastering-telemental-health` slug. |
| `syncTMH601_CleanToMkkycoyo.js` | 197 | Copies clean slug content into `mkkycoyo`, preserving `_id`/`slug`/`title` only; force-publishes after sync; writes a pre-sync backup to `interactivecourses_backups`. Dry-run by default, `APPLY=1` to write. |

### Verification
- Both placed verbatim — md5 matches source uploads (`4da7845873c668b05c06a5bcf52c9a1d`, `60a7b10de472bf49baf9b08c1e94c7d8`)
- `node --check` passes on both
- `git diff --stat origin/main..HEAD` shows exactly 2 files, +376 insertions, 0 deletions
- No protected files modified

Draft — merge is Ke's call. Do not auto-merge.

https://claude.ai/code/session_01GtxqhjEZ8HbzwR9GZcSMwx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtxqhjEZ8HbzwR9GZcSMwx)_