### PR TITLE
Viewer: 4 new block types + within-section pagination + dead-video detection

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -1114,6 +1114,16 @@ button, a, input, select, textarea, [tabindex], [draggable="true"] {
   transition: all var(--cr-transition);
 }
 .cr-video-marker:hover { background: var(--cr-burgundy-faded); border-color: var(--cr-burgundy); }
+/* -- Dead video fallback -- */
+.cr-video-dead {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 10px; padding: 28px 20px; text-align: center;
+  background: var(--cr-stone); border-radius: var(--cr-radius); min-height: 180px;
+}
+.cr-video-dead-icon { font-size: 2rem; opacity: 0.6; }
+.cr-video-dead-title { font-weight: 700; font-size: 0.95rem; color: var(--cr-text); }
+.cr-video-dead-msg { font-size: 0.82rem; color: var(--cr-text-muted); line-height: 1.5; max-width: 320px; }
+.cr-video-dead-link { font-size: 0.8rem; color: var(--cr-burgundy); text-decoration: underline; margin-top: 2px; }
 
 /* ═══════════════════════════════════════════════════════════════
    INFO CARDS (Clinical Vignettes, Myth/Fact, Skill Builders)
@@ -5928,27 +5938,65 @@ function renderResources(wrap, block) {
 // ─── VIDEO EMBED ───
 function renderVideoEmbed(wrap, block) {
   const url = block.videoUrl || '';
+
+  // Admin audit flagged this block as dead -- skip iframe
+  if (block.videoStatus === 'dead') {
+    wrap.innerHTML = crVideoDeadHtml(block, 'This video is no longer available.');
+    return wrap;
+  }
+
   let embedHtml = '';
-  
-  // YouTube
-  const ytMatch = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/);
+  let ytId = null;
+
+  const ytMatch = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\s?#]+)/);
   if (ytMatch) {
-    embedHtml = `<iframe src="https://www.youtube.com/embed/${ytMatch[1]}" allowfullscreen title="${esc(block.videoTitle || '')}"></iframe>`;
+    ytId = ytMatch[1];
+    embedHtml = `<iframe src="https://www.youtube.com/embed/${ytId}" allowfullscreen title="${esc(block.videoTitle || '')}"></iframe>`;
   } else if (url) {
     embedHtml = `<video src="${esc(url)}" controls></video>`;
   }
-  
+
   const markers = block.markers || [];
-  
+
   wrap.innerHTML = `<div class="cr-video">
     ${block.videoTitle ? `<h4 style="font-family:var(--cr-font-display);font-weight:700;color:var(--cr-navy);margin-bottom:12px">${esc(block.videoTitle)}</h4>` : ''}
-    <div class="cr-video-wrap">${embedHtml || '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--cr-text-muted)">Video not available</div>'}</div>
-    ${markers.length > 0 ? `<div class="cr-video-markers">${markers.map(m => 
-      `<span class="cr-video-marker" title="${esc(m.prompt || '')}">${esc(m.time)} — ${esc(m.label)}</span>`
+    <div class="cr-video-wrap">${embedHtml || crVideoDeadHtml(block, 'No video URL configured.')}</div>
+    ${markers.length > 0 ? `<div class="cr-video-markers">${markers.map(m =>
+      `<span class="cr-video-marker" title="${esc(m.prompt || '')}">${esc(m.time)} -- ${esc(m.label)}</span>`
     ).join('')}</div>` : ''}
     ${block.videoDuration ? `<p style="font-size:0.8em;color:var(--cr-text-muted);margin-top:6px">Duration: ${esc(block.videoDuration)}</p>` : ''}
   </div>`;
+
+  // Live async check -- swap iframe for fallback if YouTube oEmbed returns non-OK.
+  // Swallowed on network error so offline users keep their iframe.
+  if (ytId) {
+    const wrapRef = wrap;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 7000);
+    fetch('https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=' + ytId + '&format=json',
+      { signal: ctrl.signal }
+    ).then(r => { clearTimeout(timer); if (!r.ok) crReplaceVideoWithDead(wrapRef, block); })
+     .catch(() => clearTimeout(timer));
+  }
+
   return wrap;
+}
+
+// -- VIDEO DEAD-LINK HELPERS --
+function crVideoDeadHtml(block, msg) {
+  const link = block.videoUrl
+    ? '<a href="' + esc(block.videoUrl) + '" target="_blank" rel="noopener" class="cr-video-dead-link">Try opening directly</a>'
+    : '';
+  return '<div class="cr-video-dead">'
+    + '<div class="cr-video-dead-icon">&#127916;</div>'
+    + '<div class="cr-video-dead-title">' + esc(block.videoTitle || 'Video Unavailable') + '</div>'
+    + '<div class="cr-video-dead-msg">' + esc(msg || 'This video could not be loaded.') + '</div>'
+    + link + '</div>';
+}
+
+function crReplaceVideoWithDead(wrap, block) {
+  const vw = wrap.querySelector('.cr-video-wrap');
+  if (vw) vw.innerHTML = crVideoDeadHtml(block, 'This video has been removed or made private.');
 }
 
 // ─── KNOWLEDGE CHECK (multi-question inline block) ───

--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3716,6 +3716,12 @@ body.cr-has-timer .cr-glossary-btn { bottom: 220px; }
 // ═══════════════════════════════════════════════════════════════
 let course = null;
 let currentSectionIndex = 0;
+// ── Within-section pagination ──
+// When a section holds more than BLOCK_PAGE_SIZE content blocks, the viewer
+// splits them into pages so learners aren't handed an endless scroll. The
+// page index resets to 0 whenever the section changes (see goToSection).
+const BLOCK_PAGE_SIZE = 8;
+let currentBlockPage = 0;
 let completedSections = new Set();
 let visitedSections = new Set([0]); // First section always visited
 let currentView = 'section'; // 'section' | 'assessment'
@@ -4366,6 +4372,7 @@ function goToSection(i) {
   completedSections.add(currentSectionIndex);
   visitedSections.add(i);
   currentSectionIndex = i;
+  currentBlockPage = 0; // reset within-section pagination on section change
   buildSectionNav();
   renderCurrentSection();
   updateProgress();
@@ -4387,6 +4394,22 @@ function nextSection() {
   } else if (course.assessment?.questions?.length > 0) {
     showAssessment();
   }
+}
+
+// ── Within-section pagination controls ──
+// Advance/retreat the current page of content blocks without leaving the
+// section. Re-renders in place and scrolls back to the top so the next page
+// of blocks starts at the top of the viewport.
+function nextBlockPage() {
+  currentBlockPage++;
+  renderCurrentSection();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function prevBlockPage() {
+  if (currentBlockPage > 0) currentBlockPage--;
+  renderCurrentSection();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 function showAssessment() {
@@ -4617,12 +4640,34 @@ function renderCurrentSection() {
     </div>`;
   }
   
-  // Render each block
-  blocks.forEach((block, i) => {
+  // Render each block (paginated within the section). The real block index
+  // (pageStart + localIndex) is passed to renderBlock so per-block element IDs
+  // stay stable regardless of which page is showing.
+  const totalBlockPages = Math.max(1, Math.ceil(blocks.length / BLOCK_PAGE_SIZE));
+  if (currentBlockPage >= totalBlockPages) currentBlockPage = totalBlockPages - 1;
+  if (currentBlockPage < 0) currentBlockPage = 0;
+  const pageStart = currentBlockPage * BLOCK_PAGE_SIZE;
+  const pageBlocks = blocks.slice(pageStart, pageStart + BLOCK_PAGE_SIZE);
+  pageBlocks.forEach((block, localIndex) => {
+    const i = pageStart + localIndex;
     const el = renderBlock(block, i);
     if (el) area.appendChild(el);
   });
-  
+
+  // Within-section pager — only when the section spans more than one page.
+  if (totalBlockPages > 1) {
+    const pager = document.createElement('div');
+    pager.className = 'cr-block-pager';
+    pager.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:24px;padding-top:16px;border-top:1px solid var(--cr-border)';
+    pager.innerHTML = `
+      <button type="button" data-action="prevBlockPage" ${currentBlockPage === 0 ? 'disabled' : ''}
+        style="padding:8px 16px;border:1.5px solid var(--cr-border);border-radius:8px;background:#fff;color:var(--cr-navy);font-size:0.83rem;font-weight:700;cursor:${currentBlockPage === 0 ? 'default' : 'pointer'};opacity:${currentBlockPage === 0 ? '0.5' : '1'}">← Previous</button>
+      <span style="font-size:0.83rem;color:var(--cr-text-muted)">Page ${currentBlockPage + 1} of ${totalBlockPages}</span>
+      <button type="button" data-action="nextBlockPage" ${currentBlockPage >= totalBlockPages - 1 ? 'disabled' : ''}
+        style="padding:8px 16px;border:none;border-radius:8px;background:var(--cr-burgundy);color:#fff;font-size:0.83rem;font-weight:700;cursor:${currentBlockPage >= totalBlockPages - 1 ? 'default' : 'pointer'};opacity:${currentBlockPage >= totalBlockPages - 1 ? '0.5' : '1'}">More →</button>`;
+    area.appendChild(pager);
+  }
+
   // References now live in the collapsible References drawer (buildReferences()),
   // not inline. Intentionally not appended to the section body.
   const isLast = currentSectionIndex === course.sections.length - 1;
@@ -4895,11 +4940,21 @@ function renderBlock(block, index) {
     case 'callout': return renderCallout(wrap, block);
     case 'fillInBlank': return renderFillInBlank(wrap, block, index);
     case 'keyTakeaway': return renderKeyTakeaway(wrap, block);
-    default:
+    default: {
+      // Convention-based dispatch for newer block types whose renderers are
+      // named render<Type> (e.g. a "statCard" block resolves to the matching
+      // capitalized renderer). Lets us add the stat-card, case-study,
+      // pull-quote, and table block renderers without growing the switch.
+      // Falls back to the unsupported notice when no renderer is found.
+      const t = (block.type || '').toString();
+      const fnName = 'render' + t.charAt(0).toUpperCase() + t.slice(1);
+      const fn = typeof window !== 'undefined' ? window[fnName] : undefined;
+      if (typeof fn === 'function') return fn(wrap, block);
       wrap.innerHTML = `<div class="cr-card" style="border-left:4px solid var(--cr-gold)">
         <p style="font-size:0.9em;color:var(--cr-text-muted)">Unsupported block type: <code>${esc(block.type)}</code></p>
       </div>`;
       return wrap;
+    }
   }
 }
 
@@ -5754,6 +5809,97 @@ function renderKeyTakeaway(wrap, block) {
     html += '<ul style="margin:0;padding-left:18px">';
     items.forEach(t => { html += `<li style="font-size:0.85rem;line-height:1.65;margin-bottom:3px;color:var(--cr-text)">${esc(t)}</li>`; });
     html += '</ul>';
+  }
+  html += '</div>';
+  wrap.innerHTML = html;
+  return wrap;
+}
+
+// ─── STAT CARD ───
+function renderStatCard(wrap, block) {
+  const stats = block.stats || [];
+  let html = '<div class="cr-statcard">';
+  if (block.title) {
+    html += `<h4 style="font-family:var(--cr-font-display);font-weight:700;color:var(--cr-navy);margin-bottom:14px">${esc(block.title)}</h4>`;
+  }
+  html += '<div style="display:flex;flex-wrap:wrap;gap:16px">';
+  stats.forEach(s => {
+    html += `<div style="flex:1 1 140px;min-width:140px;background:var(--cr-gold-faded);border:1.5px solid var(--cr-gold);border-radius:12px;padding:18px 16px;text-align:center">
+      <div style="font-family:var(--cr-font-display);font-weight:800;font-size:1.9rem;line-height:1.1;color:var(--cr-burgundy)">${esc(s.value || '')}</div>
+      ${s.label ? `<div style="font-size:0.85rem;font-weight:700;color:var(--cr-navy);margin-top:6px">${esc(s.label)}</div>` : ''}
+      ${s.description ? `<div style="font-size:0.78rem;color:var(--cr-text-muted);margin-top:4px;line-height:1.5">${esc(s.description)}</div>` : ''}
+    </div>`;
+  });
+  html += '</div></div>';
+  wrap.innerHTML = html;
+  return wrap;
+}
+
+// ─── CASE STUDY ───
+function renderCaseStudy(wrap, block) {
+  const row = (label, value) => value
+    ? `<div style="margin-bottom:12px">
+         <div style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--cr-burgundy);margin-bottom:4px">${esc(label)}</div>
+         <div class="cr-prose" style="font-size:0.88rem;line-height:1.65;color:var(--cr-text)">${esc(value)}</div>
+       </div>`
+    : '';
+  let html = `<div class="cr-casestudy cr-card" style="border-left:4px solid var(--cr-burgundy);padding:20px 22px">
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:${block.caseClient ? '4px' : '14px'}">
+      <span style="font-size:1.1rem">📋</span>
+      <span style="font-family:var(--cr-font-display);font-weight:700;font-size:1.1rem;color:var(--cr-navy)">${esc(block.caseTitle || 'Case Study')}</span>
+    </div>`;
+  if (block.caseClient) {
+    html += `<div style="font-size:0.82rem;color:var(--cr-text-muted);margin-bottom:14px">${esc(block.caseClient)}</div>`;
+  }
+  html += row('Presenting Concerns', block.casePresentingConcerns);
+  html += row('Background', block.caseBackground);
+  html += row('Clinician Notes', block.caseClinicianNotes);
+  html += row('Discussion', block.caseDiscussion);
+  html += '</div>';
+  wrap.innerHTML = html;
+  return wrap;
+}
+
+// ─── PULL QUOTE ───
+function renderPullQuote(wrap, block) {
+  let html = `<blockquote class="cr-pullquote" style="margin:0;border-left:4px solid var(--cr-gold);background:var(--cr-gold-faded);border-radius:0 12px 12px 0;padding:20px 24px">
+    <p style="font-family:var(--cr-font-display);font-size:1.25rem;line-height:1.5;font-style:italic;color:var(--cr-navy);margin:0">${esc(block.quote || '')}</p>`;
+  if (block.attribution) {
+    html += `<footer style="font-size:0.85rem;font-weight:700;color:var(--cr-burgundy);margin-top:12px">— ${esc(block.attribution)}</footer>`;
+  }
+  html += '</blockquote>';
+  wrap.innerHTML = html;
+  return wrap;
+}
+
+// ─── TABLE BLOCK ───
+function renderTableBlock(wrap, block) {
+  const headers = block.tableHeaders || [];
+  const rows = block.tableRows || [];
+  let html = '<div class="cr-tableblock">';
+  if (block.title) {
+    html += `<h4 style="font-family:var(--cr-font-display);font-weight:700;color:var(--cr-navy);margin-bottom:12px">${esc(block.title)}</h4>`;
+  }
+  html += '<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse;font-size:0.85rem">';
+  if (headers.length) {
+    html += '<thead><tr>';
+    headers.forEach(h => {
+      html += `<th style="text-align:left;padding:10px 12px;background:var(--cr-burgundy);color:#fff;font-weight:700;border:1px solid var(--cr-border)">${esc(h)}</th>`;
+    });
+    html += '</tr></thead>';
+  }
+  html += '<tbody>';
+  rows.forEach((r, ri) => {
+    const cells = Array.isArray(r) ? r : [r];
+    html += `<tr style="background:${ri % 2 ? 'var(--cr-gold-faded)' : '#fff'}">`;
+    cells.forEach(c => {
+      html += `<td style="padding:10px 12px;border:1px solid var(--cr-border);line-height:1.55;color:var(--cr-text)">${esc(c == null ? '' : c)}</td>`;
+    });
+    html += '</tr>';
+  });
+  html += '</tbody></table></div>';
+  if (block.tableCaption) {
+    html += `<p style="font-size:0.78rem;color:var(--cr-text-muted);margin-top:8px;font-style:italic">${esc(block.tableCaption)}</p>`;
   }
   html += '</div>';
   wrap.innerHTML = html;
@@ -7908,6 +8054,8 @@ document.addEventListener('click', function(e) {
     // ─── Navigation ───
     case 'prevSection': prevSection(); break;
     case 'nextSection': nextSection(); break;
+    case 'prevBlockPage': prevBlockPage(); break;
+    case 'nextBlockPage': nextBlockPage(); break;
     case 'goToSection': goToSection(idx); break;
     case 'showAssessment': showAssessment(); break;
     

--- a/server/src/models/InteractiveCourse.js
+++ b/server/src/models/InteractiveCourse.js
@@ -62,6 +62,10 @@ const ContentBlockSchema = new mongoose.Schema({
       'timeline',
       'video',
       'videoEmbed',
+      'statCard',
+      'caseStudy',
+      'pullQuote',
+      'tableBlock',
     ],
     required: true
   },
@@ -204,7 +208,31 @@ const ContentBlockSchema = new mongoose.Schema({
     year: Number,
     source: String,
     url: String
-  }]
+  }],
+
+  // ── statCard ──
+  stats: [{
+    value: String,
+    label: String,
+    description: String
+  }],
+
+  // ── caseStudy ──
+  caseTitle: String,
+  caseClient: String,
+  casePresentingConcerns: String,
+  caseBackground: String,
+  caseClinicianNotes: String,
+  caseDiscussion: String,
+
+  // ── pullQuote ──
+  quote: String,
+  attribution: String,
+
+  // ── tableBlock ──
+  tableHeaders: [String],
+  tableRows: [[String]],
+  tableCaption: String
 }, { _id: false, strict: false });
 
 const SectionSchema = new mongoose.Schema({

--- a/server/src/scripts/auditInteractiveCourseVideos.js
+++ b/server/src/scripts/auditInteractiveCourseVideos.js
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of GA Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ *
+ * auditInteractiveCourseVideos.js
+ *
+ * Scans every video / videoEmbed block in the interactivecourses collection,
+ * checks each videoUrl via YouTube oEmbed (no API key required), and writes
+ * videoStatus: 'live' | 'dead' | 'unknown' back to each block in MongoDB.
+ *
+ * The viewer reads block.videoStatus — dead blocks show a styled fallback
+ * card instead of a broken iframe.
+ *
+ * Usage:
+ *   node src/scripts/auditInteractiveCourseVideos.js          # dry run
+ *   APPLY=1 node src/scripts/auditInteractiveCourseVideos.js  # write to DB
+ *
+ * Anti-lying gate (dry run):
+ *   node src/scripts/auditInteractiveCourseVideos.js | grep -E "checked|live|dead"
+ */
+
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import InteractiveCourse from '../models/InteractiveCourse.js';
+
+const DRY_RUN = process.env.APPLY !== '1';
+const DELAY_MS = 650; // between YouTube checks — avoids rate-limiting
+
+// ─── YouTube ID extractor ──────────────────────────────────────
+function extractYouTubeId(url) {
+  const m = url.match(
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\s?#]+)/
+  );
+  return m ? m[1] : null;
+}
+
+// ─── URL status checker ────────────────────────────────────────
+async function checkVideoUrl(url) {
+  if (!url) return { status: 'unknown', reason: 'No URL' };
+
+  const ytId = extractYouTubeId(url);
+
+  if (ytId) {
+    // YouTube: use oEmbed — no API key, returns 404 for deleted/private
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 8000);
+      const res = await fetch(
+        `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${ytId}&format=json`,
+        { signal: controller.signal }
+      );
+      clearTimeout(timer);
+      if (res.ok) {
+        const data = await res.json();
+        return { status: 'live', title: data.title };
+      }
+      if ([400, 403, 404].includes(res.status)) {
+        return { status: 'dead', reason: `oEmbed HTTP ${res.status}` };
+      }
+      return { status: 'unknown', reason: `oEmbed HTTP ${res.status}` };
+    } catch (e) {
+      return { status: 'unknown', reason: e.message };
+    }
+  }
+
+  // Non-YouTube: HEAD request
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    const res = await fetch(url, { method: 'HEAD', signal: controller.signal });
+    clearTimeout(timer);
+    return res.ok
+      ? { status: 'live' }
+      : { status: 'dead', reason: `HTTP ${res.status}` };
+  } catch (e) {
+    return { status: 'unknown', reason: e.message };
+  }
+}
+
+// ─── Main ──────────────────────────────────────────────────────
+async function main() {
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  console.log(`\nCReady Video Audit — ${DRY_RUN ? 'DRY RUN (no writes)' : '⚠️  APPLY MODE (writing to DB)'}`);
+  console.log('─'.repeat(65));
+
+  const courses = await InteractiveCourse.find({}, 'title slug sections').lean();
+  console.log(`Found ${courses.length} courses in interactivecourses\n`);
+
+  let totalChecked = 0;
+  let totalLive    = 0;
+  let totalDead    = 0;
+  let totalUnknown = 0;
+  const deadList   = [];
+  const updates    = []; // { courseId, sIdx, bIdx, status }
+
+  for (const course of courses) {
+    const videoBlocks = [];
+
+    (course.sections || []).forEach((section, sIdx) => {
+      (section.contentBlocks || []).forEach((block, bIdx) => {
+        if (block.type === 'video' || block.type === 'videoEmbed') {
+          videoBlocks.push({ section, sIdx, block, bIdx });
+        }
+      });
+    });
+
+    if (!videoBlocks.length) continue;
+
+    console.log(`📚  ${course.title}`);
+    console.log(`    slug: ${course.slug} · ${videoBlocks.length} video block(s)`);
+
+    for (const { section, sIdx, block, bIdx } of videoBlocks) {
+      totalChecked++;
+      const url = block.videoUrl || '';
+      const short = url.length > 55 ? url.substring(0, 52) + '...' : url;
+
+      process.stdout.write(`    ⏳  §${sIdx + 1} block[${bIdx}]  ${short}  `);
+
+      const result = await checkVideoUrl(url);
+      updates.push({ courseId: course._id, sIdx, bIdx, status: result.status });
+
+      if (result.status === 'live') {
+        totalLive++;
+        console.log(`✅  live${result.title ? '  —  ' + result.title : ''}`);
+      } else if (result.status === 'dead') {
+        totalDead++;
+        console.log(`❌  DEAD  —  ${result.reason}`);
+        deadList.push({
+          course:  course.title,
+          slug:    course.slug,
+          section: section.title || `Section ${sIdx + 1}`,
+          url,
+          reason:  result.reason
+        });
+      } else {
+        totalUnknown++;
+        console.log(`❓  unknown  —  ${result.reason}`);
+      }
+
+      await new Promise(r => setTimeout(r, DELAY_MS));
+    }
+
+    console.log('');
+  }
+
+  // ─── Summary ───────────────────────────────────────────────
+  console.log('─'.repeat(65));
+  console.log(
+    `SUMMARY  |  ${totalChecked} checked  ·  ` +
+    `${totalLive} live ✅  ·  ` +
+    `${totalDead} dead ❌  ·  ` +
+    `${totalUnknown} unknown ❓`
+  );
+
+  if (deadList.length) {
+    console.log('\nDEAD VIDEO LIST:');
+    deadList.forEach((d, i) => {
+      console.log(`  ${i + 1}.  ${d.course}  →  §${d.section}`);
+      console.log(`       URL:    ${d.url}`);
+      console.log(`       Reason: ${d.reason}`);
+    });
+  }
+
+  // ─── Write ─────────────────────────────────────────────────
+  if (!DRY_RUN) {
+    if (!updates.length) {
+      console.log('\nNo video blocks found — nothing to write.');
+    } else {
+      console.log(`\nWriting videoStatus to ${updates.length} blocks…`);
+      let written = 0;
+      for (const { courseId, sIdx, bIdx, status } of updates) {
+        await InteractiveCourse.updateOne(
+          { _id: courseId },
+          { $set: { [`sections.${sIdx}.contentBlocks.${bIdx}.videoStatus`]: status } }
+        );
+        written++;
+      }
+      console.log(`WROTE ${written} block(s).`);
+    }
+  } else {
+    console.log('\nDry run complete — no writes. Re-run with APPLY=1 to persist.');
+  }
+
+  await mongoose.disconnect();
+  console.log('Done.\n');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/src/scripts/bulkRebuildCourses.js
+++ b/server/src/scripts/bulkRebuildCourses.js
@@ -175,6 +175,7 @@ const VALID_BLOCK_TYPES = new Set([
   'keyTakeaway','knowledgeCheck','matching','multiSelect','multipleChoice',
   'quiz','references','reflection','resources','scenarioTree',
   'sectionDivider','sequencing','text','timeline','video','videoEmbed',
+  'statCard','caseStudy','pullQuote','tableBlock',
   // Legacy aliases — Tech Manual §10.2 documents these as forgiven by the
   // viewer. Kept here so the AI filter doesn't strip pre-existing data
   // that happens to use them.


### PR DESCRIPTION
This branch (`claude/eloquent-gates-o5s2i5`) carries **two independent tasks** because the session is pinned to a single development branch. Happy to split into two PRs if you'd prefer — see note at the bottom.

---
## Task 1 — 4 content block types + within-section pagination
### Files (3)
1. **`server/src/models/InteractiveCourse.js`** — added `statCard`, `caseStudy`, `pullQuote`, `tableBlock` to the `ContentBlockSchema.type` enum + their schema fields (`stats`, `case*`, `quote`/`attribution`, `table*`). Additive only.
2. **`server/src/scripts/bulkRebuildCourses.js`** — same 4 types added to `VALID_BLOCK_TYPES`.
3. **`client/public/interactive-course.html`** — 4 render functions (dispatched via a `render<Type>` convention in the existing `default` branch; switch left untouched) + within-section pagination (`BLOCK_PAGE_SIZE`/`currentBlockPage`, page nav, `prev/nextBlockPage`, reset on `goToSection`).

Gates: render-fn grep = 4 · pagination grep = 16 · `node --check` clean.

---
## Task 2 — Dead video link detection
### Files (2)
1. **`server/src/scripts/auditInteractiveCourseVideos.js`** (new) — scans every `video`/`videoEmbed` block, checks each `videoUrl` via YouTube oEmbed (no API key) or a HEAD request, and writes `videoStatus: live|dead|unknown` back to each block. Dry-run by default; `APPLY=1` to persist. (Persists via the schema's `strict:false` — `videoStatus` isn't a declared field.)
2. **`client/public/interactive-course.html`** — two surgical changes:
   - **CSS:** `.cr-video-dead*` fallback-card styles inserted after `.cr-video-marker:hover`.
   - **JS:** `renderVideoEmbed` now shows a styled fallback card when `block.videoStatus === 'dead'`, when no URL is configured, or when a live oEmbed check returns non-OK (swallowed on network error so offline users keep the iframe). Added `crVideoDeadHtml` / `crReplaceVideoWithDead` helpers.

### Anti-lying gates (Task 2)
- `grep -c "crVideoDeadHtml\|crReplaceVideoWithDead\|videoStatus\|cr-video-dead"` → **17** (≥17) ✅
- `wc -l client/public/interactive-course.html` → **8575** (>8379) ✅
- `node --check` on all 3 inline JS blocks → **0 errors** ✅
- `node --check server/src/scripts/auditInteractiveCourseVideos.js` → **0 errors** ✅
- New script file exists ✅
- HTML diff = exactly 2 hunks (CSS + `renderVideoEmbed`/helpers)

---
### Notes
- The Task 2 prompt named branch `task/video-dead-link-fix`, but this session is configured to develop on `claude/eloquent-gates-o5s2i5` and not push elsewhere without explicit permission — so it landed here, stacked on Task 1. Tell me if you want these split into separate PRs/branches.
- The video diff was applied from the attached reference file; the `renderVideoEmbed` being replaced was byte-identical to `main`, so the swap was clean.

https://claude.ai/code/session_01UVnV3iva3gZ7A5XwLuqM2m