### PR TITLE
Fix false ACEP non-compliance flags from stale/missing stored scalars

### DIFF
--- a/server/src/routes/adminAudit.js
+++ b/server/src/routes/adminAudit.js
@@ -6,6 +6,7 @@
 import express from 'express';
 import mongoose from 'mongoose';
 import { protect, requireAdmin } from '../middleware/auth.js';
+import { requiredWordsFor } from '../utils/courseWordCount.js';
 
 const router = express.Router();
 
@@ -19,8 +20,8 @@ function auditCourse(course) {
   const sectionsLen = Array.isArray(course.sections) ? course.sections.length : 0;
   const modulesLen  = Array.isArray(course.modules)  ? course.modules.length  : 0;
   const wc  = Number(course.wordCount || 0);
-  const ce  = Number(course.ceHours   || 0);
-  const floor = Math.floor(ce * MIN_WPCE);
+  const ce  = Number(course.ceHours || course.ceuHours || 0);
+  const floor = requiredWordsFor(ce);   // = ce * 6000 (the real ACEP minimum)
 
   const fails = [];
   if (!ce || ce <= 0)
@@ -28,7 +29,7 @@ function auditCourse(course) {
   if (!wc || wc <= 0)
     fails.push({ rule: 'R1-wordCount-missing', detail: `wordCount=${course.wordCount}` });
   if (ce > 0 && wc > 0 && wc < floor)
-    fails.push({ rule: 'R2-wordCount-below-floor', detail: `${wc} < ${ce}×${MIN_WPCE}=${floor}` });
+    fails.push({ rule: 'R2-wordCount-below-floor', detail: `${wc} < ${ce}×6000=${floor}` });
   if (sectionsLen + modulesLen === 0)
     fails.push({ rule: 'R3-no-content', detail: 'sections=0 AND modules=0' });
 
@@ -57,7 +58,7 @@ router.get('/', protect, requireAdmin, async (req, res) => {
   try {
     const db = mongoose.connection.db;
     const courses = await db.collection('interactivecourses')
-      .find({}, { projection: { slug: 1, title: 1, courseCode: 1, status: 1, ceHours: 1, wordCount: 1, sections: 1, modules: 1 } })
+      .find({}, { projection: { slug: 1, title: 1, courseCode: 1, status: 1, ceHours: 1, ceuHours: 1, wordCount: 1, sections: 1, modules: 1 } })
       .toArray();
 
     const results = courses.map(auditCourse);

--- a/server/src/scripts/backfillCeHours.js
+++ b/server/src/scripts/backfillCeHours.js
@@ -1,0 +1,77 @@
+// backfillCeHours.js
+// Backfills the STORED ceHours scalar from ceuHours where hours live only in
+// ceuHours (a common seed artifact that trips the ACEP audit's R4/R2 rules).
+//
+// Uses the RAW driver (updateMany) so schema validation cannot block fixing the
+// very field that fails validation. Only touches the interactivecourses collection.
+//
+// Run: node backfillCeHours.js
+// Requires: MONGODB_URI environment variable
+
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('❌ No MONGODB_URI environment variable set');
+  process.exit(1);
+}
+
+async function run() {
+  await mongoose.connect(MONGODB_URI);
+  console.log('Connected to MongoDB\n');
+
+  const col = mongoose.connection.db.collection('interactivecourses');
+
+  // Pull the scalars only — the collection is small and we never touch prose.
+  const docs = await col
+    .find({}, { projection: { slug: 1, title: 1, ceHours: 1, ceuHours: 1 } })
+    .toArray();
+  console.log(`Found ${docs.length} courses\n`);
+
+  const needsBackfill = []; // ceHours missing/<=0 but ceuHours > 0 → fixable
+  const needsManual   = []; // BOTH missing/<=0 → hours can't be inferred
+
+  for (const d of docs) {
+    const ce  = Number(d.ceHours);
+    const ceu = Number(d.ceuHours);
+    const ceOk  = Number.isFinite(ce)  && ce  > 0;
+    const ceuOk = Number.isFinite(ceu) && ceu > 0;
+
+    if (!ceOk && ceuOk) needsBackfill.push(d);
+    else if (!ceOk && !ceuOk) needsManual.push(d);
+  }
+
+  // Apply the fix. Single RAW updateMany over the resolved id set, using an
+  // aggregation pipeline so ceHours is set from each doc's own ceuHours.
+  for (const d of needsBackfill) {
+    const slug = (d.slug || String(d._id)).padEnd(30).slice(0, 30);
+    console.log(`${slug} | ceHours <- ceuHours (${Number(d.ceuHours)})`);
+  }
+
+  if (needsBackfill.length) {
+    await col.updateMany(
+      { _id: { $in: needsBackfill.map(d => d._id) } },
+      [{ $set: { ceHours: '$ceuHours' } }]
+    );
+  }
+
+  // List (do not modify) the docs that need a human to set hours.
+  if (needsManual.length) {
+    console.log('\n⚠ NEEDS MANUAL ceHours ───────────────────────────────');
+    for (const d of needsManual) {
+      console.log(`  ${d.slug || '(no-slug)'} | ${d.title || '(untitled)'} | ${d._id}`);
+    }
+  }
+
+  console.log('\n── Summary ────────────────────────────────────────────');
+  console.log(`  Total docs    : ${docs.length}`);
+  console.log(`  Backfilled    : ${needsBackfill.length}`);
+  console.log(`  Needs manual  : ${needsManual.length}`);
+
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error('❌ Error:', err);
+  process.exit(1);
+});

--- a/server/src/scripts/recalcAllWordCounts.js
+++ b/server/src/scripts/recalcAllWordCounts.js
@@ -19,22 +19,28 @@ async function run() {
   const courses = await InteractiveCourse.find({}).lean();
   console.log(`Found ${courses.length} courses\n`);
 
-  let increased = 0, decreased = 0, unchanged = 0;
+  let increased = 0, decreased = 0, unchanged = 0, skipped = 0;
 
   for (const raw of courses) {
     const oldWc = raw.wordCount ?? 0;
-    const doc = await InteractiveCourse.findById(raw._id);
-    await doc.save();
-    const newWc = doc.wordCount ?? 0;
-
     const slug = (raw.slug || String(raw._id)).padEnd(30).slice(0, 30);
-    const title = (raw.title || '(untitled)').slice(0, 50);
-    const arrow = oldWc === newWc ? '==' : oldWc < newWc ? '->' : '->';
-    console.log(`${slug} | ${String(oldWc).padStart(6)} ${arrow} ${String(newWc).padEnd(6)} | ${title}`);
 
-    if (newWc > oldWc) increased++;
-    else if (newWc < oldWc) decreased++;
-    else unchanged++;
+    try {
+      const doc = await InteractiveCourse.findById(raw._id);
+      await doc.save();
+      const newWc = doc.wordCount ?? 0;
+
+      const title = (raw.title || '(untitled)').slice(0, 50);
+      const arrow = oldWc === newWc ? '==' : oldWc < newWc ? '->' : '->';
+      console.log(`${slug} | ${String(oldWc).padStart(6)} ${arrow} ${String(newWc).padEnd(6)} | ${title}`);
+
+      if (newWc > oldWc) increased++;
+      else if (newWc < oldWc) decreased++;
+      else unchanged++;
+    } catch (err) {
+      skipped++;
+      console.log(`✗ SKIPPED ${(raw.slug || String(raw._id))}: ${err.message}`);
+    }
   }
 
   console.log('\n── Summary ────────────────────────────────────────────');
@@ -42,6 +48,7 @@ async function run() {
   console.log(`  Increased          : ${increased}`);
   console.log(`  Decreased          : ${decreased}`);
   console.log(`  Unchanged          : ${unchanged}`);
+  console.log(`  Skipped            : ${skipped}`);
 
   await mongoose.disconnect();
 }


### PR DESCRIPTION
## Summary

The admin ACEP audit was flagging compliant courses as non-compliant. Root cause is **stale/missing STORED scalars**, not course content:

- `ceHours` is `null` on courses where the hours actually live in `ceuHours` → false **R4** (ceHours<=0) and a broken **R2** floor.
- `wordCount` is `0` on courses seeded in a way that bypassed the pre-save hook → false **R1**.

No course prose is touched.

## Changes

### A — `server/src/scripts/backfillCeHours.js` (new)
- Connects via `process.env.MONGODB_URI`, operates only on `interactivecourses`.
- Uses the **RAW driver** (`updateMany` with an aggregation pipeline `$set: { ceHours: "$ceuHours" }`) so schema validation can't block fixing the very field that fails validation.
- Backfills every doc where `ceHours` is missing/`<=0` **and** `ceuHours` is a number `> 0`; logs each as `slug: ceHours <- ceuHours (N)`.
- Separately **lists (does not modify)** docs where *both* `ceHours` and `ceuHours` are missing/`<=0` under a `⚠ NEEDS MANUAL ceHours` header (slug + title + `_id`) — hours can't be inferred.
- Prints a summary (total / backfilled / needs-manual) and disconnects cleanly. Mirrors `recalcAllWordCounts.js` structure.

### B — `server/src/scripts/recalcAllWordCounts.js`
- Wraps the per-doc `findById` / `save()` in try/catch so one invalid doc can't abort the whole run. On failure logs `✗ SKIPPED <slug>: <err.message>` and continues.
- Adds a `Skipped` counter to the summary. No other behavior changed.

### C — `server/src/routes/adminAudit.js`
- Imports the canonical threshold helper: `import { requiredWordsFor } from '../utils/courseWordCount.js';` (single source of truth).
- Reads hours with the app-wide fallback: `const ce = Number(course.ceHours || course.ceuHours || 0);`
- R2 floor now uses the canonical value: `const floor = requiredWordsFor(ce);` (= `ce * 6000`, the real ACEP minimum). R2 detail string updated to `${wc} < ${ce}×6000=${floor}`.
- Query projection now includes `ceuHours: 1` so the fallback has data.
- R1/R3/R4 logic and the 1-hour cache are intact. R4 now only fires when **both** `ceHours` and `ceuHours` are absent (correct).
- `MIN_WPCE` is still referenced by the summary (`minWpce`), so per the task it's left defined but no longer drives the floor.

## Verification

```
$ git diff --stat
 server/src/routes/adminAudit.js           |  9 +++++----
 server/src/scripts/recalcAllWordCounts.js | 29 ++++++++++++++++++-----------
 (+ new server/src/scripts/backfillCeHours.js)

$ grep -n "ceHours || course.ceuHours\|requiredWordsFor\|ceuHours: 1" server/src/routes/adminAudit.js
9:import { requiredWordsFor } from '../utils/courseWordCount.js';
23:  const ce  = Number(course.ceHours || course.ceuHours || 0);
24:  const floor = requiredWordsFor(ce);   // = ce * 6000 (the real ACEP minimum)
61:  .find({}, { projection: { ... ceHours: 1, ceuHours: 1, wordCount: 1, ... } })

$ node --check src/scripts/backfillCeHours.js   → OK
$ node --check src/scripts/recalcAllWordCounts.js → OK (try/catch + skipped counter present)
```

## ⚠ Scripts not run here

This ephemeral environment has **no `MONGODB_URI`** (and no `server/.env`), so the two data scripts could not be executed against a live collection — both correctly fail fast with `❌ No MONGODB_URI environment variable set` (exit 1). They must be run by someone with staging/production DB access, in this order:

```
node src/scripts/backfillCeHours.js      # ceHours first (must precede recalc)
node src/scripts/recalcAllWordCounts.js  # now safe — fixes stale wordCount
```

Then hit `GET /api/admin/audit?refresh=1` to bust the 1-hour cache. The backfill summary and recalc summary (especially any NEEDS-MANUAL or SKIPPED docs) should be reviewed from that run.

https://claude.ai/code/session_01YSMnxQ4dwt6jTaaPJ1Mc3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSMnxQ4dwt6jTaaPJ1Mc3F)_