### PR TITLE
TMH601 Stage 5d.1+ — viewer UX cleanup (3-in-1)

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -3730,7 +3730,7 @@ let currentSectionIndex = 0;
 // When a section holds more than BLOCK_PAGE_SIZE content blocks, the viewer
 // splits them into pages so learners aren't handed an endless scroll. The
 // page index resets to 0 whenever the section changes (see goToSection).
-const BLOCK_PAGE_SIZE = 8;
+const BLOCK_PAGE_SIZE = 4;
 let currentBlockPage = 0;
 let completedSections = new Set();
 let visitedSections = new Set([0]); // First section always visited
@@ -8573,6 +8573,34 @@ function dismissNPS() {
     </div>
   </div>
 </div>
+<style id="cr-stage-5d1-viewer-cleanup">
+  /* Stage 5d.1+ — hide the Learning Objectives tracker on content sections */
+  #crObjectivesTracker { display: none !important; }
+
+  /* Stage 5d.1+ — pull-quote frame: text blocks whose only inner content is a single <blockquote> */
+  .cr-block[data-block-type="text"]:has(.cr-prose > blockquote:only-child),
+  .cr-block[data-block-type="text"]:has(> blockquote:only-child) {
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    margin: 1em 0 !important;
+  }
+  /* Stage 5d.1+ — punchline frame: text blocks containing only a centered italic paragraph */
+  .cr-block[data-block-type="text"]:has(.cr-prose > p:only-child[style*="text-align: center"]),
+  .cr-block[data-block-type="text"]:has(> p:only-child[style*="text-align: center"]) {
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    margin: 0.5em 0 1em !important;
+  }
+  /* Stage 5d.1+ — strip cr-prose padding so inner content reaches full width */
+  .cr-block[data-block-type="text"]:has(.cr-prose > blockquote:only-child) .cr-prose,
+  .cr-block[data-block-type="text"]:has(.cr-prose > p:only-child[style*="text-align: center"]) .cr-prose {
+    padding: 0 !important;
+  }
+</style>
 <script src="cr-retrieval-popup.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Stage 5d.1+ — Viewer UX cleanup (3-in-1)

Three small viewer fixes, all in `client/public/interactive-course.html`. No new files, no migration.

1. **Hide Learning Objectives tracker** on content sections — `#crObjectivesTracker { display: none !important; }` so content starts higher.
2. **Strip the block frame** around Stage 5d punchlines/pull-quotes — CSS `:has()` rules remove the outer `.cr-block` padding/background when a text block's only inner content is a `<blockquote>` (pull-quote) or a single centered-italic `<p>` (punchline).
3. **Lower `BLOCK_PAGE_SIZE` 8 → 4** — shorter pages, less scrolling per page.

### Changes (1 file)
- `client/public/interactive-course.html` — `BLOCK_PAGE_SIZE` 8→4 (line 3733) + a `<style id="cr-stage-5d1-viewer-cleanup">` block inserted before the Stage 5f popup script tag. Diff = 29 insertions, 1 deletion, one file.

### Verification (actual outputs)
```
grep "cr-stage-5d1-viewer-cleanup"  → 1 hit (L8576, the <style id>)
grep "BLOCK_PAGE_SIZE"              → 5 hits; definition line now = 4 (L3733)
grep -c "Stage 5d.1+"              → 4
wc -l interactive-course.html      → 8606  (was 8578, +28)
node --check on extracted inline JS → 0 errors
```

### ⚠️ One gate value differs from the prompt — not a corruption
The prompt expected `grep -c "Stage 5d.1+"` = **5**, but the actual count is **4**. The CSS block delivered in the prompt contains exactly **four** `Stage 5d.1+` comments (hide-tracker, pull-quote frame, punchline frame, strip cr-prose padding). I applied the block **byte-for-byte verbatim** — I did not add a 5th comment to force the number. The `<style id="cr-stage-5d1">` line uses `5d1` (no dots/plus) so it doesn't match the `Stage 5d.1+` pattern. So this is an off-by-one in the prompt's stated expectation, not a missing edit. Line count rose +28 (prompt estimated "~35", which was approximate). All three fixes are present and the inline JS parses cleanly.

### Stopped before merge (per prompt)
Not merged. Frontend-only; after merge → Render redeploy → reload mkkycoyo: objectives box gone, §9 punchline/pull-quote visually compact, shorter section pages.

https://claude.ai/code/session_01UVnV3iva3gZ7A5XwLuqM2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnV3iva3gZ7A5XwLuqM2m)_