### PR TITLE
Fix free-tier course gating: 4 one-CE-hour courses per month

### DIFF
--- a/server/src/__tests__/enrollment.test.js
+++ b/server/src/__tests__/enrollment.test.js
@@ -4,6 +4,13 @@
  * Unauthorized copying or distribution is strictly prohibited.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mutable holder so the mocked `protect` middleware can inject the current
+// test user onto req.user. vi.hoisted lets the mock factory reference it
+// despite vi.mock hoisting.
+const auth = vi.hoisted(() => ({ user: null }));
 
 // Mock all dependencies before importing (same approach as contentGating.test.js).
 // The mongoose stub is slightly fuller than that file's: interactiveCourseRoutes.js
@@ -33,11 +40,23 @@ vi.mock('mongoose', () => {
   };
   return { default: mongoose, Schema };
 });
-vi.mock('../models/InteractiveCourse.js', () => ({
-  Course: { findOne: vi.fn() },
-  CourseProgress: { findOne: vi.fn() },
-  ContentInteraction: {}
-}));
+
+// CourseProgress is used both as a static (findOne/countDocuments) and as a
+// constructor (`new CourseProgress({...})` then `.save()`), so the mock is a
+// vi.fn constructor with statics hung off it.
+vi.mock('../models/InteractiveCourse.js', () => {
+  const CourseProgress = vi.fn(function (data) {
+    Object.assign(this, data);
+    this.save = vi.fn().mockResolvedValue(this);
+  });
+  CourseProgress.findOne = vi.fn();
+  CourseProgress.countDocuments = vi.fn();
+  return {
+    Course: { findById: vi.fn(), findOne: vi.fn() },
+    CourseProgress,
+    ContentInteraction: {}
+  };
+});
 // interactiveCourseRoutes.js also imports these two models at module load.
 // Their real schemas reference mongoose.Schema.Types.ObjectId, which the
 // lightweight mongoose mock above does not provide — so they must be mocked
@@ -46,17 +65,18 @@ vi.mock('../models/Gamification.js', () => ({ default: {} }));
 vi.mock('../models/UserCredential.js', () => ({ default: {} }));
 vi.mock('../models/Certificate.js', () => ({ default: {} }));
 vi.mock('../models/Evaluation.js', () => ({ default: {} }));
-vi.mock('../models/User.js', () => ({ default: {} }));
+vi.mock('../models/User.js', () => ({ default: { updateOne: vi.fn().mockResolvedValue({}) } }));
 vi.mock('../middleware/auth.js', () => ({
-  protect: (req, res, next) => next(),
-  optionalAuth: (req, res, next) => next(),
+  protect: (req, res, next) => { req.user = auth.user; next(); },
+  optionalAuth: (req, res, next) => { req.user = auth.user; next(); },
   requireAdmin: (req, res, next) => next()
 }));
 vi.mock('../middleware/tenantScope.js', () => ({
   attachTenantScope: (req, res, next) => next()
 }));
 vi.mock('../services/activityTrackingService.js', () => ({
-  logActivity: vi.fn(),
+  // Returns a promise: the enroll handler chains `.catch()` on the result.
+  logActivity: vi.fn().mockResolvedValue(undefined),
   ACTIVITY_TYPES: {}
 }));
 vi.mock('../utils/certificate.js', () => ({
@@ -68,9 +88,7 @@ vi.mock('../utils/certificate.js', () => ({
 // at load time, several of which instantiate external clients on import
 // (e.g. freeCourseLimitEmail.js → `new Resend(process.env.RESEND_API_KEY)`,
 // config/twilio.js → a Twilio client). Mocking the wrapper modules keeps the
-// real clients — and their required API keys — out of the test. The original
-// contentGating.test.js predates these imports, which is why it currently
-// fails to load on main.
+// real clients — and their required API keys — out of the test.
 vi.mock('../services/freeCourseLimitEmail.js', () => ({ checkAndSendFreeLimit: vi.fn() }));
 vi.mock('../services/rewardsService.js', () => ({
   awardCourseCompletion: vi.fn(),
@@ -92,22 +110,37 @@ vi.mock('resend', () => ({
   Resend: class { constructor() { this.emails = { send: vi.fn() }; } }
 }));
 
-const { CourseProgress } = await import('../models/InteractiveCourse.js');
-const { _gateContent: gateContent } = await import('../routes/interactiveCourseRoutes.js');
+const { Course, CourseProgress } = await import('../models/InteractiveCourse.js');
+const { default: User } = await import('../models/User.js');
+const routerModule = await import('../routes/interactiveCourseRoutes.js');
+const { _gateContent: gateContent } = routerModule;
+const router = routerModule.default;
 
-// FREE_CE_HOUR_LIMIT in interactiveCourseRoutes.js is 4.
-const FREE_CE_HOUR_LIMIT = 4;
+// New policy constants (mirrors interactiveCourseRoutes.js).
+const FREE_COURSES_PER_MONTH = 4;
+
+const THIS_MONTH = new Date().toISOString().slice(0, 7); // "YYYY-MM"
+const LAST_MONTH = (() => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 1);
+  return d.toISOString().slice(0, 7);
+})();
+
+// Express app mounting the real router so route handlers run end-to-end.
+const app = express();
+app.use(express.json());
+app.use('/api/interactive-courses', router);
 
 // Course whose _id has a working toString(), matching the purchase-check pattern:
-//   pc.courseId?.toString() === courseObj._id.toString()
+//   pc.courseId?.toString() === course._id.toString()
 // accessType defaults to a *non-free* tier so the `accessType === 'free'`
-// early-return (which would short-circuit before the purchase/sub/free-hour
-// checks) does not fire. Tests that want a free course override accessType.
+// early-return does not fire. Tests that want a free course override accessType.
 function makeCourse(overrides = {}) {
   return {
     _id: { toString: () => 'course123' },
     title: 'Test Course',
     slug: 'test-course',
+    ceHours: 1,
     sections: [
       {
         title: 'Section 1',
@@ -139,6 +172,16 @@ function makeCourse(overrides = {}) {
   };
 }
 
+function freeUser(overrides = {}) {
+  return {
+    _id: 'user1',
+    role: 'user',
+    email: 'free@example.com',
+    subscription: { plan: 'free', status: 'free' },
+    ...overrides
+  };
+}
+
 // Assert the caller received the full, ungated course object.
 function expectFullContent(result) {
   expect(result._isPreview).toBeUndefined();
@@ -146,130 +189,154 @@ function expectFullContent(result) {
   expect(result.assessment.questions).toHaveLength(2);
 }
 
-// Assert the caller received the stripped preview. stripContent() sets
-// _isPreview and rewrites each section to a single truncated text preview block
-// flagged with _stripped (it does NOT empty assessment.questions), so the
-// reliable signal that gating stripped the content is the section shape.
+// Assert the caller received the stripped preview.
 function expectStripped(result) {
   expect(result._isPreview).toBe(true);
   expect(result.sections[0]._stripped).toBe(true);
   expect(result.sections[0].contentBlocks).toHaveLength(1);
 }
 
-describe('gateContent — purchasedCourses access check', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Enrollment lookup is awaited inside gateContent but does not by itself
-    // grant access; default it to null so each test starts clean.
-    CourseProgress.findOne.mockResolvedValue(null);
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.user = null;
+  CourseProgress.findOne.mockResolvedValue(null);
+  CourseProgress.countDocuments.mockResolvedValue(0);
+  User.updateOne.mockResolvedValue({});
+});
+
+describe('POST /:id/enroll — monthly free-course policy', () => {
+  it('1. free user, 0 courses this month, ceHours=1 → enrolls (201) and consumes one slot', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 1 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
+
+    const res = await request(app).post('/api/interactive-courses/course123/enroll');
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(CourseProgress).toHaveBeenCalledTimes(1); // progress doc created
+    // Slot consumed once: count bumped to 1 for the current month.
+    expect(User.updateOne).toHaveBeenCalledTimes(1);
+    const [, update] = User.updateOne.mock.calls[0];
+    expect(update.$set.freeCoursesUsedThisMonth).toBe(1);
+    expect(update.$set.freeCoursesResetMonth).toBe(THIS_MONTH);
   });
 
-  it('1. grants full content when purchasedCourses contains the matching courseId (free plan + exhausted free hours)', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'free', status: 'free' },
-      freeHoursUsed: 10, // well past FREE_CE_HOUR_LIMIT — purchase must still win
-      purchasedCourses: [
-        { courseId: { toString: () => 'course123' }, slug: 'test-course', purchasedAt: new Date() }
-      ]
-    };
-    const result = await gateContent(course, user);
-    expectFullContent(result);
+  it('2. free user, ceHours=3 → 403 OVER_FREE_HOUR_LIMIT, no progress created', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 3 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
+
+    const res = await request(app).post('/api/interactive-courses/course123/enroll');
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('OVER_FREE_HOUR_LIMIT');
+    expect(CourseProgress).not.toHaveBeenCalled();
+    expect(User.updateOne).not.toHaveBeenCalled();
   });
 
-  it('2. does NOT grant access via the purchase path when purchasedCourses holds a DIFFERENT courseId', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'free', status: 'free' },
-      freeHoursUsed: FREE_CE_HOUR_LIMIT, // exhausted so the only way to full is purchase/sub
-      purchasedCourses: [
-        { courseId: { toString: () => 'differentCourse' }, slug: 'other-course', purchasedAt: new Date() }
-      ]
-    };
-    const result = await gateContent(course, user);
-    // Non-matching purchase → falls through → free hours exhausted → stripped
-    expectStripped(result);
-    expect(result._freeHoursExhausted).toBe(true);
+  it('3. free user, freeCoursesUsedThisMonth=4 this month → 403 MONTHLY_LIMIT', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 1 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 4, freeCoursesResetMonth: THIS_MONTH });
+
+    const res = await request(app).post('/api/interactive-courses/course123/enroll');
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('MONTHLY_LIMIT');
+    expect(res.body.freeCoursesUsedThisMonth).toBe(4);
+    expect(res.body.freeCoursesLimit).toBe(FREE_COURSES_PER_MONTH);
+    expect(CourseProgress).not.toHaveBeenCalled();
   });
 
-  it('3. falls through to the subscription/free-hours check when purchasedCourses is an empty array', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'free', status: 'free' },
-      freeHoursUsed: 0,
-      purchasedCourses: []
-    };
-    const result = await gateContent(course, user);
-    // No purchase → free-tier with budget remaining → full content + free-hours meta
-    expectFullContent(result);
-    expect(result._freeHoursRemaining).toBe(FREE_CE_HOUR_LIMIT);
-    expect(result._freeHoursUsed).toBe(0);
+  it('4. free user, freeCoursesUsedThisMonth=4 but reset month is last month → allowed (counter reset)', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 1 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 4, freeCoursesResetMonth: LAST_MONTH });
+
+    const res = await request(app).post('/api/interactive-courses/course123/enroll');
+
+    expect(res.status).toBe(201);
+    expect(CourseProgress).toHaveBeenCalledTimes(1);
+    // Reset path: new count starts at 1 and the month key is rewritten.
+    const [, update] = User.updateOne.mock.calls[0];
+    expect(update.$set.freeCoursesUsedThisMonth).toBe(1);
+    expect(update.$set.freeCoursesResetMonth).toBe(THIS_MONTH);
+    expect(update.$set.freeLimitEmailSentThisMonth).toBe(false);
   });
 });
 
-describe('gateContent — subscription, free-hours, and trial gating', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe('GET /:id/progress — auto-create gating', () => {
+  it('6. free user, 3-hour course, no progress → 403 and no progress doc created', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 3 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
+
+    const res = await request(app).get('/api/interactive-courses/course123/progress');
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('OVER_FREE_HOUR_LIMIT');
+    expect(CourseProgress).not.toHaveBeenCalled();
+    expect(User.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('free user, 1-hour course, no progress → progress auto-created and slot consumed', async () => {
+    Course.findById.mockResolvedValue(makeCourse({ ceHours: 1 }));
+    auth.user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
+
+    const res = await request(app).get('/api/interactive-courses/course123/progress');
+
+    expect(res.status).toBe(200);
+    expect(CourseProgress).toHaveBeenCalledTimes(1);
+    expect(User.updateOne).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('gateContent — enrollment-gated content for free-tier users', () => {
+  it('5a. free user NOT enrolled → stripped preview with _requiresEnrollment', async () => {
     CourseProgress.findOne.mockResolvedValue(null);
-  });
+    const course = makeCourse({ ceHours: 1 });
+    const user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
 
-  it('4. serves content to a free-tier user with 0 freeHoursUsed (free-hours path)', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'free', status: 'free' },
-      freeHoursUsed: 0
-    };
     const result = await gateContent(course, user);
-    expectFullContent(result);
-    expect(result._freeHoursRemaining).toBe(FREE_CE_HOUR_LIMIT);
-  });
 
-  it('5. strips content for a free-tier user at/over FREE_CE_HOUR_LIMIT freeHoursUsed', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'free', status: 'free' },
-      freeHoursUsed: FREE_CE_HOUR_LIMIT
-    };
-    const result = await gateContent(course, user);
     expectStripped(result);
-    expect(result._freeHoursExhausted).toBe(true);
-    expect(result._freeHoursUsed).toBe(FREE_CE_HOUR_LIMIT);
+    expect(result._requiresEnrollment).toBe(true);
   });
 
-  it('6. grants full content to a user with an active trial', async () => {
-    const course = makeCourse();
-    const user = {
-      _id: 'user1',
-      role: 'user',
-      subscription: { plan: 'professional', status: 'trial' }
-    };
+  it('5b. free user ENROLLED → full content', async () => {
+    CourseProgress.findOne.mockResolvedValue({ _id: 'prog1' }); // enrolled
+    const course = makeCourse({ ceHours: 1 });
+    const user = freeUser({ freeCoursesUsedThisMonth: 0, freeCoursesResetMonth: THIS_MONTH });
+
+    const result = await gateContent(course, user);
+
+    expectFullContent(result);
+  });
+
+  it('7a. purchased course → full content regardless of month count', async () => {
+    CourseProgress.findOne.mockResolvedValue(null);
+    const course = makeCourse({ ceHours: 5 });
+    const user = freeUser({
+      freeCoursesUsedThisMonth: 99,
+      freeCoursesResetMonth: THIS_MONTH,
+      purchasedCourses: [
+        { courseId: { toString: () => 'course123' }, slug: 'test-course', purchasedAt: new Date() }
+      ]
+    });
+
     const result = await gateContent(course, user);
     expectFullContent(result);
   });
 
-  it('7. strips content for a user with an expired trial and no purchase', async () => {
-    const course = makeCourse();
+  it('7b. active paid subscription → full content regardless of hours/month count', async () => {
+    CourseProgress.findOne.mockResolvedValue(null);
+    const course = makeCourse({ ceHours: 5 });
     const user = {
       _id: 'user1',
       role: 'user',
-      subscription: { plan: 'professional', status: 'expired' },
-      // Expired (non-active) subscription falls through to the free-hours check;
-      // with hours exhausted and no purchase, the content is stripped.
-      freeHoursUsed: FREE_CE_HOUR_LIMIT,
-      purchasedCourses: []
+      email: 'pro@example.com',
+      subscription: { plan: 'professional', status: 'active' },
+      freeCoursesUsedThisMonth: 99,
+      freeCoursesResetMonth: THIS_MONTH
     };
+
     const result = await gateContent(course, user);
-    expectStripped(result);
-    expect(result._freeHoursExhausted).toBe(true);
+    expectFullContent(result);
   });
 });

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -35,7 +35,8 @@ async function findCourseByIdOrSlug(param) {
 }
 
 // ── CONTENT GATING ──────────────────────────────────────────
-const FREE_CE_HOUR_LIMIT = 4; // Free users get 4 CE hours before paywall
+const FREE_COURSES_PER_MONTH = 4;   // free plan: 4 courses/month
+const FREE_MAX_COURSE_HOURS  = 1;   // free plan covers 1-CE-hour courses only
 
 /**
  * Strip sensitive content from course for preview/unauthenticated users.
@@ -71,6 +72,53 @@ function stripContent(courseObj) {
   return obj;
 }
 
+function currentMonthKey() { return new Date().toISOString().slice(0, 7); }
+
+function effectiveFreeCoursesUsed(user) {
+  if (!user) return 0;
+  if (user.freeCoursesResetMonth !== currentMonthKey()) return 0; // month rolled over
+  return user.freeCoursesUsedThisMonth ?? 0;
+}
+
+// Free-tier eligibility for a PAID course. Read-only (does NOT consume a slot).
+function freeTierDecision(user, course) {
+  const courseHours = course.ceHours || course.ceuHours || 1;
+  if (courseHours > FREE_MAX_COURSE_HOURS) {
+    return { allowed: false, code: 'OVER_FREE_HOUR_LIMIT',
+      message: 'Free plan covers 1-hour courses only. Subscribe or purchase this course to enroll.' };
+  }
+  if (effectiveFreeCoursesUsed(user) >= FREE_COURSES_PER_MONTH) {
+    return { allowed: false, code: 'MONTHLY_LIMIT',
+      message: `You've used your ${FREE_COURSES_PER_MONTH} free courses this month. Subscribe for unlimited access.` };
+  }
+  return { allowed: true, code: 'FREE_OK' };
+}
+
+// True if user already has paid/admin/free-course access (no slot needed).
+function hasPaidOrFreeAccess(user, course) {
+  if (!user) return false;
+  if (user.role === 'admin') return true;
+  if (course.accessType === 'free') return true;
+  const purchased = user.purchasedCourses?.some(
+    pc => pc.courseId?.toString() === course._id.toString());
+  if (purchased) return true;
+  const status = user.subscription?.status || 'free';
+  const plan   = user.subscription?.plan   || 'free';
+  return ['active','trial','lifetime'].includes(status) && plan !== 'free';
+}
+
+// Atomically persist consumption of one monthly free slot (month-aware).
+async function consumeFreeSlot(user) {
+  const month = currentMonthKey();
+  const sameMonth = user.freeCoursesResetMonth === month;
+  const newCount = (sameMonth ? (user.freeCoursesUsedThisMonth ?? 0) : 0) + 1;
+  return User.updateOne({ _id: user._id }, { $set: {
+    freeCoursesResetMonth: month,
+    freeCoursesUsedThisMonth: newCount,
+    ...(sameMonth ? {} : { freeLimitEmailSentThisMonth: false })
+  }});
+}
+
 /**
  * Gate course content based on user authentication, subscription, and enrollment.
  * Returns: full course, stripped preview, or course with metadata flags.
@@ -102,21 +150,12 @@ async function gateContent(courseObj, user) {
 
   if (isActiveSub && subPlan !== 'free') return courseObj;
 
-  // Free-tier users: check CE hour budget
-  const freeHoursUsed = user.freeHoursUsed ?? 0;
-  const courseHours = courseObj.ceHours || courseObj.ceuHours || 1;
-
-  if (freeHoursUsed < FREE_CE_HOUR_LIMIT) {
-    const courseWithMeta = courseObj.toObject ? courseObj.toObject() : { ...courseObj };
-    courseWithMeta._freeHoursRemaining = FREE_CE_HOUR_LIMIT - freeHoursUsed;
-    courseWithMeta._freeHoursUsed = freeHoursUsed;
-    return courseWithMeta;
-  }
-
-  // Exhausted free hours + no subscription → strip
+  // Free-tier user on a paid course: full content ONLY if already enrolled.
+  // Enrollment (POST /enroll or first GET /progress) is the single chokepoint that
+  // enforced the 1-hour cap and the monthly quota — so trust it here.
+  if (isEnrolled) return courseObj;
   const stripped = stripContent(courseObj);
-  stripped._freeHoursExhausted = true;
-  stripped._freeHoursUsed = freeHoursUsed;
+  stripped._requiresEnrollment = true;
   return stripped;
 }
 
@@ -341,20 +380,23 @@ router.get('/:id/progress', protect, async (req, res) => {
 
     // If no progress exists, create initial progress
     if (!progress) {
+      const paid = hasPaidOrFreeAccess(req.user, course);
+      const freeDecision = paid ? { allowed: true } : freeTierDecision(req.user, course);
+      if (!paid && !freeDecision.allowed) {
+        return res.status(403).json({ success: false, error: 'Enrollment required',
+          code: freeDecision.code, message: freeDecision.message });
+      }
       progress = new CourseProgress({
         userId: req.user._id,
         courseId: course._id,
         sectionProgress: course.sections.map((section, index) => ({
-          sectionId: section._id,
-          sectionIndex: index,
-          viewedBlocks: [],
-          completedBlocks: [],
-          quizAttempts: [],
-          status: 'not_started'
+          sectionId: section._id, sectionIndex: index,
+          viewedBlocks: [], completedBlocks: [], quizAttempts: [], status: 'not_started'
         })),
         assessmentAttemptsRemaining: course.assessment?.attemptsAllowed || 3
       });
       await progress.save();
+      if (!paid) consumeFreeSlot(req.user).catch(() => {}); // free-tier consumes 1 slot, once
     }
 
     res.json({ success: true, data: progress });
@@ -398,29 +440,26 @@ router.post('/:id/enroll', protect, async (req, res) => {
 
     let accessGranted = false;
     let usedFreeHours = false;
+    let freeDenial = null;
 
     if (isAdmin || isFree || hasPurchased) {
       accessGranted = true;
     } else if (isActiveSub && subPlan !== 'free') {
       accessGranted = true;
     } else {
-      // Free-tier: check CE hour budget
-      const freeHoursUsed = user.freeHoursUsed ?? 0;
-      const courseHours = course.ceHours || course.ceuHours || 1;
-      if (freeHoursUsed + courseHours <= FREE_CE_HOUR_LIMIT) {
-        accessGranted = true;
-        usedFreeHours = true;
-      }
+      const decision = freeTierDecision(user, course);
+      if (decision.allowed) { accessGranted = true; usedFreeHours = true; }
+      else { freeDenial = decision; }
     }
 
     if (!accessGranted) {
       return res.status(403).json({
         success: false,
-        error: 'Subscription required',
-        code: 'SUBSCRIPTION_REQUIRED',
-        message: `You've used your ${FREE_CE_HOUR_LIMIT} free CE hours. Subscribe for unlimited access.`,
-        freeHoursUsed: user.freeHoursUsed ?? 0,
-        freeHoursLimit: FREE_CE_HOUR_LIMIT
+        error: freeDenial?.code === 'OVER_FREE_HOUR_LIMIT' ? 'Upgrade required' : 'Subscription required',
+        code: freeDenial?.code || 'SUBSCRIPTION_REQUIRED',
+        message: freeDenial?.message || `Subscribe for unlimited access.`,
+        freeCoursesUsedThisMonth: effectiveFreeCoursesUsed(user),
+        freeCoursesLimit: FREE_COURSES_PER_MONTH
       });
     }
 
@@ -458,11 +497,7 @@ router.post('/:id/enroll', protect, async (req, res) => {
 
     await progress.save();
 
-    // Increment free hours used (fire-and-forget)
-    if (usedFreeHours) {
-      const courseHours = course.ceHours || course.ceuHours || 1;
-      User.findByIdAndUpdate(user._id, { $inc: { freeHoursUsed: courseHours } }).catch(() => {});
-    }
+    if (usedFreeHours) { consumeFreeSlot(user).catch(() => {}); }
 
     // Log enrollment to admin activity feed (fire-and-forget)
     logActivity(ACTIVITY_TYPES.USER_ENROLLED, {

--- a/server/src/services/freeCourseLimitEmail.js
+++ b/server/src/services/freeCourseLimitEmail.js
@@ -84,9 +84,6 @@ export async function checkAndSendFreeLimit(userId) {
     user.freeCoursesResetMonth = currentMonth;
   }
 
-  // Increment usage
-  user.freeCoursesUsedThisMonth += 1;
-
   // Check if limit reached and email not yet sent
   if (user.freeCoursesUsedThisMonth >= FREE_COURSE_LIMIT && !user.freeLimitEmailSentThisMonth) {
     const firstName = user.profile?.firstName || 'there';


### PR DESCRIPTION
## Summary

Replaces the legacy "4 CE-hours per account" budget with the correct free-plan policy:

- Registered free-plan users may enroll in up to **four 1-CE-hour courses per calendar month** (counter resets each month).
- Any course with `ceHours > 1` requires an **active paid subscription** or an **individual purchase**.
- Admin, free (`accessType === 'free'`), purchased, and active-paid-subscription access are all unchanged.

## Changes

### `server/src/routes/interactiveCourseRoutes.js`
- New constants `FREE_COURSES_PER_MONTH = 4` / `FREE_MAX_COURSE_HOURS = 1` (replacing `FREE_CE_HOUR_LIMIT`).
- New helpers: `currentMonthKey`, `effectiveFreeCoursesUsed` (month-aware read), `freeTierDecision` (read-only eligibility → `OVER_FREE_HOUR_LIMIT` / `MONTHLY_LIMIT` / `FREE_OK`), `hasPaidOrFreeAccess`, and `consumeFreeSlot` (atomic, month-aware `User.updateOne`).
- `gateContent`: free-tier user on a paid course gets full content **only if already enrolled**; otherwise a stripped preview flagged `_requiresEnrollment`. Enrollment is the single chokepoint enforcing the cap.
- `GET /:id/progress`: the auto-create path is now gated — denies 403 when the free user is ineligible, and consumes one monthly slot when it does create progress.
- `POST /:id/enroll`: uses `freeTierDecision`; 403 responses now carry `code`, `freeCoursesUsedThisMonth`, `freeCoursesLimit`. Consumption switched from per-hour `$inc` to one monthly slot via `consumeFreeSlot`.

### `server/src/services/freeCourseLimitEmail.js`
- Removed the completion-time increment (`user.freeCoursesUsedThisMonth += 1`). The slot is now consumed at enrollment, so completion must not double-count. The month-reset block, the at-limit email, and `user.save()` are intact — the function is now read-only counting plus the one-time email.

### `server/src/__tests__/enrollment.test.js`
- Rewritten to the new policy. Drives the real route handlers via supertest plus direct `gateContent` checks:
  - free user, 0 used, `ceHours=1` → enroll 201, one slot consumed
  - free user, `ceHours=3` → 403 `OVER_FREE_HOUR_LIMIT`, no progress created
  - free user, used=4 this month → 403 `MONTHLY_LIMIT`
  - free user, used=4 but reset month = last month → allowed (counter reset)
  - `gateContent`: not enrolled → stripped `_requiresEnrollment`; enrolled → full
  - `GET /:id/progress`, 3-hour course, no progress → 403, no doc created
  - purchased course / active paid sub → full content regardless of hours/month count

## Verification

```
$ wc -l server/src/routes/interactiveCourseRoutes.js
1629   (>= 1578 minimum)

$ grep -n "FREE_CE_HOUR_LIMIT\|freeHoursUsed" server/src/routes/interactiveCourseRoutes.js
(no matches)
```

`npx vitest run` → 44 passed (incl. the 10 new enrollment tests). The single failing suite, `contentGating.test.js`, fails to load **before** this change (its mongoose mock lacks `Schema.Types`); it is out of scope and untouched.

https://claude.ai/code/session_01YSMnxQ4dwt6jTaaPJ1Mc3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSMnxQ4dwt6jTaaPJ1Mc3F)_