### PR TITLE
CR-303..307: enriched sexual-health CE seeds — callout pills + varied KC formats (draft)

### DIFF
--- a/server/src/scripts/seedCR303-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR303-EXPANDED-canonical.js
@@ -1,0 +1,1511 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+import 'dotenv/config';
+
+// CR-303 EXPANDED — canonical sections[] shape. Saves through the real model so the
+// pre-save wordCount hook fires (no modules->sections conversion needed).
+
+const COURSE_DATA = {
+  "title": "Sexual Health Across the Lifespan: Assessment and Evidence-Based Clinical Practice",
+  "slug": "sexual-health-across-the-lifespan",
+  "courseCode": "CR-303",
+  "description": "A comprehensive 3-hour continuing education course for licensed mental health professionals. Meets NBCC ACEP standards with graduate-level clinical content on sexual health assessment and affirming, evidence-based practice across the lifespan.",
+  "ceHours": 3,
+  "credits": 3,
+  "category": "Clinical",
+  "ceCategory": "Clinical",
+  "ceuHours": 3,
+  "ceuEligible": true,
+  "approvingBody": "NBCC",
+  "approvalNumber": "#7760",
+  "creditType": "NBCC",
+  "acepProvider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "number": "7760"
+  },
+  "instructor": "GA Integrated Therapeutic Perspectives LLC",
+  "targetAudience": [
+    "Licensed mental health professionals including LPCs, LCSWs, LMFTs, psychologists, NCCs, and psychiatric NPs who address sexual health concerns across the lifespan in clinical practice."
+  ],
+  "accessType": "subscription",
+  "price": 59.99,
+  "pricingTier": "standard",
+  "status": "draft",
+  "isPublished": false,
+  "isActive": true,
+  "passingScore": 80,
+  "maxAttempts": 3,
+  "settings": {
+    "passingScore": 80,
+    "certificateEnabled": true,
+    "requireEvaluation": true,
+    "requireAttestation": true
+  },
+  "objectives": [
+    "Apply a biopsychosocial framework to sexual health assessment across childhood, adolescence, adulthood, and later life.",
+    "Identify normative sexual development milestones and distinguish them from clinical concerns requiring assessment or mandated reporting.",
+    "Implement evidence-based, affirming approaches to sexual health clinical conversations across diverse client populations.",
+    "Recognize and respond clinically to sexual health concerns presenting in the context of chronic illness, disability, and aging.",
+    "Apply cultural humility in sexual health clinical practice with LGBTQ+ clients and clients from diverse cultural backgrounds.",
+    "Utilize validated assessment tools and referral pathways for sexual health concerns requiring specialist intervention."
+  ],
+  "assessment": {
+    "isExam": true,
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
+      {
+        "question": "The biopsychosocial model of sexual health understands sexual functioning as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Primarily determined by biological factors",
+            "isCorrect": false
+          },
+          {
+            "text": "The product of interacting biological, psychological, and sociocultural factors",
+            "isCorrect": true
+          },
+          {
+            "text": "Primarily a psychological phenomenon",
+            "isCorrect": false
+          },
+          {
+            "text": "Fixed across the lifespan unless disrupted by illness",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The biopsychosocial model integrates all three domains; no single factor is sufficient."
+      },
+      {
+        "question": "The WHO definition of sexual health is significant for clinical practice because it:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Defines sexual health solely as the absence of disease",
+            "isCorrect": false
+          },
+          {
+            "text": "Frames sexual health positively, including pleasure, safety, respect, and self-determination",
+            "isCorrect": true
+          },
+          {
+            "text": "Applies only to reproductive-age adults",
+            "isCorrect": false
+          },
+          {
+            "text": "Excludes emotional and social dimensions",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The WHO definition is positive and integrative rather than deficit-based."
+      },
+      {
+        "question": "In the PLISSIT model, providing accurate information that corrects a sexual myth corresponds to which level?",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Permission",
+            "isCorrect": false
+          },
+          {
+            "text": "Limited Information",
+            "isCorrect": true
+          },
+          {
+            "text": "Specific Suggestions",
+            "isCorrect": false
+          },
+          {
+            "text": "Intensive Therapy",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Correcting myths with accurate, targeted information is the Limited Information level."
+      },
+      {
+        "question": "Which best describes responsive desire as described by Basson?",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Desire that always precedes arousal",
+            "isCorrect": false
+          },
+          {
+            "text": "Desire that emerges in response to arousal and emotional intimacy",
+            "isCorrect": true
+          },
+          {
+            "text": "A disorder of low desire",
+            "isCorrect": false
+          },
+          {
+            "text": "Desire experienced only by men",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Responsive desire emerges in response to arousal and intimacy and is a normal pattern for many people."
+      },
+      {
+        "question": "Sexual behavior in a young child that is compulsive, non-redirectable, and accompanied by fear or aggression should be understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Developmentally normative",
+            "isCorrect": false
+          },
+          {
+            "text": "Outside the normative range, warranting careful assessment",
+            "isCorrect": true
+          },
+          {
+            "text": "Proof that abuse has occurred",
+            "isCorrect": false
+          },
+          {
+            "text": "Clinically irrelevant",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "These features fall outside the normative range and warrant assessment, though they are not by themselves proof of abuse."
+      },
+      {
+        "question": "The threshold for mandated reporting of suspected child abuse is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Proof that abuse occurred",
+            "isCorrect": false
+          },
+          {
+            "text": "Reasonable suspicion",
+            "isCorrect": true
+          },
+          {
+            "text": "A disclosure by the child",
+            "isCorrect": false
+          },
+          {
+            "text": "Confirmation by another professional",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Mandated reporting is triggered by reasonable suspicion; investigators, not clinicians, determine whether abuse occurred."
+      },
+      {
+        "question": "Arousal non-concordance refers to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "The alignment of genital and subjective arousal",
+            "isCorrect": false
+          },
+          {
+            "text": "The common finding that genital response and subjective arousal do not always match",
+            "isCorrect": true
+          },
+          {
+            "text": "A paraphilic disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "A medication side effect",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Non-concordance is the well-documented finding that genital and subjective arousal are not always aligned."
+      },
+      {
+        "question": "The dual control model conceptualizes sexual response as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A purely hormonal process",
+            "isCorrect": false
+          },
+          {
+            "text": "The balance between sexual excitation and sexual inhibition",
+            "isCorrect": true
+          },
+          {
+            "text": "A fixed four-stage cycle",
+            "isCorrect": false
+          },
+          {
+            "text": "Determined entirely by relationship satisfaction",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The dual control model frames response as the balance of excitation (accelerator) and inhibition (brakes)."
+      },
+      {
+        "question": "Cultural humility in sexual health practice is best described as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Achieving expertise in every culture's sexual norms",
+            "isCorrect": false
+          },
+          {
+            "text": "A stance of lifelong self-examination and openness to the client as expert on their own experience",
+            "isCorrect": true
+          },
+          {
+            "text": "Applying mainstream norms consistently",
+            "isCorrect": false
+          },
+          {
+            "text": "Avoiding discussion of culture entirely",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Cultural humility emphasizes self-examination and client expertise rather than achieved competence."
+      },
+      {
+        "question": "Meyer's minority stress model attributes elevated distress in sexual and gender minority populations to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Inherent features of minority identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Chronic exposure to stigma, discrimination, and internalized negative messages",
+            "isCorrect": true
+          },
+          {
+            "text": "Genetic vulnerability",
+            "isCorrect": false
+          },
+          {
+            "text": "Lack of access to medication",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Minority stress locates elevated distress in stigma and discrimination, not in the identity itself."
+      },
+      {
+        "question": "Regarding sexual activity after a cardiac event, clinicians should generally:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Advise permanent avoidance of sexual activity",
+            "isCorrect": false
+          },
+          {
+            "text": "Use risk-stratification guidance (e.g., Princeton Consensus); for most stable patients, activity is safe and reassurance is itself an intervention",
+            "isCorrect": true
+          },
+          {
+            "text": "Defer entirely to the patient with no guidance",
+            "isCorrect": false
+          },
+          {
+            "text": "Assume sexual activity is always dangerous",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Princeton Consensus guidance supports the safety of sexual activity for most stable cardiac patients; reassurance is an intervention."
+      },
+      {
+        "question": "Genitourinary syndrome of menopause (GSM) is best understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "An untreatable, inevitable end to sexual life",
+            "isCorrect": false
+          },
+          {
+            "text": "A normal and frequently treatable set of changes including dryness and tissue thinning",
+            "isCorrect": true
+          },
+          {
+            "text": "A psychiatric disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "A sign of abuse",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "GSM is normal and responds well to medical management; naming it is the first step toward treatment."
+      },
+      {
+        "question": "The social model of disability reframes the clinical goal as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Fixing bodies that do not conform to a norm",
+            "isCorrect": false
+          },
+          {
+            "text": "Removing the social and environmental barriers to sexual expression",
+            "isCorrect": true
+          },
+          {
+            "text": "Discouraging sexual activity",
+            "isCorrect": false
+          },
+          {
+            "text": "Limiting care to medical providers",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The social model targets barriers rather than 'fixing' nonconforming bodies."
+      },
+      {
+        "question": "SSRIs commonly affect sexual function by:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Increasing desire in all users",
+            "isCorrect": false
+          },
+          {
+            "text": "Causing reduced desire, delayed or absent orgasm, and arousal difficulty, contributing to nonadherence",
+            "isCorrect": true
+          },
+          {
+            "text": "Having no effect on sexual function",
+            "isCorrect": false
+          },
+          {
+            "text": "Affecting only older adults",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "SSRI sexual side effects are common and a leading, often undetected, cause of nonadherence."
+      },
+      {
+        "question": "A generalist clinician's appropriate response to entrenched sexual dysfunction beyond their competence is to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Attempt intensive sex therapy regardless of training",
+            "isCorrect": false
+          },
+          {
+            "text": "Refer to an appropriately trained or AASECT-certified clinician while continuing to provide permission and support",
+            "isCorrect": true
+          },
+          {
+            "text": "Avoid the topic",
+            "isCorrect": false
+          },
+          {
+            "text": "Tell the client nothing can be done",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Practicing within competence and referring appropriately is an ethical requirement under ACA/NBCC codes."
+      },
+      {
+        "question": "Sex assigned at birth, gender identity, gender expression, and sexual orientation are best understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Interchangeable terms for the same construct",
+            "isCorrect": false
+          },
+          {
+            "text": "Independent dimensions, none of which can be inferred from another",
+            "isCorrect": true
+          },
+          {
+            "text": "Determined entirely by anatomy",
+            "isCorrect": false
+          },
+          {
+            "text": "Relevant only when working with LGBTQ+ clients",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "These are distinct, independent dimensions; affirming practice requires asking rather than inferring one from another."
+      },
+      {
+        "question": "The most common sexual concern brought to couples therapy is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Erectile disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Desire discrepancy between partners",
+            "isCorrect": true
+          },
+          {
+            "text": "Genito-pelvic pain",
+            "isCorrect": false
+          },
+          {
+            "text": "Premature ejaculation",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Desire discrepancy — a difference between partners rather than a dysfunction in either — is the most frequent couple presentation, and reframing it is itself an intervention."
+      },
+      {
+        "question": "Common postpartum sexual changes (reduced desire, vaginal dryness) are best addressed by the clinician by:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Treating them as a sign of relationship failure",
+            "isCorrect": false
+          },
+          {
+            "text": "Normalizing them as common and often temporary and giving couples permission to communicate about them",
+            "isCorrect": true
+          },
+          {
+            "text": "Ignoring them as outside mental health scope",
+            "isCorrect": false
+          },
+          {
+            "text": "Advising indefinite abstinence",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Normalizing common, often temporary perinatal changes and opening communication prevents a normal transition from becoming a lasting rupture."
+      },
+      {
+        "question": "Capacity to consent to sexual activity in a resident with dementia is best understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Automatically absent once dementia is diagnosed",
+            "isCorrect": false
+          },
+          {
+            "text": "An all-or-nothing status conferred by diagnosis",
+            "isCorrect": false
+          },
+          {
+            "text": "Decision-specific and potentially fluctuating, requiring individualized assessment",
+            "isCorrect": true
+          },
+          {
+            "text": "Irrelevant in long-term care settings",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "Capacity is decision-specific and can fluctuate; it is assessed individually rather than presumed absent from a diagnosis."
+      },
+      {
+        "question": "When a client discloses a consensually non-monogamous relationship, affirming practice requires the clinician to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Treat the structure itself as the clinical problem",
+            "isCorrect": false
+          },
+          {
+            "text": "Distinguish the relationship structure (not the clinician's to judge) from any genuine distress or coercion within it",
+            "isCorrect": true
+          },
+          {
+            "text": "Assume the relationship is dysfunctional",
+            "isCorrect": false
+          },
+          {
+            "text": "Refer the client out for having an unconventional relationship",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Consensual non-monogamy is a relationship choice, not a disorder; the clinician supports the client within their structure while attending to genuine distress or coercion."
+      },
+      {
+        "question": "A client presents for depression and, on routine inquiry, reveals an unaddressed sexual difficulty contributing to their mood. This illustrates that:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Sexual concerns are rare and rarely relevant to other presentations",
+            "isCorrect": false
+          },
+          {
+            "text": "Sexual concerns frequently hide behind other presenting problems, so routine inquiry is needed to bring them into view",
+            "isCorrect": true
+          },
+          {
+            "text": "Depression should never be treated alongside sexual concerns",
+            "isCorrect": false
+          },
+          {
+            "text": "Clinicians should wait for clients to raise sexual concerns themselves",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Sexual concerns often surface only indirectly behind other complaints; routine, normalized inquiry is what makes the hidden sexual dimension visible and addressable."
+      },
+      {
+        "question": "A client expresses shame about a recurring sexual fantasy. The most accurate clinical framework is that:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "The content of a fantasy reliably predicts a desire to act on it",
+            "isCorrect": false
+          },
+          {
+            "text": "Fantasy is common and normal; clinical focus belongs on distress and on consent/harm in any acted-upon behavior, not on the content of private imagination",
+            "isCorrect": true
+          },
+          {
+            "text": "Unusual fantasies indicate pathology requiring elimination",
+            "isCorrect": false
+          },
+          {
+            "text": "Fantasy should always be interpreted as a hidden relationship problem",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Fantasy is near-universal and is not a plan; the clinician distinguishes private fantasy from behavior, focusing on distress and on consent/harm rather than on fantasy content."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Responsive desire — desire that arises after arousal and intimacy begin — is a normal pattern rather than evidence of a sexual disorder.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Responsive desire is normal and common, especially in long-term relationships; treating spontaneous desire as the only valid form can wrongly pathologize it."
+      },
+      {
+        "type": "trueFalse",
+        "question": "A situational sexual difficulty — present in one context but not another — points more strongly toward physiological causes than psychological or relational ones.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "A situational pattern points toward psychological, relational, or contextual contributors; a generalized, consistent difficulty raises the relative likelihood of a physiological cause."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Consensual non-monogamy is a recognized relationship structure rather than a disorder to be treated.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Consensual non-monogamy is a relationship choice; affirming practice assesses it on the client’s terms rather than pathologizing the structure."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which factors belong in a biopsychosocial formulation of a sexual concern? (Select all that apply)",
+        "options": [
+          {
+            "text": "Biological/medical contributors (conditions, medications, hormones)",
+            "isCorrect": true
+          },
+          {
+            "text": "Psychological factors (anxiety, beliefs, trauma, mood)",
+            "isCorrect": true
+          },
+          {
+            "text": "Relational and sociocultural context",
+            "isCorrect": true
+          },
+          {
+            "text": "Only the presenting physical symptom in isolation",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "A biopsychosocial formulation integrates biological, psychological, and social/relational factors rather than reducing the concern to one cause."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are appropriate generalist actions when sexual material arises unexpectedly in session? (Select all that apply)",
+        "options": [
+          {
+            "text": "Respond calmly and without surprise",
+            "isCorrect": true
+          },
+          {
+            "text": "Give permission to discuss it",
+            "isCorrect": true
+          },
+          {
+            "text": "Maintain professional boundaries and manage countertransference",
+            "isCorrect": true
+          },
+          {
+            "text": "Change the subject to avoid discomfort",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "A calm, permission-giving response that maintains boundaries is appropriate; avoiding the material signals it is unwelcome and replicates the silence many clients already experience."
+      }
+    ]
+  },
+  "sections": [
+    {
+      "title": "Module 1: Foundations — The Biopsychosocial and Lifespan Framework",
+      "order": 1,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 1,
+          "title": "Module 1",
+          "subtitle": "Module 1: Foundations — The Biopsychosocial and Lifespan Framework"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Why Sexual Health Belongs in Every Clinician's Scope</h2>\n<p>Sexual health is a fundamental dimension of human wellbeing that mental health professionals encounter across every clinical setting, yet it remains one of the most consistently undertreated dimensions of practice. The reasons are well documented: graduate training programs devote little or no curriculum to human sexuality; clinicians report discomfort and a fear of saying the wrong thing; and clients, anticipating judgment, rarely raise sexual concerns unprompted. The result is a clinical silence that leaves a large share of clients' distress unaddressed.</p>\n<p>The World Health Organization (2006) defines sexual health as \"a state of physical, emotional, mental, and social wellbeing in relation to sexuality; it is not merely the absence of disease, dysfunction, or infirmity.\" This definition has two clinically important features. First, it is positive rather than deficit-based: sexual health includes the presence of pleasure, safety, respect, and self-determination, not simply the absence of dysfunction. Second, it is integrative: it locates sexuality at the intersection of body, mind, relationship, and culture. A clinician who treats sexual concerns as purely medical, or purely psychological, will miss most of what is actually happening.</p>\n<p>This course takes the position that sexual health assessment is a general clinical competency, not a specialty reserved for certified sex therapists. The generalist clinician is not expected to provide specialized sex therapy. They are expected to be able to raise the topic without flinching, screen competently, recognize what is within their scope, and refer appropriately when it is not. That competency is what this course develops.</p>\n<h3>The Cost of Clinical Silence</h3>\n<p>When clinicians do not ask about sexual health, several predictable harms follow. Treatable conditions go untreated because they are never named. Medication side effects that drive nonadherence go undetected. Survivors of sexual trauma infer that the topic is unspeakable. And clients from marginalized groups, who already experience the healthcare system as unsafe, have that experience confirmed. The decision not to ask is not neutral; it is a clinical choice with consequences.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>The Biopsychosocial Model</h2>\n<p>The {{callout:biopsychosocial}} is the integrative framework that has replaced single-factor explanations of sexual functioning. It understands every sexual presentation as the product of the dynamic interaction of three domains, no one of which is sufficient on its own.</p>\n<h3>Biological Factors</h3>\n<p>Biological contributors include hormonal status (estrogen, testosterone, prolactin, thyroid function), vascular health (erectile and genital arousal depend on intact blood flow), neurological function, and — very commonly — medication effects. Antidepressants, antihypertensives, antipsychotics, hormonal contraceptives, and many other agents alter desire, arousal, and orgasm. Chronic illnesses such as diabetes, cardiovascular disease, and multiple sclerosis exert direct effects on sexual function. The clinician does not need to be a physician to recognize that a new sexual complaint coinciding with a new medication or diagnosis warrants medical consultation.</p>\n<h3>Psychological Factors</h3>\n<p>Psychological contributors include cognitive patterns (performance anxiety, spectatoring, catastrophic interpretation of normal variation), emotional regulation, attachment style, body image, sexual self-concept, and the residue of prior experience including trauma. Depression and anxiety both suppress and are suppressed by sexual difficulty, creating bidirectional loops that maintain distress.</p>\n<h3>Sociocultural Factors</h3>\n<p>Sociocultural contributors include cultural sexual scripts, gender-role expectations, religious and moral frameworks, relationship context, and the broader social messages a person has absorbed about what sex is supposed to be. A \"dysfunction\" in one cultural frame may be unremarkable in another; the clinician's task is to understand the meaning the client makes of their experience, not to impose a normative standard.</p>\n<p>Clinical formulation that attends to all three domains is substantially more useful than any single-factor account, because it generates a treatment plan with multiple points of entry. A man presenting with erectile difficulty may need a medical workup (biological), cognitive work on performance anxiety (psychological), and a conversation about relationship conflict and cultural expectations of male performance (social) — and addressing only one will usually fail.</p>",
+          "callouts": {
+            "biopsychosocial": {
+              "label": "Biopsychosocial Model",
+              "type": "reference",
+              "body": "A framework understanding sexual function and concerns as the product of interacting biological, psychological, and social/relational factors."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>The Lifespan Developmental Framework</h2>\n<p>Sexuality is not a static adult attribute that switches on at puberty and off in old age. It is a developmental process that begins in infancy and continues through the end of life, with characteristic concerns, normative milestones, and specific clinical considerations at each stage.</p>\n<h3>Infancy and Early Childhood</h3>\n<p>Genital sensation and self-stimulation are present from infancy and are a developmentally expected component of bodily self-discovery. Early childhood (roughly ages 3–7) brings curiosity about bodies, genital exploration, \"playing doctor\" with same-age peers, and beginning gender awareness. The clinician's role here is largely educational with caregivers: distinguishing developmentally normative curiosity from the small subset of behaviors that warrant assessment, and coaching caregivers away from shaming responses that teach children their bodies are dangerous.</p>\n<h3>Middle Childhood</h3>\n<p>Middle childhood involves the internalization of cultural messages about sexuality and gender, increasing privacy, and the consolidation of gender identity. Sexual curiosity continues but typically becomes more private as children absorb social norms.</p>\n<h3>Adolescence</h3>\n<p>Adolescence integrates physical sexual maturation, sexual and gender identity development, and the beginning of partnered sexual experience. It is simultaneously one of the most powerful periods in sexual development and one of the most clinically sensitive, because it sits at the intersection of normal development, risk (unintended pregnancy, sexually transmitted infection, coercion), and the legal and ethical complexities of working with minors.</p>\n<h3>Adulthood and Later Life</h3>\n<p>Adult sexuality must accommodate partnership, parenthood, the demands of work and caregiving, and the physical changes of midlife. Later life brings physiological change — but, contrary to a pervasive cultural myth, sexual interest and activity persist well into old age for many people. Treating older adults as asexual is both inaccurate and a barrier to care, a point developed in Module 3.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 4,
+          "prompt": "Think about your own clinical intake process. At what point, if ever, do you currently ask about sexual health? What has stopped you from asking earlier or more routinely?",
+          "placeholder": "Reflect on your current practice..."
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>The Clinical Conversation: Permission and the PLISSIT Model</h2>\n<p>The single most foundational skill in sexual health practice is <strong>permission-giving</strong>: the explicit, matter-of-fact communication that sexual health concerns are appropriate clinical topics, that the clinician is comfortable discussing them, and that the client's experiences are not inherently pathological. Permission is enacted by asking directly rather than waiting for the client to raise the subject, by tolerating the topic without visible discomfort, and by responding non-judgmentally to whatever is disclosed.</p>\n<h3>The {{callout:plissit}} Model</h3>\n<p>Annon's (1976) PLISSIT model remains the most widely used framework for organizing sexual health intervention by intensity, and it maps cleanly onto scope of practice:</p>\n<ul>\n<li><strong>P — Permission</strong>: normalizing the topic and inviting disclosure. Every clinician can and should operate at this level.</li>\n<li><strong>LI — Limited Information</strong>: providing accurate, targeted information that corrects myths and reduces distress (for example, that {{callout:responsive-desire}} is normal, or that medication side effects are common and manageable).</li>\n<li><strong>SS — Specific Suggestions</strong>: offering concrete behavioral strategies tailored to the presenting concern. This level requires some additional competence.</li>\n<li><strong>IT — Intensive Therapy</strong>: specialized treatment for entrenched concerns, typically the province of a certified sex therapist or appropriately trained clinician.</li>\n</ul>\n<p>Taylor and Davis (2006) proposed the <strong>Ex-PLISSIT</strong> revision, which makes permission the explicit foundation of every level and builds in reflection and review, addressing the tendency of clinicians to assume permission has been granted when it has not. The practical lesson is that most of what a generalist clinician needs to do — permission and limited information — is squarely within scope, and the model itself signals when to refer.</p>",
+          "callouts": {
+            "plissit": {
+              "label": "PLISSIT",
+              "type": "reference",
+              "body": "A four-level model — Permission, Limited Information, Specific Suggestions, Intensive Therapy — for graduated intervention in sexual concerns. Most generalists work at the first two levels."
+            },
+            "responsive-desire": {
+              "label": "Responsive Desire",
+              "type": "definition",
+              "body": "Desire that emerges in response to arousal and intimacy rather than preceding them — central to Basson’s circular model and common, especially in long-term relationships."
+            }
+          }
+        },
+        {
+          "type": "multipleChoice",
+          "order": 6,
+          "question": "Within the PLISSIT model, the 'Permission' level is therapeutically valuable primarily because:",
+          "options": [
+            {
+              "text": "It establishes a sexual diagnosis",
+              "isCorrect": false
+            },
+            {
+              "text": "It communicates that sexual concerns are legitimate clinical topics, reducing the shame that prevents disclosure",
+              "isCorrect": true
+            },
+            {
+              "text": "It identifies which clients need referral",
+              "isCorrect": false
+            },
+            {
+              "text": "It provides specific behavioral techniques",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Permission-giving normalizes sexual health as a clinical topic and reduces shame, which is the precondition for any further assessment or intervention.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>The Bidirectional Sexual Health–Mental Health Connection</h2>\n<p>The relationship between sexual health and overall mental health is bidirectional and clinically significant, which is the core justification for treating sexual health assessment as a standard component of general practice rather than an optional add-on.</p>\n<h3>Psychiatric Conditions Affect Sexual Function</h3>\n<p>Depression reduces desire and capacity for pleasure; anxiety drives performance concerns and avoidance; PTSD produces both hyperarousal and numbing that disrupt intimacy; and the relational withdrawal common to many conditions erodes the partnership context in which much sexual activity occurs.</p>\n<h3>Treatments Affect Sexual Function</h3>\n<p>The pharmacological treatments for these conditions frequently produce sexual side effects. Selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs) are associated with reduced desire, delayed or absent orgasm, and arousal difficulty in a substantial proportion of users. These effects are a leading cause of medication nonadherence, yet they are frequently never discussed because clinicians do not routinely ask. A clinician who monitors sexual side effects as part of ongoing medication management is not only treating a quality-of-life concern but directly protecting treatment adherence and outcome.</p>\n<h3>Sexual Difficulty Affects Mental Health</h3>\n<p>The relationship runs in the other direction as well. Sexual difficulty erodes self-esteem, strains relationships, and generates anxiety and depressive symptoms. Untreated sexual concerns can therefore undermine the very mental health treatment a client is receiving for another presenting problem.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Validated Assessment Instruments</h2>\n<p>Standardized instruments complement — they do not replace — the clinical interview, and they can be integrated into general mental health assessment, not only specialty settings.</p>\n<ul>\n<li><strong>Female Sexual Function Index (FSFI; Rosen et al., 2000)</strong>: a 19-item measure assessing six domains — desire, arousal, lubrication, orgasm, satisfaction, and pain.</li>\n<li><strong>International Index of Erectile Function (IIEF; Rosen et al., 1997)</strong>: a 15-item measure of male sexual function across erectile function, orgasmic function, desire, intercourse satisfaction, and overall satisfaction.</li>\n<li><strong>Arizona Sexual Experience Scale (ASEX)</strong>: a brief 5-item measure especially useful for tracking medication-related sexual side effects over time.</li>\n</ul>\n<p>Instruments should be administered within a clinical context that normalizes the assessment, shares results transparently with the client, and integrates the data into a biopsychosocial formulation rather than reducing a person to a score. Used well, brief instruments lower the threshold to the conversation, because completing a questionnaire can feel safer to a client than initiating disclosure aloud.</p>\n<h3>Cultural Scripts and Sexual Meaning</h3>\n<p>Gagnon and Simon's (1973) concept of <strong>sexual scripts</strong> — culturally shared cognitive frameworks that organize sexual expectations, meanings, and behavior — provides a useful lens for understanding how cultural context shapes each individual's experience. Scripts operate at cultural, interpersonal, and intrapsychic levels. Effective assessment is curious about the specific scripts organizing a given client's sexual life rather than applying mainstream Western norms as universal standards — a stance of cultural humility developed further in Module 2.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 9,
+          "prompt": "Which of the three biopsychosocial domains — biological, psychological, or sociocultural — do you most reliably attend to in your current practice, and which is most often neglected?",
+          "placeholder": "Reflect..."
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Why the Training Gap Exists — and Why It Matters</h2>\n<p>Understanding why sexual health is so often absent from clinical practice helps clinicians work past their own hesitation rather than simply feeling guilty about it. The gap is structural, not personal. Most graduate programs in counseling, social work, psychology, and psychiatry include little or no required coursework in human sexuality. Surveys of training programs across the mental health disciplines have consistently found that sexuality content is minimal, optional, or absent, and that practicum and internship supervision rarely models sexual health assessment. Clinicians therefore enter practice without having watched a competent sexual history taken, without language for the work, and without having processed their own discomfort in a supervised setting.</p>\n<p>The consequence is a self-perpetuating silence. Clinicians who were never taught to ask do not ask; clients infer that the topic is off-limits; and the absence of disclosures confirms the clinician's impression that sexual concerns are rare. In reality, sexual concerns are common across every clinical population, and the apparent rarity is an artifact of the silence itself.</p>\n<h3>The Clinical Stakes</h3>\n<p>The stakes of closing this gap are concrete. Sexual side effects are among the most common reasons clients quietly stop taking psychiatric medication, so a clinician who never asks may attribute a relapse to \"noncompliance\" while missing its actual cause. Survivors of sexual violence frequently present first for depression, anxiety, or relationship difficulty, and a clinician who cannot raise sexual health may never learn the history that organizes the presentation. Couples in distress over desire discrepancy — the single most common sexual complaint in couples work — may spend months in therapy that never names the issue. In each case, the missing competency is not specialized sex therapy; it is the basic ability to open the conversation.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Taking a Sexual History: A Practical Structure</h2>\n<p>A sexual history is not a single intrusive question dropped into an intake. It is a brief, normalized line of inquiry that can be woven into routine assessment, and it follows a recognizable structure.</p>\n<h3>Open With Normalization</h3>\n<p>The most effective openings frame the inquiry as routine and universal: \"I ask all of my clients about sexual health because it's an important part of overall wellbeing, and it's affected by a lot of the things we treat — stress, mood, medication, relationships. Is it all right if I ask you a few questions?\" This single sentence accomplishes permission, normalizes the topic, and gives the client a moment to prepare. The clinician's tone — matter-of-fact, unhurried, neither apologetic nor prurient — communicates more than the words.</p>\n<h3>The Core Domains to Cover</h3>\n<p>A competent screening history touches, at minimum, the following: whether the client is currently sexually active and with whom (without assuming gender or relationship structure); whether they have any concerns about desire, arousal, orgasm, or pain; whether they have noticed any changes related to mood, stress, or medication; their sexual safety, including any history of coercion or unwanted experiences (asked carefully and without pressure to disclose); and whether there is anything about their sexual health they would like help with. The history is calibrated to the setting and the presenting problem — a full sexual history is not required of every client at every visit — but the door is opened.</p>\n<h3>Responding to Disclosure</h3>\n<p>How the clinician responds to the first disclosure determines whether a second one ever comes. A neutral, accepting response — \"Thank you for telling me; that's exactly the kind of thing I can help with or help you find the right support for\" — keeps the door open. A visible flinch, a rushed change of subject, or premature reassurance closes it. The clinician does not need to have an immediate solution; they need to receive the disclosure without judgment and signal that it is a legitimate clinical concern.</p>\n<h3>Documentation</h3>\n<p>Sexual health information is documented with the same care, accuracy, and discretion as any other sensitive clinical content, using the client's own language, recording only what is clinically relevant, and attending to the heightened privacy considerations that sexual content carries — particularly in shared records, with adolescents, and in any situation where a record might be disclosed.</p>"
+        },
+        {
+          "order": 12,
+          "type": "sequencing",
+          "instructions": "Order the clinician’s steps when a client discloses a sexual concern for the first time.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Respond calmly and without surprise, signaling the topic is welcome"
+            },
+            {
+              "order": 2,
+              "text": "Normalize and give permission to discuss sexual concerns"
+            },
+            {
+              "order": 3,
+              "text": "Gather a focused, non-judgmental history of the concern"
+            },
+            {
+              "order": 4,
+              "text": "Offer limited information or specific suggestions within scope, or refer as needed"
+            }
+          ],
+          "explanation": "A first disclosure is fragile: the clinician’s calm, permission-giving response comes first, followed by focused assessment and then appropriately scoped intervention or referral."
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Working With Your Own Discomfort</h2>\n<p>Clinician discomfort is not a character flaw; it is a predictable product of inadequate training and the same cultural conditioning clients carry. Naming it honestly is more useful than pretending it away, because unexamined discomfort leaks into the room as avoidance, awkwardness, or subtle signals that the topic is unwelcome.</p>\n<h3>Common Sources of Discomfort</h3>\n<ul>\n<li><strong>Fear of saying the wrong thing</strong>: clinicians worry about using incorrect terminology, offending the client, or appearing incompetent. The antidote is preparation and a willingness to ask the client to teach the clinician their language.</li>\n<li><strong>Countertransference</strong>: sexual content can activate the clinician's own history, values, and reactions. Recognizing and processing these reactions — ideally in supervision or consultation — prevents them from distorting care.</li>\n<li><strong>Value conflicts</strong>: a clinician's personal, cultural, or religious values may differ sharply from a client's sexual life. Ethical practice requires bracketing those values so they do not become the basis for judgment, while also recognizing the limits of one's ability to provide affirming care and referring when necessary rather than imposing.</li>\n</ul>\n<p>The development of comfort is a process, not a prerequisite. Clinicians become comfortable by doing the work in manageable steps, debriefing in consultation, and accumulating experiences that disconfirm the catastrophic expectations that maintain avoidance. The goal is not the absence of discomfort but the capacity to remain present and useful in spite of it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Sexual Anatomy and Physiology: A Clinician's Working Knowledge</h2>\n<p>A generalist clinician does not need the detailed knowledge of a physician, but a working grasp of sexual physiology supports accurate assessment, demystifies common concerns, and allows the clinician to distinguish problems likely to have a physiological basis from those that do not.</p>\n<h3>The Physiology of Sexual Response</h3>\n<p>The two fundamental physiological processes underlying sexual response are <strong>vasocongestion</strong> — the engorgement of genital tissue with blood that produces erection in the penis and clitoris and lubrication and swelling in the vulva and vagina — and <strong>myotonia</strong>, the buildup of muscle tension that culminates in the rhythmic contractions of orgasm. Both depend on intact vascular and neurological function, which is why conditions and medications affecting blood flow or nerve conduction so frequently disrupt arousal and orgasm. This is also why a new arousal complaint coinciding with a cardiovascular diagnosis, diabetes, or a new medication points toward a physiological contributor and warrants medical consultation.</p>\n<h3>The Neuroendocrine Dimension</h3>\n<p>Sexual response is coordinated by the interaction of the autonomic nervous system and a set of hormones and neurotransmitters. Testosterone contributes to desire in people of all sexes; estrogen maintains genital tissue health; and neurotransmitter systems — particularly the balance of dopamine (which tends to facilitate sexual response) and serotonin (which tends to inhibit it) — explain why serotonergic antidepressants so reliably dampen desire and delay orgasm. Understanding this balance helps the clinician explain medication effects to clients in a way that reduces self-blame: the problem is pharmacological, not a failure of attraction or will.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Sex, Gender, and Sexual Orientation: Foundational Concepts</h2>\n<p>Accurate, affirming sexual health practice depends on a clear grasp of several concepts that are frequently conflated, and on the use of precise, respectful language.</p>\n<h3>Distinguishing the Concepts</h3>\n<ul>\n<li><strong>Sex assigned at birth</strong> refers to the classification (typically male or female) assigned on the basis of observed anatomy at birth.</li>\n<li><strong>Gender identity</strong> is a person's internal sense of their own gender, which may or may not align with the sex they were assigned.</li>\n<li><strong>Gender expression</strong> is the outward presentation of gender through appearance, behavior, and other cues.</li>\n<li><strong>Sexual orientation</strong> describes the pattern of a person's romantic and sexual attraction to others.</li>\n</ul>\n<p>These are distinct dimensions. A person's gender identity does not determine their sexual orientation, and neither is defined by anatomy. Treating them as separate axes is not merely a matter of terminology; it is a prerequisite for accurate assessment, because assumptions that collapse them lead clinicians to misunderstand clients' relationships, bodies, and concerns.</p>\n<h3>Affirming Language</h3>\n<p>Affirming practice uses the language clients use for themselves — their name, pronouns, and the terms they use for their bodies, partners, and relationships. When the clinician does not know a client's terms, the appropriate move is to ask respectfully rather than to guess, and to follow the client's lead. Asexuality (a sexual orientation characterized by little or no sexual attraction) and the diversity of relationship structures are part of the normal range of human sexuality, and recognizing them prevents the clinician from pathologizing what is simply unfamiliar.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Consent as a Clinical Framework</h2>\n<p>{{callout:sexual-consent}} is foundational to sexual health, and the clinician's understanding of consent shapes both how they assess clients' experiences and how they educate. Consent is best understood as an ongoing, freely given, reversible, informed, and specific agreement — not a one-time threshold that, once crossed, applies indefinitely.</p>\n<h3>Clinical Applications</h3>\n<p>This framework has direct assessment implications. It helps the clinician distinguish consensual sexual experiences from coercive ones, including the more subtle forms of coercion that clients may not initially name as such — pressure, manipulation, or the inability to refuse safely. It informs work with adolescents and with clients who have intellectual or developmental disabilities, where capacity to consent is a central consideration. And it underlies the clinician's own conduct: the absolute prohibition on sexual contact between clinician and client rests on the recognition that the power differential makes genuine consent impossible. Holding a clear consent framework allows the clinician to help clients evaluate their own experiences and relationships against a standard grounded in autonomy, safety, and mutual agreement.</p>",
+          "callouts": {
+            "sexual-consent": {
+              "label": "Consent",
+              "type": "definition",
+              "body": "Freely given, informed, ongoing, and revocable agreement to sexual activity; a clinical framework for screening that sexual activity is wanted and safe."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Common Sexual Myths and the Facts That Replace Them</h2>\n<p>A great deal of sexual distress is generated not by dysfunction but by false beliefs about what sex is supposed to be. Correcting these myths is a high-yield form of limited information, and it is squarely within every clinician's scope.</p>\n<h3>Myths About Desire and Frequency</h3>\n<p>The belief that healthy desire is always spontaneous causes distress for the many people whose desire is responsive; teaching that responsive desire is normal frequently resolves the concern. The belief that there is a \"normal\" frequency of sexual activity against which a couple should measure themselves drives needless comparison; the only meaningful standard is whether the partners are satisfied. The belief that desire discrepancy means something is wrong with the relationship pathologizes an almost universal feature of long-term partnerships.</p>\n<h3>Myths About Performance and Aging</h3>\n<p>The belief that sex must follow a particular script culminating in simultaneous orgasm sets up a performance standard that generates anxiety and disappointment. The belief that aging means the end of sexuality is both false and a barrier to care. The belief that any change in function signals serious dysfunction leads people to catastrophize normal variation. In each case, accurate information replaces a distressing standard with a realistic one.</p>\n<h3>Myths About What \"Counts\"</h3>\n<p>Narrow definitions of sex — typically equating it with penetrative intercourse — exclude much of human sexual experience and create problems for people whose bodies, health, or preferences do not fit that script. A broader, more accurate understanding of sexuality as encompassing a wide range of pleasurable and intimate experiences is both more inclusive and more clinically useful, particularly when working with clients managing illness, disability, or the physical changes of aging.</p>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Pleasure, Satisfaction, and Sexual Wellbeing</h2>\n<p>Because the clinical field has historically focused on dysfunction, it is easy to lose sight of the positive dimension that the WHO definition places at the center of sexual health. Sexual wellbeing is not merely the absence of problems; it includes pleasure, satisfaction, intimacy, and the freedom to express one's sexuality safely and authentically.</p>\n<h3>Why the Positive Dimension Matters Clinically</h3>\n<p>Attending to sexual wellbeing, not just dysfunction, changes the clinical conversation. It allows the clinician to support clients in building satisfying sexual lives rather than only repairing deficits, and it recognizes that two people with identical \"function\" may have very different sexual wellbeing depending on intimacy, communication, and the meaning sex holds for them. Sexual satisfaction is more strongly predicted by relational and emotional factors — communication, emotional closeness, the sense of being desired — than by mechanical function alone, which is why interventions that improve communication and intimacy often improve satisfaction even when a physical difficulty persists.</p>\n<h3>The Clinical Implication</h3>\n<p>A clinician oriented toward wellbeing asks not only \"Is anything wrong?\" but \"What would a satisfying sexual life look like for you?\" This reframing is particularly valuable for clients whose circumstances — chronic illness, disability, aging, treatment effects — mean that restoring prior function is not the goal. For these clients, the work is often about expanding the definition of satisfying sexuality rather than restoring a narrow prior norm.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Relationship Diversity and Non-Pathologizing Practice</h2>\n<p>Clients present within a wide range of relationship structures, and competent practice neither assumes monogamy nor pathologizes consensual alternatives. The clinician's task is to understand and support the client's actual relationships, whatever their configuration.</p>\n<h3>The Range of Consensual Structures</h3>\n<p>Many clients are in monogamous relationships; others are in consensually non-monogamous arrangements — including open relationships, polyamory, and other negotiated structures — that are organized around honesty and mutual agreement. Consensual non-monogamy is a relationship choice, not a disorder or a symptom, and research does not support the assumption that it reflects pathology, immaturity, or relationship dysfunction. Clinicians who reflexively interpret non-monogamy as a problem to be fixed impose their own assumptions and alienate clients who need support, not correction.</p>\n<h3>The Clinical Stance</h3>\n<p>The appropriate stance is the same disciplined non-assumption that governs all affirming practice: asking about the structure and agreements of a client's relationships rather than assuming them, supporting the client in living according to their own values and agreements, and addressing genuine distress or conflict within whatever structure the client has chosen. The clinician distinguishes carefully between a client's relationship structure (which is not the clinician's to judge) and any actual distress, coercion, or dishonesty within it (which is appropriately a clinical focus). This same non-pathologizing discipline extends to the full range of consensual sexual interests and practices, a topic developed in greater depth in dedicated coursework.</p>"
+        },
+        {
+          "order": 22,
+          "type": "multiSelect",
+          "question": "Which principles guide non-pathologizing practice with a client in a consensually non-monogamous relationship? (Select all that apply)",
+          "options": [
+            {
+              "text": "Consensual non-monogamy is a relationship choice, not a disorder",
+              "isCorrect": true
+            },
+            {
+              "text": "The clinician assesses the relationship on the client’s own terms",
+              "isCorrect": true
+            },
+            {
+              "text": "Non-monogamy should be treated as a symptom to be resolved",
+              "isCorrect": false
+            },
+            {
+              "text": "Attention to communication, agreements, and consent is appropriate",
+              "isCorrect": true
+            },
+            {
+              "text": "The clinician avoids assuming distress is caused by the structure itself",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Consensual non-monogamy is a relationship choice; affirming practice assesses it on the client’s terms and attends to agreements and communication rather than pathologizing the structure."
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Integrating Sexual Health Screening into Routine Practice</h2>\n<p>Knowing that sexual health matters is not the same as actually asking about it, and the gap between intention and practice is where most clinicians lose the thread. Integrating sexual health into routine practice requires a deliberate, sustainable approach rather than reliance on remembering in the moment.</p>\n<h3>Make It Routine, Not Exceptional</h3>\n<p>The most effective strategy is to build a brief sexual health inquiry into the standard intake and review process so that it is asked of everyone as a matter of course, not selectively when the clinician happens to suspect a concern. Selective asking communicates that the topic is unusual and reserved for problems; universal asking communicates that it is a normal part of health. A single normalized opening — \"I ask everyone about this\" — accomplishes most of the work.</p>\n<h3>The One-Question Version</h3>\n<p>For clinicians worried about time, a minimal version suffices to open the door: a single question such as \"Do you have any sexual health concerns you'd like to discuss?\" asked routinely, with genuine willingness to follow up on a positive answer. The full history is reserved for clients who indicate a concern. The goal is not to conduct an exhaustive sexual assessment with every client at every visit; it is to ensure that no client leaves believing the topic is unwelcome.</p>\n<h3>Sustaining the Practice</h3>\n<p>Clinicians sustain the practice by tolerating the early discomfort until it fades, by debriefing difficult moments in consultation, and by accumulating the experiences of clients who are visibly relieved to finally be asked. Over time, what began as an effortful addition becomes simply part of how the clinician practices.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>When Sexual Material Arises Unexpectedly: Transference and Boundaries</h2>\n<p>Sexual material does not arise only when the clinician deliberately raises it. It can emerge unexpectedly — through a client's disclosure, through erotic transference, or in the course of trauma work — and the clinician's capacity to remain steady and professional in these moments protects both the client and the work.</p>\n<h3>Erotic Transference</h3>\n<p>Clients may develop romantic or sexual feelings toward the clinician, a phenomenon long recognized in the clinical literature. Handled well, these feelings can be understood and worked with as meaningful clinical material; handled poorly — with shaming, avoidance, or, catastrophically, with reciprocation — they cause harm. The clinician's task is to respond without shaming the client, to maintain absolutely clear boundaries, and to use consultation to manage their own reactions. The prohibition on sexual contact between clinician and client is absolute, grounded in the recognition that the power differential makes genuine consent impossible and that such contact is among the most serious harms a clinician can inflict.</p>\n<h3>The Clinician's Own Reactions</h3>\n<p>Clinicians may also experience their own reactions to sexual material — discomfort, judgment, or, at times, attraction. Recognizing these reactions as ordinary, and processing them in supervision or consultation rather than acting on or denying them, is what allows the clinician to remain a safe and useful presence. The capacity to notice one's reactions without being governed by them is a hallmark of competent practice in this domain.</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>Sexual Health Education as Clinical Intervention</h2>\n<p>A large share of sexual distress arises from straightforward gaps in accurate information, the legacy of sex education that was absent, abstinence-focused, fear-based, or simply incomplete. For this reason, education is one of the most powerful and accessible interventions in the clinician's repertoire, and it falls within every clinician's scope as limited information.</p>\n<h3>Correcting the Information Deficit</h3>\n<p>Many clients carry misinformation about anatomy, about the range of normal function and variation, about how desire and arousal actually work, and about what consent requires. Correcting these misconceptions — explaining responsive desire, normalizing the diversity of sexual experience, clarifying the role of anxiety, accurately describing the effects of aging or medication — frequently resolves distress that had been experienced as a personal failing. The clinician functions, in these moments, as an educator providing the accurate information the client's prior education did not.</p>\n<h3>Education as Empowerment</h3>\n<p>Beyond correcting specific myths, sexual health education empowers clients to understand their own bodies and responses, to communicate with partners, and to make informed decisions. This educational stance is consistent with the sexual rights framework: clients have a right to accurate sexual information, and providing it is a core, accessible, and high-impact dimension of competent sexual health care across the lifespan.</p>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Examining Your Own Sexual Values</h2>\n<p>Because affirming, non-judgmental practice requires clinicians to set aside their own values when those values would distort care, a deliberate self-examination of one's sexual attitudes is itself a professional competency rather than an optional exercise.</p>\n<h3>Why Self-Examination Matters</h3>\n<p>Every clinician carries values, beliefs, and reactions about sexuality, shaped by their own culture, upbringing, religion, and experience. These are not problems in themselves, but they become clinical problems when they operate unexamined — leaking into the room as judgment, discomfort, or the subtle steering of a client toward the clinician's own preferences. A clinician who has never examined their reactions to particular sexual practices, identities, or relationship structures is more likely to communicate disapproval without intending to, and less able to recognize when their own values are shaping their clinical judgment.</p>\n<h3>The Work of Values Clarification</h3>\n<p>Useful self-examination involves honestly identifying the sexual topics, identities, behaviors, and presentations that evoke discomfort or judgment, understanding where those reactions come from, and developing the capacity to recognize them in the moment so they can be set aside in service of the client. The goal is not to erase one's values — that is neither possible nor necessary — but to hold them with enough awareness that they do not govern one's clinical conduct. Where a clinician finds that their values genuinely prevent them from providing affirming care to a particular client or concern, the ethical response is to recognize that limit and refer appropriately, rather than to impose those values on a client who came for help. This ongoing self-reflection, ideally supported by supervision and consultation, is part of what it means to practice sexual health care competently and ethically across the full diversity of the clients one serves.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 34,
+          "prompt": "What is your own most likely source of discomfort in sexual health conversations — fear of saying the wrong thing, your own reactions, or value differences? What would help you work with it?",
+          "placeholder": "Reflect..."
+        }
+      ]
+    },
+    {
+      "title": "Module 2: Assessment Across the Lifespan and Affirming Practice",
+      "order": 2,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 2,
+          "title": "Module 2",
+          "subtitle": "Module 2: Assessment Across the Lifespan and Affirming Practice"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Childhood Sexual Behavior: Normative versus Concerning</h2>\n<p>Clinicians who work with children and families must be able to distinguish developmentally normative sexual behavior from behavior that warrants assessment or mandated reporting. This is one of the highest-stakes discriminations in the field, because both over-reaction (pathologizing normal curiosity) and under-reaction (missing abuse) cause harm.</p>\n<p>Normative sexual behavior in young children is typically <strong>spontaneous, intermittent, and easily redirected</strong>; occurs between children of similar age, size, and developmental level; and is accompanied by curiosity and lightheartedness rather than fear, aggression, or compulsion. Genital self-touch, curiosity about others' bodies, and consensual same-age exploratory play fall within the normative range.</p>\n<h3>Behaviors That Warrant Assessment</h3>\n<p>Behaviors that fall outside the normative range and warrant careful assessment include sexual behavior that is compulsive and not redirectable; that involves significant age, size, or developmental differences between children; that is coercive or aggressive; that simulates adult sexual activity in detail beyond a child's expected knowledge; or that is accompanied by fear, anxiety, or distress. The presence of detailed sexual knowledge inconsistent with developmental stage is a particular concern. None of these signs is individually diagnostic of abuse, but they shift the clinical task toward careful assessment and, where indicated, mandated reporting.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Mandated Reporting and Adolescent Confidentiality</h2>\n<p>Mandated reporting obligations require clinicians to report reasonable suspicion of child abuse; the threshold is suspicion, not proof, and the determination of whether abuse occurred belongs to investigators, not to the reporting clinician. Clinicians should know their specific jurisdiction's statute, including the definitions and the reporting mechanism, before a reportable situation arises rather than during one.</p>\n<h3>Adolescents: Confidentiality, Consent, and Risk</h3>\n<p>Work with adolescents introduces distinct ethical complexity. Adolescents are developmentally driven toward autonomy and privacy, and candid disclosure depends on a confidentiality framework they can trust — yet that confidentiality has limits defined by safety and by law. Best practice is to establish the confidentiality framework explicitly at the outset, with both the adolescent and caregivers, including the specific circumstances under which information will be shared.</p>\n<p>Assessment with adolescents attends to consensual versus coercive experience, the developmental appropriateness of partners (significant age gaps raise concern), substance use in sexual contexts, sexually transmitted infection and pregnancy risk, and the adolescent's access to accurate information. The clinician's stance is neither permissive nor punitive; it is one of accurate information, risk reduction, and respect for developing autonomy within the boundaries set by safety and law.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 3,
+          "question": "A clinician observes sexual behavior in a 5-year-old client. Which feature would most strongly shift the clinical task toward careful assessment and possible mandated reporting?",
+          "options": [
+            {
+              "text": "The behavior is occasional and easily redirected",
+              "isCorrect": false
+            },
+            {
+              "text": "The behavior involves curiosity and same-age peers",
+              "isCorrect": false
+            },
+            {
+              "text": "The behavior is compulsive, not redirectable, and accompanied by fear or aggression",
+              "isCorrect": true
+            },
+            {
+              "text": "The child shows lighthearted curiosity about bodies",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "Compulsivity, non-redirectability, coercion, and accompanying fear or aggression fall outside the normative range and warrant assessment; the other options describe developmentally normative behavior.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Adult Sexual Response: Models and Their Clinical Use</h2>\n<p>Several models of sexual response inform contemporary assessment, and each corrects a limitation of its predecessor.</p>\n<h3>Masters and Johnson; Kaplan</h3>\n<p>Masters and Johnson (1966) described a four-phase response cycle — excitement, plateau, orgasm, and resolution — derived from physiological observation. Kaplan (1979) added <strong>desire</strong> as a distinct phase preceding arousal, a contribution that underlies the DSM's longstanding separation of desire, arousal, and orgasm disorders.</p>\n<h3>Basson's Circular, Responsive-Desire Model</h3>\n<p>Basson (2000, 2001) made a clinically pivotal contribution by describing a circular model in which, for many people — especially many women in established relationships — desire is <strong>responsive</strong> rather than spontaneous: it emerges in response to arousal and emotional intimacy rather than preceding them. This reframing is therapeutic in itself, because a great deal of distress arises from the mistaken belief that \"normal\" desire must be spontaneous. Teaching a client that responsive desire is normal often resolves the presenting concern without further intervention — a clear example of Limited Information in the PLISSIT framework.</p>\n<h3>The Dual Control Model</h3>\n<p>Bancroft and Janssen's dual control model conceptualizes sexual response as the balance between sexual excitation and sexual inhibition — an accelerator and a set of brakes. Many desire and arousal problems reflect high inhibition (stress, fatigue, body-image concern, relational anger) rather than low excitation. This depersonalizes the difficulty and points intervention toward reducing the brakes rather than manufacturing more accelerator.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Assessing the Major Domains of Adult Sexual Concern</h2>\n<p>Comprehensive assessment covers desire, arousal, orgasm, and pain, while distinguishing {{callout:lifelong-acquired}} from acquired and generalized from situational presentations — distinctions that carry direct treatment implications.</p>\n<ul>\n<li><strong>Desire concerns</strong>: assess whether the difficulty is lifelong or acquired, generalized or situational, and whether responsive desire has been misinterpreted as disorder. Desire discrepancy between partners — not low desire per se — is the most common couple presentation.</li>\n<li><strong>Arousal concerns</strong>: distinguish subjective from physiological arousal, attend to arousal non-concordance (the common finding that genital response and subjective arousal do not always align), and evaluate vascular and medication contributors.</li>\n<li><strong>Orgasm concerns</strong>: assess delayed, absent, or distressing orgasm; medication effects (especially SSRIs) are a frequent and often missed contributor.</li>\n<li><strong>Pain ({{callout:gpppd}}/penetration)</strong>: sexual pain always warrants medical evaluation alongside psychological assessment, because it frequently has physiological contributors (pelvic floor dysfunction, vulvodynia, {{callout:gsm}} of menopause) that respond to targeted treatment.</li>\n</ul>\n<p>The acquired-versus-lifelong and generalized-versus-situational axes are not academic. A situational, acquired difficulty points toward relational, contextual, or medication factors; a lifelong, generalized one points toward different etiologies and a different treatment pathway.</p>",
+          "callouts": {
+            "gsm": {
+              "label": "GSM",
+              "type": "clinical",
+              "body": "Genitourinary Syndrome of Menopause — common, frequently distressing, and highly treatable changes (dryness, thinning, discomfort) related to declining estrogen."
+            },
+            "gpppd": {
+              "label": "Genito-Pelvic Pain",
+              "type": "clinical",
+              "body": "Genito-Pelvic Pain/Penetration Disorder (DSM-5-TR): persistent difficulty with pain, fear, or pelvic muscle tension related to penetration; requires biopsychosocial assessment."
+            },
+            "lifelong-acquired": {
+              "label": "Lifelong vs. Acquired",
+              "type": "definition",
+              "body": "Lifelong difficulties have been present since first sexual activity; acquired difficulties develop after a period of unproblematic functioning — pointing toward what changed."
+            }
+          }
+        },
+        {
+          "type": "reflection",
+          "order": 6,
+          "prompt": "Recall a client who presented with a sexual concern (or imagine a likely one in your setting). How would distinguishing lifelong/acquired and generalized/situational change your formulation?",
+          "placeholder": "Reflect..."
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Cultural Humility and Affirming Practice with LGBTQ+ Clients</h2>\n<p>Cultural context shapes sexual values, expression, and the meaning of sexual experience, and most clinicians were trained within Western, predominantly white, heteronormative frameworks. <strong>Cultural humility</strong> — a stance of lifelong self-examination, openness to the client as the expert on their own experience, and attention to power imbalance — is the appropriate alternative to the impossible goal of \"competence\" in every culture.</p>\n<h3>Minority Stress and Affirming Sexual Health Care</h3>\n<p>Meyer's (2003) minority stress model explains the elevated rates of distress among sexual and gender minority populations not as a function of identity but as a function of chronic exposure to stigma, discrimination, expectation of rejection, and internalized negative messages. Applied to sexual health, affirming care means using the language clients use for their bodies and partners, not assuming the gender of partners or the configuration of relationships, recognizing the diversity of sexual practices without pathologizing consensual behavior, and understanding that for many LGBTQ+ clients the clinical setting itself has historically been a source of harm.</p>\n<p>Affirming practice is not a separate technique applied only with LGBTQ+ clients. It is the same stance of curiosity and non-assumption that good sexual health assessment requires with everyone — recognizing that every person's sexuality is organized by a specific cultural, developmental, and relational history that is uniquely theirs.</p>"
+        },
+        {
+          "order": 8,
+          "type": "fillInBlank",
+          "title": "Quick check — desire",
+          "blanks": [
+            {
+              "prompt": "Desire that emerges in response to arousal and intimacy rather than preceding them:",
+              "answer": "responsive desire",
+              "acceptAlternates": [
+                "responsive"
+              ]
+            },
+            {
+              "prompt": "The researcher whose circular model centers responsive desire:",
+              "answer": "Basson",
+              "acceptAlternates": [
+                "Rosemary Basson"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>The DSM-5-TR Sexual Dysfunctions: A Clinical Orientation</h2>\n<p>Generalist clinicians benefit from a working orientation to how sexual dysfunctions are classified, both to communicate with prescribers and specialists and to recognize when a presentation warrants formal assessment. The DSM-5-TR (American Psychiatric Association, 2022) organizes the sexual dysfunctions around desire, arousal, orgasm, and pain, and applies a consistent set of qualifying criteria that are as clinically important as the categories themselves.</p>\n<h3>The Qualifying Criteria</h3>\n<p>To meet the threshold for a DSM-5-TR sexual dysfunction, symptoms generally must have persisted for a minimum duration (approximately six months), must occur in most or all sexual encounters (commonly operationalized as roughly 75–100% of the time), and — critically — must cause <strong>clinically significant distress</strong>. The distress criterion is decisive: variation in sexual interest or function that does not distress the person is not a disorder. A clinician who pathologizes a couple's mismatched but mutually acceptable desire, or labels an older adult's reduced frequency as \"dysfunction,\" has misapplied the framework.</p>\n<h3>The Subtype Specifiers</h3>\n<p>Each diagnosis is specified as <strong>lifelong or acquired</strong> and <strong>generalized or situational</strong>. These specifiers are not bookkeeping; they shape formulation and treatment. An acquired, situational difficulty (present only with a particular partner or in a particular context, after a period of unremarkable function) points strongly toward relational, contextual, or medication contributors. A lifelong, generalized difficulty points toward different etiologies. The same surface complaint can therefore call for very different responses depending on these axes.</p>\n<h3>The Major Categories</h3>\n<ul>\n<li><strong>Desire/interest</strong>: male hypoactive sexual desire disorder; female sexual interest/arousal disorder (which, reflecting Basson's work, combines desire and arousal in women).</li>\n<li><strong>Arousal</strong>: erectile disorder.</li>\n<li><strong>Orgasm</strong>: delayed ejaculation, premature (early) ejaculation, female orgasmic disorder.</li>\n<li><strong>Pain</strong>: genito-pelvic pain/penetration disorder.</li>\n<li><strong>Substance/medication-induced</strong> sexual dysfunction — a category the generalist should hold actively in mind given how often medication is the driver.</li>\n</ul>\n<p>The clinical value of this orientation is not diagnostic precision for its own sake; it is the ability to recognize when a concern is transient and reassurable, when it is medication-related and warrants prescriber consultation, and when it is persistent and distressing enough to merit formal assessment or referral.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Desire Discrepancy: The Most Common Couple Presentation</h2>\n<p>The most frequent sexual concern brought to couples and individual therapists is not a dysfunction in either partner but a <strong>discrepancy</strong> in desire between partners. Reframing the problem from \"one partner has low desire\" to \"this couple has a difference they are managing poorly\" is itself a major intervention, because it removes the implicit diagnosis of a \"broken\" partner and locates the issue in the couple's dynamic.</p>\n<h3>Assessing the Discrepancy</h3>\n<p>Useful assessment establishes each partner's baseline desire pattern (spontaneous versus responsive), the meaning each attaches to sex and to its frequency, the pursuer–distancer dynamic that frequently develops (the higher-desire partner pursues, the lower-desire partner withdraws under pressure, and the pursuit itself further suppresses desire), and the contextual factors loading the brakes for the lower-desire partner — stress, fatigue, unaddressed relational resentment, body-image concerns, or untreated medical and medication factors.</p>\n<h3>Reframing Interventions</h3>\n<p>Limited-information interventions are often powerful here: teaching the couple about responsive desire (so the lower-desire partner stops experiencing their pattern as defective), about the dual control model (so both partners attend to reducing the brakes rather than demanding more accelerator), and about the pursuer–distancer trap (so the higher-desire partner understands how pursuit backfires). Many couples improve substantially with these reframes alone; those who do not are appropriate referrals for specialized couples or sex therapy.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 11,
+          "question": "Which DSM-5-TR criterion most directly prevents pathologizing a couple's mismatched but mutually acceptable level of sexual frequency?",
+          "options": [
+            {
+              "text": "The six-month duration criterion",
+              "isCorrect": false
+            },
+            {
+              "text": "The requirement that symptoms occur in 75–100% of encounters",
+              "isCorrect": false
+            },
+            {
+              "text": "The requirement of clinically significant distress",
+              "isCorrect": true
+            },
+            {
+              "text": "The lifelong/acquired specifier",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "Without clinically significant distress, variation in sexual interest or function does not meet the threshold for a disorder — this criterion guards against pathologizing acceptable difference.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>A Practical Framework for Adolescent Sexual Health Assessment</h2>\n<p>Adolescent sexual health assessment integrates into established psychosocial screening rather than standing apart from it. Structured adolescent interview frameworks (such as the widely used HEEADSSS approach, which surveys Home, Education/employment, Eating, Activities, Drugs, Sexuality, Suicide/depression, and Safety) embed sexuality within a broader developmental conversation, which is both more comfortable for the adolescent and more clinically complete.</p>\n<h3>The Sexuality Component</h3>\n<p>Within that framework, the sexuality component covers — at a developmentally appropriate pace and within a clear confidentiality agreement — whether the adolescent is in any romantic or sexual relationships; the nature, consensuality, and developmental appropriateness of those relationships (significant age gaps and any coercion are specific concerns); knowledge of and access to accurate information about contraception and sexually transmitted infection prevention; substance use in sexual contexts; and any unwanted or pressured experiences. Sexual orientation and gender identity are approached with openness and without assumption, recognizing that the clinical relationship may be one of the few safe places an adolescent has to explore these questions.</p>\n<h3>Balancing Autonomy, Safety, and Law</h3>\n<p>The clinician holds three considerations simultaneously: respect for the adolescent's developing autonomy and need for privacy; the safety obligations that set the limits of confidentiality; and the legal framework governing minors in their jurisdiction, including age-of-consent and mandated-reporting statutes. Establishing the confidentiality agreement explicitly — what stays private and what must be shared, and why — at the start of the work is what makes honest disclosure possible. The clinician's stance throughout is one of accurate information and harm reduction rather than prohibition, delivered with respect for the adolescent as an emerging adult.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Differentiating Dysfunction Subtypes: Lifelong vs. Acquired, Generalized vs. Situational</h2>\n<p>When a sexual concern does reflect a dysfunction, two descriptive axes sharpen the assessment and point toward likely contributors: whether the difficulty is lifelong or acquired, and whether it is generalized or situational. These distinctions are clinically powerful and are part of how the diagnostic framework characterizes sexual dysfunctions.</p>\n<h3>Lifelong Versus Acquired</h3>\n<p>A lifelong difficulty has been present since the person became sexually active, whereas an acquired difficulty develops after a period of unproblematic functioning. The distinction matters because an acquired problem points the clinician toward what changed — a new medication, a health condition, a relationship shift, a stressor, a loss, or a traumatic experience — whereas a lifelong pattern raises different questions about development, learning, and longstanding factors. Identifying the onset and what coincided with it is frequently the single most informative step in understanding an acquired concern.</p>\n<h3>Generalized Versus Situational</h3>\n<p>A generalized difficulty occurs across all situations and partners, whereas a situational difficulty occurs only in certain contexts, with certain partners, or under certain conditions. This distinction is especially clarifying: a situational pattern — for example, a difficulty present with a partner but not during solo sexuality, or present in one relationship but not another — points strongly toward psychological, relational, or contextual contributors rather than a primarily physiological cause. A generalized, consistent difficulty, by contrast, raises the relative likelihood of a physiological or medication-related contributor warranting medical evaluation. Used together, these two axes help the generalist form an initial picture of where a concern is likely to originate and where to focus assessment and referral, well before any specialized workup.</p>",
+          "title": "Differentiating Dysfunction Subtypes: Lifelong vs. Acquired, Generalized vs. Situational"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Screening for Sexual Coercion and Intimate Partner Violence</h2>\n<p>Sexual concerns sometimes surface in the context of coercion, pressure, or intimate partner violence, and the generalist clinician has a responsibility to recognize this possibility rather than treating every sexual complaint as a dysfunction to be managed within the relationship as it stands.</p>\n<h3>Why Screening Matters</h3>\n<p>Difficulties such as pain, aversion, low desire, or distress about sexual activity can reflect a relational context in which sex is coerced, pressured, or unsafe rather than a problem located in the individual's body or psychology. Reframing a coercion-driven difficulty as a \"sexual dysfunction\" can inadvertently pathologize a healthy protective response and obscure a safety concern. Clinicians therefore screen, in a private and non-judgmental way, for whether sexual activity is wanted and consensual, whether the client feels safe and free to decline, and whether there is a broader pattern of control, fear, or violence in the relationship.</p>\n<h3>Responding to Disclosures</h3>\n<p>When coercion or intimate partner violence is disclosed, the clinical priorities shift toward safety: assessing risk, validating the client's experience, providing information about resources and options, and supporting the client's autonomy in decisions about the relationship without pressure or directive advice. The clinician attends to confidentiality and mandated-reporting obligations as applicable, conducts safety screening privately and never in the presence of a partner, and recognizes that a client may not be ready to label or leave a situation. Throughout, the clinician holds the client's safety and self-determination as paramount, and recognizes that what presents as a sexual problem may, on careful and compassionate inquiry, be a safety problem requiring a different response.</p>",
+          "title": "Screening for Sexual Coercion and Intimate Partner Violence"
+        },
+        {
+          "order": 16,
+          "type": "cardSort",
+          "instructions": "A client reports new sexual pain. Sort each possible contributor by domain.",
+          "categories": [
+            "Biological",
+            "Psychological",
+            "Social/Relational"
+          ],
+          "cards": [
+            {
+              "id": "gsm",
+              "text": "Genitourinary changes / hormonal shifts",
+              "correctCategory": "Biological"
+            },
+            {
+              "id": "inf",
+              "text": "Infection or dermatological condition",
+              "correctCategory": "Biological"
+            },
+            {
+              "id": "anx",
+              "text": "Anticipatory anxiety and pelvic muscle guarding",
+              "correctCategory": "Psychological"
+            },
+            {
+              "id": "tr",
+              "text": "Trauma history shaping the pain response",
+              "correctCategory": "Psychological"
+            },
+            {
+              "id": "rel",
+              "text": "Relationship conflict or coercion",
+              "correctCategory": "Social/Relational"
+            },
+            {
+              "id": "cul",
+              "text": "Cultural or religious messages about sex",
+              "correctCategory": "Social/Relational"
+            }
+          ],
+          "explanation": "New sexual pain is best understood biopsychosocially — biological, psychological, and social/relational contributors interact, and assessment spans all three rather than assuming a single cause."
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Conducting the Adult Sexual Assessment Interview</h2>\n<p>Where Module 1 introduced the general sexual history, the adult assessment interview goes deeper when a client presents with a specific concern. Its purpose is to gather enough information to form a biopsychosocial formulation and to determine whether the concern is within the generalist's scope or warrants referral.</p>\n<h3>Characterizing the Concern</h3>\n<p>The interview first locates the difficulty within the response cycle — is it primarily about desire, arousal, orgasm, or pain? — and then applies the two clinical axes introduced earlier: is it lifelong or acquired, generalized or situational? A concern that is acquired and situational immediately directs attention to what changed and to the specific contexts in which the difficulty does and does not occur. The clinician also asks how long the concern has persisted and, crucially, how much distress it causes the client and any partner, since distress is what distinguishes a clinical problem from normal variation.</p>\n<h3>Surveying the Three Domains</h3>\n<p>Comprehensive assessment then surveys each biopsychosocial domain: biological factors (general health, chronic conditions, all medications including over-the-counter and recreational substances, recent physical changes), psychological factors (mood, anxiety, performance concerns, body image, history of unwanted sexual experiences, the client's beliefs and expectations about sex), and sociocultural and relational factors (relationship quality and conflict, partner concerns, cultural and religious context, life stressors such as work, finances, and caregiving). A concern that looked simple at presentation frequently turns out to be multiply determined, which is precisely why a single-domain formulation so often fails.</p>\n<h3>Toward a Formulation</h3>\n<p>The interview concludes with a shared, collaborative formulation — a hypothesis, framed in plain language and offered to the client for correction, about how the contributing factors fit together — and a plan that may include limited information, specific suggestions, medical consultation, or referral. Sharing the formulation with the client is itself therapeutic, because it replaces a sense of personal defect with an understandable, addressable account.</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Affirming Practice with LGBTQ+ Clients: Specific Skills</h2>\n<p>Affirming practice with sexual and gender minority clients is built from concrete, learnable skills, not from a vague attitude of acceptance. Because these clients experience minority stress and frequently carry histories of harm within healthcare, the specifics matter.</p>\n<h3>The Clinical Environment and Intake</h3>\n<p>Affirming care begins before the first session, in forms and environment. Intake paperwork that offers space to indicate name in use, pronouns, gender identity beyond a binary checkbox, and relationship structures beyond monogamous heterosexual defaults signals safety. Using the client's name and pronouns consistently — and repairing quickly and without excessive apology when a mistake is made — is foundational.</p>\n<h3>Non-Assumption as a Discipline</h3>\n<p>The central skill is disciplined non-assumption: not assuming the gender of a client's partners, the configuration of their relationships, the language they use for their body, or their sexual practices. The clinician asks, follows the client's lead, and uses the client's own terms. For transgender and gender-diverse clients specifically, this includes asking which words the client uses for their anatomy rather than imposing clinical or gendered terms that may cause distress.</p>\n<h3>Minority Stress in the Formulation</h3>\n<p>Affirming sexual health assessment locates a client's concerns within the minority stress framework where relevant: chronic experiences of stigma, rejection, and internalized negative messages contribute to anxiety, shame, and difficulty with intimacy, and naming this context can be clarifying and validating. At the same time, the clinician avoids attributing every concern to minority stress, which would be its own form of stereotyping.</p>\n<h3>Knowing the Limits of One's Competence</h3>\n<p>Affirming practice also includes honesty about the edge of one's competence. A clinician who lacks specific training in gender-affirming care should not improvise it; the ethical move is to provide a supportive, affirming relationship while connecting the client with appropriately trained providers, just as with any other specialized need.</p>"
+        },
+        {
+          "order": 20,
+          "type": "multiSelect",
+          "question": "Which are core skills of affirming sexual health practice with LGBTQ+ clients? (Select all that apply)",
+          "options": [
+            {
+              "text": "Using inclusive, non-assuming language about partners and bodies",
+              "isCorrect": true
+            },
+            {
+              "text": "Following the client’s own identity terms and pronouns",
+              "isCorrect": true
+            },
+            {
+              "text": "Assuming heterosexuality unless told otherwise",
+              "isCorrect": false
+            },
+            {
+              "text": "Understanding minority stress and its clinical impact",
+              "isCorrect": true
+            },
+            {
+              "text": "Not relying on the client to provide basic education",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Affirming practice uses inclusive language, follows the client’s own terms, understands minority stress, and takes responsibility for the clinician’s own education rather than assuming or burdening the client."
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Working Across Religious and Cultural Difference</h2>\n<p>Sexuality is shaped powerfully by culture and religion, and clinicians regularly work with clients whose frameworks differ sharply from their own. Cultural humility here means neither imposing the clinician's values nor abandoning clinical responsibility, but helping clients navigate their own values, relationships, and wellbeing.</p>\n<h3>Faith and Sexuality</h3>\n<p>Clients from conservative religious backgrounds may experience conflict between sexual feelings or identities and deeply held beliefs, may carry shame rooted in religious teaching, or may seek to align their sexual lives with their faith. The clinician's task is not to argue the client out of their religion or to validate self-rejection, but to help the client explore the conflict, reduce shame, and arrive at a resolution that is genuinely their own. For sexual and gender minority clients from such backgrounds, this work is especially delicate, and affirming care means supporting the client's self-determination rather than steering them toward any predetermined outcome.</p>\n<h3>Immigrant, Refugee, and Cross-Cultural Contexts</h3>\n<p>Clients from immigrant and refugee backgrounds, and clients whose cultural sexual scripts differ from mainstream Western norms, require the clinician to understand sexuality as the client's culture constructs it rather than as the clinician's training assumes. Gender roles, the meaning of marriage and family, acceptable topics of discussion, and the involvement of family in personal decisions all vary. Intersectionality — the way multiple identities (race, religion, immigration status, sexual orientation, disability) combine to shape experience — means that no single cultural script captures a given client; the clinician remains curious about this particular person's particular configuration.</p>\n<h3>Bracketing Without Abandoning</h3>\n<p>The practical stance is to bracket the clinician's own sexual values so they do not become the basis for judgment, while retaining the clinical responsibility to provide accurate information and to recognize and respond to genuine harm, coercion, or risk. When a clinician's values make it impossible to provide affirming care to a particular client, the ethical response is appropriate referral, not the imposition of those values.</p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Ejaculatory and Orgasmic Concerns: Assessment Essentials</h2>\n<p>Two of the most common male-presenting sexual concerns are premature (early) ejaculation and delayed ejaculation, and both are frequently treatable once accurately assessed. The generalist's role is to characterize the concern, identify likely contributors, and determine the appropriate level of intervention or referral.</p>\n<h3>Premature (Early) Ejaculation</h3>\n<p>Premature ejaculation involves ejaculation occurring sooner than the person or couple desires, with associated distress. Assessment establishes whether it is lifelong or acquired (an acquired pattern points toward anxiety, relationship change, or medical contributors), how much distress it causes, and its impact on the couple. Performance anxiety is a frequent maintaining factor, and the anxiety-ejaculation cycle is self-reinforcing. Many cases respond to behavioral techniques and anxiety reduction, which a trained generalist can provide or which a sex therapist can deliver; some respond to pharmacological approaches managed by a prescriber.</p>\n<h3>Delayed Ejaculation and Female Orgasmic Concerns</h3>\n<p>Delayed or absent ejaculation, and difficulty reaching orgasm in clients of any gender, share several common contributors that assessment should survey: medication (SSRIs are a leading cause across genders), anxiety and spectatoring (self-monitoring during sex that interrupts the response), insufficient or mismatched stimulation, and relationship factors. For female orgasmic concerns specifically, assessment distinguishes lifelong from acquired and generalized from situational, since a client who has never experienced orgasm requires a different approach than one who has lost a previously reliable capacity. Accurate sexual education — about the role of clitoral stimulation, about the wide range of normal experience, and about the effects of anxiety — is itself often therapeutic, and is squarely within the generalist's scope as limited information.</p>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Arousal Concerns Across Genders</h2>\n<p>Arousal difficulties — erectile difficulty in men, and reduced genital arousal and lubrication in women — share a common feature: because genital arousal is fundamentally vascular and neurological, new-onset arousal difficulty warrants consideration of medical contributors alongside psychological ones.</p>\n<h3>Erectile Difficulty</h3>\n<p>Erectile difficulty is one of the most common male sexual concerns and one of the most important to assess carefully, because it can be an early marker of cardiovascular disease — the same vascular processes that impair coronary circulation impair erectile function, often earlier. New-onset erectile difficulty therefore warrants medical evaluation, not only for the sexual concern itself but as a potential cardiovascular signal. Psychologically, the anxiety-erection cycle is powerful: a single difficult experience generates performance anxiety that makes the next one more likely, and addressing this cycle is central to treatment. A useful diagnostic clue is whether erections occur in some contexts (on waking, with self-stimulation) but not others, which points toward psychological and situational rather than purely vascular factors.</p>\n<h3>Arousal Concerns in Women</h3>\n<p>Reduced genital arousal and lubrication in women may reflect hormonal change (especially the genitourinary syndrome of menopause), medication, insufficient or mismatched stimulation, anxiety, or relationship factors, and assessment surveys each. Arousal non-concordance — the common finding that genital response and subjective arousal do not always align — is important to understand and to normalize, since clients distressed by a perceived mismatch between body and mind are often reassured to learn it is a normal feature of human sexual response rather than a sign of dysfunction or of dishonesty about their feelings.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Genito-Pelvic Pain: A Closer Assessment Look</h2>\n<p>Sexual pain deserves particular attention because it is common, frequently has treatable physiological contributors, and is too often dismissed or attributed prematurely to psychological causes. The cardinal principle, stated in Module 2 and worth repeating, is that sexual pain always warrants medical evaluation alongside psychological assessment.</p>\n<h3>Common Contributors</h3>\n<p>Genito-pelvic pain has many possible physiological contributors, including pelvic floor muscle dysfunction (overactive or poorly coordinated pelvic floor muscles), the genitourinary syndrome of menopause, vulvodynia and related pain conditions, infections, dermatological conditions, and the after-effects of childbirth or surgery. Many of these respond well to targeted treatment — pelvic floor physical therapy in particular is an essential and frequently overlooked resource — which is why premature psychological attribution can leave a treatable condition untreated.</p>\n<h3>The Pain-Fear-Tension Cycle</h3>\n<p>Physiological and psychological factors interact in a self-reinforcing cycle: pain produces anticipatory fear, fear produces muscle tension and arousal inhibition, and tension and reduced arousal worsen pain. This is why effective treatment is usually interdisciplinary, combining medical and physical-therapy management of the physiological contributors with psychological work on the fear, anxiety, and avoidance that maintain the cycle. The mental health clinician's role is to assess the psychological dimension, to ensure the client receives appropriate medical and physical-therapy evaluation, and to address the fear-tension cycle — never to treat sexual pain as a purely psychological problem.</p>"
+        },
+        {
+          "type": "text",
+          "order": 27,
+          "content": "<h2>Synthesis: Red Flags That a Concern Exceeds Generalist Scope</h2>\n<p>A central competency of generalist sexual health practice is recognizing when a concern exceeds one's scope and warrants referral. The following are practical indicators that a presentation calls for specialized assessment or treatment rather than generalist management.</p>\n<h3>Indicators for Referral</h3>\n<ul>\n<li><strong>Persistent, entrenched dysfunction</strong> that does not respond to permission, accurate information, and basic behavioral suggestions points toward specialized sex therapy.</li>\n<li><strong>Likely physiological contributors</strong> — sexual pain, new-onset erectile difficulty, symptoms coinciding with illness or medication — call for medical evaluation in parallel with any psychological work.</li>\n<li><strong>Significant trauma history</strong> driving the sexual concern, particularly where specialized trauma-focused treatment is indicated, warrants referral to or coordination with an appropriately trained trauma clinician.</li>\n<li><strong>Complex couple dynamics</strong> — entrenched desire discrepancy, conflict that overwhelms the sexual concern — may require specialized couples or sex therapy.</li>\n<li><strong>Concerns outside the clinician's training</strong>, including gender-affirming care and other specialized areas, call for connection with appropriately trained providers.</li>\n</ul>\n<h3>Referral Is Not Abandonment</h3>\n<p>Recognizing these red flags is not an admission of inadequacy; it is the exercise of the scope-of-practice judgment that ethical care requires. And referral does not mean withdrawal: the generalist frequently continues to provide the permission-giving, supportive relationship that complements specialized care. The goal is to ensure that each dimension of a client's concern is addressed by someone competent to address it, with the generalist often serving as the integrating presence across the team.</p>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Trauma-Informed Sexual Assessment</h2>\n<p>Because sexual health and sexual trauma are so frequently connected, sexual assessment must be conducted in a trauma-informed manner regardless of whether a trauma history is known. A trauma-informed approach protects clients who may have histories the clinician is unaware of, and makes disclosure possible for those who choose it.</p>\n<h3>Principles in Practice</h3>\n<p>Trauma-informed sexual assessment prioritizes the client's sense of safety and control throughout. The clinician explains why questions are being asked, signals that the client may decline any question or pause at any time, and never pressures for disclosure or for traumatic detail. Questions about unwanted or coercive sexual experiences are asked gently and without assumption, framed in a way that gives the client full control over what and whether to share. The clinician watches for signs of distress or dissociation and is prepared to slow down, ground the client, and prioritize stabilization over information-gathering.</p>\n<h3>Responding to Disclosure</h3>\n<p>When a client does disclose a history of sexual trauma, the clinician receives it without judgment, validates the courage of the disclosure, attends to the client's immediate emotional state and safety, and avoids pressing for details that are not clinically necessary in the moment. The clinician then determines, collaboratively with the client, whether specialized trauma-focused treatment is indicated and arranges appropriate referral or coordination. Throughout, the stance is one of safety, choice, and respect for the client's pace — the same principles that govern all trauma-informed care, applied to the specific sensitivity of sexual material.</p>"
+        },
+        {
+          "type": "text",
+          "order": 30,
+          "content": "<h2>When Sexual Concerns Hide Behind Other Presentations</h2>\n<p>Sexual health concerns frequently do not present as such. Because clients anticipate judgment and lack permission to raise them directly, sexual concerns often surface only indirectly, behind another presenting problem — which is yet another reason routine inquiry matters.</p>\n<h3>Common Disguises</h3>\n<p>A client who presents for depression may be depressed in part because of an unaddressed sexual difficulty, or may be experiencing sexual side effects of antidepressant treatment that they have never mentioned. A couple presenting for \"communication problems\" may be in conflict largely over an unspoken sexual issue. A client presenting with anxiety may be avoiding intimacy because of performance fears or a trauma history. A relationship described as \"growing apart\" may be drifting around a sexual disconnection neither partner can name. In each case, the sexual dimension is doing significant work in the clinical picture while remaining invisible unless the clinician asks.</p>\n<h3>The Implication for Practice</h3>\n<p>The lesson is not that every presenting problem conceals a sexual one, but that the clinician who never inquires about sexual health will systematically miss the sexual dimension of presentations where it is operative — and will sometimes treat the surface complaint while the maintaining factor goes unaddressed. Routine, normalized inquiry brings these hidden concerns into view, allowing the clinician to address the actual problem rather than only its visible expression.</p>"
+        },
+        {
+          "type": "text",
+          "order": 31,
+          "content": "<h2>Understanding Sexual Frequency and Variation</h2>\n<p>A great deal of clinical work involves helping clients let go of false standards against which they measure their sexual lives, and few standards cause more needless distress than beliefs about how often \"normal\" people have sex.</p>\n<h3>There Is No Normal Frequency</h3>\n<p>Research on sexual frequency consistently shows enormous variation across individuals and couples, with no single frequency that defines health. Frequency is influenced by age, relationship length, life circumstances, stress, health, and individual differences in desire, and it naturally changes over time within any relationship. The only meaningful clinical standard is whether the individual or couple is satisfied with their sexual life — not how their frequency compares to a real or imagined norm.</p>\n<h3>Helping Clients Reframe</h3>\n<p>Clients frequently arrive convinced that their frequency is abnormal, a belief often fueled by media portrayals and by the assumption that everyone else is having more or better sex. The clinician helps by normalizing variation, by redirecting attention from comparison to the couple's own satisfaction and connection, and by reframing changes in frequency as a normal feature of relationships rather than a sign of failure. This reframing alone frequently resolves distress, and it exemplifies the broader principle that accurate information is one of the most powerful interventions available.</p>"
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>Sexual Fantasy: Clinical Meaning and Non-Pathologizing Assessment</h2>\n<p>Sexual fantasy is a near-universal feature of human sexuality that clients sometimes raise with shame or anxiety, and clinicians benefit from a clear, non-pathologizing framework for understanding it.</p>\n<h3>Fantasy Is Normal and Common</h3>\n<p>Sexual fantasy is extremely common across genders and orientations, and the presence of fantasy — including fantasy about scenarios a person would never wish to enact in reality — is not in itself a sign of pathology or of a problem with the person's relationship. Fantasies serve many functions, including arousal, exploration, and play, and the content of a fantasy does not necessarily reflect a desire to act on it. Clients distressed by their own fantasies are frequently relieved to learn that fantasy is normal and that its content does not define them.</p>\n<h3>The Clinical Distinction</h3>\n<p>The clinician distinguishes carefully between fantasy, which is internal and harms no one, and behavior, which is where questions of consent, harm, and legality apply. A fantasy is not a plan, and pathologizing fantasy alienates clients and discourages disclosure. The relevant clinical questions concern distress (is the client troubled by their fantasy life, and if so, why?) and behavior (does any acted-upon behavior involve non-consent or harm?), not the mere content of private imagination. This non-pathologizing stance toward fantasy is consistent with the affirming, consent-focused framework that runs throughout sexual health practice, and the deeper assessment of specific consensual interests is addressed in dedicated coursework.</p>"
+        },
+        {
+          "order": 33,
+          "type": "multiSelect",
+          "question": "A client expresses shame about a recurring sexual fantasy. Which clinical responses are appropriate? (Select all that apply)",
+          "options": [
+            {
+              "text": "Normalize that fantasy is common and not equivalent to action or intent",
+              "isCorrect": true
+            },
+            {
+              "text": "Explore the meaning and the shame rather than the content alone",
+              "isCorrect": true
+            },
+            {
+              "text": "Treat the fantasy as inherently pathological",
+              "isCorrect": false
+            },
+            {
+              "text": "Distinguish distress about the fantasy from the fantasy itself",
+              "isCorrect": true
+            },
+            {
+              "text": "Attend to any genuine risk while avoiding shaming",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Fantasy is common and not equivalent to intent; affirming practice addresses the shame and meaning, distinguishes distress from content, and attends to genuine risk without shaming."
+        },
+        {
+          "type": "reflection",
+          "order": 39,
+          "prompt": "In your setting, how is sexual health currently addressed (or not) when you work with adolescents? What would a clear, explicit confidentiality agreement look like in your practice?",
+          "placeholder": "Reflect..."
+        }
+      ]
+    },
+    {
+      "title": "Module 3: Sexual Health in Context — Illness, Disability, Aging, and Referral",
+      "order": 3,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 3,
+          "title": "Module 3",
+          "subtitle": "Module 3: Sexual Health in Context — Illness, Disability, Aging, and Referral"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Sexual Health and Chronic Illness</h2>\n<p>Chronic illness affects sexual function through disease processes, treatment effects, and the psychological burden of illness — and it is one of the most reliably overlooked dimensions of chronic-disease care.</p>\n<h3>Diabetes</h3>\n<p>Diabetes produces sexual dysfunction in both men and women through vascular damage and neuropathy, contributing to erectile difficulty, reduced genital sensation and lubrication, and orgasmic change. Because these effects are physiological, they require coordination with medical care, but the clinician who raises them often surfaces a concern the client assumed was unspeakable or untreatable.</p>\n<h3>Cardiovascular Disease</h3>\n<p>Cardiovascular disease raises both physiological and fear-based barriers. Many clients and partners avoid sexual activity after a cardiac event out of fear that it is dangerous. The Princeton Consensus guidelines provide a framework for stratifying cardiac risk associated with sexual activity; for most patients with stable disease, sexual activity is safe, and clinician reassurance grounded in medical guidance is itself an intervention.</p>\n<h3>Cancer Survivorship</h3>\n<p>Cancer and its treatments — surgery, radiation, chemotherapy, and hormonal therapy — produce wide-ranging sexual effects, from anatomical change and pain to altered desire and profound shifts in body image and identity. Breast, prostate, and gynecological cancers carry particularly direct sexual consequences. Survivorship care that ignores sexual health leaves a central domain of quality of life unaddressed.</p>\n<h3>Multiple Sclerosis and Chronic Pain</h3>\n<p>Multiple sclerosis can cause neurogenic sexual dysfunction alongside fatigue and spasticity. Chronic pain conditions interfere with sexual activity directly and through the medications used to treat them. In every case, the bidirectional loop between the condition, mood, and sexual function means that attending to sexuality can improve overall adjustment to illness.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Disability and Sexuality</h2>\n<p>People with disabilities are sexual beings whose sexual health is systematically neglected because of ableist assumptions about who is, and is not, a sexual person. Affirming practice begins by rejecting that assumption.</p>\n<h3>Specific Considerations</h3>\n<ul>\n<li><strong>Spinal cord injury</strong>: the level and completeness of injury shape specific sexual implications, but sexual response and satisfaction remain possible and are an appropriate focus of rehabilitation.</li>\n<li><strong>Traumatic brain injury</strong>: may alter desire, produce disinhibition, and reshape relationship dynamics, requiring attention to both the person and their partner.</li>\n<li><strong>Intellectual and developmental disabilities</strong>: require a rights-based approach that balances the right to sexual expression and education with genuine attention to capacity and consent — neither denying sexuality nor neglecting protection.</li>\n<li><strong>Mobility limitations</strong>: often respond to practical problem-solving around positioning, timing, and adaptive approaches.</li>\n</ul>\n<p>The <strong>social model of disability</strong> reframes the clinical task: the goal is to remove the social and environmental barriers to sexual expression rather than to \"fix\" bodies that do not conform to a narrow norm.</p>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Sexuality and Aging</h2>\n<p>The belief that older adults are asexual is both empirically false and a barrier to care. Sexual interest and activity persist for many people well into later life, and older adults have a right to sexual health care that takes them seriously.</p>\n<h3>Normal Aging versus Pathology</h3>\n<p>Physiological changes accompany aging — vascular changes, hormonal shifts, slower arousal, and, after menopause, the genitourinary syndrome of menopause (GSM), which includes vaginal dryness and tissue thinning that can make intercourse painful. These changes are normal and frequently treatable; framing them as the inevitable end of a sexual life is inaccurate and harmful. GSM in particular responds well to medical management, and naming it is the first step toward treatment.</p>\n<h3>Overlooked Concerns in Older Adults</h3>\n<p>Sexually transmitted infection rates in older adults are an under-recognized public health concern, partly because clinicians do not provide sexual health education or screening to this population. Older adults in long-term care settings retain sexual rights that institutions frequently fail to accommodate, raising both clinical and ethical questions about privacy, capacity, and dignity. The clinician who carries the same matter-of-fact stance into work with older adults that they would bring to any other age group is providing care most older clients have never received.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 4,
+          "prompt": "Consider the populations you serve who live with chronic illness, disability, or aging. Where has sexual health been absent from your assessment, and what would it take to include it?",
+          "placeholder": "Reflect..."
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Medication Effects and Their Management</h2>\n<p>Because medication-related sexual effects are common, distressing, and a leading cause of nonadherence, recognizing and addressing them is a core competency even for clinicians who do not prescribe.</p>\n<ul>\n<li><strong>Antidepressants (SSRIs/SNRIs)</strong>: reduced desire, delayed or absent orgasm, and arousal difficulty are common. Management strategies that prescribers may consider include dose adjustment, timing, switching to an agent with a lower sexual side-effect profile, or augmentation — all decisions for the prescriber, but ones the non-prescribing clinician can surface and advocate for on the client's behalf.</li>\n<li><strong>Antihypertensives, antipsychotics, and hormonal agents</strong>: each carries its own profile of sexual effects.</li>\n</ul>\n<p>The essential clinical move is simple: ask. A clinician who routinely asks \"Have you noticed any changes in your sexual functioning since starting this medication?\" detects a problem that would otherwise drive silent nonadherence, and opens a collaborative conversation with the prescriber.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Scope of Practice, Ethics, and Referral Pathways</h2>\n<p>Knowing the limits of one's competence and referring appropriately is itself an ethical competency, governed by the ACA and NBCC codes' requirements to practice within one's boundaries of competence and to refer when a client's needs exceed them.</p>\n<h3>When and Where to Refer</h3>\n<ul>\n<li><strong>Certified sex therapists (AASECT-certified)</strong>: for entrenched sexual dysfunction, complex desire discrepancies, and concerns requiring specialized intervention beyond permission and limited information.</li>\n<li><strong>Pelvic floor physical therapy</strong>: for genito-pelvic pain and pelvic floor dysfunction.</li>\n<li><strong>Urology, gynecology, and primary care</strong>: for any presentation with likely physiological contributors — sexual pain, new-onset erectile difficulty, or symptoms coinciding with illness or medication.</li>\n</ul>\n<h3>Boundaries Around Sexual Content</h3>\n<p>Discussing sexual material with clients requires clear professional boundaries. The clinician's comfort with sexual topics must never blur into anything that serves the clinician's interest rather than the client's; the entire purpose of permission-giving is the client's wellbeing. Maintaining a matter-of-fact, clinical stance — neither avoidant nor prurient — is both the most effective and the most ethical posture.</p>\n<h3>Putting It Together</h3>\n<p>The generalist clinician who finishes this course should be able to raise sexual health routinely, screen with a biopsychosocial and lifespan lens, recognize normative from concerning presentations across the age range, respond competently within the Permission and Limited Information levels, and refer accurately when a concern exceeds their scope. That combination — not specialized expertise — is what closes the clinical silence that leaves so much sexual distress unaddressed.</p>"
+        },
+        {
+          "order": 7,
+          "type": "matching",
+          "matchingInstructions": "Match each sexual-health concern to the most appropriate generalist action.",
+          "matchingPairs": [
+            {
+              "term": "Mild situational difficulty tied to stress",
+              "definition": "Permission, education, and specific suggestions within generalist scope"
+            },
+            {
+              "term": "New pain with intercourse",
+              "definition": "Biopsychosocial assessment plus medical referral to rule out physical causes"
+            },
+            {
+              "term": "Complex, refractory sexual dysfunction",
+              "definition": "Referral to a specialized (e.g., AASECT-certified) sex therapist"
+            },
+            {
+              "term": "Sexual concern signaling possible coercion",
+              "definition": "Shift to safety screening and intimate partner violence resources"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Cancer Survivorship: A Closer Look</h2>\n<p>Cancer survivorship deserves specific attention because its sexual consequences are among the most profound and most neglected in all of clinical practice, and because the growing population of survivors increasingly presents to mental health professionals for the adjustment, mood, and relationship sequelae of treatment.</p>\n<h3>Treatment-Specific Effects</h3>\n<p>The sexual effects of cancer treatment are mechanism-specific. Surgery may remove or alter sexual anatomy and disrupt nerve pathways essential to arousal and orgasm. Radiation can damage tissue, producing pain, dryness, and structural change. Chemotherapy frequently induces fatigue, nausea, and — in many regimens — early menopause with its attendant sexual effects. Hormonal therapies, central to breast and prostate cancer treatment, directly suppress desire and arousal by design. Pelvic, breast, prostate, and gynecological cancers carry especially direct sexual consequences, but virtually any cancer experience reshapes a person's relationship to their body.</p>\n<h3>The Identity and Relationship Dimension</h3>\n<p>Beyond the physical, cancer reshapes sexual identity. Survivors frequently describe feeling disconnected from a body that has become a site of illness and treatment, grieving a prior sexual self, and renegotiating intimacy with partners who may themselves be navigating fear of recurrence, role change from partner to caregiver, and uncertainty about how to reintroduce physical closeness. The mental health clinician is often better positioned than the oncology team to address these dimensions, precisely because they fall outside the medical frame. Naming sexuality as a legitimate part of survivorship — rather than waiting for the survivor to raise it against the cultural pressure to simply be \"grateful to be alive\" — is frequently the intervention that matters most.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Sexual Health and Serious Mental Illness</h2>\n<p>People living with serious mental illness — including schizophrenia spectrum disorders, bipolar disorder, and severe recurrent depression — have sexual health needs that are among the most systematically ignored in the entire healthcare system, reflecting a compounding of stigma about both mental illness and sexuality.</p>\n<h3>Distinct Considerations</h3>\n<p>Several factors converge in this population. Antipsychotic medications commonly produce sexual side effects, including those mediated by elevated prolactin, and these effects are a frequent driver of nonadherence in a population for whom medication discontinuation carries high risk. Symptoms themselves — anhedonia, negative symptoms, the disorganization of acute episodes, and the impulsivity and hypersexuality that can accompany manic states — affect sexual experience and decision-making. People with serious mental illness also face elevated risk of sexual victimization and of sexually transmitted infection, alongside reduced access to sexual health education and screening.</p>\n<h3>The Clinical Posture</h3>\n<p>The appropriate posture is neither the paternalistic denial of sexuality that has historically characterized care for this population nor a neglect of genuine vulnerability. It is a recognition that people with serious mental illness have the same right to sexual health, sexual expression, and sexual safety as anyone else, combined with attentive support around capacity, consent, medication effects, and protection from exploitation. Raising sexual side effects directly with this population is particularly important, because the link between antipsychotic side effects and nonadherence is strong and the consequences of nonadherence are severe.</p>"
+        },
+        {
+          "order": 11,
+          "type": "multiSelect",
+          "question": "Why is it especially important to ask clients with serious mental illness about sexual health? (Select all that apply)",
+          "options": [
+            {
+              "text": "Their sexual health is frequently overlooked by providers",
+              "isCorrect": true
+            },
+            {
+              "text": "Psychiatric medications commonly affect sexual functioning",
+              "isCorrect": true
+            },
+            {
+              "text": "They have the same rights to sexual health and to be asked",
+              "isCorrect": true
+            },
+            {
+              "text": "People with serious mental illness are assumed to be asexual",
+              "isCorrect": false
+            },
+            {
+              "text": "Sexual side effects can affect medication adherence and quality of life",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Clients with serious mental illness have the same right to sexual health, are frequently overlooked, and commonly experience medication-related sexual side effects that affect adherence and quality of life."
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>When Trauma Underlies the Presentation: The Generalist's Role</h2>\n<p>A substantial proportion of sexual health concerns are connected, directly or indirectly, to a history of sexual trauma. The generalist clinician's role is not to provide specialized trauma treatment for sexual trauma — that is the focus of dedicated training and of separate coursework — but to recognize the connection, respond safely, and refer or coordinate appropriately.</p>\n<h3>Recognizing the Connection</h3>\n<p>Trauma may present as sexual avoidance or aversion, as dissociation during sexual activity, as compulsive sexual behavior, as genito-pelvic pain, or as difficulty with trust and intimacy. None of these presentations proves a trauma history, and clinicians must avoid assuming or suggesting trauma that a client has not reported. But holding the possibility in mind — and asking about unwanted sexual experiences gently, without pressure to disclose — allows the clinician to understand presentations that would otherwise be puzzling.</p>\n<h3>Responding Safely</h3>\n<p>When trauma is disclosed, the generalist's immediate tasks are to receive the disclosure without judgment, to prioritize the client's sense of safety and control in the conversation, to avoid pressing for traumatic detail that is not clinically necessary, and to assess current safety and stability. Specialized trauma-focused sexual health treatment — including the trauma-adapted and somatic approaches that require dedicated training — is then provided by an appropriately trained clinician, to whom the generalist refers or with whom they coordinate. Recognizing the limits of one's training here is not a failure; it is exactly the scope-of-practice judgment that ethical care requires.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Building and Using a Referral Network</h2>\n<p>Competent referral depends on having a network in place before it is needed. A clinician who recognizes that a concern exceeds their scope but has no one to refer to has only solved half the problem.</p>\n<h3>Assembling the Network</h3>\n<p>A functional sexual health referral network typically includes: certified sex therapists (the AASECT directory is the standard source for certified clinicians); pelvic floor physical therapists, who are essential partners for genito-pelvic pain and pelvic floor dysfunction; urologists and gynecologists, particularly those known to be comfortable with sexual health concerns; primary care clinicians for medication review and medical workup; and, where relevant, specialists in gender-affirming care. Clinicians who build relationships with these providers — rather than handing clients a name from a directory — make referrals that clients are far more likely to follow through on.</p>\n<h3>Making the Referral Stick</h3>\n<p>A referral is most effective when the clinician frames it as added expertise rather than as a dismissal (\"I want to bring in someone who specializes in exactly this, and I'll stay involved\"), addresses the practical and emotional barriers to following through, and — with appropriate consent — coordinates with the receiving provider rather than simply transferring the client. The generalist frequently remains involved, continuing to provide the permission-giving and supportive presence that complements specialized care.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Pregnancy, Postpartum, and Sexual Health</h2>\n<p>The perinatal period is a significant and frequently overlooked window of sexual change, and mental health clinicians working with pregnant and postpartum clients are well positioned to address it.</p>\n<h3>During Pregnancy</h3>\n<p>Sexual desire and comfort vary widely across pregnancy and across individuals — increasing for some, decreasing for others, and changing across trimesters as the body changes. Anxiety about harming the pregnancy, body-image shifts, and physical discomfort all influence sexual experience. Accurate information that, in uncomplicated pregnancies, sexual activity is generally safe (with guidance from the obstetric provider) relieves a common and unspoken worry.</p>\n<h3>The Postpartum Period</h3>\n<p>The postpartum period brings physical recovery, hormonal change (particularly the suppression of estrogen during lactation, which commonly causes vaginal dryness and discomfort), profound sleep disruption, and the reorganization of identity and relationship that accompanies new parenthood. Many couples experience a significant change in their sexual relationship that they did not anticipate and feel unable to discuss. Naming this as common and time-limited, providing accurate information about lactation-related changes and their management, and attending to the relationship strain that sexual change can produce are all within the generalist's scope and are frequently deeply appreciated by clients who assumed they were alone in the experience.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Managing Later-Life Sexual Health: Practical Clinical Guidance</h2>\n<p>Building on the rejection of the asexual-aging myth, affirming practice with older adults requires specific clinical knowledge and a willingness to raise topics that the broader healthcare system routinely omits.</p>\n<h3>Managing the Physiology of Later-Life Sexuality</h3>\n<p>Genitourinary syndrome of menopause (GSM) is common, frequently distressing, and highly treatable; clients benefit from knowing that effective management exists and from being encouraged to raise it with a medical provider. For men, changes in erectile function are common with age but are not synonymous with the end of a sexual life, and they may signal vascular conditions that warrant evaluation. The clinician who frames these changes as manageable adaptations rather than terminal losses keeps possibilities open that ageist assumptions would foreclose.</p>\n<h3>Relationship and Context in Later Life</h3>\n<p>Later-life sexuality is shaped by partner availability, widowhood, the formation of new relationships, and — for those in long-term care — institutional constraints on privacy and autonomy. Clinicians can support older adults who are forming new sexual relationships (including the often-overlooked need for sexually transmitted infection prevention), help those navigating sexuality after the loss of a long-term partner, and advocate for the sexual rights and dignity of clients in institutional settings. The capacity to consent in the context of cognitive decline raises genuine clinical and ethical complexity that deserves careful, person-centered attention rather than blanket restriction.</p>",
+          "title": "Managing Later-Life Sexual Health: Practical Clinical Guidance"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Ethics and Documentation in Sexual Health Practice</h2>\n<p>Sexual health practice raises ethical considerations that, while continuous with general clinical ethics, carry distinctive sensitivities that warrant explicit attention.</p>\n<h3>Boundaries and Scope</h3>\n<p>The ACA and NBCC codes require practice within one's boundaries of competence, appropriate referral, and the maintenance of clear professional boundaries. In sexual health work, the most important boundary is the absolute prohibition on any sexual or romantic involvement with clients, grounded in the recognition that the power differential precludes genuine consent. The clinician's comfort with sexual material exists entirely in the service of the client and must never serve the clinician's interest. A matter-of-fact, clinical stance — neither avoidant nor prurient — is both the most therapeutic and the most ethical posture.</p>\n<h3>Values, Referral, and Non-Imposition</h3>\n<p>Where a clinician's personal values conflict sharply with a client's sexual life, ethical practice requires bracketing those values rather than imposing them, and — when a clinician cannot provide genuinely affirming care — referring rather than delivering judgment-laden or substandard treatment. Referral on the basis of values must never function as a rejection of the client's identity.</p>\n<h3>Documentation</h3>\n<p>Documentation of sexual health information follows the same standards of accuracy and relevance as all clinical documentation, with heightened attention to privacy. Clinicians record what is clinically necessary in the client's own language, consider the heightened sensitivity of sexual content in shared and disclosable records, and attend to the specific confidentiality complexities that arise with adolescents and with information that, if disclosed, could expose a client to harm. Thoughtful documentation protects both the client and the clinician.</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Sexual Health and Fertility: Infertility and Its Treatment</h2>\n<p>Fertility concerns and the experience of infertility have a significant and frequently overlooked impact on sexual health, and clinicians supporting clients through family-building difficulties should understand this intersection.</p>\n<h3>How Infertility Affects Sexuality</h3>\n<p>The experience of infertility, and the process of fertility treatment, can profoundly affect a couple's sexual relationship. Sex that has been a source of pleasure and connection can become medicalized, scheduled, and goal-directed, oriented toward conception rather than intimacy or enjoyment. The pressure of timed intercourse, the intrusion of monitoring and procedures, the grief and disappointment of unsuccessful cycles, and the strain on identity and relationship can all erode desire, arousal, spontaneity, and satisfaction. Sex may come to feel like a task or a reminder of loss rather than a source of closeness, and partners may differ in how they experience and cope with this.</p>\n<h3>Supporting Clients</h3>\n<p>Clinicians support clients through fertility-related sexual difficulties by acknowledging this impact, normalizing the strain that infertility places on a sexual relationship, and helping couples preserve or rebuild intimacy and pleasure alongside or apart from conception efforts. This can include helping partners communicate about their differing experiences, distinguishing sex for connection from sex for conception, and processing the grief, identity threat, and relationship strain that infertility brings. The clinician also remains attentive to the emotional toll of infertility more broadly — including depression, anxiety, and grief — and coordinates with medical fertility providers as appropriate. Throughout, the clinician validates that the sexual difficulties accompanying infertility are a common and understandable response to an exceptionally stressful experience, not a separate failing to be judged.</p>",
+          "title": "Sexual Health and Fertility: Infertility and Its Treatment"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Sexuality in Long-Term Care: Capacity, Privacy, and Dignity</h2>\n<p>Older adults in long-term care settings retain their sexuality and their right to sexual expression, yet institutional environments frequently fail to accommodate these rights, raising clinical and ethical questions that mental health professionals are well positioned to help address.</p>\n<h3>The Core Tensions</h3>\n<p>Long-term care settings must balance residents' rights to privacy, autonomy, and intimate relationships against legitimate concerns about safety and, in some cases, capacity to consent. Too often the balance defaults to blanket prohibition — denying residents privacy, treating sexual expression as a behavior to be managed, and overriding autonomy in ways that would never be accepted for younger adults. This default reflects ageist assumptions rather than genuine ethical reasoning.</p>\n<h3>Capacity to Consent</h3>\n<p>The presence of cognitive impairment, including dementia, complicates but does not eliminate the question of sexual rights. Capacity to consent to sexual activity is decision-specific and can fluctuate; it is not an all-or-nothing status conferred or removed by a diagnosis. Thoughtful assessment asks whether the person understands the nature of the relationship, can express a consistent choice, and is free from coercion — rather than presuming incapacity from diagnosis alone. These are genuinely difficult determinations that require careful, individualized, and frequently interdisciplinary judgment.</p>\n<h3>The Clinician's Contribution</h3>\n<p>Mental health clinicians can help long-term care settings move from reflexive prohibition toward individualized, dignity-centered approaches: supporting privacy, assessing capacity thoughtfully rather than presumptively, educating staff and families, and advocating for residents' rights alongside genuine attention to protection from exploitation. The goal is neither to ignore real vulnerability nor to deny older adults a dimension of life that remains meaningful to many of them.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>A Worked Case: Integrating the Biopsychosocial-Lifespan Formulation</h2>\n<p>Consider a 58-year-old client referred for depression who, when the clinician routinely asks about sexual health, discloses distress about reduced desire and difficulty with arousal over the past year — a difficulty she has assumed signaled the end of her sexual life and has never raised with any provider. A biopsychosocial-lifespan formulation organizes the assessment.</p>\n<h3>Applying the Framework</h3>\n<p><strong>Biological:</strong> The client is perimenopausal, reports vaginal dryness and discomfort consistent with the genitourinary syndrome of menopause, and began an SSRI for depression eight months ago — two highly plausible contributors to both reduced desire and arousal difficulty. <strong>Psychological:</strong> Her depression itself suppresses desire and pleasure, and her belief that the changes are an irreversible end-point is generating anticipatory anxiety and avoidance. <strong>Sociocultural and relational:</strong> She has absorbed a cultural script that frames older women as asexual, which has made the changes feel like confirmation rather than a solvable problem, and she has withdrawn from her partner, who has interpreted the distance as rejection.</p>\n<h3>From Formulation to Plan</h3>\n<p>The formulation generates multiple points of entry. The clinician provides <strong>limited information</strong> — that GSM is common and treatable, that SSRI sexual effects are common and that the prescriber has options, and that sexuality persists and changes rather than ending in later life — which alone reduces her distress and anticipatory anxiety. The clinician coordinates with the <strong>prescriber</strong> regarding the SSRI and recommends <strong>medical evaluation</strong> of GSM, both squarely within appropriate scope. The clinician addresses the <strong>relational</strong> withdrawal directly, helping the couple communicate about a change both had silently misread. And the clinician treats the <strong>depression</strong> that is both cause and consequence of the sexual difficulty. No single intervention would have sufficed; the integrated formulation is what made an apparently hopeless complaint into a set of addressable problems.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 22,
+          "question": "In the worked case, the client's reduced desire and arousal are best understood as:",
+          "options": [
+            {
+              "text": "A purely psychological problem to be treated with insight alone",
+              "isCorrect": false
+            },
+            {
+              "text": "An inevitable, untreatable consequence of aging",
+              "isCorrect": false
+            },
+            {
+              "text": "A multiply determined difficulty with biological (GSM, SSRI), psychological (depression, beliefs), and relational contributors, each offering a point of intervention",
+              "isCorrect": true
+            },
+            {
+              "text": "A problem requiring immediate referral with no role for the generalist",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "The biopsychosocial-lifespan formulation reveals multiple contributors — each an addressable point of entry — which is why an integrated plan succeeds where any single-domain approach would fail.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Substance Use and Sexual Health</h2>\n<p>Substance use intersects with sexual health in ways that are clinically important and frequently unaddressed, and mental health clinicians — who often work with substance use directly — are well positioned to attend to this intersection.</p>\n<h3>Effects on Sexual Function</h3>\n<p>Different substances affect sexual function differently. Alcohol, though often used to reduce inhibition, impairs arousal and performance and, with chronic use, contributes to lasting sexual dysfunction. Stimulants may acutely increase arousal and risk-taking while contributing to dysfunction over time. Opioids are associated with marked suppression of desire and with hormonal effects that impair function. Tobacco contributes to vascular impairment of arousal. Recognizing these effects helps clinicians understand sexual concerns that coincide with substance use and avoid attributing them solely to psychological causes.</p>\n<h3>Sex, Risk, and Recovery</h3>\n<p>Substance use also shapes sexual decision-making and risk: intoxication impairs the capacity to negotiate consent, to assess situations, and to use protection, raising the risk of unwanted experiences, sexually transmitted infection, and unintended pregnancy. In recovery, sexuality presents its own challenges: people who have only ever experienced sex while using substances may face anxiety about sober sexual experience, and sexual situations can function as relapse triggers. Addressing sexuality as part of recovery — rather than treating it as a separate or taboo topic — supports both sexual health and sustained recovery, and is an appropriate focus for clinicians working in this area.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Sexual Health After Surgery and Medical Procedures</h2>\n<p>Beyond cancer, a range of surgeries and medical procedures carry sexual consequences that are routinely under-addressed by the medical teams performing them, leaving an opening for the mental health clinician who simply asks.</p>\n<h3>Common Examples</h3>\n<p>Hysterectomy, prostate surgery, and other pelvic procedures can affect sensation, function, and body image. The creation of an ostomy reshapes a person's relationship to their body and frequently generates anxiety about intimacy and desirability. Cardiac procedures, joint replacements, and recovery from serious illness or injury all raise questions — often unspoken — about when and how to resume sexual activity, and about whether it is safe. As with cardiac events, fear-based avoidance frequently outlasts any actual medical restriction, and accurate information paired with permission to resume is itself an intervention.</p>\n<h3>The Clinical Task</h3>\n<p>The clinician's task is to normalize sexuality as a legitimate part of recovery, to help clients and partners communicate about changes and fears, to correct misinformation about safety (while directing specific medical questions to the appropriate provider), and to support the renegotiation of intimacy that major medical events require. For many clients, simply being asked about their sexual recovery — when no one else on their care team has raised it — is what allows them to address a concern they had assumed they must simply endure.</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>Coordinating Care: The Mental Health Clinician on an Interdisciplinary Team</h2>\n<p>Because sexual health sits at the intersection of physical, psychological, relational, and social factors, effective care is frequently interdisciplinary, and the mental health clinician occupies a distinctive and valuable position on the team.</p>\n<h3>The Clinician's Distinctive Contribution</h3>\n<p>Medical providers may address the biological dimension but frequently lack the time, training, or comfort to address the psychological and relational dimensions; the mental health clinician supplies exactly these. The clinician can hold the integrated biopsychosocial formulation that no single discipline captures alone, can address the meaning a sexual concern holds for the client, can work with the relational and communication factors that medical care does not reach, and can provide the permission-giving and supportive presence that the medical encounter rarely affords.</p>\n<h3>Effective Coordination</h3>\n<p>Effective coordination requires appropriate consent and information-sharing, clear communication with the other providers about respective roles, and a collaborative rather than siloed stance. The mental health clinician frequently functions as the consistent presence who helps the client integrate the contributions of multiple providers — the urologist or gynecologist, the pelvic floor physical therapist, the prescriber, the sex therapist — into a coherent whole. In this role the clinician does not need to be the expert on every dimension; they need to recognize the dimensions, ensure each is addressed by someone competent, and help the client make sense of the whole. That integrative function is the essence of competent generalist sexual health practice across the lifespan.</p>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Sexual Health and Caregiving</h2>\n<p>The sexual lives of family caregivers represent another systematically overlooked dimension of sexual health, and one that mental health clinicians who work with caregivers are well positioned to address.</p>\n<h3>The Caregiver's Own Sexuality</h3>\n<p>People caring for an ill or disabled partner, parent, or child experience profound effects on their own sexuality and intimate relationships. When the care recipient is a partner, the relationship may shift from partnership toward a caregiving dynamic that erodes the conditions for sexual intimacy, and both partners may grieve the change. Caregiver exhaustion, depression, and the sheer absence of time and privacy suppress desire and opportunity. Caregivers frequently feel guilt about their own sexual needs in the context of a loved one's suffering, and rarely have any space in which to speak about it.</p>\n<h3>The Clinical Opening</h3>\n<p>The clinician who works with caregivers can offer that space: acknowledging that the caregiver's own needs — including sexual and relational ones — remain legitimate, helping caregiving couples preserve or renegotiate intimacy where possible, and normalizing the complicated feelings that arise. As with so much of sexual health practice, simply naming the topic as legitimate is the intervention most caregivers have never been offered.</p>"
+        },
+        {
+          "type": "text",
+          "order": 29,
+          "content": "<h2>Telehealth and Sexual Health Conversations</h2>\n<p>As telehealth has become a routine mode of mental health care, clinicians need to consider how the sexual health conversation translates to the remote setting, where both new opportunities and new considerations arise.</p>\n<h3>Opportunities and Considerations</h3>\n<p>For some clients, the relative distance of telehealth lowers the barrier to discussing sensitive sexual material, and the ability to participate from home can make care accessible to clients who could not otherwise reach it. At the same time, the remote setting raises specific considerations. Privacy is paramount: the clinician confirms that the client is in a private space where they can speak freely, recognizing that a client may not be safe or able to discuss sexual concerns — or to disclose coercion or violence — if another person is within earshot. The clinician also attends to the reduced access to nonverbal cues, checking in more deliberately about the client's emotional state during sensitive material.</p>\n<h3>Maintaining Standards Remotely</h3>\n<p>The core principles of sexual health practice — permission, normalization, accurate information, trauma-informed sensitivity, and clear boundaries — apply identically in telehealth. The clinician simply adapts their implementation to the medium, taking particular care with privacy, safety, and the confirmation that the client is able to engage in the conversation freely and securely.</p>"
+        },
+        {
+          "type": "text",
+          "order": 30,
+          "content": "<h2>Body Image and Sexual Self-Concept</h2>\n<p>Body image and sexual self-concept exert a powerful influence on sexual experience across the entire lifespan, and they intersect with nearly every theme of this course — aging, illness, disability, treatment effects, and cultural messages about bodies and desirability.</p>\n<h3>How Body Image Shapes Sexuality</h3>\n<p>Negative body image interferes with sexual experience through several mechanisms: it fuels spectatoring (self-monitoring during sex that pulls attention away from pleasure and connection), drives avoidance of sexual situations, and undermines the sense of being a desirable and sexual person. Cultural messages that equate sexual worth with a narrow standard of appearance, the bodily changes of aging, the alterations wrought by illness and treatment, and the effects of weight, disability, and difference all shape sexual self-concept — frequently in ways that generate distress disproportionate to anything about actual function.</p>\n<h3>The Clinical Focus</h3>\n<p>Addressing body image and sexual self-concept is therefore an important and accessible focus of sexual health work. Helping clients shift attention from self-monitoring to present-moment experience, challenging the internalized standards that equate worth with appearance, and supporting an expanded and more compassionate relationship with one's own body frequently improve sexual wellbeing even when no change in physical function occurs. This work is especially central for clients navigating the bodily changes of aging, illness, and treatment that recur throughout the lifespan.</p>"
+        },
+        {
+          "type": "text",
+          "order": 31,
+          "content": "<h2>Sexual Communication: Helping Clients Talk With Partners</h2>\n<p>Many sexual concerns are sustained not by dysfunction but by the absence of effective communication between partners, and helping clients communicate about sex is one of the most broadly useful interventions in sexual health practice.</p>\n<h3>Why Sexual Communication Is Hard</h3>\n<p>Sexual communication is difficult for most people, who have rarely been taught how to do it and who fear that raising a concern will hurt or offend a partner. The result is that partners frequently make consequential assumptions about each other's desires, satisfaction, and difficulties without ever checking them — assumptions that, when wrong, generate distance, resentment, and unaddressed problems. The desire-discrepancy and pursuer-distancer dynamics described earlier are sustained largely by failures of communication.</p>\n<h3>Building the Skill</h3>\n<p>Clinicians help by normalizing the difficulty, by coaching clients to express desires and concerns directly and non-blamefully, by helping partners listen without defensiveness, and by reframing sexual communication as an ongoing collaborative process rather than a one-time conversation. Even brief, well-targeted communication coaching frequently produces meaningful improvement, because it addresses a maintaining factor common to a wide range of sexual concerns. This skill complements every other intervention in this course, from reframing desire discrepancy to renegotiating intimacy after illness.</p>"
+        },
+        {
+          "type": "text",
+          "order": 38,
+          "content": "<h2>Bringing It Together: Sexual Health Across the Whole Lifespan</h2>\n<p>This course has traced sexual health from infancy through later life, across health and illness, ability and disability, and the full diversity of identities, cultures, and relationships. Several threads run through the whole.</p>\n<p>First, sexual health is a general clinical competency, not a specialty: every clinician can and should raise the topic, screen with a biopsychosocial and lifespan lens, and provide permission and accurate information. Second, the silence that surrounds sexual health is itself the central problem, and the single most consequential act a clinician performs is simply to ask. Third, sexual concerns are almost always multiply determined, which is why the integrated biopsychosocial-lifespan formulation succeeds where single-domain accounts fail. Fourth, affirming, non-pathologizing, culturally humble practice — grounded in disciplined non-assumption and in respect for each client's self-determination — is the stance that competent sexual health care requires with every client. And fifth, knowing the limits of one's scope and referring well is as much a part of competence as any technique.</p>\n<p>The generalist clinician who carries these principles into practice will not become a sex therapist, and does not need to. They will become a clinician who closes the silence — who ensures that sexual health, a fundamental dimension of human wellbeing across the entire lifespan, is no longer the dimension their clients are left to navigate alone.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 33,
+          "question": "A recurring theme across this course is that the single most consequential act a generalist clinician performs in sexual health care is to:",
+          "options": [
+            {
+              "text": "Provide intensive sex therapy",
+              "isCorrect": false
+            },
+            {
+              "text": "Diagnose a sexual dysfunction",
+              "isCorrect": false
+            },
+            {
+              "text": "Simply ask about sexual health routinely, closing the clinical silence",
+              "isCorrect": true
+            },
+            {
+              "text": "Refer every client to a specialist",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "Because clinical silence is the central barrier, routinely asking — closing that silence — is the highest-impact act available to every clinician, regardless of specialization.",
+          "showExplanation": true
+        },
+        {
+          "type": "reflection",
+          "order": 39,
+          "prompt": "After this course, what is one concrete change you will make to how you assess or respond to sexual health in your practice?",
+          "placeholder": "Reflect..."
+        }
+      ]
+    }
+  ]
+};
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+async function main() {
+  await mongoose.connect(MONGODB_URI);
+  console.log('Connected.');
+  const doc = await Course.findOne({ slug: COURSE_DATA.slug });
+  if (!doc) { console.error('CR-303 not found by slug', COURSE_DATA.slug); process.exit(1); }
+
+  // Assign expanded fields onto the existing document.
+  for (const k of Object.keys(COURSE_DATA)) doc[k] = COURSE_DATA[k];
+  doc.modules = undefined; // clear stale modules[] so only sections[] remain
+  doc.markModified('sections');
+  doc.markModified('assessment');
+
+  await doc.save(); // triggers pre-save wordCount hook + schema validation
+  const fresh = await Course.findById(doc._id).lean();
+  console.log('Saved. Sections:', fresh.sections?.length, '| wordCount:', fresh.wordCount, '| accessType:', fresh.accessType, '| status:', fresh.status);
+
+  await mongoose.disconnect();
+  console.log('Done.');
+}
+main().catch(e => { console.error('ERROR:', e.message); process.exit(1); });

--- a/server/src/scripts/seedCR304-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR304-EXPANDED-canonical.js
@@ -1,0 +1,1657 @@
+/**
+ * Copyright (c) 2026 CounselorReady / GA Integrated Therapeutic Perspectives, LLC.
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+import 'dotenv/config';
+
+// CR-304 EXPANDED — canonical sections[] shape; saves through the model (wordCount hook fires).
+const COURSE_DATA = {
+  "title": "Sexuality, Identity, and Mental Health: Affirming Clinical Practice with LGBTQ+ Clients",
+  "slug": "sexuality-identity-mental-health-lgbtq",
+  "courseCode": "CR-304",
+  "description": "A comprehensive 3-hour continuing education course for licensed mental health professionals. Meets NBCC ACEP standards with 18,030 words of graduate-level clinical content.",
+  "ceHours": 3,
+  "credits": 3,
+  "category": "Clinical",
+  "ceCategory": "Clinical",
+  "ceuHours": 3,
+  "ceuEligible": true,
+  "approvingBody": "NBCC",
+  "approvalNumber": "#7760",
+  "creditType": "NBCC",
+  "acepProvider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "number": "7760"
+  },
+  "instructor": "GA Integrated Therapeutic Perspectives LLC",
+  "targetAudience": [
+    "Licensed mental health professionals including LPCs, LCSWs, LMFTs, psychologists, and NCCs who provide clinical services to LGBTQ+ clients and wish to develop affirming, evidence-based sexual identity and mental health clinical competencies."
+  ],
+  "accessType": "subscription",
+  "price": 59.99,
+  "pricingTier": "standard",
+  "status": "draft",
+  "isPublished": false,
+  "isActive": true,
+  "passingScore": 80,
+  "maxAttempts": 3,
+  "settings": {
+    "passingScore": 80,
+    "certificateEnabled": true,
+    "requireEvaluation": true,
+    "requireAttestation": true
+  },
+  "objectives": [
+    "Apply Meyer's minority stress theory and its clinical implications to the assessment and treatment of LGBTQ+ clients.",
+    "Identify the mental health outcomes associated with family acceptance and rejection for LGBTQ+ youth and implement family-inclusive affirming interventions.",
+    "Conduct affirming, culturally humble clinical assessments with LGBTQ+ clients that distinguish identity-related concerns from clinical mental health concerns.",
+    "Apply WPATH Standards of Care Version 8 principles in working with transgender and gender-diverse clients.",
+    "Recognize and address the clinical needs of LGBTQ+ clients with intersecting marginalized identities including BIPOC LGBTQ+ clients and LGBTQ+ clients with disabilities.",
+    "Implement evidence-based affirming clinical practices that support LGBTQ+ clients' identity development, mental health, and relationship wellbeing."
+  ],
+  "assessment": {
+    "isExam": true,
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
+      {
+        "question": "Meyer's (2003) minority stress theory identifies which categories of stressors:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Internal and external stressors specific to the clinical context",
+            "isCorrect": false
+          },
+          {
+            "text": "Distal stressors (external discrimination/prejudice) and proximal stressors (internalized stigma, concealment, vigilance)",
+            "isCorrect": true
+          },
+          {
+            "text": "Acute and chronic stressors equally applicable to all minority populations",
+            "isCorrect": false
+          },
+          {
+            "text": "Social and psychological stressors arising from cultural mismatch",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is distal stressors (external discrimination/prejudice) and proximal stressors (internalized stigma, concealment, vigilance). Meyer's (2003) minority stress model specifically categorizes stressors into these two domains, with distal stressors being objective external events like discrimination and violence, and proximal stressors being subjective internal processes such as internalized homophobia, identity concealment, and hypervigilance. The option describing 'acute and chronic stressors equally applicable to all minority populations' is incorrect because Meyer's framework identifies stressors specific to the LGBTQ+ minority experience, not general stressors applicable to all groups."
+      },
+      {
+        "question": "Ryan et al. (2009) found that LGBTQ+ youth experiencing high family rejection were how many times more likely to attempt suicide:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "2.5 times",
+            "isCorrect": false
+          },
+          {
+            "text": "4.8 times",
+            "isCorrect": false
+          },
+          {
+            "text": "8.4 times",
+            "isCorrect": true
+          },
+          {
+            "text": "12.1 times",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "The correct answer is 8.4 times. Ryan et al. (2009) documented that LGBTQ+ youth experiencing high levels of family rejection were 8.4 times more likely to attempt suicide, along with 5.9 times greater likelihood of depression and 3.4 times greater likelihood of unprotected sex. The option of 4.8 times is the most plausible distractor but understates the magnitude of the risk, which the research specifically quantified at 8.4 times greater likelihood."
+      },
+      {
+        "question": "Russell et al. (2018) found that use of chosen name for transgender youth was associated with:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Increased conflict with family members",
+            "isCorrect": false
+          },
+          {
+            "text": "56% reduction in suicidal ideation",
+            "isCorrect": true
+          },
+          {
+            "text": "Improved academic performance",
+            "isCorrect": false
+          },
+          {
+            "text": "Increased disclosure of gender identity to peers",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is a 56% reduction in suicidal ideation. Russell et al. (2018) found that use of a transgender youth's chosen name was associated with a 56% reduction in suicidal ideation, a 71% reduction in severe depression symptoms, and a 65% reduction in suicidal behavior. The option suggesting increased conflict with family members is incorrect because the research demonstrated that chosen name use is a concrete family acceptance behavior with measurable positive mental health effects, not a source of increased conflict."
+      },
+      {
+        "question": "The WPATH SOC8's position on clinicians working with transgender clients is that clinicians should function as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Gatekeepers who determine eligibility for medical interventions",
+            "isCorrect": false
+          },
+          {
+            "text": "Collaborators who support clients' own gender development and goals",
+            "isCorrect": true
+          },
+          {
+            "text": "Diagnosticians who establish the presence of gender dysphoria",
+            "isCorrect": false
+          },
+          {
+            "text": "Advocates who challenge all barriers to gender-affirming care regardless of clinical readiness",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is collaborators who support clients' own gender development and goals. WPATH SOC8 (Coleman et al., 2022) represents a paradigm shift from earlier versions by explicitly positioning the clinician as a collaborator rather than a gatekeeper, emphasizing support for the client's own gender development and goals. The gatekeeper option is incorrect because SOC8 specifically moved away from this model, recognizing that treating transgender healthcare as requiring special clinical authorization constitutes a harmful form of discrimination."
+      },
+      {
+        "question": "Conversion therapy is best described as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "An evidence-based approach for LGBTQ+ clients with ego-dystonic sexual orientation",
+            "isCorrect": false
+          },
+          {
+            "text": "Any practice attempting to change sexual orientation or gender identity, which is harmful and unethical",
+            "isCorrect": true
+          },
+          {
+            "text": "A historical practice no longer in use",
+            "isCorrect": false
+          },
+          {
+            "text": "A legally prohibited practice in all US states",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that conversion therapy is any practice attempting to change sexual orientation or gender identity, which is harmful and unethical. Every major mental health professional organization (APA, ACA, NASW, AAMFT) ethically prohibits conversion therapy, and the APA Task Force (2009) found no credible evidence of efficacy and substantial evidence of harm including increased depression, anxiety, and suicidal ideation. The option describing it as a historical practice no longer in use is incorrect because conversion therapy continues to be practiced and remains legal in many U.S. states, which is why ongoing clinical vigilance against it is necessary."
+      },
+      {
+        "question": "Crenshaw's (1989) intersectionality framework is clinically relevant because:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "It establishes a hierarchy of oppression among marginalized identity groups",
+            "isCorrect": false
+          },
+          {
+            "text": "It recognizes that multiple marginalized identities produce compound effects not captured by examining each in isolation",
+            "isCorrect": true
+          },
+          {
+            "text": "It applies primarily to Black women as the original focus of the framework",
+            "isCorrect": false
+          },
+          {
+            "text": "It provides a legal rather than clinical framework for understanding discrimination",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that multiple marginalized identities produce compound effects not captured by examining each in isolation. Crenshaw's intersectionality framework is clinically essential because LGBTQ+ clients who hold multiple marginalized identities (e.g., LGBTQ+ people of color) experience compound minority stress — what Balsam et al. (2011) termed 'cultural victimization' — that cannot be understood by examining race or sexual orientation separately. The option that intersectionality establishes a hierarchy of oppression is incorrect because the framework explicitly rejects hierarchical comparisons and instead focuses on how intersecting identities create unique, compounded experiences of marginalization."
+      },
+      {
+        "question": "Affirming clinical practice with bisexual clients requires attention to which specific clinical concern:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Higher rates of substance use than gay men or lesbians",
+            "isCorrect": false
+          },
+          {
+            "text": "Biphobia and invalidation from both heterosexual and LGBTQ+ communities",
+            "isCorrect": true
+          },
+          {
+            "text": "Lower rates of relationship satisfaction than gay or lesbian individuals",
+            "isCorrect": false
+          },
+          {
+            "text": "Exclusively higher rates of mental health concerns compared to gay and lesbian individuals",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is biphobia and invalidation from both heterosexual and LGBTQ+ communities. Research consistently shows bisexual individuals have higher rates of depression, anxiety, and suicidal behavior than either gay/lesbian or heterosexual individuals, driven substantially by biphobia from heterosexual communities that may not accept bisexuality as valid and from LGBTQ+ communities that may regard it as a transitional phase. The option about higher rates of substance use than gay men or lesbians, while potentially partially true, does not capture the core clinical concern of dual-community invalidation and monosexism that is specific to bisexual minority stress."
+      },
+      {
+        "question": "An affirming clinical approach to sexual orientation and gender identity holds that:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Clinicians should remain neutral about the clinical significance of LGBTQ+ identities",
+            "isCorrect": false
+          },
+          {
+            "text": "LGBTQ+ identities are normal, healthy human variations requiring affirmation rather than pathology",
+            "isCorrect": true
+          },
+          {
+            "text": "Clinicians should support clients in exploring whether their LGBTQ+ identity is authentic",
+            "isCorrect": false
+          },
+          {
+            "text": "Religious identity always takes precedence over sexual orientation or gender identity",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that LGBTQ+ identities are normal, healthy human variations requiring affirmation rather than pathology. APA (2012, 2015) and ACA guidelines specifically require that licensed mental health practitioners provide affirming clinical services, framing affirmation as a professional ethical obligation rather than an optional clinical orientation. The option that clinicians should remain neutral is incorrect because neutrality toward LGBTQ+ identity implicitly treats it as something about which reasonable clinical disagreement exists, which contradicts the professional consensus that LGBTQ+ identities are healthy variations that do not require clinical questioning."
+      },
+      {
+        "question": "The clinical concept of 'coming out' is best understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A single discrete event that occurs once in a person's life",
+            "isCorrect": false
+          },
+          {
+            "text": "A lifelong, contextually recursive process that is never fully complete",
+            "isCorrect": true
+          },
+          {
+            "text": "A process that only occurs during adolescence and young adulthood",
+            "isCorrect": false
+          },
+          {
+            "text": "A process that is uniformly positive in its mental health effects",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that coming out is a lifelong, contextually recursive process that is never fully complete. The clinical literature has moved from linear developmental models to more complex models recognizing that each new relationship, life context, and social environment presents the coming-out decision anew, requiring ongoing assessment of the safety, costs, and benefits of disclosure. The option describing it as a single discrete event is incorrect because coming out involves continuous contextual decisions across the lifespan, not a one-time disclosure."
+      },
+      {
+        "question": "LGBTQ+ clients of color face which specific clinical pattern:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Lower rates of mental health concerns compared to white LGBTQ+ individuals",
+            "isCorrect": false
+          },
+          {
+            "text": "Compound minority stress from multiple intersecting marginalized identities",
+            "isCorrect": true
+          },
+          {
+            "text": "Uniformly stronger social support from communities of color",
+            "isCorrect": false
+          },
+          {
+            "text": "Lower rates of family rejection than white LGBTQ+ youth",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is compound minority stress from multiple intersecting marginalized identities. Balsam et al. (2011) described the experience of LGBTQ+ people of color as 'cultural victimization,' involving racism in LGBTQ+ spaces and homophobia/transphobia in communities of color, which produces compounded mental health effects. The option suggesting lower rates of mental health concerns is incorrect because intersectional research consistently shows that LGBTQ+ people of color experience additive and compounding stressors, not reduced ones, as a result of navigating multiple forms of marginalization simultaneously."
+      },
+      {
+        "question": "The clinical use of LGBTQ+ affirmative therapy contraindicates:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Exploring the religious and cultural context of clients' attitudes toward their LGBTQ+ identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Helping clients navigate family relationships that may be challenging due to their identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Applying insight-oriented approaches to LGBTQ+-related clinical concerns",
+            "isCorrect": false
+          },
+          {
+            "text": "Any practice that attempts to change, minimize, or eliminate LGBTQ+ identity",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 3,
+        "explanation": "The correct answer is any practice that attempts to change, minimize, or eliminate LGBTQ+ identity. LGBTQ+ affirmative therapy is fundamentally incompatible with conversion therapy or any approach that seeks to alter a client's sexual orientation or gender identity, as all major professional organizations identify such practices as harmful and unethical. The option about exploring religious and cultural context is incorrect as a contraindication because affirming therapy fully supports exploring these dimensions of a client's experience; it only prohibits practices aimed at changing the identity itself."
+      },
+      {
+        "question": "Two-Spirit identity is best understood as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A synonym for bisexuality specific to Indigenous communities",
+            "isCorrect": false
+          },
+          {
+            "text": "A pan-Indigenous term encompassing cultural and spiritual roles that do not map to Western LGBTQ+ categories",
+            "isCorrect": true
+          },
+          {
+            "text": "A historical identity no longer used by contemporary Indigenous people",
+            "isCorrect": false
+          },
+          {
+            "text": "A non-binary gender identity equivalent to non-binary Western identities",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is a pan-Indigenous term encompassing cultural and spiritual roles that do not map to Western LGBTQ+ categories. Two-Spirit identities are culturally specific roles with particular ceremonial, social, and spiritual functions within specific tribal communities, and they are experienced and understood within Indigenous cultural frameworks rather than Western sexual and gender identity frameworks. The option describing Two-Spirit as a synonym for bisexuality is incorrect because Two-Spirit encompasses cultural and spiritual dimensions that extend far beyond Western categories of sexual orientation."
+      },
+      {
+        "question": "The minority stress model predicts that LGBTQ+ health disparities are primarily caused by:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Inherent psychological vulnerabilities in LGBTQ+ populations",
+            "isCorrect": false
+          },
+          {
+            "text": "Chronic stress arising from stigma, discrimination, and prejudice in the social environment",
+            "isCorrect": true
+          },
+          {
+            "text": "Biological differences between LGBTQ+ and heterosexual cisgender populations",
+            "isCorrect": false
+          },
+          {
+            "text": "Inadequate access to general healthcare regardless of sexual orientation or gender identity",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is chronic stress arising from stigma, discrimination, and prejudice in the social environment. Meyer's (2003) minority stress model specifically attributes LGBTQ+ health disparities to the chronic stress produced by living in a stigmatizing social environment, not to any inherent vulnerability within LGBTQ+ individuals themselves. The option citing inherent psychological vulnerabilities is incorrect because the minority stress model explicitly rejects individual pathology explanations and instead locates the cause of health disparities in the social environment of prejudice and discrimination."
+      },
+      {
+        "question": "Family acceptance and rejection affect LGBTQ+ youth outcomes through which mechanism:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Genetic transmission of resilience or vulnerability",
+            "isCorrect": false
+          },
+          {
+            "text": "The degree to which family responses validate or invalidate the youth's identity and self-worth",
+            "isCorrect": true
+          },
+          {
+            "text": "Academic achievement and educational attainment",
+            "isCorrect": false
+          },
+          {
+            "text": "Access to peer support from other LGBTQ+ youth",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is the degree to which family responses validate or invalidate the youth's identity and self-worth. Ryan et al. (2009) demonstrated that specific family behaviors of acceptance and rejection directly predict mental health outcomes, with family acceptance serving as an active protective factor independent of the reduction of rejection. The option citing genetic transmission of resilience is incorrect because the research identifies family acceptance and rejection as psychosocial mechanisms operating through validation and invalidation of identity, not through genetic or biological pathways."
+      },
+      {
+        "question": "Affirming clinical assessment with LGBTQ+ clients distinguishes between:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Gay clients who need therapy and those who do not",
+            "isCorrect": false
+          },
+          {
+            "text": "Identity-related concerns requiring affirmation and clinical mental health concerns requiring treatment",
+            "isCorrect": true
+          },
+          {
+            "text": "Clients with acceptable and unacceptable LGBTQ+ identities",
+            "isCorrect": false
+          },
+          {
+            "text": "LGBTQ+ clients who can benefit from therapy and those who cannot",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is distinguishing between identity-related concerns requiring affirmation and clinical mental health concerns requiring treatment. Affirming assessment recognizes that gender identity and sexual orientation are not pathologies requiring clinical modification, while simultaneously attending to genuine clinical conditions such as depression, anxiety, and PTSD that may be driven by minority stress. The option about distinguishing clients who can benefit from therapy from those who cannot is incorrect because affirming assessment is not about screening clients in or out of therapy, but about correctly identifying what requires affirmation versus what requires clinical intervention."
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The growing share of younger people identifying as LGBTQ+ is generally understood to reflect:",
+        "options": [
+          {
+            "text": "A change in the underlying prevalence of these identities",
+            "isCorrect": false
+          },
+          {
+            "text": "Increasing social acceptance and safety to disclose, rather than a change in underlying prevalence",
+            "isCorrect": true
+          },
+          {
+            "text": "A temporary trend with no real meaning",
+            "isCorrect": false
+          },
+          {
+            "text": "Measurement error",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The trend is generally understood to reflect increasing acceptance and safety to disclose; LGBTQ+ people have always existed, and greater openness reflects a safer climate rather than a change in prevalence.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Homosexuality was removed from the diagnostic manual in the 1970s, a shift that:",
+        "options": [
+          {
+            "text": "Was reversed shortly afterward",
+            "isCorrect": false
+          },
+          {
+            "text": "Reflected a landmark depathologizing change, with the understanding of gender diversity later undergoing a parallel evolution",
+            "isCorrect": true
+          },
+          {
+            "text": "Applied only to research settings",
+            "isCorrect": false
+          },
+          {
+            "text": "Had no effect on practice",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The 1970s removal was a landmark depathologization; the understanding of gender diversity later underwent a parallel shift, and this history continues to shape clients’ relationship to care.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Affirming documentation practice with LGBTQ+ clients requires special attention to confidentiality because:",
+        "options": [
+          {
+            "text": "Identity information is trivial",
+            "isCorrect": false
+          },
+          {
+            "text": "Disclosure of orientation or gender identity can carry real safety, family, and employment consequences, especially for clients not out in all areas and for minors",
+            "isCorrect": true
+          },
+          {
+            "text": "Records are never seen by others",
+            "isCorrect": false
+          },
+          {
+            "text": "Confidentiality does not apply",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Identity information is sensitive and its disclosure can carry serious consequences, particularly for clients not fully out and for youth not out to families; the clinician handles it with corresponding care.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When an LGBTQ+ client presents with depression, skilled affirming assessment:",
+        "options": [
+          {
+            "text": "Attributes all difficulties to the client’s identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Distinguishes identity-related distress (e.g., minority stress) from co-occurring clinical concerns, addressing each appropriately while affirming the identity",
+            "isCorrect": true
+          },
+          {
+            "text": "Ignores minority stress entirely",
+            "isCorrect": false
+          },
+          {
+            "text": "Assumes the depression is unrelated to anything",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Skilled assessment holds both possibilities — over-attributing to identity pathologizes it, while ignoring minority stress misses real impact — and addresses identity-related distress and co-occurring conditions each appropriately.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "A clinician whose personal values would prevent them from providing affirming care to an LGBTQ+ client should:",
+        "options": [
+          {
+            "text": "Provide non-affirming care anyway",
+            "isCorrect": false
+          },
+          {
+            "text": "Attempt to change the client’s identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Develop the necessary competence or, where genuinely not possible, refer to an affirming provider — never imposing non-affirming views",
+            "isCorrect": true
+          },
+          {
+            "text": "Refuse to see any LGBTQ+ clients without explanation",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "Affirming care is the standard; the clinician develops competence or refers to an affirming provider, and never imposes non-affirming views or attempts to change a client’s identity.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "A strengths-informed stance in affirming practice means the clinician:",
+        "options": [
+          {
+            "text": "Denies the impact of minority stress",
+            "isCorrect": false
+          },
+          {
+            "text": "Holds both the impact of minority stress and the client’s resilience, community, and resources in view, supporting agency and thriving",
+            "isCorrect": true
+          },
+          {
+            "text": "Focuses only on deficits",
+            "isCorrect": false
+          },
+          {
+            "text": "Assumes all LGBTQ+ people suffer equally",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "A strengths-informed stance holds both minority stress impact and the client’s resilience and resources in view; it is more accurate and more empowering than a deficit-only view.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When working with a client who is questioning their orientation or gender, the affirming clinician should:",
+        "options": [
+          {
+            "text": "Steer the client toward a heterosexual/cisgender outcome",
+            "isCorrect": false
+          },
+          {
+            "text": "Push the client to adopt an LGBTQ+ identity quickly",
+            "isCorrect": false
+          },
+          {
+            "text": "Support open, unpressured exploration at the client’s pace, without steering toward any predetermined conclusion",
+            "isCorrect": true
+          },
+          {
+            "text": "Refuse to discuss it",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "Affirming practice supports open exploration without steering in any direction — neither away from nor prematurely toward an LGBTQ+ identity — following the client’s own process.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Affirming competence is considered a requirement of general practice rather than a specialization because:",
+        "options": [
+          {
+            "text": "Only specialists ever see LGBTQ+ clients",
+            "isCorrect": false
+          },
+          {
+            "text": "LGBTQ+ people are present throughout the population, so every clinician works with LGBTQ+ clients whether or not they are out",
+            "isCorrect": true
+          },
+          {
+            "text": "It applies only in LGBTQ+ clinics",
+            "isCorrect": false
+          },
+          {
+            "text": "Most clinicians never encounter LGBTQ+ clients",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Because LGBTQ+ people are present across all communities and caseloads, every clinician serves LGBTQ+ clients — disclosed or not — making affirming competence a basic requirement of general practice.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Helping a rejecting family move even incrementally toward acceptance is a high-impact intervention because:",
+        "options": [
+          {
+            "text": "Only full, immediate acceptance has any effect",
+            "isCorrect": false
+          },
+          {
+            "text": "Even modest reductions in rejecting behaviors and increases in accepting ones produce measurable improvement in the LGBTQ+ youth’s outcomes",
+            "isCorrect": true
+          },
+          {
+            "text": "Family responses do not affect outcomes",
+            "isCorrect": false
+          },
+          {
+            "text": "Family work is never appropriate",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Research shows that even incremental movement — reducing specific rejecting behaviors and increasing accepting ones — produces measurable benefit, making family work high-impact without requiring immediate full acceptance.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Gender dysphoria, as a clinical concept, refers to:",
+        "options": [
+          {
+            "text": "Being transgender, which is itself a disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "The distress that can arise from incongruence between gender identity and assigned sex or body — not the identity itself",
+            "isCorrect": true
+          },
+          {
+            "text": "A sexual orientation",
+            "isCorrect": false
+          },
+          {
+            "text": "A required diagnosis for all gender-diverse people",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Gender dysphoria names the distress some (not all) gender-diverse people experience, not the identity; affirming care reduces that distress by supporting authentic living, not by changing the identity.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "\"Conversion therapy\" (efforts to change orientation or gender identity) is regarded by the professional consensus as:",
+        "options": [
+          {
+            "text": "An effective evidence-based treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Ineffective and actively harmful, associated with depression, shame, and elevated suicidality, and ethically prohibited",
+            "isCorrect": true
+          },
+          {
+            "text": "Appropriate for minors only",
+            "isCorrect": false
+          },
+          {
+            "text": "A neutral option for clients to choose",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Major organizations condemn conversion practices as ineffective and harmful; every clinician is ethically obligated never to attempt to change a client’s orientation or gender identity.",
+        "showExplanation": true
+      },
+      {
+        "type": "trueFalse",
+        "question": "LGBTQ+ mental-health disparities are best explained by minority stress — the chronic stress of stigma and discrimination — rather than by anything inherent in the identities.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Per minority stress theory, disparities result from stigma and discrimination and shrink in affirming environments; they do not reflect anything unhealthy about the identities."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Under WPATH SOC8, the mental-health clinician primarily serves as a gatekeeper who decides whether clients qualify for gender-affirming care.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "SOC8 reflects a shift away from gatekeeping toward an informed-consent, client-centered model in which the clinician supports clients’ informed, autonomous decisions."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Even modest reductions in a family’s rejecting behaviors are associated with measurable improvement in an LGBTQ+ young person’s outcomes.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Family work is high-impact precisely because incremental movement toward acceptance helps; immediate full acceptance is not required for benefit."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are elements of affirming clinical practice with LGBTQ+ clients? (Select all that apply)",
+        "options": [
+          {
+            "text": "Using clients’ correct names and pronouns",
+            "isCorrect": true
+          },
+          {
+            "text": "Understanding distress through minority stress rather than pathology",
+            "isCorrect": true
+          },
+          {
+            "text": "Never attempting to change orientation or gender identity",
+            "isCorrect": true
+          },
+          {
+            "text": "Treating the identity itself as the clinical problem",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "Affirming practice uses correct names/pronouns, understands distress via minority stress, and never attempts to change identity — which is itself harmful and unethical."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are accurate regarding bisexual clients? (Select all that apply)",
+        "options": [
+          {
+            "text": "Bisexuality is a real, stable orientation",
+            "isCorrect": true
+          },
+          {
+            "text": "Bi erasure and double discrimination are specific stressors",
+            "isCorrect": true
+          },
+          {
+            "text": "A bisexual person’s orientation can be inferred from a current partner’s gender",
+            "isCorrect": false
+          },
+          {
+            "text": "Bisexual people often show mental-health disparities at least as significant as gay and lesbian people",
+            "isCorrect": true
+          }
+        ],
+        "explanation": "Bisexuality is stable and real; orientation cannot be read off a current partner; and bi-specific stressors (erasure, double discrimination) contribute to significant disparities."
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "Demarginalizing the intersection of race and sex. University of Chicago Legal Forum, 140, 139–167.",
+      "author": "Crenshaw, K",
+      "year": 1989,
+      "source": "ce and sex. University of Chicago Legal Forum, 140, 139–167."
+    },
+    {
+      "title": "Prejudice, social stress, and mental health in lesbian, gay, and bisexual populations. Psychological Bulletin, 129(5),",
+      "author": "Meyer, I",
+      "year": 2003,
+      "source": "sexual populations. Psychological Bulletin, 129(5), 674–697."
+    },
+    {
+      "title": "Family rejection as a predictor of negative health outcomes. Pediatrics, 123(1), 346–352.",
+      "author": "Ryan, C",
+      "year": 2009,
+      "source": "or of negative health outcomes. Pediatrics, 123(1), 346–352."
+    },
+    {
+      "title": "Chosen name use is linked to reduced depressive symptoms, suicidal ideation, and suicidal behavior among transgender yo",
+      "author": "Russell, S",
+      "year": 2018,
+      "source": "sgender youth. Journal of Adolescent Health, 63(4), 503–505."
+    },
+    {
+      "title": "National survey on LGBTQ youth mental health. https://www.thetrevorproject.org",
+      "author": "The Trevor Project",
+      "year": 2022,
+      "source": "LGBTQ youth mental health. https://www.thetrevorproject.org"
+    },
+    {
+      "title": "World Professional Association for Transgender Health standards of care, version 8. International Journal of Transgende",
+      "author": "Coleman, E",
+      "year": 2022,
+      "source": "nternational Journal of Transgender Health, 23(S1), S1–S259."
+    },
+    {
+      "title": "Uncovering clinical principles and techniques to address minority stress, mental health, and related health risks among",
+      "author": "Pachankis, J",
+      "year": 2014,
+      "source": "g gay and bisexual men. Clinical Psychology, 21(4), 313–330."
+    },
+    {
+      "title": "Guidelines for psychological practice with lesbian, gay, and bisexual clients. American Psychologist, 67(1), 10–42.",
+      "author": "American Psychological Association",
+      "year": 2012,
+      "source": ", and bisexual clients. American Psychologist, 67(1), 10–42."
+    },
+    {
+      "title": "Guidelines for psychological practice with transgender and gender nonconforming people. American Psychologist, 70(9), 8",
+      "author": "APA",
+      "year": 2015,
+      "source": "nonconforming people. American Psychologist, 70(9), 832–864."
+    },
+    {
+      "title": "Cultural victimization among LGBT people of color. Journal of GLBT Family Studies, 7(4), 398–421.",
+      "author": "Balsam, K",
+      "year": 2011,
+      "source": "ple of color. Journal of GLBT Family Studies, 7(4), 398–421."
+    },
+    {
+      "title": "Global health burden and needs of transgender populations. Lancet, 388(10042), 412–436.",
+      "author": "Reisner, S",
+      "year": 2016,
+      "source": "eds of transgender populations. Lancet, 388(10042), 412–436."
+    },
+    {
+      "title": "A conceptual framework for clinical work with transgender and gender nonconforming clients. Professional Psychology, 43",
+      "author": "Hendricks, M",
+      "year": 2012,
+      "source": "conforming clients. Professional Psychology, 43(5), 460–467."
+    },
+    {
+      "title": "Report. American Psychological Association.",
+      "author": "APA Task Force on Appropriate Therapeutic Responses to Sexual Orientation",
+      "year": 2009,
+      "source": "ntation. (2009). Report. American Psychological Association."
+    },
+    {
+      "title": "Ending conversion therapy: Supporting and affirming LGBTQ youth. SAMHSA.",
+      "author": "Substance Abuse and Mental Health Services Administration",
+      "year": 2015,
+      "source": "rsion therapy: Supporting and affirming LGBTQ youth. SAMHSA."
+    },
+    {
+      "title": "LGBT people in the US not protected by state non-discrimination statutes. UCLA School of Law.",
+      "author": "Williams Institute",
+      "year": 2020,
+      "source": "ed by state non-discrimination statutes. UCLA School of Law."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module 1: Minority Stress, LGBTQ+ Mental Health, and Affirming Clinical Foundations",
+      "order": 1,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 1,
+          "title": "Module 1",
+          "subtitle": "Module 1: Minority Stress, LGBTQ+ Mental Health, and Affirming Clinical Foundations",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>Minority Stress Theory and LGBTQ+ Mental Health: Clinical Applications</h2>\n<h3>Meyer's {{callout:minority-stress}} Model</h3>\n<p>The mental health of LGBTQ+ individuals is significantly shaped by the minority stress they experience as members of a stigmatized social group in a cultural environment that continues to produce discrimination, rejection, and violence directed specifically at their identities. Ilan Meyer's (2003) minority stress model — one of the most empirically robust frameworks for understanding health disparities in LGBTQ+ populations — provides a theoretical account of how the social environment of stigma and discrimination produces the elevated rates of depression, anxiety, PTSD, and suicidal behavior documented in LGBTQ+ health research.</p>\n<p>The model distinguishes between two categories of stressors:</p>\n<ul>\n<li><strong>{{callout:distal-proximal}} stressors</strong> — objective, external events including discrimination, violence, and structural exclusion</li>\n<li><strong>Proximal stressors</strong> — internalized stigma (the adoption of society's negative evaluation of LGBTQ+ identities as one's own self-assessment), concealment (the effortful management of identity disclosure in an environment where disclosure carries risk), and hypervigilance (the chronic scanning of the environment for safety threats that is a direct consequence of living in a context where one's identity has been a target of hostility)</li>\n</ul>\n<h3>Current Scope of LGBTQ+ Youth Mental Health Disparities</h3>\n<p>The Trevor Project's (2022) annual national survey on LGBTQ+ youth mental health documents the current scope of minority stress effects on the most vulnerable LGBTQ+ population:</p>\n<ul>\n<li>45% of LGBTQ+ youth seriously considered suicide in the past year</li>\n<li>14% attempted suicide</li>\n<li>75% reported that recent events negatively impacted their mental health or sense of safety</li>\n</ul>\n<p>These numbers are not evidence of an inherent psychological vulnerability in LGBTQ+ youth — they are evidence of the effects of a social environment that produces chronic stress through rejection, discrimination, and the persistent cultural message that LGBTQ+ identities are less valued, less valid, and less worthy of support than heterosexual cisgender identities. Clinicians who work with LGBTQ+ youth have a professional obligation to be aware of these population-level mental health risks and to provide the affirming, minority-stress-informed clinical care that directly addresses the mechanisms producing them.</p>\n<h3>Family Rejection as a Predictor of Mental Health Outcomes</h3>\n<p>Family rejection is among the most powerful single predictors of negative mental health outcomes for LGBTQ+ youth — more powerful than many demographic, economic, and clinical factors combined. Ryan and colleagues' (2009) foundational research on the effects of family acceptance and rejection on LGBTQ+ youth health outcomes documented that high levels of family rejection were associated with dramatically elevated risk:</p>\n<ul>\n<li>8.4 times greater likelihood of suicide attempt</li>\n<li>5.9 times greater likelihood of depression</li>\n<li>3.4 times greater likelihood of unprotected sex</li>\n</ul>\n<p>These high levels of family rejection included parental denial of LGBTQ+ identity, exclusion from family activities related to LGBTQ+ identity, and physical or verbal abuse related to LGBTQ+ identity. The clinical implications are direct: reducing family rejection is among the most powerful clinical interventions available for LGBTQ+ youth mental health, and the family system is as important a clinical target as the individual youth in LGBTQ+ affirming clinical practice.</p>\n<h3>Family Acceptance as an Active Protective Factor</h3>\n<p>Family acceptance — the active, explicit affirmation of an LGBTQ+ youth's identity by family members — is not simply the absence of rejection but an active protective factor with measurable mental health effects that are independent of the reduction of rejection. Russell and colleagues' (2018) research on chosen name use — one of the most straightforward and accessible family acceptance behaviors for families of transgender youth — found that use of a transgender youth's chosen name was associated with significant reductions:</p>\n<ul>\n<li>A 56% reduction in suicidal ideation</li>\n<li>A 71% reduction in severe depression symptoms</li>\n<li>A 65% reduction in suicidal behavior</li>\n</ul>\n<p>These findings held even after controlling for other support factors. They document that specific, concrete family acceptance behaviors produce specific, measurable mental health benefits — a finding that supports psychoeducationally focused work with families that identifies the specific behaviors most directly associated with their child's mental health and safety.</p>",
+          "order": 1,
+          "callouts": {
+            "minority-stress": {
+              "label": "Minority Stress",
+              "type": "reference",
+              "body": "Meyer’s framework: elevated mental-health difficulties among LGBTQ+ people result from the chronic stress of stigma, prejudice, and discrimination — not from the identities themselves."
+            },
+            "distal-proximal": {
+              "label": "Distal & Proximal Stressors",
+              "type": "definition",
+              "body": "Distal stressors are external events of prejudice (discrimination, rejection, violence); proximal stressors are internal processes they produce (expectation of rejection, concealment, internalized stigma)."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coming Out, Family Systems, and Affirming Clinical Practice</h2>\n<h3>Coming Out as a Lifelong Process</h3>\n<p>Coming out — the process of disclosing one's LGBTQ+ identity to others — is not a single discrete event that occurs once but a lifelong, contextually recursive process that is never fully complete. Each new relationship, new life context, and new social environment presents the coming-out decision anew, requiring ongoing assessment of the safety, costs, and benefits of disclosure in each specific context.</p>\n<p>The clinical literature on coming out has moved from models that described coming out as a linear developmental progression culminating in full disclosure and identity integration to more complex models that recognize the ongoing, contextual nature of identity disclosure across the lifespan. Clinical support for coming-out decisions involves neither pushing clients toward disclosure nor counseling against it — but rather supporting the client's own informed decision-making about who, when, and how to disclose in ways that reflect the client's own values, risk assessment, and relationship goals.</p>\n<h3>The Harms of Conversion Therapy</h3>\n<p>Conversion therapy — the umbrella term for any practice that attempts to change, minimize, or eliminate an individual's LGBTQ+ identity — is ethically prohibited by every major mental health professional organization, including APA, ACA, NASW, and AAMFT, and is specifically identified by SAMHSA (2015) as harmful and ineffective. The harms of conversion therapy are well-documented in research and clinical reports and include:</p>\n<ul>\n<li>Increased depression and anxiety</li>\n<li>Suicidal ideation</li>\n<li>PTSD</li>\n<li>Impaired ability to form authentic intimate relationships</li>\n</ul>\n<p>The American Psychological Association's Task Force on Appropriate Therapeutic Responses to Sexual Orientation (2009) reviewed all available research on sexual orientation change efforts and concluded that there is no credible evidence that they are effective and substantial evidence that they are harmful. Clinicians who encounter clients presenting for conversion therapy have an ethical obligation to decline the specific request while providing affirming support that addresses the underlying distress driving the request.</p>\n<h3>Core Elements of Affirming Clinical Practice</h3>\n<p>Affirming clinical practice with LGBTQ+ clients is not merely a specialty approach for clinicians who work primarily with LGBTQ+ populations — it is a competency that all mental health professionals must develop because LGBTQ+ individuals are present in every clinical setting and in every clinical caseload, and because clinical encounters with non-affirming practitioners cause documented harm. APA (2012, 2015) and ACA guidelines both specifically require that licensed mental health practitioners provide affirming clinical services to LGBTQ+ clients, framing affirmation not as an optional orientation but as a professional ethical obligation.</p>\n<p>The core elements of affirming clinical practice include:</p>\n<ul>\n<li>Explicit non-pathologizing of LGBTQ+ identities</li>\n<li>Clinical competency in LGBTQ+ mental health</li>\n<li>Careful examination of one's own biases and how they may affect clinical practice</li>\n<li>The active refusal to participate in any practice that attempts to change or minimize LGBTQ+ identity</li>\n</ul>\n<h3>Bisexual-Specific Clinical Concerns</h3>\n<p>Bisexual individuals face specific clinical concerns that are distinct from those of gay and lesbian individuals and that require specific clinical attention. Research consistently documents that bisexual individuals have higher rates of depression, anxiety, suicidal behavior, and poor mental health outcomes than either gay/lesbian or heterosexual individuals.</p>\n<p>This disparity is substantially explained by:</p>\n<ul>\n<li>Biphobia from both heterosexual communities (which may not accept bisexuality as valid) and LGBTQ+ communities (which may regard bisexuality as a transitional phase rather than a stable identity)</li>\n<li>The specific erasure and invalidation of bisexual identity in both mainstream and LGBTQ+ cultural contexts</li>\n<li>The monosexism that positions attraction to multiple genders as inherently unstable or inauthentic</li>\n</ul>\n<p>Clinicians who are aware of these specific bisexual minority stressors are equipped to provide the specific validation and clinical attention that bisexual clients — who may have never encountered an affirming clinical response to their specific identity — need.</p>",
+          "order": 2
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Alex, 17, is referred by their parents following a suicide attempt. Assessment reveals Alex is transgender (assigned female at birth, identifies as non-binary) and has experienced significant family rejection including parental refusal to use chosen pronouns, exclusion from family discussions about gender, and verbal hostility about gender identity. Minority stress formulation: family rejection as primary risk factor per Ryan et al. (2009); internalized transphobia as proximal stressor; social isolation from peers. Clinical plan: immediate safety planning; individual affirming therapy; family psychoeducation about the relationship between family acceptance behaviors and suicide risk; {{callout:wpath-soc8}} SOC8 informed gender assessment; school advocacy.</blockquote>",
+          "order": 3,
+          "callouts": {
+            "wpath-soc8": {
+              "label": "WPATH SOC8",
+              "type": "reference",
+              "body": "World Professional Association for Transgender Health, Standards of Care v8 — a depathologizing, informed-consent, client-centered framework that moves away from gatekeeping."
+            }
+          }
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 1: minority stress, lgbtq+ mental health, and affirming clinical foundations, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 4
+        },
+        {
+          "order": 5,
+          "type": "matching",
+          "matchingInstructions": "Match each example to the type of minority stressor it represents (Meyer, 2003).",
+          "matchingPairs": [
+            {
+              "term": "Being denied housing for being gay",
+              "definition": "Distal stressor (external event of discrimination)"
+            },
+            {
+              "term": "Constant vigilance and expecting rejection",
+              "definition": "Proximal stressor (expectation of rejection)"
+            },
+            {
+              "term": "Hiding one’s identity at work",
+              "definition": "Proximal stressor (concealment)"
+            },
+            {
+              "term": "Absorbing negative beliefs about one’s own group",
+              "definition": "Proximal stressor (internalized stigma)"
+            }
+          ]
+        },
+        {
+          "order": 6,
+          "type": "multiSelect",
+          "question": "According to the Family Acceptance Project research, which are accurate? (Select all that apply)",
+          "options": [
+            {
+              "text": "High family rejection is associated with markedly elevated depression and suicidality",
+              "isCorrect": true
+            },
+            {
+              "text": "Family acceptance is a powerful protective factor",
+              "isCorrect": true
+            },
+            {
+              "text": "Only complete, immediate acceptance produces any benefit",
+              "isCorrect": false
+            },
+            {
+              "text": "Even modest reductions in rejecting behaviors produce measurable benefit",
+              "isCorrect": true
+            },
+            {
+              "text": "Family work is therefore a high-impact intervention",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Rejection strongly predicts harm and acceptance protects; crucially, even incremental movement toward acceptance helps, making family work high-impact without requiring immediate full acceptance."
+        },
+        {
+          "type": "multipleChoice",
+          "question": "An affirming clinical stance toward LGBTQ+ identities holds that:",
+          "options": [
+            {
+              "text": "Clinicians should remain neutral about LGBTQ+ identity",
+              "isCorrect": false
+            },
+            {
+              "text": "LGBTQ+ identities are normal, healthy human variations requiring affirmation",
+              "isCorrect": true
+            },
+            {
+              "text": "Clinicians should help clients explore whether their LGBTQ+ identity is authentic",
+              "isCorrect": false
+            },
+            {
+              "text": "Religious concerns about LGBTQ+ identity always take clinical precedence",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Affirming practice — supported by APA, ACA, NASW, and all major professional organizations — holds that LGBTQ+ identities are normal healthy variations, not pathologies requiring treatment or exploration.",
+          "showExplanation": true,
+          "order": 7
+        },
+        {
+          "type": "text",
+          "content": "<h2>Foundational Terminology: Sex, Gender, and Orientation</h2>\n<p>Affirming, accurate practice rests on a clear grasp of several distinct constructs that are frequently conflated. Conflating them produces clinical errors and signals to clients that the clinician does not understand their experience.</p>\n<ul>\n<li><strong>Sex assigned at birth</strong> is the classification (typically male, female, or intersex) made at birth based on observed anatomy. Intersex variations are naturally occurring and more common than often assumed.</li>\n<li><strong>Gender identity</strong> is a person's internal sense of their own gender, which may or may not align with the sex assigned at birth. When it aligns, the person is cisgender; when it does not, the person may be transgender, {{callout:nonbinary}}, or another identity.</li>\n<li><strong>Gender expression</strong> is how a person outwardly presents gender through dress, behavior, and presentation, distinct from identity.</li>\n<li><strong>Sexual orientation</strong> is the pattern of a person's enduring sexual attraction; <strong>romantic orientation</strong> is the pattern of romantic attraction, which does not always align with sexual orientation.</li>\n</ul>\n<h3>Independent Dimensions</h3>\n<p>These are independent dimensions: knowing one tells you little about the others. A transgender man may be attracted to any gender; a person's gender expression may not match cultural expectations for their identity. The clinical implications are concrete — clinicians do not assume a client's gender identity from appearance or name, do not assume the gender of a client's partners, and ask respectfully rather than infer. Using a client's stated name, pronouns, and language for their body and relationships is a baseline of affirming care, not an advanced skill.</p>",
+          "order": 8,
+          "callouts": {
+            "nonbinary": {
+              "label": "Nonbinary",
+              "type": "definition",
+              "body": "A gender identity that is not exclusively male or female — may include both, neither, between, fluid, or beyond. A valid identity, not a phase or trend."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Diversity of Sexual Orientations</h2>\n<p>Sexual orientation encompasses a wide range of identities, and affirming practice begins with an accurate, non-hierarchical understanding of this diversity.</p>\n<h3>The Range of Identities</h3>\n<p>Orientations include lesbian and gay (attraction to the same gender), bisexual (attraction to more than one gender), pansexual (attraction regardless of gender), and asexual (little or no sexual attraction, itself a spectrum that may coexist with romantic attraction), among others. Many people use additional or more specific terms, and language continues to evolve. The clinician follows the client's own self-identification and language rather than imposing categories, recognizing that identity labels are the client's to define.</p>\n<h3>Orientation Is Not Pathology</h3>\n<p>A foundational principle, established in the professional consensus for decades, is that diverse sexual orientations are normal variations of human sexuality, not disorders. Homosexuality was removed from the diagnostic manual decades ago, and the mental health professions have since affirmed that being lesbian, gay, bisexual, or otherwise non-heterosexual is not a mental illness, a deficit, or something to be changed. Any distress a client experiences related to their orientation typically reflects the stress of stigma and rejection rather than anything inherently problematic about the orientation itself — a distinction central to everything that follows.</p>",
+          "order": 9
+        },
+        {
+          "type": "text",
+          "content": "<h2>Gender Identity and Expression</h2>\n<p>Gender identity is a person's internal sense of their gender, and the diversity of gender identities is, like sexual orientation, a normal part of human variation rather than a disorder.</p>\n<h3>The Range of Gender Identities</h3>\n<p>Many people are cisgender, meaning their gender identity aligns with their sex assigned at birth. Transgender people have a gender identity that differs from their assigned sex. Nonbinary people have a gender identity that is not exclusively male or female — which may include identifying as both, neither, between, or beyond those categories. Additional identities and terms exist, and language varies across individuals, cultures, and time. As with orientation, the clinician follows the client's own identity and language.</p>\n<h3>Depathologizing Gender Diversity</h3>\n<p>The understanding of gender diversity has shifted decisively away from pathology. Contemporary frameworks recognize that being transgender or gender-diverse is not a mental illness; the relevant diagnostic concept, {{callout:gender-dysphoria}}, refers specifically to the distress that can arise from incongruence between gender identity and assigned sex or body, not to the identity itself. This reframing — distress as the clinical focus where present, identity as a normal variation — parallels the understanding of sexual orientation and underlies affirming care for transgender and gender-diverse clients.</p>",
+          "order": 10,
+          "callouts": {
+            "gender-dysphoria": {
+              "label": "Gender Dysphoria",
+              "type": "clinical",
+              "body": "The distress that can arise from incongruence between gender identity and assigned sex or body — names the distress, not the identity, which is a normal variation."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Mechanisms of Minority Stress: Distal and Proximal Pathways</h2>\n<p>Minority stress theory, articulated influentially by Ilan Meyer, is the foundational framework for understanding LGBTQ+ mental health, and a thorough grasp of it transforms how a clinician understands a client's distress.</p>\n<h3>The Core Model</h3>\n<p>The theory holds that the elevated rates of mental health difficulties among LGBTQ+ people are not the result of anything inherent in being LGBTQ+, but of the chronic stress of stigma, prejudice, and discrimination. This minority stress is additive to the ordinary stressors everyone faces, is chronic, and is socially based — rooted in the social environment rather than in the individual.</p>\n<h3>Distal and Proximal Stressors</h3>\n<p>Meyer's model distinguishes distal stressors — external, objective experiences of prejudice such as discrimination, rejection, harassment, and violence — from proximal stressors, the internal processes that result from living in a stigmatizing environment. The proximal stressors include the expectation of rejection (vigilance and anticipation of being mistreated), concealment (the effort and stress of hiding one's identity), and internalized stigma (the absorption of negative societal messages about one's own group). These proximal processes are part of why minority stress is so corrosive: the stress operates not only through overt external events but through their internalized, ongoing psychological effects.</p>\n<h3>The Clinical Reframe</h3>\n<p>The clinical power of the model is its reframe: a client's anxiety, depression, or distress is understood as a response to a hostile social environment rather than as evidence of pathology in the client or in their identity. This locates the problem accurately — in stigma, not in the person — and directs treatment toward building resilience and affirming the client rather than toward changing who they are.</p>",
+          "order": 11
+        },
+        {
+          "type": "text",
+          "content": "<h2>LGBTQ+ Mental Health Disparities and Their Origins</h2>\n<p>LGBTQ+ populations experience elevated rates of several mental health difficulties, and understanding both the disparities and their cause is essential to affirming practice.</p>\n<h3>The Disparities</h3>\n<p>Research consistently documents that LGBTQ+ people, and especially LGBTQ+ youth and transgender people, experience elevated rates of depression, anxiety, suicidality, and other difficulties compared to their cisgender and heterosexual peers. These disparities are particularly pronounced for those facing rejection, discrimination, and unsupportive environments.</p>\n<h3>Disparities Reflect Stress, Not Identity</h3>\n<p>Crucially, these disparities do not reflect anything inherently unhealthy about being LGBTQ+. They are the predictable consequence of minority stress — of growing up and living in environments that stigmatize, reject, and discriminate. The same research that documents the disparities also documents that they shrink dramatically in supportive, affirming environments, which is the strongest evidence that the cause is the social environment rather than the identity. This understanding is not merely academic: it shapes whether a clinician approaches a client as someone with a problematic identity to be managed or as a resilient person responding to an unjust environment, and it directs intervention toward affirmation and support rather than toward change.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Family Acceptance and Rejection</h2>\n<p>Among the most important findings in LGBTQ+ mental health is the powerful effect of family acceptance and rejection on the wellbeing of LGBTQ+ young people, established through the research of the {{callout:fap}} and others.</p>\n<h3>Rejection as a Powerful Risk Factor</h3>\n<p>Family rejection is strongly associated with serious negative mental health outcomes for LGBTQ+ youth, including markedly elevated rates of depression, suicidality, and substance use. Rejecting behaviors — which may be motivated even by misguided care or fear — have measurable, harmful effects, and the degree of rejection is associated with the degree of risk.</p>\n<h3>Acceptance as an Active Protective Factor</h3>\n<p>Conversely, family acceptance is a powerful protective factor associated with better mental health, higher self-esteem, and reduced risk. Importantly, acceptance is not all-or-nothing: even modest reductions in rejecting behaviors and increases in accepting ones produce measurable benefit. This finding is clinically actionable, because it means that work with families — helping caregivers move, even incrementally, toward more accepting behaviors — is a high-impact intervention. The clinician can engage families not by demanding immediate full acceptance, which may be unattainable, but by helping them reduce specific harmful behaviors and increase specific supportive ones, meeting families where they are while protecting the young person.</p>",
+          "order": 13,
+          "callouts": {
+            "fap": {
+              "label": "Family Acceptance Project",
+              "type": "reference",
+              "body": "Research establishing that family rejection strongly predicts negative outcomes for LGBTQ+ youth, while acceptance — even incremental — is powerfully protective."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coming Out as a Developmental and Lifelong Process</h2>\n<p>Coming out — the process of recognizing, accepting, and disclosing one's LGBTQ+ identity — is a significant developmental process for many LGBTQ+ people, and understanding it helps the clinician support clients appropriately.</p>\n<h3>An Ongoing, Individual Process</h3>\n<p>Coming out is not a single event but an ongoing, lifelong process: LGBTQ+ people repeatedly navigate decisions about whether, when, how, and to whom to disclose across new relationships, workplaces, and contexts throughout life. It typically involves first coming out to oneself — recognizing and accepting one's identity — and then the ongoing navigation of disclosure to others. The process is highly individual, shaped by the person's circumstances, culture, safety, and relationships.</p>\n<h3>The Clinician's Role</h3>\n<p>The clinician supports the client's own process without pushing a particular outcome or timeline. Disclosure is the client's decision, weighed against real considerations of safety, acceptance, and circumstance; for some clients in unsafe environments, not disclosing is a reasonable protective choice rather than a failure. The clinician helps the client explore their feelings, navigate decisions, prepare for and process others' reactions, and build support, while respecting that the pace and shape of coming out belong to the client.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Conversion Therapy: Harms and the Ethical Prohibition</h2>\n<p>So-called conversion therapy — any attempt to change a person's sexual orientation or gender identity — is a critical topic for every clinician, because it is both harmful and, in the consensus of the professional community, unethical.</p>\n<h3>The Evidence of Harm</h3>\n<p>Efforts to change sexual orientation or gender identity are not only ineffective — orientation and gender identity are not changeable through such efforts — but actively harmful. They are associated with serious negative outcomes including depression, anxiety, shame, and elevated suicidality, and the harm is well documented. These practices rest on the false premise that being LGBTQ+ is a disorder to be cured, the premise that the professional consensus rejected decades ago.</p>\n<h3>The Professional Consensus</h3>\n<p>Major mental health and medical organizations have condemned conversion practices as ineffective and harmful, and a growing number of jurisdictions prohibit them, particularly with minors. Every clinician has an ethical obligation never to engage in efforts to change a client's orientation or gender identity, and to recognize that even subtle pressure toward such change is harmful. When clients present with distress about their identity, the affirming response is to support self-acceptance and to address the stigma and internalized shame driving the distress — never to attempt to change who they are. Clinicians should also be prepared to support clients who are survivors of conversion practices, for whom the experience is frequently a source of lasting harm.</p>",
+          "order": 15
+        },
+        {
+          "type": "multipleChoice",
+          "question": "LGBTQ+ mental health disparities are best explained by:",
+          "options": [
+            {
+              "text": "Something inherently unhealthy about LGBTQ+ identities",
+              "isCorrect": false
+            },
+            {
+              "text": "Minority stress — the chronic stress of stigma, prejudice, and discrimination — which is why disparities shrink in affirming environments",
+              "isCorrect": true
+            },
+            {
+              "text": "Genetic vulnerability unrelated to environment",
+              "isCorrect": false
+            },
+            {
+              "text": "Random variation",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Per minority stress theory, disparities result from the chronic stress of stigma and discrimination, not from the identities themselves; they shrink dramatically in supportive, affirming environments.",
+          "showExplanation": true,
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>Foundations of Affirming Clinical Practice</h2>\n<p>Affirming clinical practice is the standard of care for working with LGBTQ+ clients, and it rests on a clear set of foundational commitments rather than a vague attitude of acceptance.</p>\n<h3>What Affirming Practice Means</h3>\n<p>Affirming practice recognizes LGBTQ+ identities as healthy, normal variations of human experience; understands client distress through the lens of minority stress rather than pathology; actively supports clients in exploring, understanding, and accepting their identities; and never attempts to change a client's orientation or gender identity. It involves using clients' correct names and pronouns, understanding the specific stressors LGBTQ+ clients face, creating a visibly safe and welcoming clinical environment, and possessing accurate knowledge of LGBTQ+ lives and concerns.</p>\n<h3>Affirming the Person, Treating the Concern</h3>\n<p>Affirming practice does not mean ignoring genuine mental health concerns or attributing everything to minority stress. LGBTQ+ clients experience the full range of mental health conditions, which deserve competent treatment, and they also have concerns unrelated to their identity. The affirming clinician distinguishes identity-related distress (addressed by affirmation and by reducing stigma's impact) from co-occurring clinical concerns (addressed by appropriate evidence-based treatment), while affirming the client's identity throughout. Affirmation is the foundation on which all other clinical work with LGBTQ+ clients rests.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Self-Education and Not Burdening Clients</h2>\n<p>A practical but important competency is the clinician's responsibility to educate themselves rather than relying on clients to teach them about LGBTQ+ identities and experiences.</p>\n<h3>The Burden of Education</h3>\n<p>LGBTQ+ clients are frequently put in the position of having to educate their providers — explaining basic terminology, justifying their identities, or managing a clinician's discomfort or ignorance. This burden is itself a form of minority stress within the clinical encounter, and it undermines the safety and trust that effective work requires. While clinicians should always follow a client's individual language and self-understanding, they should not rely on clients for foundational education about LGBTQ+ lives.</p>\n<h3>The Clinician's Responsibility</h3>\n<p>Affirming clinicians take responsibility for their own education — learning the terminology, the relevant frameworks, the specific stressors and concerns of LGBTQ+ populations, and the standards of affirming care — through continuing education, consultation, the professional literature, and engagement with the community's own voices. This preparation allows the clinician to meet clients with competence rather than asking clients to compensate for the clinician's gaps, and it is an ongoing rather than a one-time task, given how the understanding and language of this field continue to evolve.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Microaggressions and the Clinical Environment</h2>\n<p>Even well-intentioned clinicians can inadvertently cause harm through microaggressions, and attention to the clinical environment is part of affirming practice.</p>\n<h3>Microaggressions in Care</h3>\n<p>Microaggressions are subtle, often unintentional slights, assumptions, or invalidations that communicate bias. In clinical settings they include assuming heterosexuality or a binary gender, using incorrect names or pronouns, expressing surprise at a client's identity or relationship, treating an identity as a phase, or centering the clinician's curiosity over the client's needs. Though individually small, these communicate that the client is not fully understood or safe, and they accumulate as a source of stress that can undermine the therapeutic relationship and replicate the invalidation clients experience elsewhere.</p>\n<h3>The Welcoming Environment</h3>\n<p>Affirming practice attends to the whole clinical environment: intake forms that do not assume heterosexuality, monogamy, or a gender binary; visible signals of safety and welcome; staff who are prepared to interact respectfully; and a clinician who consistently uses correct names and pronouns and repairs mistakes quickly and without excessive apology. These environmental signals matter because LGBTQ+ clients, frequently carrying histories of harm within healthcare, read them as cues to whether the setting is genuinely safe.</p>",
+          "order": 19
+        },
+        {
+          "type": "reflection",
+          "prompt": "Reflect on your own clinical environment and habits: where might an LGBTQ+ client encounter an assumption, a microaggression, or a signal that the space is not fully safe — and what is one concrete change you could make?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 33
+        },
+        {
+          "type": "text",
+          "content": "<h2>The History of Pathologization and Its Legacy</h2>\n<p>Understanding the history of how the mental health professions treated LGBTQ+ people is essential, because that history continues to shape clients' experiences and their relationship to care.</p>\n<h3>A History of Harm</h3>\n<p>For much of the twentieth century, the mental health professions classified homosexuality as a mental illness and subjected LGBTQ+ people to harmful efforts to change them. Homosexuality was removed from the diagnostic manual in the 1970s, a landmark shift driven by evidence and advocacy, and the understanding of gender diversity has since undergone a parallel depathologizing evolution. This history of pathologization caused profound harm and contributed to the stigma whose effects the field now works to counter.</p>\n<h3>The Living Legacy</h3>\n<p>This history is not merely past. Many LGBTQ+ clients — particularly older adults — lived through eras when their identities were classified as illness, and many clients of all ages approach mental health care with justified wariness, given the profession's history and the continued existence of harmful practices. The affirming clinician understands this legacy, recognizes why some clients approach care with caution, and works to demonstrate that they offer something different: care grounded in affirmation rather than pathologization. Acknowledging this history is part of building the trust that effective work requires.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Language Evolution and Following the Client</h2>\n<p>The language of sexual orientation and gender identity continues to evolve, and the clinician's relationship to this evolving language is itself a competency.</p>\n<h3>Evolving and Individual Language</h3>\n<p>Terminology in this field changes over time, varies across communities and generations, and is deeply individual. Terms that were standard in one era may be outdated or even offensive in another, new terms emerge, and individuals use language for themselves in ways that may not match any general definition. This evolution reflects communities' ongoing work to describe their own experiences accurately, and it is a sign of a living, self-defining set of identities rather than a source of confusion to be resented.</p>\n<h3>The Guiding Principle</h3>\n<p>The guiding principle is to follow each client's own language and self-understanding. Rather than memorizing a fixed glossary and applying it rigidly, the clinician learns the current frameworks, stays reasonably current, and — most importantly — listens to and adopts each client's own terms for their identity, body, and relationships. When unsure, the clinician asks respectfully. This stance of humble, responsive listening matters more than perfect command of any particular vocabulary, and it keeps the clinician's practice aligned with clients rather than with outdated assumptions.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>Prevalence and the Scope of LGBTQ+ Populations</h2>\n<p>LGBTQ+ people are a significant and growing share of the population, present in every community and every clinical caseload, which underscores why affirming competence is a general rather than a niche requirement.</p>\n<h3>A Substantial Population</h3>\n<p>Surveys consistently find that a meaningful and apparently growing proportion of people identify as LGBTQ+, with notably higher rates among younger generations — a trend generally understood to reflect increasing social acceptance and safety to disclose rather than any change in the underlying prevalence of these identities. LGBTQ+ people are present across all demographics, regions, cultures, and communities.</p>\n<h3>Implications for Every Clinician</h3>\n<p>Because LGBTQ+ people are present throughout the population, every clinician works with LGBTQ+ clients, whether or not those clients are out to them. This makes affirming competence a basic requirement of general practice rather than a specialization relevant only to some. It also means that a clinician's visible affirmation — or its absence — shapes whether clients feel safe to be known, and that clinicians cannot assume their caseload does not include LGBTQ+ people simply because no client has disclosed.</p>",
+          "order": 23
+        },
+        {
+          "type": "text",
+          "content": "<h2>The First Sessions: Establishing Safety</h2>\n<p>For LGBTQ+ clients, who frequently approach care wary from past experiences of stigma or non-affirmation, the opening sessions are decisive in establishing whether the clinician is safe.</p>\n<h3>Signaling Safety Early</h3>\n<p>Clients read early cues closely: the language on intake forms, whether the clinician uses inclusive language and asks rather than assumes, how the clinician responds to disclosures of identity, and whether the environment signals welcome. The clinician establishes safety by using inclusive, non-assuming language from the outset, asking respectfully about identity and relationships, sharing and requesting pronouns as a normal practice, and responding to disclosures with calm acceptance rather than surprise, curiosity, or discomfort. These early signals communicate that the client can be known here.</p>\n<h3>Building the Alliance</h3>\n<p>Because some clients have been harmed by previous providers, the clinician may need to demonstrate affirmation actively rather than assuming the client will take it for granted, and may acknowledge the profession's history where relevant. A strong early alliance, grounded in evident competence and affirmation, is what allows LGBTQ+ clients to engage in the deeper work and to bring forward concerns — including identity-related ones — that they might otherwise withhold.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>Resilience and Strengths in LGBTQ+ Communities</h2>\n<p>Alongside the genuine risks and disparities that minority stress produces, affirming practice attends to the remarkable resilience and strengths of LGBTQ+ people and communities, which a deficit-only view would miss.</p>\n<h3>Sources of Resilience</h3>\n<p>Despite facing significant adversity, most LGBTQ+ people are resilient and lead healthy, fulfilling lives. Sources of resilience include the process of identity development and self-acceptance itself, connection to LGBTQ+ community and chosen family, the cultivation of pride in the face of stigma, and the coping capacities developed through navigating adversity. Communities have built rich traditions of mutual support, advocacy, culture, and care that sustain their members.</p>\n<h3>A Strengths-Informed Stance</h3>\n<p>A strengths-informed stance holds both the impact of minority stress and the client's resilience and resources in view at once. This is more accurate than a purely deficit-focused view, and it is more empowering: it supports the client's agency, draws on existing strengths and community resources in treatment, and counters the narrative — internalized by some clients — that being LGBTQ+ means a life of suffering. Affirming care helps clients connect with the sources of resilience and pride that support thriving, not merely survival.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Working With Questioning Clients</h2>\n<p>Some clients are questioning or exploring their sexual orientation or gender identity, and affirming practice supports this exploration without pushing toward any conclusion.</p>\n<h3>Supporting Open Exploration</h3>\n<p>Questioning is a normal part of identity development, and clients may be uncertain, exploring, or in the process of understanding their orientation or gender. The affirming clinician supports open, unpressured exploration — neither pushing the client toward an LGBTQ+ identity nor toward a heterosexual or cisgender one, and never treating exploration as something to be resolved in a predetermined direction. The clinician provides a safe space for the client to explore their feelings, attractions, and sense of self at their own pace.</p>\n<h3>Avoiding Both Errors</h3>\n<p>Two errors are avoided: steering a questioning client away from an LGBTQ+ identity (a form of the non-affirming, change-oriented approach the field rejects), and prematurely labeling or pushing a client toward an identity they have not claimed. The clinician follows the client's own process, supports self-understanding and self-acceptance whatever the client discovers, and trusts the client to arrive at their own understanding of who they are.</p>",
+          "order": 26
+        },
+        {
+          "type": "text",
+          "content": "<h2>Affirming Care and Mental Health Outcomes: The Evidence</h2>\n<p>The case for affirming practice rests not only on ethics but on a substantial and consistent evidence base linking affirmation to better mental health outcomes.</p>\n<h3>What the Evidence Shows</h3>\n<p>Research consistently associates affirming support — family acceptance, affirming environments, the use of chosen names and pronouns, access to gender-affirming care, and affirming clinical practice — with better mental health, including lower rates of depression and suicidality, among LGBTQ+ people. Conversely, rejection, non-affirmation, and efforts to change identity are associated with worse outcomes and serious harm. This evidence base is what grounds affirming care as the standard endorsed by major mental health and medical organizations.</p>\n<h3>The Implication</h3>\n<p>The evidence reframes affirmation from a matter of mere preference or politics to a matter of clinical effectiveness and safety: affirming care is associated with measurably better outcomes, and non-affirming approaches with harm. For the clinician, this means that providing affirming care is not only the ethical course but the evidence-based one, and that affirmation — including the seemingly small acts of using correct names and pronouns — is a clinically meaningful, sometimes life-protecting, intervention.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>The Affirming Stance in Everyday Clinical Moments</h2>\n<p>Affirming practice is realized not only in major interventions but in the accumulation of everyday clinical moments, where small choices communicate safety or its absence.</p>\n<h3>Small Acts, Large Meaning</h3>\n<p>The routine moments — how a clinician phrases an intake question, whether they assume the gender of a partner, how they respond when a client shares their pronouns or corrects a mistake, whether their language defaults to heterosexual and cisgender norms — carry significant meaning for LGBTQ+ clients attuned to cues of safety. An offhand assumption can signal that the space is not fully safe; a consistently inclusive, non-assuming manner signals that it is. Because these moments recur constantly, the affirming stance must be woven into the clinician's ordinary habits rather than reserved for explicit conversations about identity.</p>\n<h3>Consistency as Care</h3>\n<p>What clients experience as affirmation is largely this consistency: the reliable, unremarkable use of correct names and pronouns, the absence of assumptions, the calm acceptance of disclosures, and the evident competence that lets the client relax rather than brace. Cultivating these habits until they become second nature is among the most important and achievable goals for any clinician seeking to provide affirming care, and it is what allows LGBTQ+ clients to bring their whole selves into the work.</p>"
+        }
+      ]
+    },
+    {
+      "title": "Module 2: Transgender Affirming Practice, Intersectionality, and Advanced Applications",
+      "order": 2,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 2,
+          "title": "Module 2",
+          "subtitle": "Module 2: Transgender Affirming Practice, Intersectionality, and Advanced Applications",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>Transgender and Gender-Diverse Affirming Clinical Practice: WPATH SOC8 Framework</h2>\n<h3>The WPATH SOC8 Paradigm Shift</h3>\n<p>Transgender and gender-diverse individuals — those whose gender identity differs from the sex assigned at birth — face specific mental health challenges that are substantially driven by minority stress, discrimination, and the barriers to gender-affirming care that characterize many healthcare and social environments. The WPATH Standards of Care Version 8 (Coleman et al., 2022) — the current clinical authority for the assessment and support of transgender and gender-diverse individuals — represents a significant paradigm shift from earlier versions.</p>\n<p>SOC8 explicitly positions the clinician as collaborator rather than gatekeeper, emphasizing that the clinician's role is to support the client's own gender development and goals rather than to apply diagnostic criteria as gatekeeping requirements for medical intervention access. This shift reflects both the accumulated evidence that gender-affirming care improves mental health outcomes and the ethical recognition that treating transgender healthcare as requiring special clinical authorization that is not required for cisgender healthcare constitutes a harmful form of discrimination.</p>\n<h3>Clinical Assessment with Transgender Clients</h3>\n<p>Clinical assessment with transgender and gender-diverse clients requires specific competencies that go beyond the application of general mental health assessment frameworks. The clinical distinction between gender dysphoria — the distress that can accompany the incongruence between gender identity and sexed body — and gender identity itself is clinically essential: gender dysphoria is a clinical condition that warrants clinical support, while gender identity is not a pathology and does not require clinical explanation or modification.</p>\n<p>Affirming assessment attends to the specific mental health concerns that a transgender client presents with — depression, anxiety, suicidal ideation, trauma history — while explicitly affirming that the gender identity itself is not a clinical concern requiring exploration or resolution. The clinical inquiry 'How is your gender identity related to the distress you're experiencing?' is substantially different from 'Is it possible that your gender identity is a symptom of an underlying condition?' — and the clinical stance that these questions reflect produces dramatically different clinical experiences for transgender clients.</p>\n<h3>{{callout:intersectionality}} and Compound Minority Stress</h3>\n<p>Intersectionality — the framework developed by Kimberlé Crenshaw (1989) to describe how multiple marginalized identities produce compound effects that are not captured by examining any single identity dimension in isolation — is among the most clinically important frameworks for understanding the specific clinical needs of LGBTQ+ clients who hold multiple marginalized identities.</p>\n<p>LGBTQ+ people of color face compound minority stress that includes both racism in LGBTQ+ spaces and homophobia and transphobia in communities of color — a specific form of multiple marginalization that Balsam and colleagues (2011) called 'cultural victimization.' Black transgender women face the highest rates of violence of any demographic group tracked in anti-violence research, reflecting the compound vulnerability produced by the intersection of racism, transphobia, and misogyny. Clinicians who apply an intersectional lens to the assessment and treatment of LGBTQ+ clients of color are better positioned to understand the specific clinical presentations produced by these compound stressors.</p>\n<h3>Core Competencies of LGBTQ+ Affirming Therapy</h3>\n<p>LGBTQ+ affirming therapy is not a single technique or protocol but a clinical orientation and set of competencies that are integrated across all aspects of clinical practice with LGBTQ+ clients. The core competencies include:</p>\n<ul>\n<li>Explicit non-pathologizing of LGBTQ+ identities as a foundational clinical stance</li>\n<li>Cultural humility that approaches each LGBTQ+ client's specific identity development with genuine curiosity rather than assumptions about what LGBTQ+ experience is like</li>\n<li>Knowledge of the specific mental health risks and protective factors relevant to LGBTQ+ populations</li>\n<li>Familiarity with LGBTQ+ community resources and their appropriate clinical integration</li>\n<li>The ongoing examination of one's own heterosexist and cisnormative assumptions and how they may affect clinical assessment, case formulation, and treatment planning</li>\n</ul>\n<p>These competencies require ongoing continuing education, supervision, and reflective practice rather than a single training event.</p>",
+          "order": 1,
+          "callouts": {
+            "intersectionality": {
+              "label": "Intersectionality",
+              "type": "reference",
+              "body": "Crenshaw’s concept: multiple identities and forms of marginalization combine to shape experience in ways no single identity, considered alone, can explain."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Intersectionality, LGBTQ+ Relationships, and Professional Development</h2>\n<h3>{{callout:two-spirit}} Identity and Cultural Specificity</h3>\n<p>Two-Spirit identity — a pan-Indigenous term that encompasses cultural and spiritual roles in Indigenous communities that do not map onto Western LGBTQ+ categories — illustrates the importance of cultural specificity in working with LGBTQ+ clients from non-Western cultural backgrounds. Two-Spirit identities are not simply Indigenous versions of Western LGBTQ+ identities — they are culturally specific roles with particular ceremonial, social, and spiritual functions within specific tribal communities, and they are often experienced and understood in ways that reflect Indigenous cultural frameworks rather than Western sexual and gender identity frameworks.</p>\n<p>Clinicians who encounter Two-Spirit clients should approach their identities with the genuine cultural humility that recognizes the inadequacy of Western LGBTQ+ frameworks as the lens through which to understand Indigenous experiences of gender and sexuality.</p>\n<h3>LGBTQ+ Relationship and Couples Considerations</h3>\n<p>The relationship history and intimate partner functioning of LGBTQ+ clients present specific clinical considerations that require both affirming practice and specific clinical knowledge. LGBTQ+ couples face both the universal challenges of intimate partnership and specific minority stress effects, including:</p>\n<ul>\n<li>The impact of discrimination</li>\n<li>The absence of legal protections in many jurisdictions</li>\n<li>The absence of cultural and familial models for same-sex partnership</li>\n<li>The specific dynamics that can arise when one partner is more or less out than the other</li>\n</ul>\n<p>Couples work with LGBTQ+ partnerships requires application of the standard evidence-based couples therapy approaches — EFT, the Gottman Method, integrative behavioral couples therapy — within an affirming framework that does not pathologize the LGBTQ+ relationship itself while attending to the specific stressors that LGBTQ+ partnerships navigate.</p>\n<h3>Treating Comorbid Clinical Conditions in LGBTQ+ Clients</h3>\n<p>The assessment and treatment of LGBTQ+ clients with comorbid clinical conditions — depression, anxiety, PTSD, substance use disorders — requires the integration of evidence-based treatment for the specific clinical condition with the LGBTQ+-affirming orientation that attends to minority stress as a contributing etiological and maintaining factor. The standard cognitive-behavioral, acceptance-based, and psychodynamic treatment approaches that constitute the evidence base for depression, anxiety, and PTSD are broadly applicable to LGBTQ+ clients with specific adaptations that reflect the LGBTQ+-specific content of cognitive distortions, avoidance patterns, and interpersonal dynamics.</p>\n<p>Pachankis (2014) has described the adaptation of CBT for gay and bisexual men as involving specific attention to the way minority stress experiences shape the cognitive and behavioral patterns that CBT targets, providing a model for culturally adapted evidence-based treatment that respects the standard's efficacy while attending to the population-specific clinical context.</p>\n<h3>Ongoing Professional Development</h3>\n<p>Professional development in LGBTQ+ affirming clinical practice is an ongoing obligation for all mental health clinicians — not a one-time training event but a continuous process of learning, self-examination, and practice improvement that reflects the evolving nature of both the clinical evidence base and the specific cultural context within which LGBTQ+ clients live. The clinical field's understanding of LGBTQ+ mental health has advanced substantially in the past decade, and the standard of affirmative care has become increasingly specific and increasingly well-evidenced.</p>\n<p>Clinicians who invest in ongoing LGBTQ+ affirmative practice development — through continuing education, consultation, supervision with LGBTQ+-competent supervisors, and personal reflection on the ways heterosexism and cisnormativity may affect their clinical practice — are making an investment in clinical quality that directly benefits the LGBTQ+ clients in their caseloads who deserve nothing less than the most affirming, competent, and evidence-informed clinical care available.</p>",
+          "order": 2,
+          "callouts": {
+            "two-spirit": {
+              "label": "Two-Spirit",
+              "type": "reference",
+              "body": "A culturally specific, pan-Indigenous term for a person embodying both masculine and feminine spirits or a distinct gender/social role; carries spiritual and cultural meaning beyond Western categories."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Marcus, 32, a Black gay man, presents with depression and relationship conflict. He reports chronic hypervigilance — checking exits when entering rooms, monitoring others' reactions to his presence — that he attributes to daily experiences of both racial microaggressions and homophobic comments at work. Intersectional formulation: compound minority stress from racism and homophobia; internalized shame from both communities; limited social support due to racism in gay spaces and homophobia in Black community. Clinical plan: intersectional trauma-informed formulation; affirmation of both racial and sexual identities as valid and co-constitutive; community connection facilitation; CBT addressing hypervigilance with LGBTQ+ and racial minority stress context.</blockquote>",
+          "order": 3
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 2: transgender affirming practice, intersectionality, and advanced applications, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 4
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Intersectionality (Crenshaw, 1989) is clinically relevant because:",
+          "options": [
+            {
+              "text": "It establishes a hierarchy of marginalized identities",
+              "isCorrect": false
+            },
+            {
+              "text": "Multiple marginalized identities produce compound effects not captured by examining each in isolation",
+              "isCorrect": true
+            },
+            {
+              "text": "It applies primarily to Black women as originally described",
+              "isCorrect": false
+            },
+            {
+              "text": "It provides a legal framework without clinical applications",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Intersectionality recognizes that LGBTQ+ clients with multiple marginalized identities (e.g., Black transgender women) experience compound stressors that require clinical attention beyond any single identity dimension.",
+          "showExplanation": true,
+          "order": 5
+        },
+        {
+          "order": 6,
+          "type": "multiSelect",
+          "question": "Why is so-called conversion therapy considered both harmful and unethical? (Select all that apply)",
+          "options": [
+            {
+              "text": "Orientation and gender identity are not changeable through such efforts",
+              "isCorrect": true
+            },
+            {
+              "text": "It is associated with depression, shame, and elevated suicidality",
+              "isCorrect": true
+            },
+            {
+              "text": "It rests on the false premise that being LGBTQ+ is a disorder",
+              "isCorrect": true
+            },
+            {
+              "text": "It is an effective evidence-based treatment",
+              "isCorrect": false
+            },
+            {
+              "text": "Major organizations have condemned it",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Conversion efforts are ineffective and actively harmful, rest on a false pathologizing premise, and are condemned by major organizations; every clinician is obligated never to attempt them."
+        },
+        {
+          "type": "multipleChoice",
+          "question": "The WPATH SOC8 positions clinicians working with transgender clients as:",
+          "options": [
+            {
+              "text": "Gatekeepers determining eligibility for medical interventions",
+              "isCorrect": false
+            },
+            {
+              "text": "Collaborators supporting clients' own gender development and goals",
+              "isCorrect": true
+            },
+            {
+              "text": "Primary diagnosticians establishing gender dysphoria",
+              "isCorrect": false
+            },
+            {
+              "text": "Advocates challenging all barriers regardless of clinical readiness",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "WPATH SOC8 explicitly positions the clinician as collaborator rather than gatekeeper, supporting the client's own gender development and goals rather than applying external criteria for intervention access.",
+          "showExplanation": true,
+          "order": 7
+        },
+        {
+          "type": "text",
+          "content": "<h2>Transgender and Gender-Diverse Care: Core Commitments and Individualized Paths</h2>\n<p>Affirming care for transgender and gender-diverse clients is grounded in the recognition that diverse gender identities are normal, that being transgender is not a mental illness, and that affirming a person's gender supports their wellbeing.</p>\n<h3>The Core Commitments</h3>\n<p>Gender-affirming care recognizes and respects each client's gender identity, supports clients in living authentically, and addresses gender dysphoria where present while never treating the identity itself as the problem. It is supported by the major mental health and medical organizations as the appropriate, evidence-based approach, and research links gender-affirming support to improved mental health, including reduced depression and suicidality. The clinician's role is to provide support, accurate information, and competent mental health care within this affirming framework.</p>\n<h3>A Spectrum of Needs</h3>\n<p>Transgender and gender-diverse clients have varied needs and paths. Some seek social transition only, some pursue medical interventions, some neither; some experience significant dysphoria, others little. Affirming care does not assume a single trajectory or push any particular path, but supports each client's own self-determined needs and goals. The clinician follows the client's self-understanding rather than imposing assumptions about what being transgender or gender-diverse must involve.</p>",
+          "order": 8
+        },
+        {
+          "type": "text",
+          "content": "<h2>The WPATH Standards of Care, Version 8</h2>\n<p>The World Professional Association for Transgender Health (WPATH) Standards of Care, Version 8 (SOC8), represent the leading clinical guidance for the care of transgender and gender-diverse people, and they reflect an important evolution in the field.</p>\n<h3>The Paradigm Shift</h3>\n<p>SOC8 reflects a depathologizing, client-centered paradigm. It moves away from older gatekeeping models — in which mental health professionals primarily assessed whether clients \"qualified\" for care — toward a model emphasizing informed consent, client autonomy, and the clinician's role in supporting clients to make informed decisions about their own care. It recognizes the diversity of gender identities and expressions, affirms that being transgender or gender-diverse is not a mental disorder, and centers the client's own goals.</p>\n<h3>Implications for Practice</h3>\n<p>For the mental health clinician, SOC8 reframes the role from gatekeeper to collaborator and supporter. The clinician helps clients explore their gender, understand their options, prepare for and navigate transition where desired, and access care — rather than serving primarily as a barrier clients must pass. Where assessment and documentation are involved (for example, in supporting access to certain medical interventions), the orientation is toward supporting informed, autonomous decision-making rather than withholding care. Clinicians working with transgender and gender-diverse clients should be familiar with SOC8 and the contemporary, affirming standard of care it represents.</p>",
+          "order": 9
+        },
+        {
+          "type": "text",
+          "content": "<h2>Gender-Affirming Care: Social, Medical, and Supportive Dimensions</h2>\n<p>Gender-affirming care spans a range of social, medical, and psychological dimensions, and understanding the landscape helps the clinician support clients and coordinate care, even when the clinician's own role is focused on mental health support.</p>\n<h3>Dimensions of Affirmation</h3>\n<p>Social affirmation includes the steps by which a person lives in accordance with their gender — name, pronouns, presentation, and social recognition — and is frequently the most immediately impactful form of affirmation. Medical dimensions, managed by appropriate medical providers, may include hormone therapy and, for some, surgical interventions; these are pursued by some clients and not others, according to their individual needs. Legal dimensions include changes to identity documents. Psychological support spans the entire process.</p>\n<h3>An Individualized Path</h3>\n<p>No single combination of these dimensions defines being transgender or constitutes a \"complete\" transition; each client's path is individual, and a person's gender identity is valid regardless of which steps they take. The clinician supports the client's self-determined path, provides mental health care and support throughout, and coordinates with medical and other providers as appropriate, without assuming that any particular intervention is necessary or desired.</p>",
+          "order": 10
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Mental Health Clinician's Role in Gender-Affirming Care</h2>\n<p>The mental health clinician occupies a distinctive and valuable role in gender-affirming care, one that has evolved substantially toward support and collaboration.</p>\n<h3>Core Functions</h3>\n<p>The clinician supports clients in exploring and understanding their gender, provides a space to process the many emotional and practical dimensions of identity and transition, offers competent treatment for any co-occurring mental health conditions, supports clients through the social and interpersonal challenges of living authentically, and helps clients access and navigate gender-affirming care. The clinician also frequently supports families and helps build the affirming environment that protects wellbeing.</p>\n<h3>Assessment and Documentation</h3>\n<p>In some contexts, mental health clinicians provide assessment and documentation to support access to medical gender-affirming care. Under the contemporary, SOC8-informed model, this role is oriented toward supporting informed, autonomous decision-making rather than functioning as gatekeeping. The clinician assesses for any factors relevant to informed decision-making and to the client's wellbeing, supports the client's readiness and understanding, and documents in a manner that facilitates rather than obstructs access to needed care. Throughout, the clinician's stance is collaborative and affirming, centered on the client's own goals and autonomy.</p>",
+          "order": 11
+        },
+        {
+          "type": "text",
+          "content": "<h2>Nonbinary and Gender-Expansive Identities</h2>\n<p>Nonbinary and gender-expansive identities deserve specific attention, as clients with these identities frequently face distinct challenges and are sometimes overlooked even within otherwise affirming care.</p>\n<h3>Understanding Nonbinary Identities</h3>\n<p>Nonbinary people have a gender identity that is not exclusively male or female — they may identify as both, neither, between, fluid, or beyond the binary, using a range of terms. Nonbinary identities are valid gender identities, not a phase, a trend, or an attempt to be different. The clinician follows each client's own identity, language, and pronouns, recognizing the diversity within nonbinary experience.</p>\n<h3>Specific Challenges</h3>\n<p>Nonbinary clients frequently encounter particular difficulties: a social world organized around a gender binary that constantly invalidates their existence, the erasure or dismissal of their identity even by otherwise well-meaning people and providers, the misgendering that pervasive binary assumptions produce, and the difficulty of accessing affirming care in systems built around binary categories. Affirming practice with nonbinary clients requires the clinician to move beyond the binary in their own assumptions, to use the client's correct language and pronouns consistently, and to validate identities that the surrounding world frequently fails to recognize.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Gender Dysphoria: Understanding and Support</h2>\n<p>Gender dysphoria refers to the distress that can arise from incongruence between a person's gender identity and their sex assigned at birth or their body, and understanding it accurately is central to affirming care.</p>\n<h3>Distress, Not Identity</h3>\n<p>The crucial distinction is that gender dysphoria names the distress, not the identity. Being transgender or gender-diverse is not itself a disorder; gender dysphoria refers specifically to the distress some (not all) gender-diverse people experience, and the affirming clinical response is to reduce that distress — primarily by supporting the client in affirming and living as their authentic gender — rather than by attempting to change the identity. Gender-affirming care, including social and where desired medical affirmation, is the evidence-based approach to relieving dysphoria, and is associated with improved wellbeing.</p>\n<h3>Supporting the Client</h3>\n<p>The clinician supports clients experiencing dysphoria by validating their experience, helping them access affirming care and steps that reduce distress, addressing the minority stress and any co-occurring conditions that compound it, and supporting their authentic self-expression. Not all gender-diverse clients experience significant dysphoria, and its absence does not invalidate a person's identity; conversely, its presence is a treatable form of distress, not evidence that the identity is a problem.</p>",
+          "order": 13
+        },
+        {
+          "order": 14,
+          "type": "sequencing",
+          "instructions": "Order how a WPATH SOC8-informed clinician supports a client considering a step in transition.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Provide a space to explore the client’s gender, hopes, and concerns"
+            },
+            {
+              "order": 2,
+              "text": "Share accurate information about options"
+            },
+            {
+              "order": 3,
+              "text": "Support the client’s informed, autonomous decision-making"
+            },
+            {
+              "order": 4,
+              "text": "Facilitate access to care and coordinate with providers as needed"
+            }
+          ],
+          "explanation": "SOC8 reframes the clinician from gatekeeper to collaborator: exploring, informing, supporting autonomous decisions, and facilitating — rather than deciding whether a client “qualifies.”"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Bisexual and Pansexual Clients: Specific Concerns</h2>\n<p>Bisexual and pansexual clients — those attracted to more than one gender or regardless of gender — face specific challenges that affirming clinicians should understand, since their experiences are frequently erased even within LGBTQ+ contexts.</p>\n<h3>Bi Erasure and Double Discrimination</h3>\n<p>Bisexual people frequently encounter bi erasure — the denial, dismissal, or invalidation of bisexuality as a real and stable orientation, including the false beliefs that it is \"really\" being gay or straight, a phase, or mere indecision. They may also experience discrimination from both heterosexual and lesbian/gay communities, a double marginalization that can leave them without a clearly supportive community. Research documents that bisexual people frequently show mental health disparities at least as significant as those of lesbian and gay people, in part because of these specific stressors and the lack of validation and community support.</p>\n<h3>Affirming Practice</h3>\n<p>Affirming clinicians validate bisexuality and pansexuality as real, stable orientations; avoid assuming a client's orientation from the gender of their current partner (a bisexual person in a relationship with one gender remains bisexual); recognize the specific stressors of erasure and double discrimination; and avoid the erasure and invalidation that bisexual clients experience so often elsewhere. This validation is itself clinically important, given how rarely bisexual clients encounter it.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Asexuality and the Ace Spectrum</h2>\n<p>Asexuality — characterized by little or no sexual attraction — is a valid sexual orientation and part of the diversity of human sexuality, yet it is frequently misunderstood, including by clinicians.</p>\n<h3>Understanding Asexuality</h3>\n<p>Asexuality exists on a spectrum and varies widely: asexual people may experience little or no sexual attraction while still experiencing romantic attraction (and may identify with a romantic orientation such as biromantic or homoromantic), may have varying relationships to sexual activity, and have diverse relationship desires and structures. Asexuality is not a disorder, a dysfunction, a result of trauma, or a hormonal problem, and it is distinct from sexual dysfunctions involving distress about low desire and from celibacy as a choice.</p>\n<h3>Affirming Practice</h3>\n<p>Affirming clinicians recognize asexuality as a valid orientation rather than a problem to be fixed, take care not to pathologize it or attribute it to other causes, and support asexual clients in understanding and accepting their identity and navigating relationships and a world that frequently assumes universal sexual attraction. A particular risk is misapplying a sexual dysfunction framework to an asexual person who is not distressed by their lack of sexual attraction; the distress that brings an asexual client to therapy is far more often about others' invalidation than about their orientation itself.</p>",
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>Intersex People and Clinical Considerations</h2>\n<p>Intersex people — those born with variations in sex characteristics that do not fit typical binary definitions of male or female bodies — have distinct experiences and clinical considerations that affirming clinicians should understand.</p>\n<h3>Understanding Intersex Variations</h3>\n<p>Intersex variations are naturally occurring and more common than widely assumed. Being intersex concerns physical sex characteristics and is distinct from gender identity and sexual orientation, though an intersex person, like anyone, has their own gender identity and orientation. Many intersex people and advocates have raised significant concerns about a history of non-consensual medical interventions performed on intersex infants and children to make their bodies conform to binary norms, interventions that can cause lasting physical and psychological harm.</p>\n<h3>Clinical Stance</h3>\n<p>Affirming clinicians approach intersex clients with respect for their bodily autonomy and self-determination, understand the potential impact of past medical experiences (including non-consensual interventions and the secrecy that frequently surrounded them), avoid pathologizing naturally occurring variation, and support clients in processing their experiences and in self-acceptance. As with all affirming practice, the clinician follows the client's own understanding and language and centers their autonomy.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Affirming Assessment: Distinguishing Identity From Clinical Concerns</h2>\n<p>A core competency in affirming practice is conducting assessment that distinguishes identity-related concerns from co-occurring clinical concerns, so that each is addressed appropriately.</p>\n<h3>The Distinction</h3>\n<p>LGBTQ+ clients present for the full range of reasons that anyone does, and their presenting concerns may be related to their identity (such as minority stress, internalized stigma, coming out, transition, or family rejection), entirely unrelated to it (such as depression, anxiety, or grief arising from other sources), or some combination. A frequent error is attributing all of an LGBTQ+ client's difficulties to their identity, which both pathologizes the identity and misses the actual clinical concern; the opposite error ignores the real and specific impact of minority stress. Skilled assessment holds both possibilities and clarifies which concerns are operating.</p>\n<h3>Conducting the Assessment</h3>\n<p>Affirming assessment gathers a full clinical picture in an affirming, non-assuming way: using inclusive language, not assuming heterosexuality or a binary gender, asking respectfully about identity and relationships, understanding the role minority stress may play, and assessing co-occurring conditions competently. The clinician neither over-attributes to identity nor ignores its impact, and formulates a picture that guides appropriately targeted treatment — affirmation and stigma-focused work for identity-related distress, and evidence-based treatment for co-occurring conditions, with the two frequently proceeding together.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Names, Pronouns, and Language in Practice</h2>\n<p>The consistent use of a client's correct name and pronouns is among the most basic and most important elements of affirming practice, with measurable effects on wellbeing.</p>\n<h3>Why It Matters</h3>\n<p>Using a person's correct name and pronouns affirms their identity and communicates respect and safety; being misgendered or called by a former name (sometimes called deadnaming) is invalidating and is associated with distress, while the use of chosen names and pronouns is associated with improved mental health, particularly for transgender youth. This is not a matter of etiquette alone but of clinical impact: correct language supports wellbeing, and incorrect language harms it.</p>\n<h3>In Practice</h3>\n<p>The clinician asks for and consistently uses each client's name and pronouns, includes the routine sharing and requesting of pronouns as a normal practice, and updates records appropriately. When the clinician makes a mistake — as anyone occasionally will — the appropriate response is a brief correction and a return to the conversation, without excessive apology that centers the clinician's discomfort and burdens the client. Following each client's own language for themselves, their body, and their relationships, and adapting as that language evolves, is a continuous part of affirming care.</p>",
+          "order": 19
+        },
+        {
+          "type": "reflection",
+          "prompt": "How consistently does your current practice — including intake forms, records, and routine interaction — support the correct use of clients’ names and pronouns? What is one improvement you could make?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 31
+        },
+        {
+          "type": "text",
+          "content": "<h2>Supporting Clients Through Transition Decisions</h2>\n<p>For transgender and gender-diverse clients considering aspects of transition, the clinician provides support for informed, autonomous decision-making rather than direction or gatekeeping.</p>\n<h3>A Supportive, Non-Directive Role</h3>\n<p>Clients weighing social, medical, or other steps benefit from a space to explore their feelings, hopes, and concerns; to access accurate information about options; to consider the personal, relational, and practical dimensions of their choices; and to prepare for the steps they decide to take. The clinician supports this exploration without steering the client toward or away from any particular path, recognizing that the decisions belong to the client and that the clinician's role is to support informed, autonomous choice consistent with the contemporary standard of care.</p>\n<h3>Holding Complexity</h3>\n<p>The clinician can hold space for genuine exploration — including a client's uncertainty, questions, and ambivalence — without treating exploration as a barrier to be cleared or as doubt that invalidates the client's identity. Supporting a client in thinking carefully about significant decisions is part of affirming care, not a departure from it, provided it is done in a spirit of support for the client's autonomy and self-determination rather than as gatekeeping or as an attempt to dissuade.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Spectrum of Transition Experiences</h2>\n<p>Affirming care supports transgender and gender-diverse clients across the full range of their experiences, including the minority of people whose path changes over time.</p>\n<h3>Varied Paths Over Time</h3>\n<p>Most people who transition experience it as affirming and right for them, and report improved wellbeing. A smaller number of people detransition or shift their understanding of their gender over time, for a range of reasons that may include changes in identity, the impact of external pressures and lack of support, or other factors. Both experiences are part of the human diversity of gender, and neither invalidates the other; the existence of people who detransition does not undermine the validity of transgender identities or the evidence for gender-affirming care, just as it does not erase the experiences of those for whom transition is affirming.</p>\n<h3>Non-Judgmental Support</h3>\n<p>The affirming clinician supports each client wherever they are in their journey, including clients who are reconsidering or changing course, with the same non-judgmental respect for self-determination that governs all affirming care. A client exploring or revising their understanding of their gender deserves support rather than judgment or \"I told you so\" responses, and a client for whom transition is affirming deserves support rather than skepticism. The clinician follows the individual client's experience rather than any external agenda, in either direction.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documentation and Confidentiality With LGBTQ+ Clients</h2>\n<p>Documentation and confidentiality carry specific considerations in affirming practice, given the sensitivity of identity information and the real risks some clients face.</p>\n<h3>Sensitive Information</h3>\n<p>A client's sexual orientation or gender identity is sensitive information whose disclosure can carry real consequences — including safety, family, employment, and other risks — particularly for clients who are not out in all areas of their lives. The clinician handles this information with care, is mindful of who may have access to records, and does not disclose a client's identity without appropriate consent. Records should use the client's correct name and pronouns while the clinician remains aware of contexts in which records may be seen by others.</p>\n<h3>Confidentiality and Minors</h3>\n<p>Confidentiality considerations are especially significant with LGBTQ+ youth, some of whom are not out to their families and for whom inadvertent disclosure could result in rejection or danger. The clinician navigates the confidentiality and family-involvement considerations specific to minors with particular attention to the young person's safety, clarifying confidentiality arrangements thoughtfully and avoiding actions that could out a young person to an unsupportive family. Across all clients, respecting the client's control over their own identity information is part of affirming, ethical care.</p>",
+          "order": 23
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Regarding clients who detransition or change their understanding of gender over time, affirming practice holds that:",
+          "options": [
+            {
+              "text": "Their existence invalidates transgender identities and gender-affirming care",
+              "isCorrect": false
+            },
+            {
+              "text": "They deserve the same non-judgmental, self-determination-respecting support as any client, and their experiences neither invalidate nor are invalidated by others’ affirming transitions",
+              "isCorrect": true
+            },
+            {
+              "text": "They should be told \"I told you so\"",
+              "isCorrect": false
+            },
+            {
+              "text": "They were never really transgender",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Affirming care supports each client across the full spectrum of experience with non-judgmental respect for self-determination; detransition experiences and affirming-transition experiences are both part of human diversity and neither invalidates the other.",
+          "showExplanation": true,
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>Affirming Group and Community Modalities</h2>\n<p>Group and community-based modalities have particular value for LGBTQ+ clients, directly countering the isolation that stigma produces.</p>\n<h3>What Groups Offer</h3>\n<p>Because stigma so often isolates LGBTQ+ people and because many have lacked affirming community, group treatment and peer support can be powerfully beneficial: the experience of being among others who share aspects of one's identity and experience reduces isolation, provides validation and role models, and offers belonging. Affirming groups — whether for specific identities, life stages, or shared experiences — can complement individual care and provide something individual therapy alone cannot.</p>\n<h3>Considerations</h3>\n<p>Group modalities require skilled, affirming facilitation, thoughtful composition, and attention to the diversity within LGBTQ+ communities, so that groups do not inadvertently replicate marginalization (for example, of bisexual, transgender, nonbinary, or BIPOC members within broader LGBTQ+ groups). Well-run affirming groups, matched to clients' needs, are a valuable resource, and the clinician can help clients connect with appropriate group and community supports as part of comprehensive care.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coordinating Gender-Affirming Care Across Providers</h2>\n<p>Comprehensive care for transgender and gender-diverse clients frequently involves multiple providers, and the mental health clinician's role in coordinating this care strengthens it.</p>\n<h3>The Interdisciplinary Picture</h3>\n<p>A client may work with mental health providers, medical providers managing hormonal or surgical care, and others, alongside navigating legal and social dimensions of transition. The mental health clinician frequently serves as a consistent, supportive presence who helps the client integrate these elements, communicates with other providers as appropriate and with consent, and supports the client through the practical and emotional dimensions of coordinating their care.</p>\n<h3>Affirming Coordination</h3>\n<p>Effective coordination ensures that the providers involved are themselves affirming, since non-affirming providers in the network can cause harm, and that care is integrated around the client's self-determined goals rather than fragmented or obstructive. The clinician helps build and navigate an affirming care network, ensuring each dimension of the client's needs is met by a competent, affirming provider, and supports the client's autonomy throughout the process.</p>",
+          "order": 26
+        }
+      ]
+    },
+    {
+      "title": "Module 3: Intersectionality, Lifespan, Relationships, and Ethical Practice",
+      "order": 2,
+      "estimatedTime": 25,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 3,
+          "title": "Module 3",
+          "subtitle": "Module 3: Intersectionality, Lifespan, Relationships, and Ethical Practice"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Intersectionality and Compound Minority Stress</h2>\n<p>LGBTQ+ people hold multiple identities, and affirming practice requires understanding how these intersect — a recognition captured by the concept of intersectionality.</p>\n<h3>The Concept</h3>\n<p>Intersectionality describes how multiple identities and forms of marginalization — such as race, ethnicity, disability, socioeconomic status, immigration status, and religion, alongside sexual orientation and gender identity — combine to shape a person's experience in ways that cannot be understood by considering any single identity in isolation. An LGBTQ+ person of color, for example, does not experience racism and anti-LGBTQ+ stigma as two separate streams but as a combined, distinctive experience.</p>\n<h3>Compound Minority Stress</h3>\n<p>People with multiple marginalized identities frequently face compounded minority stress, navigating prejudice on multiple fronts — including, at times, within the very communities that might otherwise offer support (experiencing racism within LGBTQ+ spaces, or anti-LGBTQ+ stigma within their racial, ethnic, or faith communities). This can leave a person without a fully supportive community and facing stressors that are more than the sum of their parts. The clinician attends to the whole person and the specific intersection of their identities, rather than treating any one identity as the entirety of their experience, and remains curious about each client's particular configuration.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>BIPOC LGBTQ+ Clients</h2>\n<p>LGBTQ+ people who are Black, Indigenous, or other people of color frequently face distinctive challenges at the intersection of racism and anti-LGBTQ+ stigma, and affirming practice attends to this combined experience.</p>\n<h3>Distinctive Stressors</h3>\n<p>BIPOC LGBTQ+ clients may experience racism within predominantly white LGBTQ+ spaces and anti-LGBTQ+ stigma within their racial, ethnic, and cultural communities, alongside the broader racism and anti-LGBTQ+ prejudice of the wider society. They may face difficult negotiations between identities and communities, and the specific cultural meanings of sexuality and gender within their communities of origin. These compounded stressors are associated with significant mental health impact, and they unfold in a context shaped by the broader experience of racism, including within healthcare.</p>\n<h3>Affirming, Culturally Responsive Practice</h3>\n<p>Competent care integrates LGBTQ+ affirmation with cultural responsiveness and anti-racist awareness, understanding each client's experience at the specific intersection of their identities. The clinician remains attentive to their own potential biases, approaches the client as the expert on their own experience, and supports the client in navigating the multiple communities and identities they hold. This requires the clinician to hold both LGBTQ+ competence and cultural humility simultaneously rather than treating them as separate.</p>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Two-Spirit Identity and Cultural Specificity</h2>\n<p>Two-Spirit is a term used by some Indigenous North American people to describe a person who embodies both masculine and feminine spirits or who holds a distinct gender or social role within their cultural tradition, and it illustrates the cultural specificity of gender and sexuality.</p>\n<h3>Understanding the Term</h3>\n<p>Two-Spirit is a culturally specific, pan-Indigenous English term, and its meanings vary across the many distinct Indigenous nations and traditions; it is not simply a synonym for LGBTQ+ identity, and it carries spiritual, cultural, and community dimensions that Western categories do not capture. Importantly, it reflects the fact that many Indigenous cultures historically recognized and honored gender and sexual diversity in ways that were disrupted by colonization, which imposed binary and heteronormative frameworks and suppressed Indigenous understandings.</p>\n<h3>Clinical Implications</h3>\n<p>The concept underscores that gender and sexuality are understood differently across cultures, and that Western clinical categories are not universal. The clinician approaches Two-Spirit clients, and clients from any cultural tradition with its own understandings of gender and sexuality, with humility and curiosity — following the client's own self-understanding, recognizing the cultural and historical context including the impact of colonization, and avoiding the imposition of Western frameworks onto identities those frameworks do not fit.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>LGBTQ+ People With Disabilities</h2>\n<p>LGBTQ+ people with disabilities navigate the intersection of ableism with anti-LGBTQ+ stigma, and they are frequently overlooked even within LGBTQ+-affirming care.</p>\n<h3>Distinctive Challenges</h3>\n<p>LGBTQ+ people with disabilities may face the desexualization and infantilization that disabled people frequently encounter — including the false assumption that they are not sexual beings or do not have sexual or gender identities — alongside anti-LGBTQ+ stigma. They may encounter inaccessible LGBTQ+ spaces and services, providers untrained in either or both dimensions, and dependence on caregivers or systems that may not be affirming. These intersecting stressors, and the barriers to affirming care, can compound mental health impact.</p>\n<h3>Affirming, Accessible Practice</h3>\n<p>Competent care affirms both the client's LGBTQ+ identity and their experience of disability, presumes the client's competence and self-determination, ensures accessibility, and rejects the assumptions that desexualize or infantilize disabled people. The clinician attends to the specific intersection of these identities and to the practical barriers the client faces, supporting their autonomy across both dimensions of their experience.</p>"
+        },
+        {
+          "order": 5,
+          "type": "fillInBlank",
+          "title": "Quick check — intersectionality",
+          "blanks": [
+            {
+              "prompt": "The concept (Crenshaw, 1989) describing how multiple identities and forms of marginalization combine:",
+              "answer": "intersectionality",
+              "acceptAlternates": [
+                "intersectional"
+              ]
+            },
+            {
+              "prompt": "A pan-Indigenous term for a person embodying both masculine and feminine spirits or a distinct gender role:",
+              "answer": "Two-Spirit",
+              "acceptAlternates": [
+                "two spirit",
+                "twospirit"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>LGBTQ+ Youth: Specific Considerations</h2>\n<p>LGBTQ+ youth are a population of particular clinical concern, facing elevated risk alongside powerful protective factors that clinical work can strengthen.</p>\n<h3>Risk and Protection</h3>\n<p>LGBTQ+ youth experience elevated rates of depression, anxiety, and suicidality, driven largely by family rejection, school victimization and bullying, and unsupportive environments. The protective factors are equally well established and clinically actionable: family acceptance, supportive adults, affirming schools, access to affirming care, and the ability to live authentically all substantially reduce risk. Even one supportive adult is associated with meaningfully better outcomes — a finding that clarifies how impactful the clinician, and the affirming adults the clinician can help mobilize, can be.</p>\n<h3>Working With Youth</h3>\n<p>Work with LGBTQ+ youth involves supporting the young person's identity development and wellbeing, engaging and educating families toward greater acceptance (recognizing that incremental movement matters), collaborating with schools and other systems where appropriate, and navigating the confidentiality and safety considerations specific to minors — including the reality that some youth are not safe to be out at home. Throughout, the clinician affirms the young person while working to strengthen the protective factors that the research identifies as decisive.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>LGBTQ+ Older Adults</h2>\n<p>LGBTQ+ older adults are a frequently overlooked population with distinctive histories and needs, shaped by having lived much of their lives in far more hostile times.</p>\n<h3>A Distinctive Cohort</h3>\n<p>Today's LGBTQ+ older adults came of age when their identities were criminalized, classified as mental illness, and met with pervasive hostility, and many carry the lasting effects of decades of stigma, concealment, and loss — including, for many, the profound losses of the AIDS epidemic. Some have remained closeted for safety; many have experienced rejection from families of origin and have built families of choice. These histories shape their current wellbeing and their relationship to disclosure and trust.</p>\n<h3>Specific Concerns</h3>\n<p>LGBTQ+ older adults may face particular challenges in aging: the prospect of returning to concealment in aging-services and long-term-care settings that may not be affirming, the loss of chosen-family support networks, isolation, and the intersection of ageism with anti-LGBTQ+ stigma. Affirming practice attends to these histories and concerns, validates the resilience these clients have shown across a lifetime, supports their continued authentic living and their chosen families, and advocates for affirming care within aging-services systems.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>LGBTQ+ Relationships, Couples, and Diverse Structures</h2>\n<p>LGBTQ+ clients form relationships of many kinds, and affirming practice supports these relationships without assuming they mirror heterosexual or normative templates.</p>\n<h3>Affirming Diverse Relationships</h3>\n<p>LGBTQ+ relationships are diverse in structure and form, and the clinician supports them on their own terms — not assuming monogamy, not mapping heterosexual roles onto same-gender couples, and not treating any relationship structure as inherently problematic. Some LGBTQ+ clients are in consensually non-monogamous or other negotiated relationship structures, which, as established elsewhere, are relationship choices rather than disorders. The clinician asks about and supports each client's actual relationships and agreements.</p>\n<h3>Specific Relational Stressors</h3>\n<p>LGBTQ+ couples and relationships may face specific external stressors — differing degrees of outness between partners, family rejection of the relationship, legal and social non-recognition in some contexts, and the impact of minority stress on the relationship itself — alongside the ordinary challenges all relationships face. Affirming couples work attends to these specific stressors, supports the couple in navigating an environment that may not affirm them, and applies relational skill within an affirming, non-pathologizing frame.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>LGBTQ+ Parenting and Family Building</h2>\n<p>Many LGBTQ+ people are parents or wish to become parents, and affirming practice supports LGBTQ+ family building and parenting against a backdrop of both progress and continued stigma.</p>\n<h3>Paths and Challenges</h3>\n<p>LGBTQ+ people build families through many paths, and the research is clear that children of LGBTQ+ parents fare as well as those of heterosexual parents — a finding that decisively refutes the stigmatizing assumptions LGBTQ+ parents frequently encounter. Nonetheless, LGBTQ+ parents and prospective parents may face specific stressors: stigma and intrusive questioning, legal complexities of recognition and parentage in some jurisdictions, barriers in family-building systems, and the work of preparing children to navigate a world that may stigmatize their family.</p>\n<h3>The Clinician's Support</h3>\n<p>The clinician supports LGBTQ+ clients in family building and parenting by affirming the validity and health of LGBTQ+ families, helping clients navigate the specific stressors and systems they encounter, and rejecting the stigmatizing assumptions that research has long refuted. Families of choice — the chosen networks of support that many LGBTQ+ people build, particularly where families of origin have been rejecting — also deserve recognition and support as legitimate and vital family structures.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 10,
+          "prompt": "Which LGBTQ+ population or life stage — youth, older adults, couples, parents, or a specific intersection — do you feel least prepared to serve, and what learning or consultation would strengthen your competence?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Religion, Spirituality, and LGBTQ+ Identity</h2>\n<p>Religion and spirituality occupy a complex place in many LGBTQ+ clients' lives — sometimes a source of pain and conflict, sometimes a source of strength and meaning, and frequently both.</p>\n<h3>The Possible Conflict</h3>\n<p>Many LGBTQ+ people are raised in or belong to religious traditions that condemn their identities, and this can be a profound source of shame, internalized stigma, family and community rejection, and the painful conflict between identity and faith. Some LGBTQ+ clients have experienced religious-based rejection or have been subjected to faith-framed efforts to change their identity, with lasting harm. This conflict can be a central clinical concern.</p>\n<h3>The Clinician's Stance</h3>\n<p>The affirming clinician helps clients navigate the relationship between their identity and their faith in a way that honors the client's own values and self-determination — never pressuring a client to abandon either their identity or their faith, but supporting them in reducing shame and finding their own resolution. For many clients this includes recognizing that affirming faith communities and traditions exist, and that identity and spirituality can be integrated. For others, spirituality is a source of strength and resilience to be supported. The clinician approaches the client's religious and spiritual life with respect, supporting the client's autonomy rather than imposing any particular outcome.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Suicide Risk and Protective Factors</h2>\n<p>Because LGBTQ+ people, and especially LGBTQ+ youth and transgender people, experience elevated rates of suicidality, every clinician working with this population should understand both the risk and, crucially, the protective factors that affirming care can strengthen.</p>\n<h3>Understanding the Elevated Risk</h3>\n<p>The elevated suicidality among LGBTQ+ populations is, like other disparities, a consequence of minority stress — of rejection, discrimination, victimization, and unsupportive environments — rather than anything inherent in LGBTQ+ identity. The risk is highest among those facing family rejection, victimization, and hostile environments, and among those unable to live authentically. Understanding this directs the clinician toward the social and relational drivers of risk.</p>\n<h3>Protective Factors and Clinical Response</h3>\n<p>The protective factors are well established and clinically actionable: family acceptance, supportive adults and peers, affirming environments and schools, access to affirming care, and the ability to live authentically all reduce risk substantially. Gender-affirming care and the use of chosen names and pronouns are associated with reduced suicidality among transgender people. The clinician assesses risk competently and compassionately, responds to acute concerns with appropriate safety planning and support, and — central to prevention — works to strengthen the protective factors and reduce the minority stress that drive the risk. Affirmation itself is a protective, potentially life-saving intervention. (Given the sensitivity of this material, clinicians ensure they are also supporting their own wellbeing and accessing consultation when working with high-risk clients.)</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Trauma and LGBTQ+ Clients</h2>\n<p>LGBTQ+ people experience elevated rates of certain traumatic experiences, and trauma-informed, affirming care attends to this intersection.</p>\n<h3>Elevated Trauma Exposure</h3>\n<p>LGBTQ+ people, particularly transgender people and those with intersecting marginalized identities, experience elevated rates of victimization, including harassment, violence, and sexual violence, as well as the chronic trauma-like impact of pervasive stigma and rejection. Some have experienced family rejection, religious-based harm, or the trauma of conversion practices. These experiences can produce trauma-related difficulties layered onto minority stress.</p>\n<h3>Affirming, Trauma-Informed Care</h3>\n<p>Competent care integrates affirming practice with trauma-informed principles: recognizing the elevated trauma exposure, screening sensitively, providing trauma treatment that is affirming of the client's identity, and understanding how minority stress and trauma interact. The clinician avoids the error of treating trauma without affirming the client's identity, or of attributing trauma symptoms to the identity itself, and ensures that trauma care and identity affirmation proceed together. Where trauma treatment exceeds the clinician's competence, referral to an affirming trauma specialist is appropriate.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Substance Use and Co-Occurring Conditions</h2>\n<p>LGBTQ+ populations experience elevated rates of substance use and various co-occurring conditions, again as a consequence of minority stress rather than identity, and affirming care addresses these competently.</p>\n<h3>Understanding Co-Occurrence</h3>\n<p>Elevated rates of substance use among LGBTQ+ people are associated with minority stress — with coping with stigma, rejection, and discrimination — and, historically, with the role of certain venues as among the few safe social spaces available. LGBTQ+ clients also experience the full range of mental health conditions, sometimes compounded by minority stress. As throughout, these difficulties reflect the impact of a hostile environment rather than anything inherent in the identity.</p>\n<h3>Integrated, Affirming Treatment</h3>\n<p>Affirming care treats co-occurring conditions competently and in an affirming context — understanding the role minority stress plays, ensuring substance-use and mental health treatment settings are themselves affirming (since non-affirming treatment settings can replicate the very stigma that drives the difficulties), and addressing both the presenting condition and the underlying minority stress. The clinician neither ignores genuine clinical conditions nor attributes them to the identity, and ensures that all treatment proceeds within an affirming frame.</p>"
+        },
+        {
+          "order": 15,
+          "type": "multiSelect",
+          "question": "Which protective factors are associated with reduced suicide risk among LGBTQ+ youth? (Select all that apply)",
+          "options": [
+            {
+              "text": "Family acceptance",
+              "isCorrect": true
+            },
+            {
+              "text": "At least one supportive adult",
+              "isCorrect": true
+            },
+            {
+              "text": "Affirming schools and environments",
+              "isCorrect": true
+            },
+            {
+              "text": "Concealment of identity for safety in all settings",
+              "isCorrect": false
+            },
+            {
+              "text": "Access to affirming care and the ability to live authentically",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Risk stems from minority stress; protective factors — family acceptance, supportive adults, affirming environments, and the ability to live authentically — substantially reduce it, and affirmation is itself protective."
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Ethics, Scope, Advocacy, and Ongoing Development</h2>\n<p>Affirming practice carries distinctive ethical commitments and an orientation toward advocacy and continued growth.</p>\n<h3>Ethical Commitments</h3>\n<p>The central ethical commitments include never attempting to change a client's orientation or gender identity, providing affirming care as the standard rather than an option, practicing within one's competence while taking responsibility for developing that competence, examining one's own biases and assumptions, and ensuring the clinical environment is genuinely safe and welcoming. Where a clinician's own values would prevent them from providing affirming care, the ethical response is to develop the necessary competence or, where that is genuinely not possible, to refer to an affirming provider — never to impose non-affirming views on a client.</p>\n<h3>Advocacy and Development</h3>\n<p>Because so much of what harms LGBTQ+ clients is environmental, affirming practice frequently extends to advocacy — within systems, schools, and communities — on behalf of clients and the conditions that protect their wellbeing. And because the understanding, language, and standards of this field continue to evolve, affirming practice requires ongoing development: continuing education, consultation, engagement with the professional literature and with the community's own voices, and continued examination of one's own practice. The affirming clinician understands competence in this area as a continuing commitment rather than a destination.</p>"
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>Course Summary: Affirming Practice With LGBTQ+ Clients</h2>\n<p>This course has established the foundations of affirming clinical practice with LGBTQ+ clients. Several principles unify the material.</p>\n<p>First, LGBTQ+ identities are healthy, normal variations of human experience, not disorders; the mental health difficulties LGBTQ+ people experience at elevated rates result from minority stress — the chronic stress of stigma, prejudice, and discrimination — not from the identities themselves, and they diminish in affirming environments. Second, affirming practice is the standard of care: it affirms clients' identities, understands distress through the lens of minority stress, never attempts to change orientation or gender identity, and creates genuinely safe and welcoming care. Third, family and environmental acceptance are powerful, clinically actionable protective factors, and strengthening them — even incrementally — meaningfully improves outcomes and reduces risk.</p>\n<p>Fourth, affirming practice attends to the full diversity of LGBTQ+ people: across sexual orientations and gender identities, across the lifespan, across relationship and family structures, and across the intersections of identity that shape each person's distinctive experience. And finally, competent affirming practice requires the clinician's own ongoing education, self-examination, and humility in a field that continues to evolve. The clinician who carries these principles forward provides care that affirms clients' dignity and identities, addresses the genuine impact of an often-hostile world, and supports LGBTQ+ clients in living authentic, healthy, and whole lives.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 33,
+          "prompt": "After this course, what is one concrete change you will make to your practice or your clinical environment to provide more affirming care to LGBTQ+ clients?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Building an Affirming Practice and Environment</h2>\n<p>Affirming care is enacted not only in the clinician's stance but in the concrete features of the practice and environment, which signal safety to clients before a word is exchanged.</p>\n<h3>Concrete Steps</h3>\n<p>Building an affirming practice includes intake forms that offer inclusive options for name in use, pronouns, gender identity beyond a binary, and relationship structures; visible signals of welcome and safety; staff trained to interact respectfully; records systems that support correct names and pronouns; nondiscrimination policies; and accessible information about the clinician's affirming approach. These features communicate to LGBTQ+ clients — who frequently scan new settings for cues to safety — that the practice is genuinely welcoming.</p>\n<h3>Beyond the Surface</h3>\n<p>Environmental signals must be backed by substance: a welcoming form means little if the clinician then misgenders the client or reveals discomfort. Building an affirming practice is therefore an ongoing project that aligns the environment, the staff, and the clinician's own competence and stance. The aim is a setting in which an LGBTQ+ client encounters safety and competence consistently, from the first point of contact through the clinical work itself.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Examining the Clinician's Own Biases</h2>\n<p>Every clinician carries assumptions and biases shaped by a society organized around heterosexual and cisgender norms, and examining these is a prerequisite for genuinely affirming care.</p>\n<h3>Why Self-Examination Matters</h3>\n<p>Even clinicians who consider themselves accepting may hold unexamined assumptions — defaulting to heterosexuality and a gender binary, harboring discomfort or curiosity that centers the clinician's needs, or carrying beliefs absorbed from a non-affirming culture. Unexamined, these leak into the clinical encounter as microaggressions, assumptions, and subtle non-affirmation that clients detect and that undermine care. Heteronormative and cisnormative assumptions are pervasive precisely because they are the cultural default, which is why they require deliberate examination rather than good intentions alone.</p>\n<h3>The Ongoing Work</h3>\n<p>Affirming clinicians commit to ongoing self-examination: identifying their own assumptions and reactions, understanding where these come from, noticing them in clinical moments, and continuing to learn and grow. This work is supported by education, consultation, feedback, and engagement with LGBTQ+ communities' own perspectives. Where a clinician discovers biases that genuinely prevent affirming care, the responsibility is to address them; and where that is not yet possible, to ensure clients are referred to affirming providers rather than subjected to non-affirming care. This self-examination is a continuing professional commitment, not a one-time achievement.</p>",
+          "order": 20
+        },
+        {
+          "type": "text",
+          "content": "<h2>Resources and Referral for LGBTQ+ Clients</h2>\n<p>Connecting LGBTQ+ clients with appropriate resources and affirming providers is part of comprehensive care, and it requires the clinician to know the affirming landscape in their area and field.</p>\n<h3>Building Affirming Networks</h3>\n<p>Clinicians benefit from knowing affirming resources: medical providers competent in gender-affirming and LGBTQ+ health care, affirming specialists for trauma, substance use, and other needs, LGBTQ+ community organizations and support services, resources for families and for youth, and reputable informational resources. A vetted, affirming referral network allows the clinician to ensure that each dimension of a client's needs is met by someone competent and affirming — recognizing that referring an LGBTQ+ client to a non-affirming provider can cause harm.</p>\n<h3>Community and Peer Support</h3>\n<p>Beyond professional services, connection with affirming community and peer support is frequently powerfully beneficial for LGBTQ+ clients, countering the isolation that stigma produces and providing belonging, role models, and validation. The clinician can help clients find affirming communities, support groups, and resources suited to their specific identities and needs, recognizing that community connection is itself protective and that the clinician's own relationship is not a substitute for it.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Telehealth and Access to Affirming Care</h2>\n<p>Telehealth has particular significance for LGBTQ+ clients, for whom access to affirming care is frequently limited by geography and local climate.</p>\n<h3>Expanding Access</h3>\n<p>Affirming care is unevenly available, and LGBTQ+ people in rural areas, in hostile regions, or in communities with few affirming providers may struggle to find competent care locally. Telehealth can dramatically expand access, connecting clients with affirming clinicians regardless of location and allowing clients to receive care they could not otherwise obtain. For some clients, telehealth also offers privacy and safety advantages.</p>\n<h3>Considerations</h3>\n<p>As with all telehealth, the clinician confirms the client is in a private space where they can speak freely — a consideration with specific weight for clients who are not out in their households — and attends to safety planning and to the practical and legal dimensions of providing care across locations. The core principles of affirming practice apply identically; telehealth is a means of extending affirming care to those who need it, with attention to the privacy and safety that some LGBTQ+ clients particularly require.</p>",
+          "order": 22
+        },
+        {
+          "order": 23,
+          "type": "matching",
+          "matchingInstructions": "Match each clinical-environment problem to the affirming practice that addresses it.",
+          "matchingPairs": [
+            {
+              "term": "Intake form assuming heterosexuality and binary gender",
+              "definition": "Inclusive options for name in use, pronouns, gender, and relationships"
+            },
+            {
+              "term": "Misgendering and use of a former name",
+              "definition": "Consistent use of correct name and pronouns; quick, low-key repair of mistakes"
+            },
+            {
+              "term": "Relying on the client to explain basic terminology",
+              "definition": "Clinician self-education through CE, consultation, and the literature"
+            },
+            {
+              "term": "Assuming a client’s partner’s gender",
+              "definition": "Asking respectfully rather than inferring"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>Integrating Affirming Practice Into General Care</h2>\n<p>Because every clinician works with LGBTQ+ clients, affirming competence is not a specialization to be left to others but a basic component of general practice to be integrated into ordinary care.</p>\n<h3>Making Affirmation the Default</h3>\n<p>Integrating affirming practice means building inclusive, non-assuming language and intake into standard practice for all clients; maintaining an environment that signals safety; developing and maintaining foundational competence in LGBTQ+ concerns and the relevant frameworks; and applying the affirming stance consistently rather than only when a client has disclosed an LGBTQ+ identity. Because clinicians cannot know in advance which clients are LGBTQ+, affirmation built into the default ensures that LGBTQ+ clients encounter safety whether or not they have come out.</p>\n<h3>Knowing One's Limits</h3>\n<p>Integrating affirming practice also means knowing the limits of one's competence and referring appropriately — for example, to clinicians with specialized expertise in gender-affirming care, or to affirming specialists for particular needs — while taking responsibility for one's own foundational competence rather than treating all LGBTQ+ care as someone else's specialty. The generalist who integrates affirming practice serves the many LGBTQ+ clients who would otherwise encounter non-affirming care in ordinary settings.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Clinician's Self-Care in Affirming Work</h2>\n<p>Affirming work, particularly with clients facing significant adversity and risk, places demands on the clinician that warrant attention to their own sustainability.</p>\n<h3>The Demands of the Work</h3>\n<p>Clinicians doing this work engage with clients' experiences of rejection, discrimination, trauma, and risk, and may themselves be affected by the broader social and political climate surrounding LGBTQ+ lives. Clinicians who are themselves LGBTQ+ may experience particular resonance and demands in this work. Sustaining oneself through consultation, peer support, manageable caseloads, attention to one's own wellbeing, and connection to community supports the steady, affirming presence that clients need.</p>\n<h3>Sustaining Affirming Practice</h3>\n<p>Sustaining affirming practice over time also means continuing to learn in an evolving field, processing the emotional impact of the work, and maintaining hope and perspective in the face of the adversity clients face. A clinician who attends to their own sustainability is better able to provide the consistent, competent, affirming care that supports LGBTQ+ clients' wellbeing across the long term.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Allyship, Advocacy, and the Clinician's Broader Role</h2>\n<p>Because so much of what affects LGBTQ+ clients' wellbeing lies in the social environment, the affirming clinician's role frequently extends beyond the individual session.</p>\n<h3>Advocacy as Part of Care</h3>\n<p>The minority stress framework makes clear that improving LGBTQ+ clients' wellbeing involves changing the environments that harm them, and clinicians are positioned to advocate — within their own institutions and systems for affirming policies and practices, within schools and communities on behalf of young clients, and within the profession for affirming standards. Advocacy on behalf of clients and the conditions that protect their wellbeing is a legitimate extension of affirming care, consistent with the profession's commitment to clients' welfare and to social justice.</p>\n<h3>Allyship Done Well</h3>\n<p>Effective allyship centers the needs and voices of LGBTQ+ people rather than the clinician, follows the leadership of the communities served, and is grounded in humility and ongoing learning. The clinician recognizes the limits of their own perspective, defers to clients' and communities' own understandings of their needs, and uses their professional position in service of clients rather than in ways that center the clinician. Allyship and advocacy, done well, are expressions of the same affirming commitment that governs the clinical work itself.</p>",
+          "order": 26
+        },
+        {
+          "type": "text",
+          "content": "<h2>Working With Families Toward Acceptance</h2>\n<p>Because family acceptance is such a powerful protective factor, helping families move toward greater acceptance is among the highest-impact interventions available, particularly for LGBTQ+ youth.</p>\n<h3>Meeting Families Where They Are</h3>\n<p>Families respond to a member's LGBTQ+ identity in varied ways, and some who initially struggle are motivated by genuine, if misguided, care and fear. The clinician engages such families non-judgmentally, providing education about the harms of rejection and the protective power of acceptance, helping families understand their member's experience, and supporting them in moving — even incrementally — toward more accepting behaviors. Because even modest reductions in rejecting behaviors and increases in accepting ones produce measurable benefit, this work does not require achieving immediate full acceptance to be valuable.</p>\n<h3>Protecting the Client</h3>\n<p>Family work is conducted in a way that protects and centers the LGBTQ+ person, never pressuring them to manage the family's feelings at their own expense and never compromising the affirming stance. Where families remain rejecting despite intervention, the clinician supports the LGBTQ+ client in protecting themselves, building other sources of support including chosen family, and reducing the impact of rejection. The goal throughout is the wellbeing of the LGBTQ+ client, whether that is best served by increasing family acceptance or by supporting the client in the face of its absence.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "content": "<h2>Key Takeaways for Practice</h2>\n<p>Several practical takeaways distill this course into principles the clinician can carry into work with LGBTQ+ clients.</p>\n<h3>What to Remember</h3>\n<p>Understand LGBTQ+ identities as healthy, normal variations and client distress through the lens of minority stress rather than pathology. Make affirmation the default — inclusive language, correct names and pronouns, a welcoming environment — for all clients, since you cannot know in advance who is LGBTQ+. Never attempt to change a client's orientation or gender identity, and recognize even subtle pressure as harmful. Strengthen the protective factors, especially family and environmental acceptance, that the evidence identifies as decisive. Attend to the full diversity of LGBTQ+ people across identities, the lifespan, relationships, and the intersections of identity. Examine your own assumptions and biases, and take responsibility for your own education rather than burdening clients. And refer to affirming providers when needed, while building your own foundational competence.</p>\n<h3>The Underlying Commitment</h3>\n<p>Beneath these is a single commitment: to affirm each client's dignity and identity, to address the genuine impact of an often-hostile world, and to support LGBTQ+ clients in living authentic, healthy, and whole lives. The clinician who holds this commitment provides care that is both ethically sound and, the evidence shows, clinically effective and sometimes life-protecting.</p>",
+          "order": 28
+        }
+      ]
+    }
+  ]
+};
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+async function main(){
+  await mongoose.connect(MONGODB_URI); console.log('Connected.');
+  const doc = await Course.findOne({ slug: COURSE_DATA.slug });
+  if(!doc){ console.error('CR-304 not found:', COURSE_DATA.slug); process.exit(1); }
+  for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
+  doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  await doc.save();
+  const fresh=await Course.findById(doc._id).lean();
+  console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);
+  await mongoose.disconnect(); console.log('Done.');
+}
+main().catch(e=>{console.error('ERROR:',e.message);process.exit(1);});

--- a/server/src/scripts/seedCR305-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR305-EXPANDED-canonical.js
@@ -1,0 +1,1587 @@
+/**
+ * Copyright (c) 2026 CounselorReady / GA Integrated Therapeutic Perspectives, LLC.
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+import 'dotenv/config';
+
+// CR-305 EXPANDED — canonical sections[] shape; saves through the model (wordCount hook fires).
+const COURSE_DATA = {
+  "title": "Sexual Trauma: Assessment, Treatment, and Evidence-Based Interventions",
+  "slug": "sexual-trauma-assessment-treatment",
+  "courseCode": "CR-305",
+  "description": "A comprehensive 3-hour continuing education course for licensed mental health professionals. Meets NBCC ACEP standards with 20,176 words of graduate-level clinical content.",
+  "ceHours": 3,
+  "credits": 3,
+  "category": "Clinical",
+  "ceCategory": "Clinical",
+  "ceuHours": 3,
+  "ceuEligible": true,
+  "approvingBody": "NBCC",
+  "approvalNumber": "#7760",
+  "creditType": "NBCC",
+  "acepProvider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "number": "7760"
+  },
+  "instructor": "GA Integrated Therapeutic Perspectives LLC",
+  "targetAudience": [
+    "Licensed mental health professionals including LPCs, LCSWs, LMFTs, psychologists, and NCCs who assess and treat sexual trauma survivors across clinical settings."
+  ],
+  "accessType": "subscription",
+  "price": 59.99,
+  "pricingTier": "standard",
+  "status": "draft",
+  "isPublished": false,
+  "isActive": true,
+  "passingScore": 80,
+  "maxAttempts": 3,
+  "settings": {
+    "passingScore": 80,
+    "certificateEnabled": true,
+    "requireEvaluation": true,
+    "requireAttestation": true
+  },
+  "objectives": [
+    "Define the major categories of sexual trauma and articulate how each affects biopsychosocial functioning.",
+    "Apply neurobiological knowledge of tonic immobility, dissociation, and traumatic memory to clinical assessment and treatment.",
+    "Administer and interpret validated trauma instruments including the PCL-5 and LEC-5.",
+    "Describe the evidence base for TF-CBT, EMDR, CPT, and Prolonged Exposure as first-line treatments.",
+    "Recognize the specific clinical needs of male survivors, LGBTQ+ survivors, BIPOC survivors, and trafficking survivors.",
+    "Apply trauma-informed principles throughout clinical contact with sexual trauma survivors."
+  ],
+  "assessment": {
+    "isExam": true,
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
+      {
+        "question": "Tonic immobility is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A voluntary protective behavior",
+            "isCorrect": false
+          },
+          {
+            "text": "An involuntary neurobiological response in ~70% of rape survivors",
+            "isCorrect": true
+          },
+          {
+            "text": "Evidence of consent",
+            "isCorrect": false
+          },
+          {
+            "text": "Specific to prior trauma history",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that tonic immobility is an involuntary neurobiological response occurring in approximately 70% of rape survivors. Research by Möller et al. (2017) established this as an automatic freeze response mediated by the brainstem, not a voluntary behavior. It is not evidence of consent (option C), as it represents a survival mechanism beyond conscious control, which has critical implications for legal proceedings and clinical psychoeducation."
+      },
+      {
+        "question": "The PCL-5 is most valuable for trauma treatment because:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "It provides a definitive DSM-5 diagnosis",
+            "isCorrect": false
+          },
+          {
+            "text": "Its sensitivity to change allows tracking treatment progress",
+            "isCorrect": true
+          },
+          {
+            "text": "It assesses all dissociative subtypes",
+            "isCorrect": false
+          },
+          {
+            "text": "It identifies trauma type and perpetrator relationship",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that the PCL-5's sensitivity to change makes it most valuable for tracking treatment progress over time. While it is a validated self-report measure aligned with DSM-5 PTSD criteria, it does not provide a definitive diagnosis (option A), which requires a structured clinical interview. Its primary clinical utility lies in repeated administration to monitor symptom reduction and guide treatment decisions."
+      },
+      {
+        "question": "TF-CBT's distinctive feature not found in other first-line trauma treatments is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Imaginal exposure to traumatic memories",
+            "isCorrect": false
+          },
+          {
+            "text": "Cognitive restructuring of stuck points",
+            "isCorrect": false
+          },
+          {
+            "text": "Parallel parent/caregiver treatment sessions",
+            "isCorrect": true
+          },
+          {
+            "text": "Bilateral stimulation during processing",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "The correct answer is parallel parent/caregiver treatment sessions, which is the distinctive component of TF-CBT not present in other first-line trauma treatments such as CPT, PE, or EMDR. TF-CBT uniquely includes caregivers in parallel sessions to improve the child's support environment and enhance treatment outcomes. Imaginal exposure (option A) is a core component of Prolonged Exposure therapy, not a distinctive feature of TF-CBT."
+      },
+      {
+        "question": "Window of Tolerance describes:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Session time limits for trauma processing",
+            "isCorrect": false
+          },
+          {
+            "text": "Optimal arousal zone between hyperarousal and dissociation",
+            "isCorrect": true
+          },
+          {
+            "text": "Maximum exposure intensity",
+            "isCorrect": false
+          },
+          {
+            "text": "Duration of stabilization phase",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that the Window of Tolerance describes the optimal arousal zone between hyperarousal and dissociation, a concept developed by Daniel Siegel. Within this zone, individuals can process information and emotions effectively without becoming overwhelmed or shutting down. Maximum exposure intensity (option C) is incorrect because the Window of Tolerance refers to an individual's regulatory capacity, not a treatment parameter for exposure dosing."
+      },
+      {
+        "question": "CPT's primary mechanism targets:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Conditioned fear extinction through exposure",
+            "isCorrect": false
+          },
+          {
+            "text": "Maladaptive beliefs (stuck points) about trauma and its meaning",
+            "isCorrect": true
+          },
+          {
+            "text": "Somatic discharge of incomplete survival responses",
+            "isCorrect": false
+          },
+          {
+            "text": "Bilateral stimulation facilitating adaptive information processing",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that CPT primarily targets maladaptive beliefs, known as stuck points, about the trauma and its meaning. CPT uses cognitive restructuring techniques such as Socratic questioning and worksheets to challenge distorted cognitions related to safety, trust, power, esteem, and intimacy. Conditioned fear extinction through exposure (option A) describes the mechanism of Prolonged Exposure therapy, not CPT."
+      },
+      {
+        "question": "Phase-based trauma treatment is specifically indicated when:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "The trauma was adult onset and circumscribed",
+            "isCorrect": false
+          },
+          {
+            "text": "Early-onset, repeated, or complex trauma with severe dissociation is present",
+            "isCorrect": true
+          },
+          {
+            "text": "The client is highly verbal with strong regulatory skills",
+            "isCorrect": false
+          },
+          {
+            "text": "The client requests time-limited structured treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that phase-based treatment is specifically indicated when early-onset, repeated, or complex trauma with severe dissociation is present. These clients often lack the regulatory capacity needed for direct trauma processing and require stabilization first. Adult-onset circumscribed trauma (option A) typically responds well to standard evidence-based treatments like CPT, PE, or EMDR without the need for an extended phased approach."
+      },
+      {
+        "question": "Male survivors most commonly present with which obscuring symptom profile:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Explicit sexual trauma disclosure with overt distress",
+            "isCorrect": false
+          },
+          {
+            "text": "Substance use, anger, somatic symptoms without explicit trauma identification",
+            "isCorrect": true
+          },
+          {
+            "text": "Hypersexuality and relationship seeking",
+            "isCorrect": false
+          },
+          {
+            "text": "Social withdrawal and explicit PTSD symptom reporting",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that male survivors most commonly present with substance use, anger, somatic symptoms, and other externalizing behaviors without explicitly identifying sexual trauma. Socialized masculine norms around self-reliance and stigma surrounding male victimization create barriers to direct disclosure. Explicit sexual trauma disclosure with overt distress (option A) is incorrect because male survivors are significantly less likely to disclose due to shame, fear of disbelief, and concerns about masculinity."
+      },
+      {
+        "question": "Trauma bonding in trafficking survivors involves:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A voluntary choice to maintain the relationship",
+            "isCorrect": false
+          },
+          {
+            "text": "Intense emotional attachment through alternating abuse and affection under dependency",
+            "isCorrect": true
+          },
+          {
+            "text": "A psychiatric disorder requiring medication management",
+            "isCorrect": false
+          },
+          {
+            "text": "A personality trait predisposing to exploitative relationships",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that trauma bonding involves intense emotional attachment formed through alternating cycles of abuse and affection under conditions of dependency and power imbalance. This neurobiological process, sometimes compared to Stockholm syndrome, makes it extremely difficult for trafficking survivors to leave or cooperate with intervention. It is not a voluntary choice (option A); rather, it is a survival adaptation driven by intermittent reinforcement and the basic human need for attachment under conditions of captivity."
+      },
+      {
+        "question": "The primary rationale for stabilization before trauma processing in phase-based treatment is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Insurance and administrative requirements",
+            "isCorrect": false
+          },
+          {
+            "text": "Adequate regulatory capacity prevents retraumatization during processing",
+            "isCorrect": true
+          },
+          {
+            "text": "Legal protocols for trauma-informed care",
+            "isCorrect": false
+          },
+          {
+            "text": "Evidence that stabilization eliminates need for trauma processing",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that adequate regulatory capacity prevents retraumatization during trauma processing. Without sufficient emotion regulation skills, grounding techniques, and distress tolerance, direct engagement with traumatic material can overwhelm the client and cause destabilization or retraumatization. The claim that stabilization eliminates the need for trauma processing (option D) is incorrect, as stabilization is a preparatory phase that builds the capacity needed for effective trauma processing, not a replacement for it."
+      },
+      {
+        "question": "Secondary traumatic stress produces:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "General burnout without trauma-specific symptoms",
+            "isCorrect": false
+          },
+          {
+            "text": "PTSD-parallel symptoms from indirect trauma exposure through clinical work",
+            "isCorrect": true
+          },
+          {
+            "text": "Compassion satisfaction as a protective countermeasure",
+            "isCorrect": false
+          },
+          {
+            "text": "Exclusively countertransference without clinical impairment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that secondary traumatic stress produces PTSD-parallel symptoms from indirect trauma exposure through clinical work with trauma survivors. Clinicians may develop intrusive imagery, avoidance, hyperarousal, and emotional numbing that mirror their clients' symptoms. General burnout (option A) is incorrect because burnout involves exhaustion and depersonalization from workplace demands broadly, whereas secondary traumatic stress is specifically trauma-related and can occur even in clinicians who otherwise find their work fulfilling."
+      },
+      {
+        "question": "Peritraumatic dissociation serves as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Voluntary escape from overwhelming experience",
+            "isCorrect": false
+          },
+          {
+            "text": "Neurobiological protective mechanism reducing immediate psychological impact",
+            "isCorrect": true
+          },
+          {
+            "text": "A pathological response requiring immediate clinical intervention",
+            "isCorrect": false
+          },
+          {
+            "text": "Evidence of prior psychiatric history",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that peritraumatic dissociation is a neurobiological protective mechanism that reduces the immediate psychological impact of overwhelming traumatic experience. Mediated by the dorsal vagal system, it involves depersonalization, derealization, and altered time perception during the traumatic event. It is not a voluntary escape (option A); rather, it is an automatic neurobiological response that occurs beyond conscious control when fight and flight responses are unavailable."
+      },
+      {
+        "question": "EMDR bilateral stimulation is theorized to facilitate:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Conditioned extinction through graduated exposure",
+            "isCorrect": false
+          },
+          {
+            "text": "Adaptive information processing of traumatic memories",
+            "isCorrect": true
+          },
+          {
+            "text": "Cognitive restructuring of stuck points",
+            "isCorrect": false
+          },
+          {
+            "text": "Somatic discharge of freeze responses",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that EMDR bilateral stimulation is theorized to facilitate adaptive information processing of traumatic memories. According to Shapiro's Adaptive Information Processing model, bilateral stimulation (eye movements, tapping, or auditory tones) helps the brain reprocess traumatic memories that have been stored in a dysfunctional, unprocessed state. Conditioned extinction through graduated exposure (option A) describes the mechanism of Prolonged Exposure therapy, not the theoretical basis of EMDR."
+      },
+      {
+        "question": "BIPOC sexual trauma survivors require treatment that includes:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Exclusive focus on individual PTSD symptoms",
+            "isCorrect": false
+          },
+          {
+            "text": "Awareness of racial trauma as a distinct intersecting dimension",
+            "isCorrect": true
+          },
+          {
+            "text": "Prioritizing cultural accommodation over evidence-based protocols",
+            "isCorrect": false
+          },
+          {
+            "text": "Referral only to BIPOC clinicians as standard of care",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that BIPOC sexual trauma survivors require treatment that includes awareness of racial trauma as a distinct intersecting dimension affecting their experience. Clinicians must understand how historical and ongoing racial trauma compounds sexual trauma, creating unique barriers to disclosure, trust, and help-seeking. Prioritizing cultural accommodation over evidence-based protocols (option C) is incorrect because effective treatment integrates cultural responsiveness within evidence-based frameworks rather than abandoning empirically supported approaches."
+      },
+      {
+        "question": "Post-traumatic growth is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "The expected outcome of all effective trauma treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "A genuine possibility for some survivors, not an expectation for all",
+            "isCorrect": true
+          },
+          {
+            "text": "Only possible with spiritual or religious frameworks",
+            "isCorrect": false
+          },
+          {
+            "text": "Associated exclusively with complete symptom remission",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that post-traumatic growth is a genuine possibility for some survivors but not an expectation for all. Research by Tedeschi and Calhoun identifies domains of growth including changed self-perception, deeper relationships, and new life priorities that can emerge through the struggle with trauma. It is not the expected outcome of all effective treatment (option A), as imposing growth expectations can invalidate survivors' experiences and create additional pressure that undermines therapeutic progress."
+      },
+      {
+        "question": "The most powerful predictor of sexual trauma disclosure to a professional is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Symptom severity",
+            "isCorrect": false
+          },
+          {
+            "text": "Time since trauma",
+            "isCorrect": false
+          },
+          {
+            "text": "Clinician-created safety and explicit invitation for disclosure",
+            "isCorrect": true
+          },
+          {
+            "text": "Trauma type",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "The correct answer is clinician-created safety and explicit invitation for disclosure. Research consistently shows that survivors are most likely to disclose sexual trauma when clinicians establish a safe therapeutic environment and directly but sensitively ask about sexual trauma history. Symptom severity (option A) is incorrect because many survivors with severe symptoms never disclose unless specifically asked, as shame, self-blame, and fear of judgment often override symptom-driven motivation to seek help."
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Complex PTSD, as distinct from classic PTSD, is characterized by additional persistent disturbances in:",
+        "options": [
+          {
+            "text": "Only re-experiencing symptoms",
+            "isCorrect": false
+          },
+          {
+            "text": "Affect regulation, self-concept, and relationships",
+            "isCorrect": true
+          },
+          {
+            "text": "Physical health alone",
+            "isCorrect": false
+          },
+          {
+            "text": "Memory for unrelated events",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Complex PTSD adds disturbances in affect regulation, self-concept (shame, worthlessness), and relationships to the core PTSD features.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When supporting a survivor with arousal responses that occurred during an assault, the clinician should explain that:",
+        "options": [
+          {
+            "text": "Such responses indicate the survivor wanted or consented to the assault",
+            "isCorrect": false
+          },
+          {
+            "text": "Bodily responses are automatic physiological events that carry no meaning about consent or desire",
+            "isCorrect": true
+          },
+          {
+            "text": "The survivor should feel responsible for the response",
+            "isCorrect": false
+          },
+          {
+            "text": "Arousal responses never occur during assault",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Automatic physiological responses during assault carry no meaning about consent; explaining this directly addresses a profound source of survivor shame and self-doubt.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Cognitive Processing Therapy is especially well matched to sexual trauma because it targets:",
+        "options": [
+          {
+            "text": "Only physical symptoms",
+            "isCorrect": false
+          },
+          {
+            "text": "Stuck points such as self-blame and shattered beliefs about safety, trust, and intimacy",
+            "isCorrect": true
+          },
+          {
+            "text": "Exclusively childhood memories",
+            "isCorrect": false
+          },
+          {
+            "text": "Medication adherence",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "CPT targets the conflicted beliefs (stuck points) — self-blame, safety, trust, esteem, intimacy — that organize much sexual trauma distress.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The recommended stance toward co-occurring substance use in sexual trauma survivors is to:",
+        "options": [
+          {
+            "text": "Require complete resolution of substance use before any trauma work",
+            "isCorrect": false
+          },
+          {
+            "text": "Treat the trauma and substance use as entirely separate problems",
+            "isCorrect": false
+          },
+          {
+            "text": "Use integrated, coordinated approaches that understand substance use in the context of the trauma it manages",
+            "isCorrect": true
+          },
+          {
+            "text": "Ignore substance use during trauma treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "Integrated approaches that address both problems together, understanding substance use in the context of the trauma, are generally more effective than sequential or siloed treatment.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Vicarious traumatization in clinicians is best understood as:",
+        "options": [
+          {
+            "text": "A sign of professional inadequacy",
+            "isCorrect": false
+          },
+          {
+            "text": "A recognized occupational reality of empathic engagement with trauma, requiring deliberate self-care",
+            "isCorrect": true
+          },
+          {
+            "text": "Evidence the clinician should leave the field",
+            "isCorrect": false
+          },
+          {
+            "text": "Identical to the survivor’s PTSD",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Vicarious traumatization is a recognized occupational reality, not a weakness; sustainable practice requires deliberate self-care, consultation, and caseload management.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The phase-based principle \"safety before processing\" means that:",
+        "options": [
+          {
+            "text": "Survivors should never process their trauma",
+            "isCorrect": false
+          },
+          {
+            "text": "Stabilization and safety skills are established before direct trauma-memory processing begins",
+            "isCorrect": true
+          },
+          {
+            "text": "Processing must occur in the first session",
+            "isCorrect": false
+          },
+          {
+            "text": "Safety is addressed only after treatment ends",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Attempting to process traumatic memory before the survivor can tolerate it is harmful; the phase-based model sequences safety and stabilization first.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Supporting sexual recovery after sexual trauma typically belongs to which phase, and centers on what principle?",
+        "options": [
+          {
+            "text": "The first session; rapid exposure",
+            "isCorrect": false
+          },
+          {
+            "text": "The reconnection phase; restoring the survivor’s choice and control over their body and sexual experience",
+            "isCorrect": true
+          },
+          {
+            "text": "Acute aftercare; mandatory reporting",
+            "isCorrect": false
+          },
+          {
+            "text": "It is never part of trauma treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Sexual recovery generally occurs in the reconnection phase, once stabilization and processing have established safety, and centers on restoring the survivor’s choice and control.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When a survivor experienced bodily arousal during an assault, the clinician should convey that such responses:",
+        "options": [
+          {
+            "text": "Mean the survivor consented",
+            "isCorrect": false
+          },
+          {
+            "text": "Are automatic physiological events carrying no meaning about consent or desire",
+            "isCorrect": true
+          },
+          {
+            "text": "Are extremely rare and abnormal",
+            "isCorrect": false
+          },
+          {
+            "text": "Should be a focus of blame",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Automatic physiological responses during assault carry no meaning about consent; explaining this addresses a profound source of survivor shame.",
+        "showExplanation": true
+      },
+      {
+        "type": "trueFalse",
+        "question": "Phase-based trauma treatment begins with safety and stabilization rather than immediately processing traumatic memories.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Stabilization precedes processing; beginning memory processing before the survivor is stabilized risks destabilization."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Secondary traumatic stress and vicarious traumatization are signs of clinician weakness rather than recognized occupational realities of trauma work.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "They are recognized occupational realities of empathic trauma work — not signs of weakness — and warrant proactive attention to clinician wellbeing."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Dissociation in session is a signal to slow down and ground the client rather than to intensify memory processing.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Dissociation indicates the client has left the window of tolerance; the clinician pauses, orients, and grounds before continuing."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are evidence-based psychotherapies for PTSD from sexual trauma? (Select all that apply)",
+        "options": [
+          {
+            "text": "Cognitive Processing Therapy (CPT)",
+            "isCorrect": true
+          },
+          {
+            "text": "Prolonged Exposure (PE)",
+            "isCorrect": true
+          },
+          {
+            "text": "EMDR",
+            "isCorrect": true
+          },
+          {
+            "text": "Trauma-Focused CBT (TF-CBT)",
+            "isCorrect": true
+          }
+        ],
+        "explanation": "CPT, PE, EMDR, and TF-CBT all have strong evidence for treating PTSD, including trauma from sexual assault."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which support a clinician’s sustainability in sexual-trauma work? (Select all that apply)",
+        "options": [
+          {
+            "text": "Consultation and supervision for the emotional impact of the work",
+            "isCorrect": true
+          },
+          {
+            "text": "Manageable caseloads and a varied mix of clinical work",
+            "isCorrect": true
+          },
+          {
+            "text": "Ignoring early signs of secondary stress and pushing through",
+            "isCorrect": false
+          },
+          {
+            "text": "Attention to the clinician’s own physical and emotional health",
+            "isCorrect": true
+          }
+        ],
+        "explanation": "Sustainability comes from consultation, manageable caseloads, and self-care — recognizing and responding to secondary stress early rather than pushing through it."
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "The National Intimate Partner and Sexual Violence Survey. CDC.",
+      "author": "Basile, K",
+      "year": 2022,
+      "source": "e National Intimate Partner and Sexual Violence Survey. CDC."
+    },
+    {
+      "title": "Treating trauma and traumatic grief in children and adolescents (2nd ed.). Guilford Press.",
+      "author": "Cohen, J",
+      "year": 2017,
+      "source": "grief in children and adolescents (2nd ed.). Guilford Press."
+    },
+    {
+      "title": "Prolonged exposure therapy for PTSD: Therapist guide (2nd ed.). Oxford University Press.",
+      "author": "Foa, E",
+      "year": 2019,
+      "source": "or PTSD: Therapist guide (2nd ed.). Oxford University Press."
+    },
+    {
+      "title": "In an unspoken voice. North Atlantic Books.",
+      "author": "Levine, P",
+      "year": 2010,
+      "source": "e, P. A. (2010). In an unspoken voice. North Atlantic Books."
+    },
+    {
+      "title": "Tonic immobility during sexual assault. Acta Obstetricia et Gynecologica Scandinavica, 96(8), 932–938.",
+      "author": "Möller, A",
+      "year": 2017,
+      "source": "ta Obstetricia et Gynecologica Scandinavica, 96(8), 932–938."
+    },
+    {
+      "title": "Statistics about sexual violence.",
+      "author": "National Sexual Violence Resource Center",
+      "year": 2015,
+      "source": "e Resource Center. (2015). Statistics about sexual violence."
+    },
+    {
+      "title": "Trauma and the body. Norton.",
+      "author": "Ogden, P",
+      "year": 2006,
+      "source": "Minton, K., & Pain, C. (2006). Trauma and the body. Norton."
+    },
+    {
+      "title": "The polyvagal theory. Norton.",
+      "author": "Porges, S",
+      "year": 2011,
+      "source": "Porges, S. W. (2011). The polyvagal theory. Norton."
+    },
+    {
+      "title": "Cognitive processing therapy for PTSD. Guilford Press.",
+      "author": "Resick, P",
+      "year": 2017,
+      "source": "017). Cognitive processing therapy for PTSD. Guilford Press."
+    },
+    {
+      "title": "Trauma-informed care in behavioral health services (TIP 57).",
+      "author": "SAMHSA",
+      "year": 2014,
+      "source": "Trauma-informed care in behavioral health services (TIP 57)."
+    },
+    {
+      "title": "Eye movement desensitization and reprocessing therapy (3rd ed.). Guilford Press.",
+      "author": "Shapiro, F",
+      "year": 2018,
+      "source": "tization and reprocessing therapy (3rd ed.). Guilford Press."
+    },
+    {
+      "title": "The developing mind. Guilford Press.",
+      "author": "Siegel, D",
+      "year": 1999,
+      "source": "Siegel, D. J. (1999). The developing mind. Guilford Press."
+    },
+    {
+      "title": "The Posttraumatic Growth Inventory. Journal of Traumatic Stress, 9(3), 455–471.",
+      "author": "Tedeschi, R",
+      "year": 1996,
+      "source": "rowth Inventory. Journal of Traumatic Stress, 9(3), 455–471."
+    },
+    {
+      "title": "The body keeps the score. Viking.",
+      "author": "van der Kolk, B",
+      "year": 2014,
+      "source": "an der Kolk, B. A. (2014). The body keeps the score. Viking."
+    },
+    {
+      "title": "The PTSD Checklist for DSM-5 (PCL-5). National Center for PTSD.",
+      "author": "Weathers, F",
+      "year": 2013,
+      "source": "PTSD Checklist for DSM-5 (PCL-5). National Center for PTSD."
+    },
+    {
+      "title": "Child abuse: Betrayal and disclosure. Child Abuse & Neglect, 33(4), 209–217.",
+      "author": "Foynes, M",
+      "year": 2014,
+      "source": "rayal and disclosure. Child Abuse & Neglect, 33(4), 209–217."
+    },
+    {
+      "title": "Family rejection as predictor of negative health outcomes. Pediatrics, 123(1), 346–352.",
+      "author": "Ryan, C",
+      "year": 2009,
+      "source": "or of negative health outcomes. Pediatrics, 123(1), 346–352."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module 1: Foundations, Neurobiology, and Clinical Assessment",
+      "order": 1,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 1,
+          "title": "Module 1",
+          "subtitle": "Module 1: Foundations, Neurobiology, and Clinical Assessment",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>Defining Sexual Trauma: Scope, Prevalence, and Clinical Significance</h2>\n<h3>Categories of Sexual Trauma</h3>\n<p>Sexual trauma encompasses a broad range of involuntary sexual experiences occurring without meaningful consent. Each category carries distinct clinical implications shaped by the survivor's developmental stage, the perpetrator relationship, and the social context in which the trauma occurred. The major categories include:</p>\n<ul>\n<li><strong>Childhood sexual abuse (CSA)</strong> — any sexual activity imposed on a minor by a person in a position of power or trust, disrupting core developmental processes including the formation of bodily self-concept, the development of trust in caregiving relationships, and the establishment of sexual schema that will later mediate adult sexual experience.</li>\n<li><strong>Adult sexual assault</strong> — including rape and other non-consensual contact, carrying the specific trauma burden of bodily violation in a context where adult capacity for self-protection was anticipated by both the survivor and their social world, often amplifying shame when escape or resistance was prevented by force, threat, or tonic immobility.</li>\n<li><strong>Intimate partner sexual violence (IPSV)</strong> — sexual coercion or assault by an intimate partner, the most commonly experienced form of sexual violence and the least frequently recognized by survivors and clinicians alike, because its occurrence within an intimate relationship challenges the social scripts that define assault as something perpetrated by strangers.</li>\n<li><strong>Commercial sexual exploitation</strong> — encompassing trafficking and survival sex, in which the exchange of sexual acts for survival resources under conditions of coercion, dependency, or lack of genuine alternatives creates trauma presentations of extraordinary complexity.</li>\n</ul>\n<h3>Prevalence as a Public Health Crisis</h3>\n<p>The prevalence of sexual trauma across all categories constitutes a genuine public health crisis whose full clinical significance is rarely reflected in mental health training or practice. The CDC's National Intimate Partner and Sexual Violence Survey documents that approximately one in five women and one in fourteen men have been raped, and that an additional 22% of women and 4% of men have experienced other forms of sexual violence during their lifetimes.</p>\n<p>Childhood sexual abuse is estimated to have affected approximately one in four girls and one in thirteen boys in the United States, figures that almost certainly underestimate true prevalence given the pervasive underreporting that characterizes this form of trauma. These prevalence rates mean that in any general outpatient clinical caseload — regardless of the presenting diagnoses — sexual trauma is present in a substantial proportion of clients, many of whom have never disclosed their experience to any healthcare provider and none of whom will disclose without a clinical environment that makes such disclosure possible. Clinicians who do not screen for sexual trauma history, or who screen only when the presenting concern explicitly references sexual violence, are systematically missing a clinically significant dimension of many of their clients' presentations.</p>\n<h3>Mental Health Outcomes</h3>\n<p>The relationship between sexual trauma and mental health outcomes is among the most extensively documented in the clinical literature, spanning decades of research across diverse clinical populations and methodological approaches. Sexual trauma is associated with substantially elevated rates of PTSD — lifetime PTSD rates following rape are estimated at 30-50% — as well as:</p>\n<ul>\n<li>Major depression</li>\n<li>Anxiety disorders</li>\n<li>Substance use disorders</li>\n<li>Dissociative disorders</li>\n<li>Borderline personality disorder</li>\n<li>Somatic symptom disorders</li>\n<li>Complex trauma presentations that resist single-diagnosis categorization</li>\n</ul>\n<p>The ICD-11's introduction of {{callout:cptsd}} as a distinct diagnostic entity reflects the accumulated clinical and research evidence that survivors of prolonged, repeated, or early-onset sexual trauma — particularly those who experienced abuse within primary caregiving relationships — often present with disturbances in emotion regulation, negative self-concept, and relational functioning that exceed the scope of standard PTSD criteria and require treatment approaches that address these additional dimensions of impairment. Understanding when a presentation reflects PTSD, Complex PTSD, or both — and the clinical implications of this distinction for treatment planning — is essential for clinicians providing trauma-informed care to sexual trauma survivors.</p>\n<h3>Barriers to Trauma Disclosure</h3>\n<p>Trauma disclosure is among the most clinically complex events in mental health practice, both for the survivor who risks the vulnerability of disclosure and for the clinician who receives it. Research consistently documents that the majority of sexual trauma survivors never disclose to formal support systems during their lifetimes, and that professional disclosure — when it occurs — typically follows years or decades of private carrying of the trauma.</p>\n<p>The barriers to disclosure are substantial, varied, and frequently underestimated by clinicians who have not received specific training in the clinical phenomenology of sexual trauma:</p>\n<ul>\n<li>Profound shame about both the traumatic experience itself and about one's responses during and after it</li>\n<li>Fear of not being believed or of being blamed for the victimization</li>\n<li>Concern about the responses of significant others who may be affected by the disclosure</li>\n<li>Fear of legal processes and their potential disruption of existing life arrangements</li>\n<li>Cognitive effects of trauma including fragmented, non-narrative memory that makes coherent disclosure difficult</li>\n<li>The pervasive absence of clinical environments in which sexual trauma disclosure is explicitly invited and skillfully received</li>\n</ul>",
+          "order": 1,
+          "callouts": {
+            "cptsd": {
+              "label": "Complex PTSD",
+              "type": "clinical",
+              "body": "A trauma response to prolonged or repeated victimization, adding disturbances in self-organization — affect regulation, self-concept, and relationships — to core PTSD symptoms."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h3>Creating a Disclosure-Facilitating Clinical Environment</h3>\n<p>Creating a clinical environment that makes sexual trauma disclosure possible is both an ethical obligation and a clinical competency that requires specific training and deliberate practice. The most important single element of a disclosure-facilitating environment is the explicit invitation — the direct, matter-of-fact communication that sexual health and trauma history are topics the clinician is prepared and willing to address.</p>\n<p>This invitation can be built into intake paperwork through questions about trauma history and sexual concerns, communicated verbally in the initial clinical interview through normalizing statements, and reinforced throughout the treatment relationship through the consistent demonstration that when sensitive content emerges the clinician remains present, attuned, and non-avoidant. Research by Foynes and colleagues (2014) confirms that the quality of the anticipated response — the degree to which the survivor believed the recipient would respond with care and without judgment — is among the strongest predictors of whether disclosure occurs, underscoring that the clinician's demonstrated readiness to receive trauma content is not a minor clinical variable but a primary determinant of whether disclosure is possible.</p>\n<h3>Mandated Reporting Obligations</h3>\n<p>The mandated reporting obligations that apply to sexual trauma disclosures require specific clinical attention and ongoing familiarity with the applicable statutory provisions. In all U.S. jurisdictions, mental health clinicians are mandated reporters who must report reasonable suspicion of ongoing child abuse or neglect.</p>\n<p>When an adult client discloses historical childhood sexual abuse, the mandatory reporting analysis depends on multiple factors:</p>\n<ul>\n<li>Whether the perpetrator is currently in contact with children</li>\n<li>Whether there are current minor victims</li>\n<li>Whether the perpetrator is in a position of trust with children such as a school or religious setting</li>\n<li>The specific provisions of the jurisdiction's mandatory reporting statute</li>\n</ul>\n<p>These analyses are genuinely complex and variable, and clinicians should seek legal or ethics consultation when the applicability of mandatory reporting obligations is unclear. Mandatory reporting should be discussed explicitly with adult survivors before a trauma history inquiry, within the broader informed consent framework, so that survivors are not surprised by the possibility of mandatory reporting and can make an informed decision about what to disclose.</p>\n<h3>SAMHSA's Trauma-Informed Care Framework</h3>\n<p>Trauma-informed care as a comprehensive service delivery framework, as elaborated by SAMHSA (2014), incorporates four key elements:</p>\n<ol>\n<li><strong>Realization</strong> of the widespread impact of trauma and understanding potential paths for recovery</li>\n<li><strong>Recognition</strong> of the signs and symptoms of trauma in clients, families, and staff</li>\n<li><strong>Response</strong> by fully integrating knowledge about trauma into policies, procedures, and practices</li>\n<li><strong>Resistance</strong> to re-traumatization</li>\n</ol>\n<p>Applied to sexual trauma clinical work, a trauma-informed approach means that every aspect of the clinical encounter — from the physical arrangement of the clinical space to the language used on intake forms, from the informed consent process to the conduct of the clinical interview, from the management of the therapeutic relationship to the pace and content of treatment — is shaped by awareness of how trauma affects the client's experience and by a consistent commitment to safety, transparency, and the preservation of the client's agency and control.</p>\n<h3>The Therapeutic Alliance in Trauma Treatment</h3>\n<p>The concept of the therapeutic alliance — the collaborative, trust-based working relationship between clinician and client — is particularly central to sexual trauma treatment because trauma, especially when perpetrated by a caregiver, profoundly disrupts the fundamental trust in human relationships that the therapeutic alliance requires and simultaneously demonstrates. Research consistently documents that the quality of the therapeutic alliance is the strongest predictor of treatment outcomes across psychotherapy approaches, and this finding applies with particular force in trauma treatment where the client's capacity to engage in the demands of trauma processing is directly dependent on the safety, trust, and attunement of the relational container in which that processing occurs.</p>\n<p>Clinicians who are trained in the management of therapeutic alliance in trauma contexts — including the recognition and repair of ruptures, the management of transference and countertransference in the trauma treatment relationship, and the use of the relational experience itself as a therapeutic intervention — are equipped to provide trauma treatment that is substantially more effective than technique alone can achieve.</p>",
+          "order": 2
+        },
+        {
+          "type": "text",
+          "content": "<h2>Neurobiology of Sexual Trauma: Clinical Applications</h2>\n<h3>Trauma as a Whole-Body Biological Event</h3>\n<p>The neurobiology of trauma has undergone revolutionary development in the past three decades, producing a body of knowledge that has transformed both the theoretical understanding and the practical clinical treatment of traumatic stress responses. The foundational insight of neurobiological trauma research — captured most accessibly in van der Kolk's (2014) The Body Keeps the Score — is that traumatic experience is not merely a psychological event encoded in narrative memory but a whole-body biological event whose effects on neurological architecture, physiological regulation, and somatic experience persist long after the originating event has ended.</p>\n<p>Understanding these neurobiological mechanisms is not merely an academic exercise for mental health clinicians — it has direct implications for how trauma presentations are assessed, how trauma-informed interventions are selected and sequenced, how the therapeutic relationship is managed, and how psychoeducation is delivered to survivors who are struggling to make sense of their ongoing trauma responses in light of what happened to them.</p>\n<h3>The Stress Response System</h3>\n<p>The stress response system — the hypothalamic-pituitary-adrenal axis working in concert with the sympathetic nervous system — governs the acute physiological response to perceived threat through the rapid mobilization of cortisol, adrenaline, and noradrenaline that prepare the body for the fight-or-flight survival response. During sexual trauma, this survival response system operates in a context of profound complexity: the source of threat is frequently a trusted person, the body that is both the site of violation and the instrument of survival response, and the social and relational dimensions of the experience create an extraordinarily complex mixture of signals that the nervous system must simultaneously process while managing an existential threat.</p>\n<p>The neurobiological consequence of this complexity is a trauma encoding that is simultaneously biological, emotional, somatic, and relational — and that cannot be fully processed through verbal, cognitive, or narrative approaches alone, a finding that provides the scientific rationale for body-based and somatic approaches to trauma treatment.</p>\n<h3>Tonic Immobility</h3>\n<p>Tonic immobility is one of the most clinically significant neurobiological responses to sexual trauma and one of the least discussed in clinical training. Tonic immobility — the involuntary motor paralysis that occurs when the fight-or-flight response is unavailable and the nervous system moves to the freeze or shutdown response — has been documented in a substantial proportion of sexual assault survivors, with Möller and colleagues (2017) finding significant tonic immobility in approximately 70% of rape survivors in their sample.</p>\n<p>The clinical significance of this finding extends far beyond its neurobiological interest: tonic immobility is the primary neurobiological mechanism underlying the common survivor experience of 'freezing,' 'going numb,' or 'not fighting back' during an assault — experiences that are frequently accompanied by profound shame and self-blame that maintain PTSD symptoms and impede recovery. Psychoeducation about tonic immobility — providing survivors with the neurobiological framework to understand that their freeze response was an involuntary physiological event rather than a personal failure of resistance — is among the most immediately clinically effective brief interventions available in sexual trauma work, directly challenging the shame and self-blame that sustain PTSD.</p>\n<h3>Traumatic Memory Encoding</h3>\n<p>Traumatic memory is encoded, stored, and retrieved differently from ordinary autobiographical memory — a difference with profound clinical implications that explains features of trauma presentations that might otherwise be confusing or pathologized. During acute trauma, high cortisol levels functionally impair the hippocampus, disrupting its normal role in integrating the sensory and emotional elements of experience into the coherent, sequentially organized, time-stamped narrative that characterizes ordinary autobiographical memory.</p>\n<p>The result is that traumatic memories are encoded primarily as fragments of sensory experience — vivid visual images, specific sounds, smells, tactile sensations, and intense visceral emotional states — rather than as organized narratives with clear beginnings, middles, and ends. These sensory fragments are stored in ways that respond more readily to sensory and contextual cues than to deliberate recall, and they are experienced not as clearly time-stamped memories of past events but as intrusive re-experiencing — the flashback, the nightmare, the somatic intrusion — that occurs in the present tense.</p>\n<p>This memory architecture explains why trauma survivors may have fragmentary or inconsistent recollections of traumatic events, why sensory triggers can produce intense trauma reactions without the survivor immediately recognizing their source, and why narrative-focused therapy alone may be insufficient for processing memories stored primarily in non-narrative sensory form.</p>",
+          "order": 3
+        },
+        {
+          "type": "text",
+          "content": "<h3>{{callout:dissociation}} as a Trauma Response</h3>\n<p>Dissociation — the disruption of normal integration of consciousness, memory, identity, and perception — represents the most severe end of the neurobiological spectrum of trauma responses and is a clinically essential consideration in sexual trauma assessment and treatment. Peritraumatic dissociation — the acute dissociative response occurring during the traumatic event itself — is a neurobiological protective mechanism that reduces the psychological impact of overwhelming experience by creating experiential distance from it.</p>\n<p>When peritraumatic dissociation is followed by persistent post-traumatic dissociation, the clinical presentation may range from mild depersonalization and derealization at the less severe end to severe identity fragmentation and amnestic barriers at the more severe end of the dissociative continuum, with dissociative identity disorder representing the most complex presentation associated with severe, early-onset, repeated childhood trauma. Assessing the degree and type of dissociation is an essential component of trauma assessment because it directly affects treatment selection and sequencing: trauma processing approaches such as {{callout:emdr}} and {{callout:pe}} may produce destabilizing dissociative flooding in clients with significant dissociation, requiring substantial modification or a more extended stabilization phase before trauma processing can safely proceed.</p>\n<h3>Polyvagal Theory</h3>\n<p>Polyvagal theory, developed by Stephen Porges (2011), provides a neurobiological framework that has transformed clinical understanding of trauma presentations and treatment approaches. Porges' model describes three hierarchically organized autonomic neural circuits:</p>\n<ul>\n<li>The <strong>ventral vagal circuit</strong> supporting social engagement and safety cues</li>\n<li>The <strong>sympathetic circuit</strong> supporting mobilization responses</li>\n<li>The <strong>dorsal vagal circuit</strong> supporting immobilization and shutdown</li>\n</ul>\n<p>In sexual trauma, particularly when the perpetrator is a caregiver, the social engagement system that normally mediates safety through connection is profoundly disrupted — the relational cues that normally signal safety become unreliable or dangerous, leaving the survivor with a chronically activated threat response system that cannot be adequately co-regulated through normal social connection.</p>\n<p>Clinical implications of the polyvagal framework include:</p>\n<ul>\n<li>The importance of attending to the safety signals in the clinical environment</li>\n<li>The use of relational co-regulation as a primary early therapeutic intervention</li>\n<li>The rationale for somatic and breath-based practices that directly target the autonomic nervous system rather than operating exclusively through cognitive processing</li>\n</ul>\n<h3>The {{callout:window-tolerance}}</h3>\n<p>The Window of Tolerance concept — developed by Siegel (1999) and elaborated by Ogden and colleagues (2006) — provides one of the most clinically useful frameworks for managing the neurobiological demands of trauma treatment. The window of tolerance describes the zone of arousal within which the integrated processing of difficult material is possible, bounded below by the hypoarousal of dissociation and emotional shutdown and above by the hyperarousal of overwhelm and retraumatization.</p>\n<p>Within this window, the client can engage with traumatic material while maintaining the capacity for present-moment awareness, affect regulation, and reflective function. Outside this window — in either direction — the therapeutic work is essentially inaccessible: the client is either disconnected from the material in ways that preclude processing or overwhelmed by it in ways that preclude integration. The clinical art of trauma treatment involves the continuous monitoring of the client's arousal state and the real-time titration of the intensity, pace, and content of therapeutic work to maintain processing within the window of tolerance — an ongoing clinical attunement that requires both theoretical understanding and practiced clinical skill.</p>\n<h3>Neurobiology as the Foundation for Evidence-Based Treatments</h3>\n<p>The understanding of trauma's neurobiological mechanisms provides the scientific foundation for several of the evidence-based trauma treatments that are described in subsequent sections:</p>\n<ul>\n<li><strong>EMDR's bilateral stimulation protocol</strong> is theorized to work through a mechanism similar to the bilateral eye movements of REM sleep — facilitating the adaptive information processing of traumatic memories by engaging the same neural mechanisms that ordinarily support the consolidation and integration of difficult memories during sleep.</li>\n<li><strong>Somatic Experiencing's</strong> focus on facilitating incomplete survival responses draws directly on the polyvagal and freeze-response research to target the stuck physiological activation that maintains trauma symptoms.</li>\n<li><strong>The phase-based treatment model's</strong> emphasis on stabilization before trauma processing reflects the window of tolerance framework — ensuring adequate regulatory capacity before initiating trauma processing that will inherently stretch that capacity.</li>\n</ul>\n<p>Clinicians who understand the neurobiological basis of these treatment approaches are better equipped to apply them with clinical intelligence rather than mechanical protocol adherence, adapting them to each client's specific neurobiological profile in ways that optimize therapeutic effectiveness.</p>",
+          "order": 4,
+          "callouts": {
+            "emdr": {
+              "label": "EMDR",
+              "type": "clinical",
+              "body": "Eye Movement Desensitization and Reprocessing — an evidence-based trauma therapy using bilateral stimulation while processing traumatic memories."
+            },
+            "pe": {
+              "label": "Prolonged Exposure",
+              "type": "clinical",
+              "body": "An evidence-based PTSD treatment using imaginal and in-vivo exposure to reduce avoidance and the power of trauma-related cues."
+            },
+            "window-tolerance": {
+              "label": "Window of Tolerance",
+              "type": "reference",
+              "body": "The zone of arousal in which a person can process experience without becoming hyperaroused or hypoaroused; trauma treatment works to keep clients within it."
+            },
+            "dissociation": {
+              "label": "Dissociation",
+              "type": "clinical",
+              "body": "A protective disconnection from thoughts, feelings, memory, or sense of self/surroundings; in trauma work it signals a need to slow down and ground."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Clinical Assessment of Sexual Trauma: Tools and Frameworks</h2>\n<h3>Overview of Evidence-Based Treatment Approaches</h3>\n<p>Evidence-based treatment for sexual trauma sequelae is well-developed, with multiple randomized controlled trials, meta-analyses, and clinical practice guidelines supporting the effectiveness of several distinct psychotherapeutic approaches. The major first-line evidence-based treatments — Trauma-Focused Cognitive Behavioral Therapy ({{callout:tf-cbt}}), Eye Movement Desensitization and Reprocessing (EMDR), {{callout:cpt}} (CPT), and Prolonged Exposure (PE) — each have robust empirical support across diverse trauma populations, including sexual trauma survivors specifically.</p>\n<p>Clinicians who provide trauma treatment bear a professional and ethical obligation to be familiar with this evidence base and to select and implement treatment approaches whose effectiveness is supported by clinical research, rather than relying exclusively on general-purpose psychotherapy techniques that have not been specifically validated for trauma presentations.</p>\n<h3>Trauma-Focused Cognitive Behavioral Therapy (TF-CBT)</h3>\n<p>TF-CBT, developed by Cohen, Mannarino, and Deblinger, was specifically designed and empirically validated for child and adolescent survivors of sexual abuse and has accumulated the most extensive evidence base of any psychotherapy for this population. TF-CBT follows the PRACTICE acronym:</p>\n<ul>\n<li><strong>P</strong>sychoeducation</li>\n<li><strong>R</strong>elaxation</li>\n<li><strong>A</strong>ffect modulation</li>\n<li><strong>C</strong>ognitive coping</li>\n<li><strong>T</strong>rauma narrative development and processing</li>\n<li><strong>I</strong>n vivo mastery of trauma reminders</li>\n<li><strong>C</strong>onjoint parent-child sessions</li>\n<li><strong>E</strong>nhancing safety</li>\n</ul>\n<p>This structured, skills-based, and exposure-incorporating treatment addresses both the trauma symptom profile and the developmental disruptions associated with childhood sexual abuse. The conjoint parent-child component of TF-CBT — which involves parallel psychoeducation and skill-building with non-offending caregivers — is a distinctive and clinically essential feature that addresses the critical role of parental support and response in mediating the child's trauma recovery. Multiple randomized controlled trials and systematic meta-analyses document TF-CBT's superiority over non-trauma-focused comparison conditions on measures of PTSD, depression, behavioral problems, and caregiver distress, and its effects are durable at long-term follow-up.</p>\n<h3>Eye Movement Desensitization and Reprocessing (EMDR)</h3>\n<p>EMDR, developed by Francine Shapiro beginning in 1987, uses bilateral stimulation — most commonly lateral eye movements, but also alternating auditory tones or bilateral tactile stimulation — while the client maintains attention to a traumatic memory, theorized to facilitate the adaptive information processing and integration of traumatic material. The EMDR protocol proceeds through eight structured phases:</p>\n<ol>\n<li>History-taking and treatment planning</li>\n<li>Client preparation including psychoeducation and resource development</li>\n<li>Assessment of the target memory including identification of image, negative cognition, positive cognition, emotion, body sensation, and validity of cognition measures</li>\n<li>Desensitization using bilateral stimulation while processing the traumatic material</li>\n<li>Installation of the positive cognition</li>\n<li>Body scan</li>\n<li>Closure</li>\n<li>Reevaluation</li>\n</ol>\n<p>Meta-analytic reviews document EMDR's efficacy for PTSD with effect sizes comparable to those of other first-line treatments. EMDR's unique combination of cognitive, affective, somatic, and imaginal components makes it particularly well-suited for trauma presentations involving significant somatic symptoms, trauma memories that resist verbalization, and clients who have not achieved sufficient benefit from more cognitively focused approaches.</p>\n<h3>Cognitive Processing Therapy (CPT)</h3>\n<p>CPT, developed by Patricia Resick and colleagues, addresses the cognitive mechanisms that maintain PTSD symptoms through the identification and modification of maladaptive beliefs about the trauma and its meaning — called stuck points — that prevent natural emotional processing. The CPT protocol proceeds through structured phases:</p>\n<ul>\n<li>Psychoeducation about PTSD and the cognitive model</li>\n<li>Development of an impact statement articulating the client's beliefs about the trauma's causes and effects</li>\n<li>Introduction of cognitive restructuring tools</li>\n<li>Extensive worksheet-based practice challenging stuck points</li>\n<li>Application of cognitive restructuring to the five challenge domains — safety, trust, power and control, esteem, and intimacy — most frequently disrupted by sexual trauma</li>\n</ul>\n<p>CPT's structured, skills-focused, psychoeducationally rich format makes it particularly accessible for clients who respond well to cognitive approaches and for clients who find imaginal exposure approaches less tolerable. The evidence base for CPT in adult sexual assault survivors and veterans is particularly strong, with multiple randomized controlled trials documenting significant PTSD symptom reduction and high client satisfaction.</p>",
+          "order": 5,
+          "callouts": {
+            "tf-cbt": {
+              "label": "TF-CBT",
+              "type": "clinical",
+              "body": "Trauma-Focused Cognitive Behavioral Therapy — an evidence-based, phase-oriented treatment integrating psychoeducation, skills, gradual exposure, and cognitive processing."
+            },
+            "cpt": {
+              "label": "CPT",
+              "type": "clinical",
+              "body": "Cognitive Processing Therapy — an evidence-based PTSD treatment focused on identifying and modifying trauma-related “stuck points” in thinking."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h3>Prolonged Exposure (PE)</h3>\n<p>Prolonged Exposure, developed by Edna Foa and colleagues, uses repeated, systematic imaginal and in vivo exposure to traumatic memories and avoided stimuli to facilitate the emotional processing and gradual extinction of conditioned fear responses. The PE protocol includes:</p>\n<ul>\n<li>Psychoeducation about PTSD and the exposure rationale</li>\n<li>Breathing retraining</li>\n<li>In vivo exposure homework to avoided situations, places, and activities</li>\n<li>Repeated imaginal exposure to the trauma memory in session, followed by processing of the emotional and cognitive meaning of the experience</li>\n</ul>\n<p>The rationale for PE is grounded in emotional processing theory and conditioning models of fear: PTSD symptoms are maintained by the avoidance of trauma-related stimuli and memories, which prevents the natural extinction of conditioned fear responses and the processing of the traumatic memory. Repeated exposure to the traumatic memory and its associated conditioned stimuli, within a safe therapeutic context, allows the gradual extinction of fear responses and the modification of the cognitive meanings associated with the trauma. PE has an extensive evidence base across multiple randomized controlled trials, with effect sizes among the largest documented for any psychotherapy for PTSD.</p>\n<h3>Phase-Based Treatment</h3>\n<p>Phase-based treatment — the organization of trauma therapy into sequential phases of stabilization, trauma processing, and integration — is the standard of care for complex trauma presentations and is particularly important for sexual trauma survivors with childhood onset abuse, severe dissociation, significant affect dysregulation, or significant personality disruption. The rationale for phase-based treatment is grounded in the neurobiological understanding of trauma: trauma processing inherently requires the capacity for affect regulation that may be insufficiently developed in clients with early-onset complex trauma, and initiating exposure-based trauma processing before adequate regulatory capacity has been established risks retraumatization and clinical deterioration rather than therapeutic progress.</p>\n<p>The three phases proceed as follows:</p>\n<ol>\n<li><strong>Stabilization</strong> — builds the affect regulation, distress tolerance, and therapeutic alliance that are prerequisites for safe trauma processing</li>\n<li><strong>Trauma processing</strong> — applies evidence-based interventions to the traumatic memories themselves</li>\n<li><strong>Integration</strong> — consolidates gains, supports meaning-making, and prepares for the conclusion of formal treatment</li>\n</ol>\n<p>The duration and content of each phase are individualized based on the specific clinical presentation and progress.</p>\n<h3>Treatment Selection</h3>\n<p>Treatment selection among the available evidence-based trauma approaches requires clinical judgment informed by the client's specific presentation, preferences, and goals. TF-CBT is the clear treatment of choice for child and adolescent sexual abuse survivors; EMDR, CPT, and PE have relatively comparable evidence bases for adult PTSD with some differential characteristics in terms of their specific mechanisms and populations of strongest evidence.</p>\n<p>Client preferences and tolerability are clinically relevant considerations: some clients find the direct engagement with traumatic memory that PE requires more challenging than the cognitive focus of CPT; others find EMDR's non-verbal, somatic engagement more accessible than the structured cognitive worksheets of CPT. Practical considerations including the clinician's specific training and certification, the client's preferences and prior treatment history, and the availability of specific treatments in the clinical setting each appropriately influence treatment selection. What should not influence treatment selection is the clinician's unfamiliarity with available evidence-based approaches, which is a training gap rather than a clinically defensible treatment selection rationale.</p>\n<h3>Clinician Self-Care and Secondary Traumatic Stress</h3>\n<p>Self-care and the prevention of secondary traumatic stress are professional obligations for all clinicians providing trauma treatment, and they are obligations that are frequently neglected in the daily pressures of clinical practice. Secondary traumatic stress — the indirect trauma response that develops in clinicians through repeated exposure to clients' traumatic material — produces a symptom profile that closely parallels PTSD: intrusive imagery from clients' trauma disclosures, hyperarousal, emotional numbing, avoidance of trauma-related content, and disruptions in the clinician's own sense of safety and meaning.</p>\n<p>For clinicians working in sexual trauma specializations, the sustained intensity of the clinical material creates genuine occupational risk that requires proactive, systematic management. The essential components of an effective secondary trauma prevention plan include:</p>\n<ul>\n<li>Regular clinical supervision that explicitly addresses the emotional impact of trauma work</li>\n<li>Peer consultation with colleagues who understand the specific demands of sexual trauma treatment</li>\n<li>Personal therapy when the burden of secondary exposure warrants it</li>\n<li>Deliberate cultivation of non-clinical sources of meaning and replenishment</li>\n</ul>",
+          "order": 6
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Sarah, 29, presents for relationship problems. In session three she discloses childhood sexual abuse by her stepfather ages 8–14, never previously disclosed. Clinical response: visible calm, explicit validation, non-blame statement, normalization of delayed disclosure, transparent mandatory reporting explanation, PCL-5 baseline, phase-based treatment plan, trauma specialist referral.</blockquote>",
+          "order": 7
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 1: foundations, neurobiology, and clinical assessment, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 24
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Tonic immobility during sexual assault:",
+          "options": [
+            {
+              "text": "Is voluntary and reflects lack of resistance",
+              "isCorrect": false
+            },
+            {
+              "text": "Is an involuntary neurobiological freeze response occurring in ~70% of survivors",
+              "isCorrect": true
+            },
+            {
+              "text": "Indicates prior trauma history",
+              "isCorrect": false
+            },
+            {
+              "text": "Is associated with lower PTSD severity",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Tonic immobility is an involuntary neurobiological response to overwhelming threat. Möller et al. (2017) documented it in ~70% of rape survivors. Psychoeducation about this response is among the most powerful shame-reduction interventions.",
+          "showExplanation": true,
+          "order": 9
+        },
+        {
+          "order": 10,
+          "type": "fillInBlank",
+          "title": "Quick check — arousal regulation",
+          "blanks": [
+            {
+              "prompt": "The zone of arousal in which a person can process experience without becoming overwhelmed or shut down:",
+              "answer": "window of tolerance",
+              "acceptAlternates": [
+                "window-of-tolerance"
+              ]
+            },
+            {
+              "prompt": "Arousal above that window (panic, flooding) is called:",
+              "answer": "hyperarousal",
+              "acceptAlternates": [
+                "hyper-arousal"
+              ]
+            }
+          ]
+        },
+        {
+          "order": 11,
+          "type": "sequencing",
+          "instructions": "Order the phases of phase-based trauma treatment.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Safety and stabilization (skills, regulation, establishing safety)"
+            },
+            {
+              "order": 2,
+              "text": "Processing the traumatic memories"
+            },
+            {
+              "order": 3,
+              "text": "Integration and reconnection (meaning, relationships, moving forward)"
+            }
+          ],
+          "explanation": "Phase-based treatment establishes safety and stabilization before processing trauma, then supports integration — processing too early, before stabilization, risks destabilizing the survivor."
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Acute Aftermath and Sexual Assault Aftercare</h2>\n<p>Clinicians frequently encounter survivors in the acute aftermath of a sexual assault, and understanding the acute-care landscape allows the clinician to respond helpfully and to connect survivors with appropriate resources.</p>\n<h3>Immediate Medical and Forensic Care</h3>\n<p>In the hours and days after an assault, survivors may benefit from specialized medical care, including evaluation and treatment for injury, prophylaxis against sexually transmitted infection, emergency contraception, and — if the survivor chooses — forensic evidence collection conducted by a Sexual Assault Nurse Examiner ({{callout:sane}}) or equivalent specially trained provider. Crucially, decisions about medical care, evidence collection, and reporting belong to the survivor; the restoration of choice and control begins immediately, and pressuring a survivor toward any particular decision replicates the dynamics of the assault.</p>\n<h3>The Clinician's Role Acutely</h3>\n<p>Acutely, the mental health clinician prioritizes safety, stabilization, and the provision of accurate information about options and resources rather than trauma processing, which is not appropriate in the immediate aftermath. Normalizing the wide range of acute responses — including numbness, calm, agitation, and the absence of an expected emotional reaction — relieves survivors who fear their response is \"wrong.\" Connecting the survivor with advocacy services, which can accompany and support them through medical, legal, and practical systems, is often among the most valuable things a clinician can do at this stage.</p>",
+          "order": 12,
+          "callouts": {
+            "sane": {
+              "label": "SANE",
+              "type": "reference",
+              "body": "Sexual Assault Nurse Examiner — a specially trained clinician who provides forensic and medical care after sexual assault."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Trauma and Memory: Clinical and Forensic Considerations</h2>\n<p>The way traumatic events are encoded and remembered has important clinical and forensic implications, and clinicians benefit from an accurate understanding that avoids both dismissing and over-claiming.</p>\n<h3>How Traumatic Memory Differs</h3>\n<p>As described in the neurobiology section, the conditions of extreme stress affect how memory is encoded. Traumatic memories are frequently fragmented, sensory, and non-linear rather than organized and narrative, and survivors may recall vivid sensory details while being unable to sequence events or recall others. Gaps, inconsistencies, and difficulty providing a coherent timeline are characteristic features of traumatic memory, not evidence of fabrication — a fact of particular importance because survivors are so often disbelieved on exactly these grounds.</p>\n<h3>Delayed Recall and Forensic Caution</h3>\n<p>Memory for trauma may also surface or become more accessible over time. Clinicians should hold this with care: they neither dismiss survivors' memories nor actively work to \"recover\" memories through suggestive techniques, which can distort memory and cause harm. The clinician's role is to support the survivor's processing and healing, not to serve as a forensic investigator; when legal matters are involved, the clinician maintains appropriate boundaries, documents carefully and factually, and avoids any practice that could be construed as implanting or shaping memory. This balanced stance — believing and supporting survivors while avoiding suggestive techniques — protects both the survivor and the integrity of the clinical work.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Spectrum of Traumatic Stress Responses</h2>\n<p>Not every survivor of sexual trauma develops PTSD, and the range of possible responses is wide. Understanding this spectrum prevents the clinician from pathologizing normal responses or missing significant ones.</p>\n<h3>Acute Stress and the Trajectory of Recovery</h3>\n<p>In the initial weeks after a trauma, many survivors experience significant distress — intrusion, hyperarousal, avoidance, dissociation — that for a substantial proportion diminishes over time as natural recovery proceeds. When these symptoms are severe in the first month, the presentation may meet criteria for acute stress disorder. Persistence beyond a month, with the characteristic symptom clusters, defines PTSD. Recognizing that considerable early distress is common and frequently self-limiting helps the clinician avoid over-pathologizing while remaining alert to those whose symptoms persist or worsen.</p>\n<h3>Delayed, Absent, and Variable Presentations</h3>\n<p>PTSD may also have delayed onset, emerging months or years after the trauma, sometimes triggered by a later event, life transition, or reminder. Some survivors show few classic PTSD symptoms but significant difficulties in other domains — depression, substance use, relational or sexual difficulties, or the broader disturbances of complex trauma. The clinical lesson is to assess broadly rather than screening only for classic PTSD, and to remain open to trauma's role in presentations that do not announce themselves as trauma-related.</p>",
+          "order": 14
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Fragmented, non-linear, sensory traumatic memories with gaps and inconsistencies are best understood as:",
+          "options": [
+            {
+              "text": "Strong evidence that the account is fabricated",
+              "isCorrect": false
+            },
+            {
+              "text": "Characteristic features of how traumatic memory is encoded, not evidence of fabrication",
+              "isCorrect": true
+            },
+            {
+              "text": "A sign the survivor has a separate memory disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "Always indicative of dissociative identity disorder",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Fragmentation, sensory vividness, and inconsistency are characteristic of traumatic memory encoding under extreme stress — not evidence of fabrication, a distinction crucial because survivors are so often disbelieved on these grounds.",
+          "showExplanation": true,
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Universal, Trauma-Informed Screening</h2>\n<p>Because sexual trauma is common, frequently undisclosed, and relevant across nearly every presenting concern, a trauma-informed approach favors routine, sensitive screening rather than waiting for spontaneous disclosure or asking only when trauma is suspected.</p>\n<h3>Asking Routinely and Safely</h3>\n<p>Universal screening means asking about trauma history as a normal part of assessment, framed in a way that gives the client full control over what and whether to disclose, explaining why the question is asked, and signaling that the client may decline. Routine asking communicates that the topic is welcome and that disclosure will be met with care rather than alarm. It also catches the many survivors who would never volunteer their history but will respond to a gentle, normalized inquiry. Screening is not interrogation: the goal is to open a door, not to extract a detailed account, and the clinician follows the client's lead on pace and depth.</p>\n<h3>Responding to What Screening Reveals</h3>\n<p>How the clinician responds to disclosure determines whether screening helps or harms. A calm, believing, non-intrusive response that validates the disclosure, attends to the client's immediate state, and does not press for unnecessary detail makes screening safe. The clinician then collaboratively determines next steps. Screening without the capacity to respond supportively is worse than not screening at all, which is why trauma-informed screening and trauma-informed responding are inseparable.</p>",
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>System-Induced Re-Traumatization</h2>\n<p>Survivors are frequently re-traumatized not only by reminders of the original event but by the very systems meant to help them — a phenomenon trauma-informed care exists in part to prevent.</p>\n<h3>How Systems Re-Traumatize</h3>\n<p>Medical, legal, social-service, and even mental health systems can replicate the dynamics of the original trauma: stripping survivors of choice and control, requiring repeated retelling to different officials, responding with disbelief or blame, conducting necessary procedures without consent or explanation, and prioritizing institutional needs over the survivor's wellbeing. Each of these echoes the powerlessness and violation of the trauma itself, deepening harm at the moment the survivor sought help.</p>\n<h3>Preventing It</h3>\n<p>Trauma-informed practice prevents system-induced re-traumatization by consistently restoring choice and control, minimizing unnecessary retelling, explaining procedures and seeking consent, responding with belief and respect, and organizing services around the survivor's needs. Clinicians can also advocate within and across systems for trauma-informed practices, recognizing that the survivor's experience of help-seeking is shaped by every point of contact, not only the therapy room.</p>",
+          "order": 17
+        },
+        {
+          "order": 18,
+          "type": "multiSelect",
+          "question": "Why is trauma-informed universal screening considered inseparable from trauma-informed care? (Select all that apply)",
+          "options": [
+            {
+              "text": "Trauma is common and frequently undisclosed without asking",
+              "isCorrect": true
+            },
+            {
+              "text": "Undetected trauma shapes presentations that are otherwise misunderstood",
+              "isCorrect": true
+            },
+            {
+              "text": "Screening, done sensitively, communicates that the topic is safe to raise",
+              "isCorrect": true
+            },
+            {
+              "text": "Screening should be reserved only for clients who look traumatized",
+              "isCorrect": false
+            },
+            {
+              "text": "Identification allows trauma to be addressed rather than missed",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Because trauma is common and frequently undisclosed, sensitive universal screening surfaces what would otherwise be missed and signals that the topic is safe — making it integral to trauma-informed care."
+        },
+        {
+          "type": "text",
+          "content": "<h2>The First Sessions: Engagement and Safety</h2>\n<p>The opening sessions of trauma treatment set the foundation for everything that follows, and their primary aims are engagement, safety, and the beginning of the therapeutic alliance rather than any rush toward trauma content.</p>\n<h3>Establishing the Frame</h3>\n<p>Early sessions establish how treatment will work, what the survivor can expect, and that the survivor remains in control of the pace and the process. The clinician explains the phase-based approach, normalizes trauma responses, and makes explicit that the survivor will not be pushed to discuss the trauma before they are ready. This predictability and shared control directly counter the powerlessness of the trauma and begin to build the safety on which all later work depends. For survivors whose trust has been violated, the clinician's consistency, reliability, and respect for boundaries in these early sessions are themselves the intervention.</p>\n<h3>Beginning Assessment Within a Relationship</h3>\n<p>Assessment in trauma work is woven into a developing relationship rather than conducted as a detached intake. The clinician gathers what is needed to understand the survivor and plan treatment while attending continuously to the survivor's comfort and safety, following their lead on disclosure, and prioritizing the alliance over the completion of any checklist. A survivor who experiences the early sessions as safe, respectful, and collaborative is far more likely to engage in the difficult work ahead.</p>",
+          "order": 19
+        }
+      ]
+    },
+    {
+      "title": "Module 2: Evidence-Based Treatment and Special Populations",
+      "order": 2,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 2,
+          "title": "Module 2",
+          "subtitle": "Module 2: Evidence-Based Treatment and Special Populations",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>First-Line Evidence-Based Treatments: TF-CBT, EMDR, CPT, and Prolonged Exposure</h2>\n<p>Special populations within sexual trauma clinical practice require specific clinical knowledge, attitudinal preparation, and adapted intervention approaches that go beyond the general framework of trauma assessment and treatment. Four populations deserve dedicated clinical attention because of the systematic ways in which their experiences have been underrepresented in clinical research, undertreated in clinical services, and misunderstood in clinical training:</p>\n<ul>\n<li>Male survivors</li>\n<li>LGBTQ+ survivors</li>\n<li>BIPOC survivors</li>\n<li>Survivors of sex trafficking</li>\n</ul>\n<p>Each of these populations faces specific barriers to disclosure and help-seeking, presents with specific clinical features that may be misread without specialized knowledge, and benefits from clinical approaches that are explicitly tailored to their particular experiences and needs.</p>\n<h3>Male Survivors</h3>\n<p>Male survivors of sexual trauma carry a disproportionate burden of shame and isolation relative to female survivors because of the specific cultural messaging that defines masculinity in terms of invulnerability and sexual dominance. Cultural norms that equate male victimization with weakness or with evidence of homosexuality create profound barriers to male survivors' disclosure and help-seeking — barriers so powerful that many male survivors never disclose their trauma to any professional and do not identify as survivors at all.</p>\n<p>When male survivors do present in clinical settings, they frequently present with presentations that do not immediately signal sexual trauma: substance use disorders, anger management issues, depression with aggressive features, somatic symptoms, or sexual dysfunction may all be presentations through which untreated sexual trauma surfaces in male clients without explicit trauma disclosure. Clinicians who do not specifically inquire about sexual trauma history with male clients — operating on the implicit assumption that men are not sexual trauma survivors — will systematically miss this clinical history in a population where it is both significantly prevalent and significantly underrecognized.</p>\n<h3>Shame Dynamics in Male Sexual Trauma</h3>\n<p>The specific shame dynamics of male sexual trauma deserve dedicated clinical attention because of their role in maintaining trauma symptoms and preventing help-seeking. Male survivors frequently experience intense shame specifically about the physiological responses their bodies produced during the assault — including erection or ejaculation, which are involuntary physiological responses to physical stimulation that can occur regardless of consent or desire — and about tonic immobility or other freeze responses that prevented physical resistance.</p>\n<p>These physiological responses are profoundly misunderstood by male survivors as evidence of voluntary participation, sexual enjoyment, or personal failure, and this misunderstanding is a major mechanism maintaining shame, self-blame, and PTSD symptoms. Psychoeducation about the involuntary nature of these physiological responses — delivered with explicit acknowledgment of how confusing and shameful they can feel and with clear clinical communication that they reflect physiology, not consent — is one of the most therapeutically powerful brief interventions available in male sexual trauma clinical work.</p>\n<h3>LGBTQ+ Survivors</h3>\n<p>LGBTQ+ survivors of sexual trauma navigate the compounding of sexual trauma sequelae and minority stress in ways that create specific clinical presentations and specific barriers to care that require both trauma-informed and affirming clinical approaches simultaneously. Research documents elevated rates of sexual victimization among all LGBTQ+ subgroups compared to heterosexual cisgender counterparts, with particularly high rates among transgender women and bisexual individuals.</p>\n<p>LGBTQ+ survivors face specific barriers to trauma treatment including:</p>\n<ul>\n<li>Fear of encountering homophobia or transphobia in clinical settings</li>\n<li>Concerns about having their sexual orientation or gender identity pathologized in ways that conflate minority identity with sexual dysfunction</li>\n<li>The absence of affirming clinical environments where both dimensions of their experience can be safely addressed</li>\n</ul>\n<p>Effective trauma treatment for LGBTQ+ survivors integrates the clinical approaches described throughout this course within an explicitly affirming clinical framework that consistently validates the client's identity, assesses minority stress exposure as a distinct contributing factor, and attends to the ways in which LGBTQ+ identity, minority stress, and sexual trauma interact in this specific client's presentation.</p>",
+          "order": 1
+        },
+        {
+          "type": "text",
+          "content": "<h3>BIPOC Survivors</h3>\n<p>BIPOC survivors of sexual trauma carry the compounding burden of racial trauma and sexual trauma in ways that require a clinical framework sophisticated enough to hold both dimensions simultaneously. The historical legacy of racial violence and the specific sexualization of Black, Indigenous, and other people of color's bodies as elements of white supremacist systems creates a specific cultural and historical context for sexual trauma in BIPOC communities that is not adequately addressed by trauma frameworks derived from predominantly white research samples.</p>\n<p>American Indian and Alaska Native women experience sexual violence at rates substantially higher than any other racial group in the United States — a disparity that is inseparable from the history and ongoing consequences of colonization, including the specific sexual violence perpetrated in boarding schools and the ongoing structural conditions that create elevated vulnerability. Effective trauma treatment for BIPOC survivors requires clinicians who are trained in the intersectionality of racial and sexual trauma, who understand the specific historical and cultural contexts that shape trauma experience and healing in BIPOC communities, and who provide services in culturally accessible, affirming ways that do not require BIPOC clients to educate their clinicians about racism as a prerequisite for receiving competent trauma care.</p>\n<h3>Sex Trafficking Survivors</h3>\n<p>Survivors of sex trafficking present with clinical profiles of exceptional complexity that challenge clinicians who have not received specific training in trafficking survivor care. Common clinical features of trafficking survivor presentations include:</p>\n<ul>\n<li>Complex trauma histories beginning in childhood</li>\n<li>Profound attachment to traffickers organized through the neurobiological mechanism of trauma bonding</li>\n<li>Extensive comorbidity including substance use disorders and serious mental illness</li>\n<li>Involvement in criminal justice systems that may include charges related to survival activities</li>\n<li>Multiple unsuccessful attempts at exit from exploitative situations</li>\n<li>Profound shame and self-blame</li>\n</ul>\n<p>Trauma bonding — the intense emotional attachment that develops between trafficking survivors and their traffickers through the cyclical alternation of abuse and affection in the context of total dependency — is among the most clinically challenging features of these presentations because it produces ambivalence about exit that is frequently misread as preference or choice rather than as the psychological consequence of a specific form of coercive control. Clinicians who respond to trafficking survivors' ambivalence about leaving exploitative situations with judgment, pressure, or confusion about why they haven't simply left are demonstrating the absence of the specialized training that effective trafficking survivor care requires.</p>\n<h3>Clinical Response to Trafficking Survivors</h3>\n<p>The clinical response to sex trafficking survivors requires a trauma-informed, survivor-centered framework that prioritizes safety, does not require exit from trafficking situations as a precondition for service, and builds trust over time with a population that has extensive reasons to be skeptical of professional helpers. Safety planning for trafficking survivors must address the specific safety architecture of their situations — including the presence of traffickers, the economic dimensions of their dependency, the involvement of other victims, and the potential for retaliation.</p>\n<p>Harm reduction approaches — which meet the survivor where they are rather than requiring behavior change as a prerequisite for support — are the most clinically effective framework for engagement with trafficking survivors in the earlier stages of their relationship with services. The development of the therapeutic alliance in this population may require substantially more time and indirect engagement than in other trauma presentations, and clinicians who apply standard alliance-building assumptions to trafficking survivor presentations may misread appropriate wariness as resistance.</p>\n<h3>Cultural Humility as an Essential Clinical Stance</h3>\n<p>Cultural humility is the essential clinical stance throughout sexual trauma work with all special populations, requiring clinicians to approach each client's trauma experience with genuine curiosity about their specific cultural framework, to hold their own clinical assumptions about trauma, healing, and help-seeking with appropriate tentativeness, and to maintain ongoing self-reflection about the ways in which their cultural background — including their racial, gender, and class positioning — shapes their clinical responses.</p>\n<p>For many BIPOC survivors, LGBTQ+ survivors, male survivors, and trafficking survivors, the experience of being seen, believed, and treated with genuine care and without pathologizing assumptions is itself transformative — an experience that is not achievable through clinical technique alone but requires the kind of genuine humanity and committed professionalism that cultural humility, rather than cultural compliance, represents.</p>",
+          "order": 2
+        },
+        {
+          "type": "text",
+          "content": "<h2>Special Populations: Male Survivors, LGBTQ+, BIPOC, and Trafficking Survivors</h2>\n<h3>Trauma-Informed Assessment</h3>\n<p>Trauma-informed assessment is a clinical process that is simultaneously diagnostic, therapeutic, and relational — it gathers essential clinical information while simultaneously beginning the work of safety-building, shame reduction, and the establishment of the trust that effective trauma treatment requires. Effective trauma assessment attends to multiple clinical domains:</p>\n<ul>\n<li>Trauma exposure history</li>\n<li>The nature, severity, and chronicity of trauma symptoms</li>\n<li>The presence and degree of dissociation</li>\n<li>Functional impairment across domains of daily life</li>\n<li>The quality of current social support</li>\n<li>The client's prior treatment history and response</li>\n<li>The presence of co-occurring conditions including substance use, depression, anxiety, and personality disorder</li>\n<li>The client's own explanatory model for their experience, their goals for treatment, and their readiness to engage in specific clinical approaches</li>\n</ul>\n<h3>Validated Trauma Assessment Instruments</h3>\n<p>Validated trauma assessment instruments provide standardized, psychometrically robust data that complement clinical interview and behavioral observation in comprehensive trauma evaluation. Key instruments include:</p>\n<ul>\n<li><strong>PTSD Checklist for DSM-5 (PCL-5)</strong> — a 20-item self-report measure assessing symptom severity across the four DSM-5 PTSD symptom clusters: intrusion, avoidance, negative alterations in cognitions and mood, and alterations in arousal and reactivity. Validated for use across diverse trauma populations including sexual trauma survivors.</li>\n<li><strong>Life Events Checklist for DSM-5 (LEC-5)</strong> — provides standardized assessment of trauma exposure history across 17 categories of potentially traumatic events, commonly used in conjunction with the PCL-5.</li>\n<li><strong>Dissociative Experiences Scale (DES)</strong> — provides validated screening for dissociation severity.</li>\n<li><strong>Clinician-Administered PTSD Scale (CAPS-5)</strong> — the gold-standard structured diagnostic interview for PTSD diagnosis when precise diagnostic determination is clinically required.</li>\n</ul>\n<p>The PCL-5 can be scored as a continuous severity measure for tracking treatment progress or interpreted using a pattern-of-symptom approach for provisional PTSD diagnosis.</p>\n<h3>The Structured Clinical Interview</h3>\n<p>The structured clinical interview for sexual trauma — encompassing a systematic inquiry into trauma history, trauma symptomatology, and the impact of trauma across domains of functioning — requires specific training and careful attention to the clinical conditions necessary for effective and ethical trauma disclosure. The interview should be:</p>\n<ul>\n<li>Prefaced with explicit explanation of the purpose, process, and limits of confidentiality</li>\n<li>Conducted in a private, comfortable space that communicates safety and respect</li>\n<li>Paced in response to the client's emotional state and window of tolerance</li>\n<li>Conducted with open-ended, non-leading questions that invite the client's narrative rather than imposing clinical framing</li>\n<li>Completed across multiple sessions for complex presentations rather than compressed into a single intake session</li>\n</ul>\n<p>The clinician's non-verbal communication throughout the interview — visible calm, genuine attunement, absence of distress or shock responses to traumatic content — is at least as clinically significant as the specific words used, communicating the essential message that this content is receivable and that the clinician is present and capable.</p>\n<h3>Assessing Tonic Immobility</h3>\n<p>The assessment of tonic immobility specifically deserves direct clinical attention in sexual trauma evaluation because of its high prevalence, its clinical significance for shame and PTSD severity, and the rarity with which it is addressed in clinical training. A direct, psychoeducationally framed inquiry — introducing the neurobiological concept of tonic immobility before asking about it, to provide the explanatory context that makes the question sensible — both gathers important clinical information and begins the therapeutic work of shame reduction.</p>\n<p>A question such as: 'Research shows that many people who experience sexual assault find that their body becomes frozen or paralyzed during the assault — not because they chose not to resist but because of a normal neurobiological response. Is that something that happened for you?' provides the biological framework before the inquiry and reduces the likelihood that the client will interpret the question as suggesting that their freeze response was a choice.</p>",
+          "order": 3
+        },
+        {
+          "type": "text",
+          "content": "<h3>Co-Occurring Conditions</h3>\n<p>Co-occurring conditions are the rule rather than the exception in sexual trauma clinical presentations, and comprehensive trauma assessment must include systematic screening for the most common comorbidities. Depression is present in approximately 50% of PTSD presentations and the bidirectional relationship between PTSD and depression — each worsening the other, each maintaining the other through shared mechanisms including avoidance, anhedonia, and social withdrawal — makes coordinated treatment of both conditions more effective than treatment of either in isolation.</p>\n<p>Substance use disorders are present in approximately 30-50% of PTSD presentations in clinical samples, often reflecting the use of substances as self-medication for hyperarousal, intrusion symptoms, and emotional pain. Assessment should include specific inquiry about the temporal relationship between substance use and trauma — whether substance use increased following the trauma and is understood by the client in relation to their trauma symptoms — which has direct implications for treatment sequencing and integration.</p>\n<h3>Safety Assessment</h3>\n<p>Safety assessment in sexual trauma clinical work includes attention to suicidality, self-harm, and ongoing interpersonal safety concerns that may be directly related to the trauma history. Sexual trauma is associated with significantly elevated suicide risk — particularly in presentations involving childhood sexual abuse, complex PTSD, and significant comorbidities — and systematic assessment of suicidality should be a component of every trauma evaluation.</p>\n<p>Self-harm — including non-suicidal self-injury — is particularly prevalent among survivors of childhood sexual abuse and may serve as:</p>\n<ul>\n<li>An affect regulation strategy</li>\n<li>A form of self-punishment related to shame and self-blame</li>\n<li>A way of making internal distress externally visible</li>\n</ul>\n<p>For survivors whose trauma occurred within a current relationship — particularly intimate partner sexual violence — ongoing safety assessment is essential and may require clinical responses including safety planning, referral to domestic violence resources, and mandatory reporting when children are involved in the household.</p>\n<h3>Functional Assessment</h3>\n<p>Functional assessment across domains of daily life provides essential clinical information about the degree to which trauma symptoms are affecting the client's occupational functioning, relational functioning, parenting, physical health management, and quality of life. Trauma symptoms that are clinically present but not significantly impairing occupational and relational functioning may be approached differently than equivalent symptom severity that is producing significant functional disability.</p>\n<p>The degree of functional impairment also has clinical implications for treatment intensity: clients with significant occupational and relational impairment may benefit from more intensive treatment formats — including intensive outpatient programming, case management support, and coordination with vocational and social services — alongside standard outpatient psychotherapy.</p>\n<h3>Cultural and Contextual Factors</h3>\n<p>Cultural and contextual factors in trauma assessment include specific inquiry about the client's cultural framework for understanding their trauma experience and its aftermath, the availability of cultural and community resources relevant to their healing, and any cultural or religious considerations that may affect treatment planning or engagement.</p>\n<p>For clients from cultural backgrounds in which disclosure of sexual trauma carries specific stigma or shame consequences — including many immigrant and refugee communities, communities with restrictive religious norms around sexuality, and communities where family honor is bound to the sexual behavior of female members — the barriers to disclosure, the meaning of the trauma to the client, and the cultural resources for healing are shaped by a specific cultural context that requires genuine curiosity and humility from clinicians whose own cultural background may not provide access to this understanding.</p>",
+          "order": 4
+        },
+        {
+          "type": "text",
+          "content": "<h2>Long-Term Recovery, Meaning-Making, and Professional Sustainability</h2>\n<p>The recovery journey from sexual trauma is not a linear process with a defined endpoint but an ongoing developmental trajectory that unfolds across the lifespan, intersects with subsequent life events and relationships, and is shaped throughout by the twin forces of the trauma's genuine lasting effects and the human capacity for resilience and post-traumatic growth. Long-term clinical work with sexual trauma survivors must hold both dimensions in consistent view — acknowledging the real, lasting impact of traumatic experience without reinforcing a catastrophizing narrative that defines the survivor entirely by their trauma history and forecloses the possibility of genuine recovery.</p>\n<h3>Post-Traumatic Growth</h3>\n<p>Post-traumatic growth — the positive psychological changes that some survivors report as outcomes of their struggle with traumatic experience — is a clinical reality that deserves recognition and facilitation without becoming an expectation or a standard against which survivors who do not experience it are measured as falling short. Research by Tedeschi and Calhoun (1996) identified five domains in which post-traumatic growth is reported:</p>\n<ol>\n<li>Personal strength</li>\n<li>New possibilities</li>\n<li>Relating to others</li>\n<li>Appreciation for life</li>\n<li>Spiritual change</li>\n</ol>\n<p>For some sexual trauma survivors, the recovery journey produces genuine and lasting transformations in these domains — a deepened capacity for empathy, a clearer sense of personal values and priorities, stronger and more authentic intimate relationships, and a spiritual or existential framework that incorporates the trauma experience without being defined by it. These outcomes are not guarantees, and they should not be presented to survivors as the expected trajectory of recovery. They are genuine possibilities that clinicians can facilitate through meaning-making work, narrative integration, and the consistent communication that the survivor's identity is larger than their trauma.</p>\n<h3>The Role of Social Support</h3>\n<p>The role of social support in long-term trauma recovery is consistently documented as one of the most powerful predictors of recovery outcomes, and its cultivation is therefore a central component of effective trauma treatment. Social support encompasses the availability of trusting relationships in which the survivor can be genuine about their experience and needs; the quality of intimate partnerships; the presence of chosen family and community connections; and access to communities of survivors whose shared experience provides the unique form of support that comes from being understood by those who have had similar experiences.</p>\n<p>Survivor support groups — including both peer-facilitated and clinician-facilitated formats — provide a specific form of social support that can reduce the isolation of trauma experience, normalize recovery processes, and offer practical wisdom from others at various stages of the recovery journey.</p>\n<h3>Sexual Trauma and Intimate Partnerships</h3>\n<p>The relationship between sexual trauma and intimate partnership presents specific clinical challenges that extend throughout the treatment process. Trauma symptoms affect intimate relationships through multiple pathways:</p>\n<ul>\n<li>Avoidance of intimacy and physical contact</li>\n<li>Intrusive imagery and dissociation during sexual activity</li>\n<li>Hypervigilance that is triggered by partner behavior</li>\n<li>Anger and irritability that strain relational closeness</li>\n<li>Emotional numbing that impairs the affective engagement that intimate relationships require</li>\n<li>The specific impact of sexual health sequelae on the couple's sexual relationship</li>\n</ul>\n<p>Partners of sexual trauma survivors face their own clinical needs — including the management of their responses to their partner's symptoms, the grief of relational limitations created by trauma, and the challenge of providing support while managing their own emotional responses. Couples therapy that integrates trauma-informed principles provides specific value for survivors in partnerships whose relationships have been significantly affected by trauma symptoms.</p>",
+          "order": 5
+        },
+        {
+          "type": "text",
+          "content": "<h3>Termination of Trauma Treatment</h3>\n<p>Termination of trauma treatment requires specific clinical attention for sexual trauma survivors because the ending of a significant therapeutic relationship reactivates attachment-related concerns that may be directly connected to the trauma history. Many sexual trauma survivors have experienced significant relationship losses through betrayal, abandonment, or the disruption of attachment by the abuser's behavior — losses that leave them with specific vulnerabilities to the experience of therapeutic termination.</p>\n<p>Well-conducted termination involves:</p>\n<ul>\n<li>Sufficient advance planning — typically several weeks to months for long-term treatment relationships</li>\n<li>Explicit processing of the client's feelings about ending, including any attachment-related anxiety</li>\n<li>Consolidation of gains and the client's own understanding of their recovery trajectory</li>\n<li>Explicit communication about the availability of booster sessions or return to treatment when life events reactivate trauma-related distress</li>\n<li>Recognition of the significance of the therapeutic relationship without encouraging dependency</li>\n</ul>\n<h3>Advocacy as Professional Obligation</h3>\n<p>Advocacy — both clinical advocacy on behalf of individual clients navigating systems that may be insensitive to their trauma history, and systemic advocacy for improved policies, training standards, and services for sexual trauma survivors — is an extension of the clinician's professional ethical obligations that is particularly relevant in sexual trauma practice.</p>\n<p>Individual clinical advocacy might include accompanying or preparing a client for a difficult conversation with law enforcement, a medical provider, or an insurance company; advocating within a client's school or workplace system for accommodations related to trauma-related functional impairment; or facilitating access to legal support for a client navigating a civil or criminal case related to their victimization. Systemic advocacy includes participation in professional organizations that advance trauma-informed care standards, advocacy for LGBTQ+ and BIPOC survivor-specific services, and engagement with community and policy-level efforts to address the systemic conditions that produce elevated rates of sexual violence.</p>\n<h3>Course Competencies Summary</h3>\n<p>The completion of this course provides a foundational clinical framework for assessment and treatment of sexual trauma that equips clinicians to provide significantly better care to the sexual trauma survivors in their caseloads. The specific competencies developed here include:</p>\n<ul>\n<li>Neurobiological literacy</li>\n<li>Validated assessment tools</li>\n<li>Evidence-based treatment selection</li>\n<li>Special population clinical knowledge</li>\n<li>Trauma-informed practice principles</li>\n</ul>\n<p>These are professional tools that directly serve the recovery of the individuals who come seeking clinical help following experiences that have profoundly disrupted their lives. The investment in this training is ultimately an investment in those individuals and in the quality of care they will receive from clinicians who are genuinely prepared to meet them with skill, knowledge, and the sustained human commitment that effective trauma care requires.</p>",
+          "order": 6
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>James, 35, referred for depression and alcohol use. In session six he discloses assault by a coach at age 12. Clinical response: normalize male victimization, tonic immobility psychoeducation, integrated trauma formulation, PCL-5 baseline, phase-based plan, EMDR or CPT referral, couples work once stabilized.</blockquote>",
+          "order": 7
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 2: evidence-based treatment and special populations, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 28
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Male sexual trauma survivors most commonly present with:",
+          "options": [
+            {
+              "text": "Explicit trauma disclosure with overt distress",
+              "isCorrect": false
+            },
+            {
+              "text": "Obscuring presentations including substance use, anger, and somatic symptoms",
+              "isCorrect": true
+            },
+            {
+              "text": "Sexual dysfunction as the primary presenting concern",
+              "isCorrect": false
+            },
+            {
+              "text": "Avoidance of all clinical settings",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Cultural messages defining masculinity as incompatible with victimization create powerful barriers to male survivor disclosure, producing presentations that don't immediately signal trauma history.",
+          "showExplanation": true,
+          "order": 9
+        },
+        {
+          "order": 10,
+          "type": "matching",
+          "matchingInstructions": "Match each clinician-impact concept to its definition.",
+          "matchingPairs": [
+            {
+              "term": "Secondary traumatic stress",
+              "definition": "Trauma-like symptoms developed from exposure to clients’ trauma material"
+            },
+            {
+              "term": "Vicarious traumatization",
+              "definition": "Cumulative transformation of the clinician’s own beliefs about safety and trust"
+            },
+            {
+              "term": "Burnout",
+              "definition": "Emotional exhaustion and depletion from the demands of the work"
+            },
+            {
+              "term": "Compassion fatigue",
+              "definition": "Reduced capacity for empathy from the cost of caring over time"
+            }
+          ]
+        },
+        {
+          "order": 11,
+          "type": "matching",
+          "matchingInstructions": "Match each evidence-based trauma treatment to its primary mechanism.",
+          "matchingPairs": [
+            {
+              "term": "CPT",
+              "definition": "Identifying and modifying trauma-related “stuck points” in thinking"
+            },
+            {
+              "term": "Prolonged Exposure",
+              "definition": "Imaginal and in-vivo exposure to reduce avoidance and cue power"
+            },
+            {
+              "term": "EMDR",
+              "definition": "Processing traumatic memories with bilateral stimulation"
+            },
+            {
+              "term": "TF-CBT",
+              "definition": "Phased integration of skills, gradual exposure, and cognitive processing"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>Survivors With Disabilities</h2>\n<p>People with disabilities, including intellectual and developmental disabilities, experience sexual violence at substantially higher rates than the general population, yet face significant barriers to disclosure, services, and justice. This population is too often overlooked in trauma services.</p>\n<h3>Elevated Risk and Barriers</h3>\n<p>The elevated risk arises from multiple sources: dependence on caregivers (who are sometimes the perpetrators), social isolation, communication barriers, the assumption that people with disabilities are not sexual and therefore not at risk, and a history of having their reports disbelieved or dismissed. Survivors with disabilities may face inaccessible services, clinicians untrained in adapting care, and systems that doubt their capacity to report accurately.</p>\n<h3>Adapting Care</h3>\n<p>Competent care requires adapting communication and treatment to the individual's needs and abilities without condescension, presuming competence, ensuring accessibility, and attending to the specific dynamics of abuse within caregiving relationships. For survivors with intellectual or developmental disabilities, this includes using accessible language and materials, allowing additional time, involving trusted supports appropriately while protecting the survivor's autonomy, and addressing the heightened safety considerations that dependence can create. The same trauma-informed principles apply; their implementation is individualized.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Older Adult Survivors and Late Disclosure</h2>\n<p>Sexual trauma among older adults takes two distinct forms, both frequently neglected: trauma experienced earlier in life that is disclosed or resurfaces in later life, and abuse occurring in old age, including within caregiving and institutional settings.</p>\n<h3>Late Disclosure of Earlier Trauma</h3>\n<p>Many older adults carry decades-old sexual trauma never previously disclosed, having come of age in eras of even greater silence and stigma. Such trauma may resurface with the losses, reflection, and life review of aging, with retirement or bereavement, or with medical experiences that evoke earlier violations. A survivor disclosing for the first time in later life deserves the same belief, validation, and care as any survivor, along with recognition of the particular weight of having carried the trauma silently for so long.</p>\n<h3>Abuse in Later Life</h3>\n<p>Older adults are also subject to sexual abuse occurring in old age, including in the context of caregiving dependence, cognitive impairment, and residential and institutional care — settings where power imbalances, isolation, and assumptions that older adults are not sexual or not credible create risk and impede detection. Clinicians should be alert to this possibility, attend to safety, and understand the relevant adult-protective and reporting obligations in their jurisdiction.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>Military and Institutional Sexual Trauma</h2>\n<p>Sexual trauma occurring within institutions carries distinctive dynamics, captured in part by the concept of institutional betrayal — the additional harm done when an institution a person depends on and trusts fails to prevent, or responds inadequately to, their victimization.</p>\n<h3>Military Sexual Trauma</h3>\n<p>Military sexual trauma (MST) refers to sexual assault or persistent sexual harassment experienced during military service. Its dynamics are shaped by the military context: survivors frequently continue to live and work alongside perpetrators, depend on the chain of command (which may include the perpetrator) for reporting and protection, and risk career consequences for disclosing. These features intensify the trauma and complicate recovery, and MST is associated with significant mental health sequelae. Clinicians working with veterans should screen for MST regardless of gender, recognizing that male survivors of MST are numerous and frequently overlooked.</p>\n<h3>Institutional Betrayal More Broadly</h3>\n<p>The same dynamics appear in other institutional contexts — schools, religious organizations, workplaces, residential facilities — where survivors depended on and trusted an institution that failed them. Institutional betrayal compounds the original trauma, deepening difficulties with trust and adding a layer of injury that treatment must address. Recognizing and naming institutional betrayal can itself be validating for survivors who have struggled to articulate why the institutional response wounded them so deeply.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Somatic and Body-Based Approaches</h2>\n<p>Because sexual trauma is so profoundly a bodily experience, body-based and somatic approaches have an important place in trauma treatment, frequently as complements to the established evidence-based protocols.</p>\n<h3>The Rationale</h3>\n<p>Trauma lives in the body as well as the mind: survivors carry trauma in patterns of tension, in dysregulated arousal, in numbness and disconnection from bodily sensation, and in the dissociation that severs awareness from the body. Approaches that work directly with the body — attending to sensation, to the regulation of the nervous system, and to the gradual restoration of a tolerable relationship with bodily experience — address dimensions of sexual trauma that purely verbal or cognitive approaches may not reach.</p>\n<h3>Application and Cautions</h3>\n<p>Somatic approaches such as those emphasizing bottom-up regulation of the nervous system and gradual, titrated attention to bodily experience can help survivors rebuild a sense of safety in their own bodies — a particularly relevant goal given how sexual trauma disrupts the body relationship. These approaches require specific training, and they must be applied with the same attention to the window of tolerance, pacing, and choice that governs all trauma work; working with the body can be powerful but can also evoke intense activation, so competence and careful pacing are essential. Clinicians lacking this training can still attend to the body's role and can refer to or collaborate with appropriately trained providers.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Group and Peer Support in Trauma Recovery</h2>\n<p>While individual therapy is the most common format for trauma treatment, group modalities and peer support offer distinctive benefits, particularly for the isolation and shame that characterize sexual trauma.</p>\n<h3>What Groups Offer</h3>\n<p>Sexual trauma is profoundly isolating, and the shame survivors carry thrives in secrecy and in the belief that they are uniquely damaged or alone. Group treatment and peer support directly counter this: the experience of being among others who understand, of witnessing others' recovery, and of being believed and accepted by peers can reduce shame and isolation in ways individual therapy alone cannot. Groups can also provide a setting for practicing trust, connection, and the relational skills that trauma has disrupted.</p>\n<h3>Considerations</h3>\n<p>Group work for sexual trauma requires skilled facilitation, careful attention to safety and to the risk of vicarious activation among members, thoughtful screening and timing (survivors generally need sufficient stabilization before group trauma work), and clarity about the group's purpose, whether primarily support, skills-building, or processing. Well-run groups, appropriately timed within a survivor's recovery, are a valuable complement to individual care; poorly timed or poorly facilitated groups can overwhelm members, so the format and timing are matched to the survivor's readiness.</p>",
+          "order": 16
+        },
+        {
+          "type": "multipleChoice",
+          "question": "The concept of \"institutional betrayal\" refers to:",
+          "options": [
+            {
+              "text": "A survivor betraying an institution",
+              "isCorrect": false
+            },
+            {
+              "text": "The additional harm when a trusted, depended-upon institution fails to prevent or adequately respond to victimization",
+              "isCorrect": true
+            },
+            {
+              "text": "A treatment technique for PTSD",
+              "isCorrect": false
+            },
+            {
+              "text": "The legal process of reporting abuse",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Institutional betrayal is the compounding harm done when an institution a person depends on and trusts fails them, deepening difficulties with trust and adding a layer of injury treatment must address.",
+          "showExplanation": true,
+          "order": 17
+        },
+        {
+          "order": 18,
+          "type": "multiSelect",
+          "question": "Which considerations apply when working with sexual-trauma survivors who have intellectual or developmental disabilities? (Select all that apply)",
+          "options": [
+            {
+              "text": "They experience sexual victimization at substantially elevated rates",
+              "isCorrect": true
+            },
+            {
+              "text": "Communication and consent supports must be adapted to the individual",
+              "isCorrect": true
+            },
+            {
+              "text": "Their reports should be presumed unreliable",
+              "isCorrect": false
+            },
+            {
+              "text": "Treatment can be adapted rather than withheld",
+              "isCorrect": true
+            },
+            {
+              "text": "Dependence on caregivers can complicate safety and disclosure",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Survivors with IDD face elevated victimization and deserve adapted communication, consent supports, and adapted (not withheld) treatment; presuming unreliability compounds the harm."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Telehealth Delivery of Trauma Treatment</h2>\n<p>Trauma treatment is increasingly delivered via telehealth, which expands access for survivors who face barriers to in-person care but introduces specific considerations the clinician must manage.</p>\n<h3>Opportunities</h3>\n<p>For many survivors, telehealth lowers barriers: it removes travel, allows participation from a chosen safe space, and can make care accessible to those in underserved areas or with mobility, disability, or scheduling constraints. Some survivors feel safer engaging difficult material from their own environment.</p>\n<h3>Considerations and Safeguards</h3>\n<p>Telehealth trauma work requires particular attention to privacy and safety. The clinician confirms the survivor is in a private space where they can speak freely and are not within earshot of an abuser, and establishes a safety plan for the remote context — including what to do if the survivor becomes highly activated or dissociated, how to reach emergency support, and the survivor's physical location at each session. The reduced access to nonverbal cues requires more deliberate checking-in, especially when approaching difficult material or watching for dissociation. The core principles of trauma treatment apply unchanged; their delivery is adapted, with safety and privacy receiving heightened attention.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documentation in Trauma Care</h2>\n<p>Documentation in sexual trauma cases carries particular weight because records may become relevant to legal proceedings, and because the way trauma is documented can either protect or expose the survivor.</p>\n<h3>Principles of Sound Documentation</h3>\n<p>Clinicians document factually and objectively, recording the clinical picture, assessment, treatment plan, and progress without editorializing and without recording unnecessary graphic detail of the trauma itself. The clinician distinguishes between the survivor's report (\"client reported...\") and clinical observation, avoids language that draws unwarranted conclusions about events the clinician did not witness, and refrains from forensic determinations that are outside the clinical role. Sound documentation supports good care, meets ethical and legal obligations, and protects the survivor's privacy and the integrity of any future legal process.</p>\n<h3>Balancing Competing Needs</h3>\n<p>Documentation must balance thoroughness with discretion: enough to support continuity and quality of care and to meet record-keeping obligations, but not so much detail that the record itself becomes a source of risk or re-exposure for the survivor. When records may be subpoenaed, awareness of this possibility informs — but does not distort — what is recorded. The guiding aim is an accurate, professional, respectful record that serves the survivor's care.</p>",
+          "order": 20
+        },
+        {
+          "type": "text",
+          "content": "<h2>Adolescent Survivors: Developmental and Family Considerations</h2>\n<p>Adolescent survivors of sexual trauma require approaches attuned to their developmental stage and to the family and systems around them, blending the considerations of work with minors with the specifics of trauma care.</p>\n<h3>Developmental Attunement</h3>\n<p>Adolescence is a period of identity formation, emerging sexuality, growing autonomy, and intense peer relationships, and sexual trauma intersects with all of these. Trauma can disrupt identity and sexual development, affect peer and romantic relationships, and interact with the normal upheavals of adolescence in ways that complicate both assessment and treatment. Evidence-based treatments such as TF-CBT have particularly strong support with this age group, and developmentally attuned care meets adolescents where they are rather than imposing adult frameworks.</p>\n<h3>Family and Confidentiality</h3>\n<p>Work with adolescent survivors involves the family and care systems, raising the confidentiality and mandated-reporting considerations addressed earlier. Caregivers are frequently essential allies in recovery, and engaging them supportively can be powerfully therapeutic; at the same time, the clinician protects the adolescent's appropriate confidentiality and remains alert to family dynamics, including the possibility of intrafamilial abuse or unsupportive responses to disclosure. Balancing family involvement with the adolescent's autonomy and safety is a central clinical task.</p>",
+          "order": 21
+        },
+        {
+          "type": "multipleChoice",
+          "question": "A key added safeguard when delivering trauma treatment via telehealth is to:",
+          "options": [
+            {
+              "text": "Avoid all difficult material permanently",
+              "isCorrect": false
+            },
+            {
+              "text": "Confirm the survivor is in a private space and establish a remote safety plan including location and emergency contacts",
+              "isCorrect": true
+            },
+            {
+              "text": "Assume nonverbal cues are unnecessary",
+              "isCorrect": false
+            },
+            {
+              "text": "Document less carefully than in person",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Telehealth requires confirming privacy (no abuser within earshot), establishing a remote safety plan, knowing the survivor’s location, and more deliberate checking-in for dissociation.",
+          "showExplanation": true,
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>Resilience and Protective Factors</h2>\n<p>Alongside the risks and difficulties that sexual trauma produces, the clinician attends to resilience — the survivor's strengths, resources, and capacities — because recovery builds on these, and because a deficit-only view distorts both assessment and treatment.</p>\n<h3>What Supports Recovery</h3>\n<p>Many factors support recovery from sexual trauma: supportive relationships and the experience of being believed, internal resources such as coping skills and a sense of agency, access to competent care, economic and practical stability, and the survivor's own strengths and meaning systems. Survivors are not defined by their trauma, and many demonstrate remarkable resilience even amid significant suffering. Identifying and building on existing strengths and resources is as much a part of treatment as addressing symptoms.</p>\n<h3>A Strengths-Informed Stance</h3>\n<p>A strengths-informed stance does not minimize the trauma or the survivor's pain; it holds both the injury and the survivor's capacities in view at once. This balanced perspective is more accurate than a purely pathology-focused one, and it is also more hopeful and empowering for the survivor, supporting the agency and self-efficacy that recovery requires.</p>",
+          "order": 23
+        }
+      ]
+    },
+    {
+      "title": "Module 3: Treatment in Depth, Sexual Recovery, and Clinical Sustainability",
+      "order": 2,
+      "estimatedTime": 25,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 3,
+          "title": "Module 3",
+          "subtitle": "Module 3: Treatment in Depth, Sexual Recovery, and Clinical Sustainability"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>The Phase-Based Model of Trauma Treatment</h2>\n<p>While the manualized evidence-based treatments are essential tools, contemporary trauma practice is most often organized around a phase-based framework, articulated influentially by Judith Herman, that sequences the work according to the survivor's readiness. Attempting to process traumatic memory before a survivor has the stability and skills to tolerate it is one of the most common and harmful errors in trauma treatment, and the phase-based model exists to prevent it.</p>\n<h3>Phase 1: Safety and Stabilization</h3>\n<p>The first phase establishes physical and psychological safety and builds the capacity to regulate overwhelming emotion before any direct trauma processing begins. This includes attending to the survivor's external safety (housing, ongoing danger, relationship safety), stabilizing co-occurring conditions and any self-harm or suicidality, and — centrally — teaching the affect-regulation and grounding skills that allow the survivor to stay within their window of tolerance. For many survivors, particularly those with complex or developmental trauma, this phase is lengthy and is itself profoundly therapeutic.</p>\n<h3>Phase 2: Remembrance and Mourning</h3>\n<p>The second phase involves the actual processing of traumatic memory — the work that the evidence-based protocols structure — along with the grief that accompanies confronting what was lost. This phase is entered only when the stabilization of Phase 1 is sufficient to tolerate it, and it moves at a pace the survivor can sustain.</p>\n<h3>Phase 3: Reconnection and Integration</h3>\n<p>The third phase involves reconnecting with life, relationships, identity, and — for sexual trauma survivors specifically — sexuality, integrating the trauma into a life narrative that is no longer organized around it. The phases are not strictly linear; survivors move between them, and stabilization skills remain relevant throughout. But the sequencing principle — safety before processing — is one of the most important in all of trauma practice.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Stabilization and Grounding Skills</h2>\n<p>Because the capacity to regulate overwhelming states is the foundation on which all trauma processing rests, building stabilization and grounding skills is a core competency, and one that even clinicians who refer out for formal trauma processing should possess.</p>\n<h3>Grounding for Dissociation and Hyperarousal</h3>\n<p>Grounding techniques help a survivor who is becoming overwhelmed, flooded, or dissociated return to the present moment and to a tolerable level of arousal. Sensory grounding (orienting to present sensory information — what one can see, hear, touch), breath-based techniques, and movement can interrupt escalating activation or the drift into dissociation. The clinician teaches these skills explicitly, practices them with the survivor when the survivor is calm, and uses them in session the moment signs of overwhelm or dissociation appear.</p>\n<h3>Affect Regulation and the Window of Tolerance</h3>\n<p>Beyond acute grounding, stabilization builds the survivor's broader capacity to identify, tolerate, and modulate emotion — to widen and stay within the window of tolerance introduced earlier. This includes psychoeducation that normalizes trauma responses (reducing the shame and fear that survivors often feel about their own reactions), the development of a personalized set of regulation strategies, and the building of internal and external resources the survivor can draw on. This skill-building is not a preliminary to the \"real\" work; for many survivors it is among the most transformative parts of treatment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Trauma-Focused Cognitive Behavioral Therapy (TF-CBT) in Depth</h2>\n<p>TF-CBT is among the most extensively researched treatments for trauma, with the strongest evidence base for children and adolescents and growing application with adults. It is a structured, components-based, phase-oriented treatment, frequently summarized by the acronym PRACTICE.</p>\n<h3>The Core Components</h3>\n<p>The components include <strong>P</strong>sychoeducation about trauma and its effects and <strong>P</strong>arenting skills (in work with youth); <strong>R</strong>elaxation and stress-management skills; <strong>A</strong>ffective expression and regulation; <strong>C</strong>ognitive coping, which addresses the distorted, trauma-related beliefs survivors develop; the <strong>T</strong>rauma narrative and processing, in which the survivor gradually constructs and works through an account of what happened; <strong>I</strong>n vivo mastery of trauma reminders; <strong>C</strong>onjoint sessions (with caregivers in youth work); and <strong>E</strong>nhancing safety and future development.</p>\n<h3>Application to Sexual Trauma</h3>\n<p>The structure embodies the phase-based principle: skill-building precedes the trauma narrative, which precedes consolidation. For sexual trauma specifically, the cognitive component addresses the self-blame, shame, and beliefs about responsibility, safety, trust, and the body that are so characteristic of sexual trauma, and the gradual trauma narrative allows processing at a pace the survivor can tolerate. The structured, skills-first nature of TF-CBT makes it well suited to survivors who need substantial stabilization before processing.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Eye Movement Desensitization and Reprocessing (EMDR) in Depth</h2>\n<p>EMDR is a well-established, eight-phase treatment for trauma that uses bilateral stimulation while the survivor attends to traumatic material, and it has a strong evidence base for PTSD including PTSD arising from sexual trauma.</p>\n<h3>The Eight Phases</h3>\n<p>EMDR proceeds through history-taking and treatment planning; preparation (including the stabilization and resourcing that embody the safety-first principle); assessment of the target memory and its associated negative cognition, desired positive cognition, emotions, and body sensations; desensitization using bilateral stimulation; installation of the adaptive positive cognition; a body scan to address residual somatic disturbance; closure; and reevaluation. The model proposes that bilateral stimulation facilitates the adaptive reprocessing of memories that were maladaptively stored at the time of trauma.</p>\n<h3>Application to Sexual Trauma</h3>\n<p>EMDR is particularly relevant to sexual trauma for several reasons: it does not require detailed verbal recounting of the trauma, which some survivors find retraumatizing or impossible; it directly targets the somatic and body-based dimensions of sexual trauma through the body scan and the attention to body sensation; and it addresses the negative cognitions about the self and the body — \"I am damaged,\" \"my body is not mine,\" \"it was my fault\" — that are central to sexual trauma. As with all processing work, adequate preparation and stabilization (Phase 2) are essential before desensitization begins.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Cognitive Processing Therapy (CPT) in Depth</h2>\n<p>CPT is a structured, evidence-based cognitive therapy for PTSD with a particularly strong record in the treatment of sexual-assault-related PTSD, where much of its foundational research was conducted.</p>\n<h3>Stuck Points and Cognitive Work</h3>\n<p>CPT centers on identifying and modifying \"stuck points\" — the conflicted or distorted beliefs that keep a survivor trapped in the trauma. These frequently cluster around themes of safety, trust, power and control, esteem, and intimacy, and around assimilated beliefs (distorting the event to fit prior assumptions, as in self-blame) or over-accommodated beliefs (over-generalizing, as in \"no one can be trusted\"). Through structured worksheets and Socratic dialogue, the survivor learns to examine and rebalance these beliefs.</p>\n<h3>Application to Sexual Trauma</h3>\n<p>CPT is especially apt for sexual trauma because the stuck points it targets — self-blame (\"I should have fought harder,\" \"I should have known\"), shattered assumptions about safety and trust, and beliefs about one's own worth and the meaning of intimacy — are precisely the cognitions that organize so much sexual trauma distress. CPT can be delivered with or without a written trauma account, offering flexibility for survivors for whom a detailed narrative would be overwhelming, and its focus on present-day beliefs rather than repeated exposure to the memory makes it tolerable for many survivors.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Prolonged Exposure (PE) and Treatment Selection</h2>\n<p>Prolonged Exposure is a strongly evidence-based treatment that works by reducing the avoidance that maintains PTSD, through imaginal exposure (repeatedly revisiting the trauma memory in a safe context) and in vivo exposure (gradually approaching avoided but safe situations and reminders).</p>\n<h3>Special Considerations for Sexual Trauma</h3>\n<p>PE is effective for sexual-trauma-related PTSD, but it requires particular care. The repeated revisiting of the trauma memory is demanding, and adequate preparation, a strong alliance, and attention to the survivor's window of tolerance are essential to prevent the exposure from becoming retraumatizing. In vivo exposure must be designed thoughtfully so that it targets genuinely safe but avoided situations rather than situations that carry real risk. For some survivors, particularly those with significant dissociation or complex trauma, other approaches or a longer stabilization phase may be more appropriate before, or instead of, exposure-based work.</p>\n<h3>Selecting Among the Treatments</h3>\n<p>No single treatment is superior for every survivor. Selection considers the survivor's preferences and tolerance, the presence and severity of dissociation, the complexity of the trauma history, co-occurring conditions, and the survivor's stability and resources. A survivor with significant dissociation may need extended stabilization and may do better with approaches that do not require detailed verbal recounting; a survivor whose distress is organized around self-blame may be especially well served by CPT; a survivor who finds verbal processing intolerable may prefer EMDR. Matching treatment to the survivor — collaboratively, and with attention to the phase-based principle — is itself a clinical skill.</p>"
+        },
+        {
+          "order": 7,
+          "type": "multiSelect",
+          "question": "Which principles characterize phase-based trauma treatment? (Select all that apply)",
+          "options": [
+            {
+              "text": "Stabilization and safety precede memory processing",
+              "isCorrect": true
+            },
+            {
+              "text": "Pacing is titrated to keep the client within the window of tolerance",
+              "isCorrect": true
+            },
+            {
+              "text": "Processing should begin immediately regardless of stability",
+              "isCorrect": false
+            },
+            {
+              "text": "The survivor’s sense of safety and control is continuously prioritized",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Phase-based treatment prioritizes stabilization and safety first, paces processing within the window of tolerance, and continuously centers the survivor’s safety and control."
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Complex PTSD and Childhood Sexual Abuse</h2>\n<p>Sexual trauma that is repeated, that begins in childhood, or that occurs in the context of a caregiving or trusted relationship frequently produces a clinical picture broader than classic PTSD — a presentation increasingly recognized as complex PTSD, included in the ICD-11.</p>\n<h3>The Complex PTSD Presentation</h3>\n<p>In addition to the core PTSD features of re-experiencing, avoidance, and hyperarousal, complex PTSD involves persistent disturbances in three further domains: affect regulation (difficulty managing emotion, including chronic dysregulation and dissociation), self-concept (pervasive shame, guilt, and a sense of being damaged or worthless), and relationships (difficulty with trust, intimacy, and closeness). For survivors of childhood sexual abuse, these disturbances develop during the formative years and become woven into personality and attachment, which is why treatment is frequently longer and more relationally focused than for single-incident adult trauma.</p>\n<h3>Treatment Implications</h3>\n<p>Complex trauma generally calls for a longer stabilization phase, sustained attention to affect regulation and dissociation, careful work with attachment and the therapeutic relationship itself (which becomes a primary vehicle of healing), and patience with a non-linear course. The relationship between survivor and clinician — consistent, attuned, and reliably safe — is for many complex trauma survivors a corrective experience as powerful as any specific technique.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Dissociation in the Clinical Encounter</h2>\n<p>Dissociation — introduced earlier as a neurobiological trauma response — is something the clinician must be able to recognize and respond to in real time, because a survivor who dissociates in session is no longer able to engage in or benefit from the work, and unrecognized dissociation can allow processing to proceed in a way that is ineffective or harmful.</p>\n<h3>Recognizing Dissociation</h3>\n<p>Signs that a survivor is dissociating include a glazed or vacant expression, a sudden change in voice or affect, apparent loss of contact with the present, slowed or absent responses, reports of feeling far away, unreal, or numb, and gaps in awareness. The clinician learns to watch for these signs continuously, particularly when approaching difficult material.</p>\n<h3>Responding to Dissociation</h3>\n<p>When dissociation appears, the priority shifts immediately from content to grounding: the clinician helps the survivor reorient to the present using the grounding skills established in stabilization, slows or pauses the processing, and re-establishes safety before continuing. Over time, the clinician and survivor develop a shared language and signals for noticing and interrupting dissociation, which both keeps the work within the window of tolerance and builds the survivor's own capacity to recognize and manage dissociation outside of session.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Sexual Functioning and Intimacy After Sexual Trauma</h2>\n<p>For a course on sexual trauma, the recovery of sexual wellbeing deserves specific attention, because it is frequently the dimension survivors most want addressed and the one clinicians are least prepared to address. Sexual trauma can profoundly disrupt a survivor's relationship to their own body, sexuality, and capacity for intimacy, and supporting sexual recovery is a legitimate and important part of trauma treatment — typically in the reconnection phase, once stabilization and processing have established sufficient safety.</p>\n<h3>How Trauma Disrupts Sexuality</h3>\n<p>Sexual trauma may manifest as sexual avoidance or aversion, as dissociation during sexual activity (a survivor may \"leave\" their body during sex, often without choosing to), as difficulty with arousal or with the experience of pleasure, as flashbacks or intrusion triggered by sexual situations, as genito-pelvic pain, or as compulsive sexual behavior. Arousal non-concordance — the dissociation between bodily response and subjective experience — can be especially distressing and confusing for survivors, who may have experienced bodily responses during the assault that generate shame and self-doubt; clinicians help by explaining that such responses are automatic physiological events that carry no meaning about consent or desire.</p>\n<h3>Supporting Sexual Recovery</h3>\n<p>Supporting sexual recovery involves normalizing the wide range of sexual responses to trauma, helping the survivor re-establish a sense of choice and control over their own body and sexual experience, and pacing the work at the survivor's tolerance. Trauma-adapted approaches — including modified sensate-focus exercises that emphasize choice, pacing, and the freedom to stop at any moment — can help survivors gradually reclaim positive bodily experience. For survivors with partners, the partner's involvement and understanding are frequently important. Where the work exceeds the clinician's competence, referral to a clinician with combined trauma and sexual health expertise is appropriate; but the generalist trauma clinician can and should at minimum name sexuality as a legitimate dimension of recovery rather than leaving it unaddressed.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 11,
+          "prompt": "How prepared do you currently feel to address sexual functioning and intimacy as part of trauma recovery? What would help you raise it rather than leave it unaddressed?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Working With Partners and Intimate Relationships</h2>\n<p>Sexual trauma occurs within and reverberates through relationships, and a survivor's intimate partnerships are frequently both affected by the trauma and important to recovery.</p>\n<h3>The Impact on Partnerships</h3>\n<p>Trauma can strain intimate relationships through changes in sexual functioning, through the survivor's difficulty with trust and closeness, and through the partner's own reactions — which may include confusion, helplessness, fear of \"doing something wrong,\" secondary traumatic stress, and, for partners of survivors disclosing past abuse, their own grief and anger. Partners frequently want to help but do not know how, and may inadvertently respond in ways that increase the survivor's distress.</p>\n<h3>The Clinician's Role</h3>\n<p>The clinician can support the survivor's relationships by helping the survivor communicate their needs and boundaries, by providing the partner (where appropriate and with the survivor's consent) with education about trauma responses and about how to be supportive without pressure, and by helping the couple renegotiate physical and sexual intimacy at the survivor's pace. The guiding principle is the restoration of the survivor's choice and control; intimacy that proceeds at the survivor's pace and under the survivor's control supports recovery, while pressure — however well-intentioned — undermines it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Safety, Suicidality, and Co-Occurring Substance Use</h2>\n<p>Sexual trauma survivors are at elevated risk for suicidality and self-harm and for co-occurring substance use, and competent trauma care attends to both throughout treatment, not only at intake.</p>\n<h3>Safety and Suicidality</h3>\n<p>Survivors of sexual trauma have elevated rates of suicidal ideation and self-harm, and the clinician assesses and monitors safety as an ongoing part of treatment, with particular attention around the processing of difficult material. Stabilization and safety planning are prerequisites to trauma processing, not afterthoughts: a survivor whose safety is not stable is not ready for the demands of remembrance work, and attending to safety is part of the phase-based sequencing rather than a departure from the trauma work.</p>\n<h3>Co-Occurring Substance Use</h3>\n<p>Substance use frequently co-occurs with sexual trauma, often functioning as an attempt to manage unbearable trauma-related states. Treating the trauma and the substance use as wholly separate, or insisting that substance use be fully resolved before any trauma work can begin, frequently fails; integrated approaches that address both in a coordinated way, and that understand the substance use in the context of the trauma it is being used to manage, are generally more effective. The clinician assesses substance use, understands its function, and coordinates care so that neither problem is treated in isolation from the other.</p>"
+        },
+        {
+          "order": 14,
+          "type": "sequencing",
+          "instructions": "A survivor begins to dissociate in session (vacant expression, slowed responses). Order the clinician’s response.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Recognize the signs of dissociation and pause the processing"
+            },
+            {
+              "order": 2,
+              "text": "Gently orient the client to the present and to safety"
+            },
+            {
+              "order": 3,
+              "text": "Use grounding (senses, breath, contact with the room)"
+            },
+            {
+              "order": 4,
+              "text": "Re-establish the window of tolerance before continuing or closing"
+            }
+          ],
+          "explanation": "Dissociation signals the client has left the window of tolerance; the clinician pauses, orients to the present, grounds, and re-stabilizes before any further processing."
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Clinician Sustainability: Vicarious Trauma and Self-Care</h2>\n<p>Working with sexual trauma exposes clinicians to material that can, over time, affect them profoundly, and attending to this is both an ethical obligation to oneself and a prerequisite for sustainable, competent care.</p>\n<h3>{{callout:vicarious-trauma}} and Secondary Traumatic Stress</h3>\n<p>Vicarious traumatization refers to the cumulative transformation of the clinician's own inner world — their beliefs about safety, trust, and the world — through empathic engagement with survivors' trauma. Secondary traumatic stress refers to trauma-like symptoms the clinician may develop from this exposure, and burnout to the emotional exhaustion and depletion that can accompany the work. These are not signs of weakness or inadequacy; they are recognized occupational realities for those who do this work well, precisely because doing it well requires genuine empathic engagement.</p>\n<h3>Sustaining the Work</h3>\n<p>Sustainable practice requires deliberate attention to one's own wellbeing: maintaining manageable caseloads and a mix of clinical work, using consultation and supervision not only for clinical guidance but for processing the emotional impact of the work, maintaining boundaries between professional and personal life, attending to one's own physical and emotional health, and recognizing and responding to early signs of secondary stress or burnout rather than pushing through them. Organizations bear responsibility here as well, through reasonable caseloads and supportive structures. A clinician who is depleted or vicariously traumatized cannot provide the steady, attuned presence that trauma survivors need; self-care is therefore not a luxury but a component of competent practice.</p>",
+          "callouts": {
+            "vicarious-trauma": {
+              "label": "Vicarious Trauma",
+              "type": "definition",
+              "body": "The cumulative transformation of a clinician’s inner world and beliefs (about safety, trust, the world) from empathic engagement with clients’ trauma."
+            }
+          }
+        },
+        {
+          "type": "reflection",
+          "order": 30,
+          "prompt": "What is your current plan for sustaining yourself in trauma work — consultation, caseload management, and recognizing your own signs of secondary stress? Where is it strongest, and where does it need strengthening?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Pharmacological Approaches as Adjuncts</h2>\n<p>While trauma-focused psychotherapy is the first-line treatment for PTSD, medication has an adjunctive role that clinicians should understand in order to coordinate care, even when they do not prescribe.</p>\n<h3>The Evidence and the Role</h3>\n<p>Certain medications have evidence for reducing PTSD symptoms and are frequently used alongside psychotherapy, particularly when symptoms are severe, when co-occurring depression or anxiety is prominent, or when symptom relief is needed to enable engagement in psychotherapy. Medications can also target specific features, such as the use of particular agents for trauma-related nightmares and sleep disturbance. Medication is generally understood as a complement to, rather than a replacement for, trauma-focused psychotherapy, which addresses the trauma itself.</p>\n<h3>Coordinating Care</h3>\n<p>Non-prescribing clinicians contribute by recognizing when a medication consultation may help, by referring to and coordinating with prescribers, by monitoring response and side effects (including sexual side effects, which matter especially for survivors working toward sexual recovery), and by helping the survivor make informed, autonomous decisions about medication. As with every dimension of trauma care, the survivor's choice and control are respected, and medication decisions are made collaboratively rather than imposed.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Cultural Adaptation of Evidence-Based Treatments</h2>\n<p>The evidence-based treatments were developed and tested largely in particular cultural contexts, and delivering them effectively across diverse populations requires thoughtful cultural adaptation rather than rote application.</p>\n<h3>Why Adaptation Matters</h3>\n<p>Culture shapes how trauma is experienced and expressed, what meanings are attached to sexual violation, how distress is communicated, what help-seeking is acceptable, and how concepts central to treatment — such as disclosure, cognitive change, or the expression of emotion — are understood. A treatment delivered without attention to these factors may be less effective or may fail to engage the survivor. Cultural adaptation preserves the active, evidence-based elements of a treatment while adjusting language, framing, examples, and delivery to fit the survivor's cultural context.</p>\n<h3>The Clinician's Stance</h3>\n<p>Cultural humility, introduced earlier, is the foundation: the clinician approaches each survivor as the expert on their own cultural context, remains curious rather than assuming, and collaborates with the survivor to deliver care that fits. This includes attending to how factors such as race, ethnicity, religion, immigration status, language, and community shape both the trauma and the recovery, and to the intersecting forms of marginalization that many survivors carry. Evidence-based and culturally responsive care are not in tension; competent practice integrates both.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Meaning, Spirituality, and the Reconstruction of a Life</h2>\n<p>Recovery from sexual trauma is ultimately not only the reduction of symptoms but the reconstruction of a meaningful life and a coherent sense of self, and questions of meaning and, for many survivors, spirituality are part of this work.</p>\n<h3>Meaning-Making After Trauma</h3>\n<p>Sexual trauma frequently shatters a survivor's assumptions about safety, justice, trust, and their own identity, and a central task of recovery is the gradual reconstruction of a way of understanding self and world that integrates the trauma without being wholly defined by it. This is not about finding that the trauma was \"for the best\" — a framing that can be invalidating — but about the survivor's own gradual construction of meaning, which may include a revised but livable understanding of safety and trust, a reclaimed sense of identity, and, for some, a commitment to purpose or advocacy that grows out of the experience.</p>\n<h3>Spirituality and Religion</h3>\n<p>For many survivors, spiritual or religious frameworks are deeply relevant to recovery — as sources of strength and meaning, and sometimes as sites of additional struggle, particularly where religious teaching has contributed to shame or where the trauma occurred in a religious context. The clinician approaches the survivor's spirituality with respect and curiosity, supporting the survivor in drawing on it as a resource and in working through any conflict, without imposing the clinician's own beliefs. Meaning and spirituality are the survivor's to define; the clinician supports their exploration.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>When Treatment Stalls: Recognizing and Addressing Impasse</h2>\n<p>Trauma treatment does not always proceed smoothly, and recognizing and responding to impasse is part of competent practice rather than evidence of failure.</p>\n<h3>Common Sources of Impasse</h3>\n<p>Treatment may stall for many reasons: insufficient stabilization for the processing being attempted, unrecognized dissociation, ongoing unsafety or external stressors that make processing impossible, a rupture in the therapeutic alliance, co-occurring conditions that need attention, or the survivor's readiness and pace being out of step with the treatment plan. Attempting to push processing forward when the survivor is not stable or safe enough is a frequent and counterproductive source of impasse.</p>\n<h3>Responding to Impasse</h3>\n<p>When treatment stalls, the clinician steps back to reassess: Is the survivor safe and stable enough for the current work? Is dissociation interfering? Has the alliance been ruptured, and can it be repaired? Does the pace need to slow, or the phase to shift back toward stabilization? Consultation is especially valuable at these moments, both for fresh clinical perspective and for the clinician's own support. Impasse handled well — with reassessment, recalibration, and patience — frequently becomes a turning point rather than an ending, and modeling this steady, non-blaming response to difficulty is itself therapeutic for survivors accustomed to being blamed when things go wrong.</p>",
+          "order": 20
+        },
+        {
+          "order": 21,
+          "type": "multiSelect",
+          "question": "Which statements about pharmacological treatment of PTSD from sexual trauma are accurate? (Select all that apply)",
+          "options": [
+            {
+              "text": "Medication can be a useful adjunct to trauma-focused psychotherapy",
+              "isCorrect": true
+            },
+            {
+              "text": "Certain antidepressants have evidence for PTSD symptoms",
+              "isCorrect": true
+            },
+            {
+              "text": "Medication alone is generally sufficient and preferred over therapy",
+              "isCorrect": false
+            },
+            {
+              "text": "Prescribing is coordinated with medical providers",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Medication is best understood as an adjunct to trauma-focused psychotherapy, coordinated with prescribers — not as a standalone substitute for trauma processing."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coordinating With Advocacy and Legal Systems</h2>\n<p>Survivors frequently interact with advocacy, medical, and legal systems alongside mental health treatment, and the clinician's ability to coordinate with and help the survivor navigate these systems is part of comprehensive care.</p>\n<h3>The Advocacy Role</h3>\n<p>Victim advocates — through rape crisis centers and similar organizations — provide a distinct and valuable service: they can accompany survivors through medical, legal, and practical processes, explain options, and offer support that complements clinical treatment. Connecting survivors with advocacy services is frequently among the most concretely helpful referrals a clinician can make, and clinicians benefit from knowing the resources available in their community.</p>\n<h3>Navigating Legal Involvement</h3>\n<p>For survivors who pursue legal action, the process can be lengthy, uncertain, and re-traumatizing, requiring repeated retelling and exposing the survivor to disbelief and scrutiny. The clinician supports the survivor through this — helping them prepare for and cope with the demands of the process, maintaining the survivor's choice about whether and how to engage with legal systems, and keeping the clinical role distinct from any forensic role. Whether or not a survivor pursues legal action is their decision, and the clinician supports that autonomy rather than steering it. Throughout, the integrating principle of all sexual trauma care holds: the restoration of the survivor's choice, control, and dignity.</p>",
+          "order": 22
+        },
+        {
+          "type": "multipleChoice",
+          "question": "A strengths-informed stance in trauma treatment means the clinician:",
+          "options": [
+            {
+              "text": "Minimizes the trauma by focusing only on positives",
+              "isCorrect": false
+            },
+            {
+              "text": "Holds both the injury and the survivor’s strengths and resources in view, building recovery on existing capacities",
+              "isCorrect": true
+            },
+            {
+              "text": "Ignores symptoms entirely",
+              "isCorrect": false
+            },
+            {
+              "text": "Assumes all survivors are equally resilient",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "A strengths-informed stance holds both the pain and the survivor’s capacities in view; it is more accurate and more empowering than a pathology-only view and supports the agency recovery requires.",
+          "showExplanation": true,
+          "order": 23
+        },
+        {
+          "order": 24,
+          "type": "multiSelect",
+          "question": "Regarding a survivor’s decision to pursue legal action, the clinician should: (Select all that apply)",
+          "options": [
+            {
+              "text": "Support the survivor’s autonomy in the decision",
+              "isCorrect": true
+            },
+            {
+              "text": "Provide information about options and likely demands of the process",
+              "isCorrect": true
+            },
+            {
+              "text": "Direct the survivor toward or away from pressing charges",
+              "isCorrect": false
+            },
+            {
+              "text": "Attend to the emotional impact of the legal process either way",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "The clinician supports the survivor’s autonomy, informs without directing, and attends to the emotional impact — the decision belongs to the survivor."
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Integrating the Course: Principles for Sustainable, Survivor-Centered Practice</h2>\n<p>Across assessment, neurobiology, the evidence-based treatments, special populations, sexual recovery, and clinician sustainability, several principles unify competent sexual trauma care and are worth carrying forward into practice.</p>\n<p>First, safety and stabilization precede processing; the phase-based sequence protects survivors from the harm of being pushed into trauma content before they can tolerate it. Second, the restoration of choice and control is the through-line of all sexual trauma work, from the first disclosure through acute care, treatment decisions, sexual recovery, and any engagement with legal systems — because the trauma was defined by their absence. Third, the therapeutic relationship — consistent, attuned, believing, and reliably safe — is for many survivors as powerful as any specific technique, and for survivors of complex and developmental trauma it is frequently the central vehicle of healing.</p>\n<p>Fourth, survivors are diverse, and competent care is individualized, culturally responsive, and attentive to the specific needs of male survivors, LGBTQ+ survivors, survivors of color, survivors with disabilities, older and adolescent survivors, and survivors of institutional and military trauma. Fifth, sexuality and intimacy are legitimate dimensions of recovery that deserve explicit attention rather than silence. And finally, sustainable practice requires that clinicians attend to their own wellbeing, using consultation, boundaries, and self-care to remain the steady presence that survivors need. A clinician who carries these principles offers survivors not only symptom relief but the restoration of safety, dignity, connection, and a life no longer organized around what was done to them.</p>"
+        }
+      ]
+    }
+  ]
+};
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+async function main(){
+  await mongoose.connect(MONGODB_URI); console.log('Connected.');
+  const doc = await Course.findOne({ slug: COURSE_DATA.slug });
+  if(!doc){ console.error('CR-305 not found:', COURSE_DATA.slug); process.exit(1); }
+  for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
+  doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  await doc.save();
+  const fresh=await Course.findById(doc._id).lean();
+  console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);
+  await mongoose.disconnect(); console.log('Done.');
+}
+main().catch(e=>{console.error('ERROR:',e.message);process.exit(1);});

--- a/server/src/scripts/seedCR306-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR306-EXPANDED-canonical.js
@@ -1,0 +1,1801 @@
+/**
+ * Copyright (c) 2026 CounselorReady / GA Integrated Therapeutic Perspectives, LLC.
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+import 'dotenv/config';
+
+// CR-306 EXPANDED — canonical sections[] shape; saves through the model (wordCount hook fires).
+const COURSE_DATA = {
+  "title": "Sex Therapy Foundations: Integrating Sexual Health Into Counseling Practice",
+  "slug": "sex-therapy-foundations",
+  "courseCode": "CR-306",
+  "description": "A comprehensive 3-hour continuing education course for licensed mental health professionals. Meets NBCC ACEP standards with 18,275 words of graduate-level clinical content.",
+  "ceHours": 3,
+  "credits": 3,
+  "category": "Clinical",
+  "ceCategory": "Clinical",
+  "ceuHours": 3,
+  "ceuEligible": true,
+  "approvingBody": "NBCC",
+  "approvalNumber": "#7760",
+  "creditType": "NBCC",
+  "acepProvider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "number": "7760"
+  },
+  "instructor": "GA Integrated Therapeutic Perspectives LLC",
+  "targetAudience": [
+    "Licensed mental health professionals including LPCs, LCSWs, LMFTs, psychologists, and NCCs who wish to integrate sexual health assessment and evidence-based sex therapy foundations into their clinical practice."
+  ],
+  "accessType": "subscription",
+  "price": 59.99,
+  "pricingTier": "standard",
+  "status": "draft",
+  "isPublished": false,
+  "isActive": true,
+  "passingScore": 80,
+  "maxAttempts": 3,
+  "settings": {
+    "passingScore": 80,
+    "certificateEnabled": true,
+    "requireEvaluation": true,
+    "requireAttestation": true
+  },
+  "objectives": [
+    "Define the scope of sex therapy and distinguish between sexual concerns addressed in general mental health practice and those requiring referral to a certified sex therapist.",
+    "Apply the PLISSIT and Ex-PLISSIT models as frameworks for providing graduated sexual health interventions at levels appropriate to one's training.",
+    "Describe the biopsychosocial model of sexual functioning and its application to clinical assessment of sexual health concerns.",
+    "Identify and apply validated sexual health assessment instruments including the FSFI, IIEF, and SFQ within a culturally responsive assessment framework.",
+    "Describe the evidence base for sensate focus, cognitive-behavioral sex therapy, and mindfulness-based approaches for common sexual health presentations.",
+    "Apply an affirming, culturally humble clinical stance to sexual health concerns across diverse client populations including LGBTQ+ clients and clients from diverse cultural backgrounds."
+  ],
+  "assessment": {
+    "isExam": true,
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
+      {
+        "question": "The PLISSIT model's four levels are:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Prevention, Learning, Information, Screening, Intervention, Treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Permission, Limited Information, Specific Suggestions, Intensive Therapy",
+            "isCorrect": true
+          },
+          {
+            "text": "Primary, Limited, Secondary, Intensive",
+            "isCorrect": false
+          },
+          {
+            "text": "Presentation, Listening, Inquiry, Skills, Information, Therapy",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "Masters and Johnson's human sexual response cycle includes which sequence:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Desire, arousal, orgasm, resolution",
+            "isCorrect": false
+          },
+          {
+            "text": "Excitement, plateau, orgasm, resolution",
+            "isCorrect": true
+          },
+          {
+            "text": "Desire, excitement, orgasm, refractory period",
+            "isCorrect": false
+          },
+          {
+            "text": "Arousal, desire, orgasm, resolution",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "Basson's (2001) circular model of female sexual response specifically addressed:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Orgasmic disorder as the most common female sexual concern",
+            "isCorrect": false
+          },
+          {
+            "text": "Responsive desire as a normative pathway for women that differs from spontaneous desire",
+            "isCorrect": true
+          },
+          {
+            "text": "The neurobiological mechanisms underlying clitoral erectile response",
+            "isCorrect": false
+          },
+          {
+            "text": "The role of testosterone in female sexual desire disorders",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "The FSFI is a validated instrument that assesses:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Male erectile function exclusively",
+            "isCorrect": false
+          },
+          {
+            "text": "Female sexual function across six domains including desire, arousal, and satisfaction",
+            "isCorrect": true
+          },
+          {
+            "text": "Both male and female sexual function on a single scale",
+            "isCorrect": false
+          },
+          {
+            "text": "Sexual dysfunction severity for medication trial eligibility",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "Sensate focus exercises, developed by Masters and Johnson, specifically involve:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Progressive relaxation as the primary therapeutic mechanism",
+            "isCorrect": false
+          },
+          {
+            "text": "Graduated non-demand pleasuring exercises that systematically reduce performance anxiety",
+            "isCorrect": true
+          },
+          {
+            "text": "In vivo exposure to sexual anxiety triggers",
+            "isCorrect": false
+          },
+          {
+            "text": "Cognitive restructuring of sexual performance beliefs",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "The biopsychosocial model of sexual functioning:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Prioritizes biological factors as the primary determinants of sexual health",
+            "isCorrect": false
+          },
+          {
+            "text": "Treats psychological factors as secondary to biological treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Integrates biological, psychological, and sociocultural factors as interacting determinants",
+            "isCorrect": true
+          },
+          {
+            "text": "Is primarily applicable to medically-based sexual dysfunctions",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": ""
+      },
+      {
+        "question": "A core principle of culturally responsive sexual health clinical practice is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Applying universal Western sexual norms as clinical standards for all populations",
+            "isCorrect": false
+          },
+          {
+            "text": "Assuming that LGBTQ+ clients have sexual concerns primarily related to their identity",
+            "isCorrect": false
+          },
+          {
+            "text": "Approaching each client's sexual values and practices with genuine curiosity and humility",
+            "isCorrect": true
+          },
+          {
+            "text": "Avoiding discussion of cultural factors to prevent stereotyping",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": ""
+      },
+      {
+        "question": "Directed masturbation is an evidence-based first-line intervention for:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Erectile disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Premature ejaculation",
+            "isCorrect": false
+          },
+          {
+            "text": "Female orgasmic disorder",
+            "isCorrect": true
+          },
+          {
+            "text": "Genitourinary syndrome of menopause",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": ""
+      },
+      {
+        "question": "The squeeze technique and stop-start method are evidence-based interventions for:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Female hypoactive sexual desire disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Erectile disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Premature ejaculation",
+            "isCorrect": true
+          },
+          {
+            "text": "Vaginismus",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": ""
+      },
+      {
+        "question": "Mindfulness-based sex therapy approaches have the strongest evidence base for:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Erectile disorder in older adult men",
+            "isCorrect": false
+          },
+          {
+            "text": "Female sexual interest and arousal disorder, particularly post-cancer",
+            "isCorrect": true
+          },
+          {
+            "text": "Male orgasmic disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Genito-pelvic pain/penetration disorder",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "When is referral to an AASECT-certified sex therapist most clearly indicated:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "When the client presents with any sexual health concern",
+            "isCorrect": false
+          },
+          {
+            "text": "When the clinical complexity of sexual dysfunction presentation exceeds the referring clinician's training",
+            "isCorrect": true
+          },
+          {
+            "text": "When the client is LGBTQ+",
+            "isCorrect": false
+          },
+          {
+            "text": "When the sexual concern is more than 6 months in duration",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "The concept of 'sexual scripts' (Gagnon & Simon, 1973) refers to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Therapist-provided behavioral protocols for sexual skill development",
+            "isCorrect": false
+          },
+          {
+            "text": "Culturally shared cognitive frameworks that organize sexual expectations and behavior",
+            "isCorrect": true
+          },
+          {
+            "text": "Standardized behavioral assignments used in sex therapy homework",
+            "isCorrect": false
+          },
+          {
+            "text": "Partner communication scripts developed in sex therapy sessions",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "Genitourinary syndrome of menopause (GSM) is relevant to sexual health clinical work because:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "It is a condition requiring psychiatric management rather than gynecological referral",
+            "isCorrect": false
+          },
+          {
+            "text": "It produces vulvovaginal changes that cause sexual pain and dysfunction that is highly treatable",
+            "isCorrect": true
+          },
+          {
+            "text": "It affects primarily post-menopausal women who are not in active clinical treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "It is primarily a psychological rather than a physical condition",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "Which statement about sexual desire is most consistent with current clinical evidence:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Normal sexual desire is spontaneous, frequent, and consistent across all contexts",
+            "isCorrect": false
+          },
+          {
+            "text": "Responsive desire — emerging in response to erotic stimuli rather than arising spontaneously — is normative, particularly for women",
+            "isCorrect": true
+          },
+          {
+            "text": "Sexual desire is primarily a biological drive with minimal psychological or relational determinants",
+            "isCorrect": false
+          },
+          {
+            "text": "Low sexual desire is always a clinical condition requiring treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "question": "The Ex-PLISSIT model extends the original PLISSIT model by adding:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Extended information-giving as a fifth level",
+            "isCorrect": false
+          },
+          {
+            "text": "Explicit acknowledgment and discussion of sexuality at all levels as a foundational practice",
+            "isCorrect": true
+          },
+          {
+            "text": "Extended therapy as a replacement for intensive therapy",
+            "isCorrect": false
+          },
+          {
+            "text": "Extra screening questions at the permission-giving stage",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": ""
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The PLISSIT levels most fully within every general clinician’s scope are:",
+        "options": [
+          {
+            "text": "Intensive Therapy only",
+            "isCorrect": false
+          },
+          {
+            "text": "Permission and Limited Information",
+            "isCorrect": true
+          },
+          {
+            "text": "Specific Suggestions and Intensive Therapy",
+            "isCorrect": false
+          },
+          {
+            "text": "None of the levels",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Permission and Limited Information resolve a large share of sexual concerns and are within every clinician’s scope; Intensive Therapy generally requires specialized training.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The dual control model frames many sexual difficulties as resulting from:",
+        "options": [
+          {
+            "text": "Too little of the sexual \"accelerator\" only",
+            "isCorrect": false
+          },
+          {
+            "text": "Excess activation of the inhibitory \"brakes\" (anxiety, stress, distraction) rather than too little excitation",
+            "isCorrect": true
+          },
+          {
+            "text": "Purely hormonal causes",
+            "isCorrect": false
+          },
+          {
+            "text": "Moral failings",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The dual control model highlights that many difficulties reflect over-active inhibition (the brakes) — anxiety, stress, distraction — reframing treatment toward reducing inhibition.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Sexual pain (genito-pelvic pain/penetration disorder) should always be approached with:",
+        "options": [
+          {
+            "text": "Psychological treatment alone",
+            "isCorrect": false
+          },
+          {
+            "text": "Medical evaluation alongside psychological assessment, often interdisciplinary care including pelvic floor physical therapy",
+            "isCorrect": true
+          },
+          {
+            "text": "Immediate intercourse to desensitize",
+            "isCorrect": false
+          },
+          {
+            "text": "Avoidance of all treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Sexual pain always warrants medical evaluation alongside psychological work; effective care is usually interdisciplinary and frequently includes pelvic floor physical therapy.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Reframing desire discrepancy in a couple as \"a difference between two people\" rather than one partner’s deficiency is therapeutic because it:",
+        "options": [
+          {
+            "text": "Blames the higher-desire partner",
+            "isCorrect": false
+          },
+          {
+            "text": "Removes the \"patient\" role from the lower-desire partner and positions the discrepancy as a shared challenge, frequently reducing the pressure that suppresses desire",
+            "isCorrect": true
+          },
+          {
+            "text": "Proves one partner is dysfunctional",
+            "isCorrect": false
+          },
+          {
+            "text": "Ends the relationship",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Reframing relieves the lower-desire partner of the patient role and the higher-desire partner of feeling rejected, making the discrepancy a shared challenge and often reducing pressure.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Universal screening for sexual concerns is recommended because:",
+        "options": [
+          {
+            "text": "Sexual concerns are rare",
+            "isCorrect": false
+          },
+          {
+            "text": "Sexual concerns are common and frequently undisclosed, so routine, normalized asking (paired with supportive responding) brings them into view",
+            "isCorrect": true
+          },
+          {
+            "text": "Clients always raise them spontaneously",
+            "isCorrect": false
+          },
+          {
+            "text": "It replaces the clinical interview",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Because sexual concerns are common and seldom volunteered, universal, normalized screening — inseparable from supportive responding — is needed to bring them into view.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Directed masturbation programs have particularly strong evidence for:",
+        "options": [
+          {
+            "text": "Erectile disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Lifelong female anorgasmia",
+            "isCorrect": true
+          },
+          {
+            "text": "Genito-pelvic pain",
+            "isCorrect": false
+          },
+          {
+            "text": "Premature ejaculation",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Directed masturbation has strong evidence for lifelong female anorgasmia, helping clients learn what produces arousal and orgasm and build confidence and awareness.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Contemporary sex therapy is best characterized as:",
+        "options": [
+          {
+            "text": "Prescriptive, enforcing a single standard of normal sexuality",
+            "isCorrect": false
+          },
+          {
+            "text": "Affirming, culturally humble, trauma-informed, and non-pathologizing, supporting each client’s sexual wellbeing as they define it",
+            "isCorrect": true
+          },
+          {
+            "text": "Focused only on heterosexual couples",
+            "isCorrect": false
+          },
+          {
+            "text": "Concerned only with mechanical function",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Contemporary sex therapy is affirming, culturally humble, trauma-informed, and non-pathologizing, supporting each client’s self-defined sexual wellbeing.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When sex therapy stalls because relationship distress overwhelms the sexual work, the clinician should:",
+        "options": [
+          {
+            "text": "Continue the sexual techniques unchanged",
+            "isCorrect": false
+          },
+          {
+            "text": "Reassess and address the relationship distress first or concurrently, as it is impeding the sexual work",
+            "isCorrect": true
+          },
+          {
+            "text": "End treatment immediately",
+            "isCorrect": false
+          },
+          {
+            "text": "Assume the client is resistant",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Relationship distress that overwhelms the sexual concern is a common obstacle; reassessing and addressing it first or concurrently is the appropriate response.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Combining medical and psychological treatment for a sexual concern is frequently superior because:",
+        "options": [
+          {
+            "text": "Medication alone resolves all dimensions",
+            "isCorrect": false
+          },
+          {
+            "text": "Each addresses dimensions the other cannot — medical treatment the physiological contributors, sex therapy the anxiety, beliefs, communication, and relationship factors",
+            "isCorrect": true
+          },
+          {
+            "text": "Psychological treatment is unnecessary",
+            "isCorrect": false
+          },
+          {
+            "text": "They should never be combined",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Integrated treatment works because medical and psychological approaches each reach dimensions the other cannot; combining them frequently produces more complete results.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Examining one’s own sexual values is considered a professional competency because:",
+        "options": [
+          {
+            "text": "Clinicians should impose their values on clients",
+            "isCorrect": false
+          },
+          {
+            "text": "Unexamined values leak into the room as judgment or subtle steering, undermining affirming care; awareness lets them be set aside, with referral where values prevent affirming care",
+            "isCorrect": true
+          },
+          {
+            "text": "It eliminates the need for training",
+            "isCorrect": false
+          },
+          {
+            "text": "Values are irrelevant to practice",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Unexamined values distort care; self-examination lets the clinician set them aside in service of the client, and refer when values genuinely prevent affirming care.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "New-onset erectile difficulty is clinically significant beyond the sexual concern itself because it can be:",
+        "options": [
+          {
+            "text": "A sign the relationship has ended",
+            "isCorrect": false
+          },
+          {
+            "text": "An early marker of cardiovascular disease warranting medical evaluation",
+            "isCorrect": true
+          },
+          {
+            "text": "Always purely psychological",
+            "isCorrect": false
+          },
+          {
+            "text": "Untreatable",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Because erection is a vascular event, new-onset erectile difficulty can be an early cardiovascular marker and warrants medical evaluation in addition to addressing the sexual concern.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Sex therapy, properly understood, is:",
+        "options": [
+          {
+            "text": "A practice involving physical sexual contact or demonstration",
+            "isCorrect": false
+          },
+          {
+            "text": "An entirely talk-based psychotherapy focused on sexual concerns, never involving sexual contact between clinician and client",
+            "isCorrect": true
+          },
+          {
+            "text": "Only for couples",
+            "isCorrect": false
+          },
+          {
+            "text": "Identical to medical treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Sex therapy is entirely talk-based and never involves nudity, demonstration, or sexual contact; the prohibition on clinician-client sexual contact is absolute.",
+        "showExplanation": true
+      },
+      {
+        "type": "trueFalse",
+        "question": "Responsive desire — desire that arises after arousal and intimacy begin — is a normal pattern and not, by itself, evidence of a sexual dysfunction.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Responsive desire is a normal and common pattern, particularly in long-term relationships; treating spontaneous desire as the only valid form can wrongly pathologize it."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Because PLISSIT’s Intensive Therapy level requires specialized training, a generalist counselor should refer every sexual concern rather than intervene at all.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Most sexual concerns can be addressed at PLISSIT’s first levels — Permission, Limited Information, and Specific Suggestions — within generalist scope; only concerns exceeding that scope warrant referral for Intensive Therapy."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Spectatoring tends to improve sexual functioning by increasing a person’s awareness of their own performance.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Spectatoring — self-monitoring and evaluating one’s performance during sex — heightens anxiety and disrupts arousal; reducing it (e.g., via sensate focus) is therapeutic."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which factors does a biopsychosocial assessment of a sexual concern consider? (Select all that apply)",
+        "options": [
+          {
+            "text": "Biological and medical contributors (health conditions, medications, hormones)",
+            "isCorrect": true
+          },
+          {
+            "text": "Psychological factors (anxiety, beliefs, history, mood)",
+            "isCorrect": true
+          },
+          {
+            "text": "Relational and sociocultural context",
+            "isCorrect": true
+          },
+          {
+            "text": "Only the presenting physical symptom in isolation",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "A biopsychosocial assessment integrates biological, psychological, and social/relational factors rather than reducing a sexual concern to a single cause."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are appropriate reasons to refer a client to a specialized (e.g., AASECT-certified) sex therapist? (Select all that apply)",
+        "options": [
+          {
+            "text": "The concern exceeds the generalist’s training or scope",
+            "isCorrect": true
+          },
+          {
+            "text": "Complex or refractory sexual dysfunction needing intensive treatment",
+            "isCorrect": true
+          },
+          {
+            "text": "The client identifies as LGBTQ+",
+            "isCorrect": false
+          },
+          {
+            "text": "Significant trauma or relational complexity requiring specialized expertise",
+            "isCorrect": true
+          }
+        ],
+        "explanation": "Referral is guided by complexity and scope, not by a client’s identity; LGBTQ+ clients are served within affirming generalist practice and referred only when the clinical concern itself warrants specialization."
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "AASECT scope of practice. https://www.aasect.org",
+      "author": "American Association of Sexuality Educators, Counselors and Therapists",
+      "year": 2023,
+      "source": "ts. (2023). AASECT scope of practice. https://www.aasect.org"
+    },
+    {
+      "title": "Human sexuality and its problems (3rd ed.). Churchill Livingstone.",
+      "author": "Bancroft, J",
+      "year": 2009,
+      "source": "sexuality and its problems (3rd ed.). Churchill Livingstone."
+    },
+    {
+      "title": "Using a different model for female sexual response to address women's problematic low sexual desire. Journal of Sex & M",
+      "author": "Basson, R",
+      "year": 2001,
+      "source": "al desire. Journal of Sex & Marital Therapy, 27(5), 395–403."
+    },
+    {
+      "title": "Group mindfulness-based therapy significantly improves sexual desire in women. Behaviour Research and Therapy, 57, 43–5",
+      "author": "Brotto, L",
+      "year": 2014,
+      "source": "desire in women. Behaviour Research and Therapy, 57, 43–54."
+    },
+    {
+      "title": "Becoming orgasmic: A sexual and personal growth program for women. Prentice Hall.",
+      "author": "Heiman, J",
+      "year": 1988,
+      "source": "sexual and personal growth program for women. Prentice Hall."
+    },
+    {
+      "title": "Disorders of sexual desire. Brunner/Mazel.",
+      "author": "Kaplan, H",
+      "year": 1979,
+      "source": "an, H. S. (1979). Disorders of sexual desire. Brunner/Mazel."
+    },
+    {
+      "title": "Principles and practice of sex therapy (4th ed.). Guilford Press.",
+      "author": "Leiblum, S",
+      "year": 2007,
+      "source": "iples and practice of sex therapy (4th ed.). Guilford Press."
+    },
+    {
+      "title": "Human sexual response. Little, Brown.",
+      "author": "Masters, W",
+      "year": 1966,
+      "source": "Johnson, V. E. (1966). Human sexual response. Little, Brown."
+    },
+    {
+      "title": "Sexual awareness: Your guide to healthy couple sexuality. Routledge.",
+      "author": "McCarthy, B",
+      "year": 2012,
+      "source": "wareness: Your guide to healthy couple sexuality. Routledge."
+    },
+    {
+      "title": "The Female Sexual Function Index (FSFI): A multidimensional self-report instrument for the assessment of female sexual",
+      "author": "Rosen, R",
+      "year": 2000,
+      "source": "function. Journal of Sex & Marital Therapy, 26(2), 191–208."
+    },
+    {
+      "title": "The International Index of Erectile Function (IIEF). Urology, 49(6), 822–830.",
+      "author": "Rosen, R",
+      "year": 1997,
+      "source": "Index of Erectile Function (IIEF). Urology, 49(6), 822–830."
+    },
+    {
+      "title": "A new view of women's sexual problems: Why new? Why now? Journal of Sex Research, 38(2), 89–96.",
+      "author": "Tiefer, L",
+      "year": 2001,
+      "source": "ms: Why new? Why now? Journal of Sex Research, 38(2), 89–96."
+    },
+    {
+      "title": "Intersystems approaches to sex therapy. In K. Hertlein, G. Weeks, & N. Gambescia (Eds.), Systemic sex therapy (2nd ed.,",
+      "author": "Weeks, G",
+      "year": 2015,
+      "source": "(Eds.), Systemic sex therapy (2nd ed., pp. 3–24). Routledge."
+    },
+    {
+      "title": "Defining sexual health: Report of a technical consultation on sexual health. WHO.",
+      "author": "World Health Organization",
+      "year": 2006,
+      "source": "h: Report of a technical consultation on sexual health. WHO."
+    },
+    {
+      "title": "The new male sexuality (Rev. ed.). Bantam.",
+      "author": "Zilbergeld, B",
+      "year": 1999,
+      "source": "rgeld, B. (1999). The new male sexuality (Rev. ed.). Bantam."
+    },
+    {
+      "title": "Psychological and interpersonal dimensions of sexual function and dysfunction. Journal of Sexual Medicine, 13(4), 538–5",
+      "author": "Brotto, L",
+      "year": 2016,
+      "source": "and dysfunction. Journal of Sexual Medicine, 13(4), 538–571."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module 1: Foundations of Sex Therapy and Sexual Health Assessment",
+      "order": 1,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 1,
+          "title": "Module 1",
+          "subtitle": "Module 1: Foundations of Sex Therapy and Sexual Health Assessment",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>History, Scope, and the PLISSIT Model</h2>\n<p>Sex therapy as a clinical discipline emerged from the pioneering research of William Masters and Virginia Johnson, whose laboratory studies of human sexual response published in 1966 produced the first scientific model of the human sexual response cycle and whose subsequent treatment outcome research demonstrated for the first time that sexual dysfunctions were clinically treatable conditions rather than permanent character deficits. Before {{callout:masters-johnson}}, sexual concerns were either ignored in medical and mental health practice or addressed through psychoanalytic approaches that were theoretically elaborate but empirically unvalidated. The publication of Human Sexual Response in 1966, followed by Human Sexual Inadequacy in 1970, constituted a scientific revolution in the understanding and treatment of sexual health that legitimized sexuality as a domain of clinical inquiry and established the foundations of sex therapy as a clinical discipline. Subsequent contributions by Helen Singer Kaplan — who added the desire phase to the Masters and Johnson response cycle, creating the triphasic model (desire, arousal, orgasm) and pioneering the integration of psychodynamic and behavioral approaches in the treatment of sexual dysfunction — and by the development of AASECT as the primary credentialing body for sex therapy, have further developed the field into the evidence-based clinical discipline it is today.</p>\n<p>The scope of sex therapy encompasses assessment and treatment of sexual dysfunctions across all phases of the sexual response cycle — including disorders of desire, arousal, orgasm, and sexual pain — as well as clinical concerns related to sexual identity, sexual relationship functioning, sexual trauma sequelae, and the specific sexual health needs of specialized populations including medically ill clients, older adults, LGBTQ+ clients, and survivors of sexual abuse. The boundary between sexual health concerns that mental health generalists can address through standard clinical practice and those that require the specialized training of a certified sex therapist is defined by the {{callout:plissit}} model — which provides a framework for graduated clinical involvement that enables generalist clinicians to provide sexual health care at levels appropriate to their training, while clearly identifying when referral to a sex therapy specialist is indicated. Understanding this boundary is clinically essential: undertreating sexual concerns by withholding available clinical assistance deprives clients of care they need; overextending beyond one's training into specialized sex therapy interventions without adequate competency may produce clinical harm.</p>\n<p>The {{callout:biopsychosocial}} of sexual functioning — the contemporary theoretical framework that has replaced earlier, single-factor models of sexual health — understands sexual experience, sexual functioning, and sexual dysfunction as the product of the complex, dynamic interaction of biological factors (including neurobiology, hormonal status, vascular function, medication effects, and physical health conditions), psychological factors (including cognitive patterns, emotional regulatory capacity, attachment style, body image, sexual self-concept, and the psychological dimensions of the relationship), and sociocultural factors (including cultural sexual scripts, gender role expectations, religious and moral frameworks about sexuality, media influences on sexual expectations, and the specific relational culture of intimate partnerships). This integrative model has direct clinical implications: any adequate clinical assessment of a sexual health concern must attend to all three domains; any clinical formulation that attributes sexual dysfunction to exclusively biological, psychological, or sociocultural factors is providing an incomplete account that will produce an incomplete treatment plan. The biopsychosocial model is not merely a theoretical framework — it is the clinical foundation for comprehensive, effective sexual health practice.</p>\n<p>Cultural context shapes sexual experience, sexual values, and sexual functioning in ways that are directly clinically relevant and that require genuine cultural humility from clinicians whose training in sexual health has typically been derived from Western, predominantly white, heteronormative frameworks. The concept of sexual scripts — developed by Gagnon and Simon (1973) to describe the culturally shared cognitive frameworks that organize sexual expectations, sexual meanings, and sexual behavior — provides a clinically useful framework for understanding how cultural context shapes individual sexual experience. Sexual scripts operate at three levels: cultural scenarios that specify the broad outlines of culturally normative sexual behavior; interpersonal scripts that govern the specific interactive dimension of sexual encounters; and intrapsychic scripts that organize individual sexual fantasy, arousal, and desire. These levels interact in ways that are individually unique and that are shaped by each person's specific cultural, developmental, and experiential history. Clinicians who approach sexual health assessment with genuine curiosity about the specific sexual scripts that organize each client's sexual experience — rather than applying generic assumptions derived from mainstream Western sexual norms — are providing the kind of culturally responsive care that sexual health assessment requires.</p>",
+          "order": 1,
+          "callouts": {
+            "plissit": {
+              "label": "PLISSIT",
+              "type": "reference",
+              "body": "A four-level model — Permission, Limited Information, Specific Suggestions, Intensive Therapy — for graduated intervention in sexual concerns. Most generalists work at the first two levels."
+            },
+            "masters-johnson": {
+              "label": "Masters & Johnson",
+              "type": "reference",
+              "body": "Pioneering researchers whose linear four-phase response model and behavioral techniques (including sensate focus) founded modern sex therapy."
+            },
+            "biopsychosocial": {
+              "label": "Biopsychosocial Model",
+              "type": "reference",
+              "body": "A framework understanding sexual function and concerns as the product of interacting biological, psychological, and social/relational factors."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Biopsychosocial Model and Validated Assessment Instruments</h2>\n<p>The PLISSIT model, developed by Annon (1976), provides a practical framework for graduated sexual health clinical involvement that is applicable across all clinical settings and all levels of clinical training. The Permission level — communicating to clients that their sexual concerns are clinically appropriate topics and that their experiences, values, and practices are not inherently pathological — is the level at which all clinical practitioners should be able to function and which alone has significant therapeutic value for many clients who carry sexual shame or who have never had a clinical context in which sexual health could be discussed. The Limited Information level — providing accurate, clinically relevant psychoeducation about sexual health, including information about normative sexual variation, the effects of medications and medical conditions on sexual functioning, and the relationship between psychological and physical factors in sexual response — is also accessible to all trained clinicians. The Specific Suggestions level — offering behavioral guidance for specific sexual health concerns — requires more specific sexual health training and should be provided only when the clinician has adequate knowledge to ensure the suggestions are accurate, appropriate, and safe. The Intensive Therapy level — comprehensive sex therapy addressing complex or treatment-resistant sexual dysfunction — requires the specialized training of a certified sex therapist. The {{callout:ex-plissit}} model, a subsequent elaboration, adds the explicit recommendation that Permission be extended throughout all levels of clinical contact rather than only at the initial assessment.</p>\n<p>Psychoeducation as a sexual health intervention is among the most clinically efficient and most widely applicable tools available to mental health generalists who work with clients experiencing sexual health concerns. The provision of accurate, normalizing, evidence-based information about sexual health — about normative variation in sexual desire and response, about the expected effects of aging and medical conditions on sexual functioning, about the relationship between psychological factors and sexual response, and about the available treatment options for specific sexual health concerns — provides direct therapeutic benefit for many clients whose sexual distress is substantially maintained by misinformation, shame-based beliefs about sexual normality, or the absence of a clinical context in which sexual concerns can be openly discussed. Psychoeducation that explicitly addresses the most common sources of sexual shame and misinformation — including the myth of spontaneous, constant sexual desire as the normal baseline; the conflation of performance anxiety with character defect; and the pathologizing of sexual variation that falls within the normal range of human sexual diversity — is providing a form of harm reduction that has genuine clinical value at the lowest level of clinical effort.</p>\n<p>The sexual history as a clinical interview component requires specific training and clinical skill that goes beyond the conduct of a general psychosocial history. Taking a comprehensive sexual history involves systematic inquiry across multiple domains: the client's current sexual relationship context and satisfaction; specific sexual functioning concerns including desire, arousal, orgasm, and any pain symptoms; the client's sexual development history and early sexual experiences including any history of sexual trauma; significant past sexual relationships and their impact; current sexual practices and any health concerns related to them; sexual identity and attraction patterns; body image and its relationship to sexual experience; medication and substance use effects on sexual functioning; and any medical conditions or surgeries that may affect sexual response. This breadth of inquiry requires a matter-of-fact, non-judgmental clinical stance that communicates comfort with the topic through the clinician's own ease — because sexual shame is contagious in clinical interactions, and the clinician who is visibly uncomfortable discussing sexual topics communicates to the client that these topics are indeed shameful and inappropriate, precisely the opposite of the Permission-level therapeutic message.</p>\n<p>Validated sexual health assessment instruments provide standardized, psychometrically robust data that complement the clinical interview in comprehensive sexual health evaluation. The Female Sexual Function Index (FSFI) is a 19-item self-report instrument assessing sexual function in women across six domains: desire, arousal, lubrication, orgasm, satisfaction, and pain. The FSFI has established reliability, validity, and normative data across diverse samples and provides a quantitative profile of sexual functioning that guides clinical formulation and tracks treatment progress. The International Index of Erectile Function (IIEF) is the most widely used self-report measure of male sexual function, assessing five domains: erectile function, orgasmic function, sexual desire, intercourse satisfaction, and overall satisfaction. Like the FSFI, the IIEF has excellent psychometric properties and is useful for both initial assessment and treatment monitoring. These instruments should be used within a clinical context that includes explicit explanation of their purpose, normalization of the sexual health focus of the assessment, and transparent sharing of results with the client as part of a collaborative assessment process.</p>",
+          "order": 2,
+          "callouts": {
+            "ex-plissit": {
+              "label": "Ex-PLISSIT",
+              "type": "reference",
+              "body": "An extension of PLISSIT emphasizing that permission-giving and reflection recur at every level, with attention to the clinician’s own assumptions and the client’s autonomy."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Maria, 42, presents for couples therapy. She discloses 'never really wanting sex anymore' and significant relationship tension around {{callout:desire-discrepancy}}. Comprehensive biopsychosocial assessment: individual desire assessment inside and outside the relationship; FSIAD vs. normative {{callout:responsive-desire}} screening; GSM screening given perimenopause; SSRI review for medication effects; FSFI administration; psychoeducation about Basson's responsive desire model as Permission/Limited Information intervention. Plan: couples sex therapy for desire discrepancy; individual work on any individual dysfunction; gynecological referral for GSM; medication review.</blockquote>",
+          "order": 3,
+          "callouts": {
+            "responsive-desire": {
+              "label": "Responsive Desire",
+              "type": "definition",
+              "body": "Desire that emerges in response to arousal and intimacy rather than preceding them — central to Basson’s circular model and common, especially in long-term relationships."
+            },
+            "desire-discrepancy": {
+              "label": "Desire Discrepancy",
+              "type": "definition",
+              "body": "A difference between partners in desired frequency or type of sexual activity — a relational pattern rather than an individual disorder, and the most common couple presentation."
+            }
+          }
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 1: foundations of sex therapy and sexual health assessment, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 4
+        },
+        {
+          "type": "multipleChoice",
+          "question": "The PLISSIT model's Permission level involves:",
+          "options": [
+            {
+              "text": "Prescribing behavioral homework for sexual dysfunction",
+              "isCorrect": false
+            },
+            {
+              "text": "Communicating that sexual concerns are clinically appropriate topics and experiences are not inherently pathological",
+              "isCorrect": true
+            },
+            {
+              "text": "Providing specific techniques for addressing sexual dysfunction",
+              "isCorrect": false
+            },
+            {
+              "text": "Conducting formal sexual dysfunction assessment",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "The Permission level — communicating that sexual concerns are clinically appropriate and non-pathological — is accessible to all clinicians and has direct therapeutic value for clients carrying sexual shame.",
+          "showExplanation": true,
+          "order": 5
+        },
+        {
+          "order": 6,
+          "type": "matching",
+          "matchingInstructions": "Match each model of sexual response to its defining feature.",
+          "matchingPairs": [
+            {
+              "term": "Masters & Johnson (linear)",
+              "definition": "Four sequential phases: excitement, plateau, orgasm, resolution"
+            },
+            {
+              "term": "Kaplan (triphasic)",
+              "definition": "Adds desire as a distinct phase preceding arousal"
+            },
+            {
+              "term": "Basson (circular)",
+              "definition": "Desire emerges responsively from intimacy and arousal rather than always preceding them"
+            },
+            {
+              "term": "Dual control model",
+              "definition": "Response reflects the balance of sexual excitation and inhibition systems"
+            }
+          ]
+        },
+        {
+          "order": 7,
+          "type": "fillInBlank",
+          "title": "Quick check — core terminology",
+          "blanks": [
+            {
+              "prompt": "The structured touch-based exercises that reduce performance pressure by removing goal-directed expectations:",
+              "answer": "sensate focus",
+              "acceptAlternates": [
+                "sensate-focus"
+              ]
+            },
+            {
+              "prompt": "Self-monitoring and evaluating one’s own performance during sex, which disrupts arousal:",
+              "answer": "spectatoring",
+              "acceptAlternates": [
+                "spectating"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>What Sex Therapy Is — and Is Not</h2>\n<p>Sex therapy is a specialized form of psychotherapy focused on sexual concerns, sexual functioning, and sexual wellbeing. Despite persistent public misconceptions, it is a talk-based clinical practice: it never involves nudity, sexual contact, or physical demonstration of any kind between clinician and client. Understanding what sex therapy is, and where it sits relative to general mental health practice, is the foundation for practicing within one's competence and referring appropriately.</p>\n<h3>A Spectrum, Not a Wall</h3>\n<p>There is no sharp wall between \"sex therapy\" and \"general practice.\" Sexual health concerns exist on a spectrum, and clinicians address them at the level their training supports. Every competent clinician can provide normalization, accurate information, and basic suggestions; clinicians with additional training address more specific dysfunctions and relational sexual concerns; and certified sex therapists handle the most complex and entrenched presentations. This course equips general mental health clinicians to work confidently at the foundational levels of that spectrum and to recognize when to refer.</p>\n<h3>The Goal of Sex Therapy</h3>\n<p>The goal is not to enforce a particular standard of \"normal\" sexuality but to help clients achieve sexual wellbeing as they define it — reducing distress, resolving dysfunction where possible, and supporting satisfying, consensual sexual lives. This affirming, client-centered orientation distinguishes contemporary sex therapy from earlier, more prescriptive approaches.</p>",
+          "order": 8
+        },
+        {
+          "type": "text",
+          "content": "<h2>A Brief History of the Field</h2>\n<p>Modern sex therapy emerged in the mid-twentieth century and has evolved substantially in both technique and stance.</p>\n<h3>Masters and Johnson</h3>\n<p>The pioneering work of Masters and Johnson, beginning in the 1960s, established the first systematic model of the human sexual response and the first structured behavioral treatments for sexual dysfunction, including {{callout:sensate-focus}}. Their work moved sexual concerns from the shadows into the domain of treatable clinical problems and established that many dysfunctions respond to behavioral intervention.</p>\n<h3>Kaplan and the Integration of Desire</h3>\n<p>Helen Singer Kaplan subsequently integrated psychodynamic understanding with behavioral techniques and, importantly, added desire to the response model, recognizing that many sexual concerns involve desire rather than only the mechanics of arousal and orgasm. Her triphasic model (desire, excitement, orgasm) shaped both diagnosis and treatment.</p>\n<h3>The Contemporary Field</h3>\n<p>Since then the field has incorporated the biopsychosocial model, feminist and affirming critiques that challenged narrow and heteronormative assumptions, mindfulness-based and cognitive approaches, and a far more diverse and inclusive understanding of sexuality. Contemporary sex therapy is evidence-informed, affirming, culturally responsive, and attentive to the relational and contextual dimensions of sexual concerns rather than focusing narrowly on mechanics.</p>",
+          "order": 9,
+          "callouts": {
+            "sensate-focus": {
+              "label": "Sensate Focus",
+              "type": "clinical",
+              "body": "A structured series of touch-based, pleasure-focused exercises (originating with Masters and Johnson) that reduces performance pressure by removing goal-directed expectations."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The PLISSIT and Ex-PLISSIT Models in Depth</h2>\n<p>The PLISSIT model is the most widely used framework for organizing graduated sexual health intervention, and it maps directly onto the spectrum of clinician competence. Its four levels describe increasingly specialized interventions.</p>\n<h3>The Four Levels</h3>\n<p><strong>Permission</strong> involves giving clients permission to be sexual, to have concerns, and to discuss them — communicating that sexuality is a legitimate topic and that the client's experiences and questions are normal. <strong>Limited Information</strong> provides accurate, targeted information that corrects misconceptions and addresses the specific concern. <strong>Specific Suggestions</strong> offers concrete, tailored behavioral recommendations and techniques directed at the particular problem. <strong>Intensive Therapy</strong> provides specialized, in-depth treatment for complex or entrenched concerns, typically requiring advanced training.</p>\n<h3>Why the Lower Levels Matter Most</h3>\n<p>The crucial insight of PLISSIT is that the first two levels — Permission and Limited Information — resolve a large proportion of sexual concerns and are within every clinician's scope. Many clients need only permission to discuss a concern and accurate information to correct a distressing misconception. The Ex-PLISSIT (Extended PLISSIT) revision emphasizes that permission-giving is not a one-time first step but a stance maintained throughout, with the clinician returning to explicit permission at every level and continually reflecting on their own assumptions. This framework allows clinicians to intervene effectively at the level their training supports while clarifying when the Intensive Therapy level calls for referral.</p>",
+          "order": 10
+        },
+        {
+          "type": "text",
+          "content": "<h2>Models of Sexual Response</h2>\n<p>Several models describe how sexual response unfolds, and each informs assessment and treatment differently. No single model captures every person's experience, and contemporary practice draws on multiple models.</p>\n<h3>Linear and Triphasic Models</h3>\n<p>The Masters and Johnson model described a linear four-phase cycle (excitement, plateau, orgasm, resolution). Kaplan's triphasic model reframed response around desire, excitement, and orgasm, foregrounding desire. These models remain useful for localizing where a difficulty occurs, but their linear, uniform structure does not fit everyone — particularly many women and many people in long-term relationships.</p>\n<h3>Basson's Circular Model</h3>\n<p>Rosemary Basson proposed a circular, intimacy-based model that better describes the experience of many women and of people in established relationships. In this model, sexual activity often begins not from spontaneous desire but from a state of sexual neutrality, with emotional intimacy and receptivity to a partner's initiation leading to arousal, and desire emerging in response to arousal rather than preceding it. This concept of <strong>responsive desire</strong> — as opposed to spontaneous desire — is one of the most clinically useful ideas in the field, because it normalizes a pattern that clients frequently mistake for dysfunction.</p>\n<h3>The {{callout:dual-control}} Model</h3>\n<p>The dual control model proposes that sexual response reflects the balance between sexual excitation (the \"accelerator,\" responding to sexually relevant stimuli) and sexual inhibition (the \"brakes,\" responding to threat, distraction, stress, or fear). Individuals vary in the sensitivity of each system. This model is powerfully clinical: many sexual difficulties reflect too much activation of the brakes — anxiety, stress, distraction, relationship tension — rather than too little accelerator, which reframes treatment toward reducing inhibition rather than forcing arousal.</p>",
+          "order": 11,
+          "callouts": {
+            "dual-control": {
+              "label": "Dual Control Model",
+              "type": "reference",
+              "body": "A model (Bancroft & Janssen) framing sexual response as the balance between sexual excitation and sexual inhibition, with the set-point varying across individuals."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Biopsychosocial Model of Sexual Functioning</h2>\n<p>Sexual functioning is determined by the interaction of biological, psychological, and social factors, and the biopsychosocial model is the organizing framework for both assessment and treatment in sex therapy. Sexual concerns are almost always multiply determined, and effective treatment addresses the relevant contributors across all three domains.</p>\n<h3>The Three Domains</h3>\n<p><strong>Biological</strong> factors include general health, chronic illness (diabetes, cardiovascular disease, neurological conditions), hormonal status, medications (especially antidepressants, antihypertensives, and hormonal agents), substance use, and the physical changes of aging. <strong>Psychological</strong> factors include mood and anxiety, performance concerns and the self-monitoring known as {{callout:spectatoring}}, body image, beliefs and expectations about sex, and history of trauma or negative sexual experiences. <strong>Social and relational</strong> factors include relationship quality and conflict, communication, cultural and religious messages about sexuality, life stressors, and partner concerns.</p>\n<h3>Why the Model Matters Clinically</h3>\n<p>A concern that appears simple at presentation frequently turns out to involve contributors across all three domains, and single-domain formulations are a common source of treatment failure. A man with erectile difficulty may have early vascular disease (biological), performance anxiety amplifying the problem (psychological), and relationship tension and avoidance (social) all at once — and effective help addresses each. The biopsychosocial model also dictates collaboration: sex therapy frequently works alongside medical providers, because addressing the biological dimension is often essential.</p>",
+          "order": 12,
+          "callouts": {
+            "spectatoring": {
+              "label": "Spectatoring",
+              "type": "definition",
+              "body": "Self-monitoring during sexual activity — mentally observing and evaluating one’s own performance — which heightens anxiety and disrupts natural arousal."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Conducting the Sexual Health Assessment</h2>\n<p>Assessment in sex therapy is both a clinical task and a therapeutic intervention: the way the clinician asks about sexuality models that the topic is safe and discussable, and a thorough, respectful assessment frequently begins to reduce a client's distress.</p>\n<h3>Creating Safety</h3>\n<p>Effective sexual assessment depends on the clinician's own comfort. A clinician who asks about sexuality matter-of-factly, without embarrassment, using clear and respectful language, communicates that the topic is welcome. Normalizing statements (\"Many people have questions or concerns about this\") and explicit permission lower the barrier to disclosure. The clinician uses the client's own language for their body, partners, and practices, and follows the client's lead on pace and depth.</p>\n<h3>The Structure of Assessment</h3>\n<p>A comprehensive sexual assessment characterizes the concern (which phase of response, lifelong or acquired, generalized or situational, level of distress), surveys the biopsychosocial domains, and gathers relevant sexual and relationship history. The two clinical axes — lifelong versus acquired and generalized versus situational — are especially informative: an acquired, situational difficulty immediately directs attention to what changed and to the specific contexts in which the difficulty does and does not occur, frequently pointing toward psychological or relational contributors rather than purely biological ones.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Evidence Base for Sex Therapy: What the Research Supports</h2>\n<p>Sex therapy is an evidence-based field, and a generalist integrating sexual health work into practice benefits from understanding, at a high level, what the research supports — both to practice responsibly and to convey appropriate hope to clients.</p>\n<h3>Established Effectiveness</h3>\n<p>Psychological and behavioral treatments for the common sexual concerns have a substantial evidence base, and many sexual difficulties respond well to appropriate treatment. Behavioral techniques, cognitive-behavioral approaches, mindfulness-based interventions, and structured experiences such as sensate focus have research support across a range of presenting concerns, and integrated approaches that combine psychological treatment with medical management where indicated frequently produce the best outcomes. This evidence base is the foundation for the realistic optimism a clinician can offer: many people who seek help for sexual concerns experience meaningful improvement.</p>\n<h3>Reading the Evidence Responsibly</h3>\n<p>At the same time, the clinician reads the evidence with appropriate nuance. The research base is stronger for some concerns than others, much of it has historically centered particular populations and presentations, and outcomes depend on accurate assessment, the fit of the intervention to the specific concern and its contributors, and attention to relational and contextual factors rather than technique alone. The most effective practice is not the mechanical application of a technique but the thoughtful matching of evidence-based approaches to a well-formulated understanding of the individual client. A clinician who understands both the genuine effectiveness of sex therapy and the limits and conditions of that evidence can offer hope honestly, set realistic expectations, and know when a concern calls for specialized or medical referral rather than continued generalist treatment.</p>",
+          "order": 14,
+          "title": "The Evidence Base for Sex Therapy: What the Research Supports"
+        },
+        {
+          "order": 15,
+          "type": "multiSelect",
+          "question": "Which statements about responsive desire are accurate? (Select all that apply)",
+          "options": [
+            {
+              "text": "It emerges in response to arousal and intimacy rather than always preceding them",
+              "isCorrect": true
+            },
+            {
+              "text": "It is especially common in long-term relationships",
+              "isCorrect": true
+            },
+            {
+              "text": "Its presence indicates a sexual desire disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "Expecting only spontaneous desire can pathologize a normal pattern",
+              "isCorrect": true
+            },
+            {
+              "text": "It occurs only in women",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "Responsive desire is a normal pattern, especially in established relationships; treating spontaneous desire as the only valid form can wrongly pathologize it. It is not gender-exclusive and does not itself indicate a disorder."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Talking About Sex: The Clinician's Comfort and Language</h2>\n<p>The single greatest barrier to sexual health work is not lack of technique but the clinician's own discomfort, and developing comfort with sexual material is a foundational competency for anyone practicing in this area.</p>\n<h3>Sources of Discomfort</h3>\n<p>Clinicians may feel discomfort from inadequate training, from personal or cultural inhibition about discussing sex, from fear of saying the wrong thing or appearing prurient, and from uncertainty about language. This discomfort, when unaddressed, leaks into the room as avoidance — clinicians simply do not raise sexuality — and clients, reading the avoidance as a signal that the topic is unwelcome, stay silent. The result is a mutual silence that leaves significant concerns unaddressed.</p>\n<h3>Building Comfort</h3>\n<p>Comfort develops through education, through examining one's own attitudes and reactions (the values-clarification work that is itself a competency), through practice, and through consultation. It includes developing a usable vocabulary — clear, respectful, neither clinical-to-the-point-of-coldness nor euphemistic to the point of vagueness — and the ability to match the client's language. Over time, what begins as effortful becomes simply part of how the clinician practices, and the clinician's evident ease becomes a model that gives clients permission to speak.</p>",
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>Scope of Practice, Referral, and Certification</h2>\n<p>Practicing sexual health work competently requires a clear understanding of one's own scope and a readiness to refer when a concern exceeds it — a judgment that is itself a core competency rather than an admission of inadequacy.</p>\n<h3>Knowing When to Refer</h3>\n<p>Indicators that a concern may exceed general competence include entrenched dysfunction unresponsive to permission and basic suggestions, concerns with significant medical contributors requiring coordinated care, presentations rooted in significant trauma, complex relational or couple dynamics, and concerns outside one's training such as certain specialized presentations. Referral does not mean abandonment: the generalist frequently continues to provide a supportive, affirming relationship alongside specialized care, and serves as the integrating presence across providers.</p>\n<h3>AASECT Certification</h3>\n<p>The American Association of Sexuality Educators, Counselors and Therapists (AASECT) is the primary certifying body for sex therapists in the United States, setting standards for the specialized education, training, and supervision required for certification. Clinicians seeking to practice at the intensive level pursue this advanced training; clinicians practicing at the foundational levels should know how to identify and refer to certified sex therapists for concerns beyond their scope. Understanding this credentialing landscape helps clinicians locate their own practice on the spectrum of competence and build appropriate referral networks.</p>",
+          "order": 17
+        },
+        {
+          "type": "reflection",
+          "prompt": "Where on the spectrum of sexual health competence do you currently locate your own practice, and what is one concrete step that would extend it by one level?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 30
+        },
+        {
+          "type": "text",
+          "content": "<h2>The First Sessions and the Therapeutic Frame</h2>\n<p>The opening sessions of sexual health work establish whether a client experiences the clinician as a safe person with whom to discuss intimate concerns, and this frame shapes everything that follows.</p>\n<h3>Establishing Safety and Expectations</h3>\n<p>Early sessions clarify how the work will proceed, normalize the discussion of sexuality, and convey that the client controls the pace and depth of disclosure. The clinician's calm, matter-of-fact, non-judgmental manner in these first conversations is itself the intervention: it gives the client permission to speak about material they may never have discussed with any professional. Explicit normalization and the invitation to raise any concern, however embarrassing, lower the barrier that keeps so many sexual concerns unspoken.</p>\n<h3>Informed Consent and Collaboration</h3>\n<p>The frame also includes the practical elements of informed consent — confidentiality and its limits, the nature and boundaries of the work (including that sex therapy is entirely talk-based), and a collaborative stance in which goals are set with the client rather than for them. A clear, respectful frame protects the client, supports the alliance, and models the openness that sexual health work requires.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documentation in Sexual Health Care</h2>\n<p>Documentation of sexual health concerns requires both thoroughness and discretion, balancing the needs of good care with respect for the sensitivity of the material.</p>\n<h3>Principles</h3>\n<p>The clinician documents factually and professionally — the clinical picture, assessment, formulation, plan, and progress — without recording unnecessary graphic detail, and distinguishes the client's report from clinical observation. Sound documentation supports continuity and quality of care and meets ethical and record-keeping obligations, while protecting the client's privacy. Awareness that records may in some circumstances be accessed by others informs, but does not distort, what is recorded. The aim is an accurate, respectful record that serves the client's care without becoming a source of risk or exposure.</p>",
+          "order": 20
+        },
+        {
+          "type": "text",
+          "content": "<h2>Universal Screening for Sexual Concerns</h2>\n<p>Because sexual concerns are common, frequently undisclosed, and relevant across many presentations, a sexual health orientation favors routine screening rather than waiting for spontaneous disclosure or asking only when a concern is suspected.</p>\n<h3>Asking Everyone, Routinely</h3>\n<p>Universal screening means asking about sexual health as a normal part of assessment, framed so the client retains full control over what and whether to disclose, with an explicit signal that the topic is welcome. Selective asking communicates that the topic is reserved for problems; universal asking communicates that it is a normal part of health. A single normalized opening — \"I ask everyone about this\" — accomplishes most of the work, and a brief version (a single question, with genuine willingness to follow up) suffices for clinicians worried about time.</p>\n<h3>Screening and Responding Are Inseparable</h3>\n<p>How the clinician responds to disclosure determines whether screening helps. A calm, accepting, non-intrusive response that validates the concern and follows the client's lead makes screening safe; screening without the capacity to respond supportively can do more harm than good. Trauma-informed screening and trauma-informed responding go together.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Sexual Health and the Therapeutic Alliance</h2>\n<p>The therapeutic alliance is the foundation on which sexual health work rests, and it carries particular weight given the vulnerability of the material.</p>\n<h3>Why the Alliance Is Central</h3>\n<p>Clients disclose sexual concerns only to a clinician they experience as safe, non-judgmental, and trustworthy, and the quality of the alliance frequently determines whether significant concerns ever surface. For clients whose sexuality has been a source of shame, secrecy, or harm, the experience of being met with acceptance and respect is itself therapeutic, independent of any technique. The clinician builds the alliance through consistent, attuned, non-judgmental engagement and through the evident comfort that gives clients permission to speak.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>Confidentiality and Informed Consent</h2>\n<p>Sexual material is among the most sensitive a client discloses, and clear confidentiality and informed consent are essential to the trust that sexual health work requires.</p>\n<h3>Confidentiality and Its Limits</h3>\n<p>Clients need to understand that what they disclose is held in confidence, and also to understand the limits of that confidentiality — including mandated-reporting obligations and other legal exceptions that vary by jurisdiction. With couples, the clinician clarifies in advance how information shared individually will be handled, since secrets within couple work raise particular clinical and ethical challenges. Clarity about these matters at the outset protects both the client and the work.</p>\n<h3>Informed Consent</h3>\n<p>Informed consent for sexual health work includes the nature and boundaries of the work — notably that it is entirely talk-based and never involves physical sexual contact — the goals and methods, and the collaborative, client-directed nature of treatment. Clients retain the right to decline any topic or intervention and to control the pace of the work, and the clinician's respect for this autonomy is itself part of the corrective, empowering experience that sexual health work can provide.</p>",
+          "order": 23
+        },
+        {
+          "type": "text",
+          "content": "<h2>Integrating Sexual Health Into Your Existing Practice</h2>\n<p>The aim of this course is not to turn every clinician into a sex therapist but to integrate sexual health competence into ordinary practice, and a few deliberate steps make that integration sustainable.</p>\n<h3>Make It Routine</h3>\n<p>The most effective change is to build a brief sexual health inquiry into standard intake and review so it is asked of everyone as a matter of course, with a normalized opening that conveys the topic is welcome. The full assessment is reserved for clients who indicate a concern; the routine question simply ensures no client leaves believing the topic is off-limits. Over time, what begins as an effortful addition becomes part of how the clinician practices.</p>\n<h3>Practice at the Foundational Levels</h3>\n<p>Clinicians can begin applying the PLISSIT framework immediately, offering permission and accurate information — the levels that resolve a large share of concerns — while building toward specific suggestions as comfort and skill grow. Tolerating the early discomfort until it fades, debriefing difficult moments in consultation, and accumulating the experiences of relieved clients all sustain the practice. The spectrum of competence is something clinicians move along over a career, not a threshold crossed once.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Anatomy and Physiology Essentials for the Generalist</h2>\n<p>A working knowledge of sexual physiology helps the generalist formulate accurately and know when a medical referral is warranted, without requiring the depth of a physician.</p>\n<h3>The Response Cycle in Physiological Terms</h3>\n<p>Desire is a neurobiological and psychological phenomenon modulated by neurotransmitters (notably dopamine, which is excitatory, and serotonin, which is generally inhibitory — the mechanism behind SSRI-related desire suppression) and by hormones, including the contribution of testosterone to desire across genders. Arousal is fundamentally a vascular and neurological event: neural signals increase blood flow to genital tissue, producing erection and engorgement and lubrication, which is why conditions and medications affecting blood flow or nerve function impair it directly. Orgasm is a reflexive neuromuscular event that can be disrupted by medication, anxiety, and neurological factors, and resolution is the return to baseline.</p>\n<h3>The Clinical Payoff</h3>\n<p>Understanding this sequence lets the clinician localize where a difficulty occurs — desire, arousal, or orgasm — which is the first step in formulation, and it supports a low threshold for medical consultation when a concern is new, physical, or coincides with illness or medication, paired with reassurance about the wide range of normal variation when no pathology is present.</p>"
+        }
+      ]
+    },
+    {
+      "title": "Module 2: Sexual Dysfunctions, Evidence-Based Treatments, and Advanced Applications",
+      "order": 2,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 2,
+          "title": "Module 2",
+          "subtitle": "Module 2: Sexual Dysfunctions, Evidence-Based Treatments, and Advanced Applications",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>Major Sexual Dysfunction Categories and Evidence-Based Treatments</h2>\n<p>The major categories of sexual dysfunction addressed in sex therapy correspond to the DSM-5 diagnostic framework, which organizes sexual disorders into dysfunction categories organized by phase of the sexual response cycle and by gender of the client experiencing them. Female sexual interest and arousal disorder (FSIAD) encompasses the range of presentations involving low or absent sexual desire and reduced or absent sexual arousal in women. Male hypoactive sexual desire disorder (MHSDD) similarly encompasses low or absent desire in men. {{callout:erectile-disorder}} (ED) encompasses difficulty obtaining or maintaining erections sufficient for satisfying sexual activity. Female orgasmic disorder (FOD) and delayed ejaculation describe difficulties reaching orgasm. Early ejaculation describes ejaculation that occurs before or very shortly after penetration, before the person desires. {{callout:gpppd}}/penetration disorder (GPPPD) encompasses the range of presentations involving vulvovaginal pain, pelvic floor muscle dysfunction, and difficulty with penetration that was previously categorized as vaginismus and dyspareunia. Each diagnostic category has a distinct clinical profile, a distinct evidence base for treatment, and a distinct set of clinical considerations for assessment and formulation.</p>\n<p>Female sexual interest and arousal disorder is the most commonly reported sexual concern among women presenting in clinical settings and has a complex etiology that reflects the multiple biopsychosocial factors that influence female sexual desire and arousal. Rosemary Basson's circular model of female sexual response — which describes responsive desire, emerging in response to erotic stimuli within an intimate context, as a normative pathway for female sexual experience distinct from the spontaneous desire model derived from male sexual response research — is among the most clinically important contributions to contemporary sex therapy, because it reframes the experience of absent or low spontaneous desire as potentially normative rather than disordered for women whose desire is responsive rather than spontaneous. Clinicians who apply the responsive desire model in clinical assessment are providing a psychoeducational intervention that alone has significant clinical benefit for women who have been distressed by comparisons between their experience of responsive desire and the spontaneous desire model that dominant cultural representations of sexuality normalize.</p>\n<p>Erectile disorder has a complex biopsychosocial etiology in which biological factors — including cardiovascular disease, diabetes, medication side effects, and hypogonadism — interact with psychological factors — including performance anxiety, depression, and relationship conflict — in ways that often make the primary causal factor difficult to disentangle and that require integrated biopsychosocial assessment and treatment planning. Performance anxiety — the self-monitoring, self-critical cognitive process that disrupts the automatic, physiologically-driven arousal that erection requires — is the most prevalent psychological mechanism in erectile disorder and is the primary target of the behavioral and cognitive interventions that constitute sex therapy for ED. Sensate focus — which reduces performance anxiety by explicitly prohibiting performance goals during initial exercises and directing attention to pleasurable sensory experience rather than arousal monitoring — directly addresses the performance anxiety mechanism, as do cognitive interventions targeting the catastrophizing thoughts about erectile performance that maintain the anxiety cycle.</p>\n<p>Female orgasmic disorder — difficulty reaching orgasm despite adequate arousal and stimulation — is the second most common sexual concern among women presenting in clinical settings and has an evidence-based first-line treatment: directed masturbation, developed by LoPiccolo and Lobitz (1972). Directed masturbation is a graduated, behavioral approach to orgasmic development that begins with non-genital sensory exploration, progresses to focused genital self-stimulation, and gradually extends orgasmic response to partnered sexual situations. The strong evidence base for directed masturbation is clinically significant because it positions sex therapists and, at the Specific Suggestions level, trained mental health generalists, to provide a highly effective first-line intervention for a prevalent sexual health concern that is profoundly affected by shame, misinformation, and the absence of adequate sexual education that many women have received. Psychoeducation about female genital anatomy — specifically the anatomy and function of the clitoris — is an essential complement to directed masturbation instruction because many women lack basic accurate information about their own anatomy that is prerequisite to directed self-stimulation.</p>",
+          "order": 1,
+          "callouts": {
+            "gpppd": {
+              "label": "Genito-Pelvic Pain",
+              "type": "clinical",
+              "body": "Genito-Pelvic Pain/Penetration Disorder (DSM-5-TR): persistent difficulty with pain, fear, or pelvic muscle tension related to penetration; requires biopsychosocial assessment."
+            },
+            "erectile-disorder": {
+              "label": "Erectile Disorder",
+              "type": "clinical",
+              "body": "Persistent difficulty obtaining or maintaining an erection sufficient for sexual activity; frequently has interacting vascular, medication, and psychological contributors."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Desire Discrepancy, Medication Effects, and Evidence-Based Techniques</h2>\n<p>Genito-pelvic pain/penetration disorder (GPPPD) encompasses presentations that were previously categorized separately as vaginismus — involuntary muscular contraction of the vaginal introitus preventing penetration — and dyspareunia — recurrent genital pain associated with sexual activity. The DSM-5 integration of these two previously separate categories reflects the clinical recognition that their presentations frequently overlap and their treatment approaches substantially converge. GPPPD has a complex biopsychosocial etiology that typically involves interactions among physical factors including vulvovaginal tissue changes, pelvic floor muscle dysfunction, and inflammatory or dermatological conditions; psychological factors including pain catastrophizing, fear of pain, and sexual trauma history; and relational factors including partner responses to the pain condition and the impact of pain avoidance on relationship functioning. Comprehensive treatment planning for GPPPD typically requires coordination between the mental health clinician providing sex therapy and medical providers — including gynecologists, urogynecologists, and pelvic floor physical therapists — in an integrated multidisciplinary approach.</p>\n<p>Early ejaculation — previously called premature ejaculation — is the most commonly reported sexual concern among men presenting in sexual health settings and has well-established behavioral treatments with decades of evidence. The squeeze technique — applying pressure to the penis just before ejaculation to reduce arousal and delay the ejaculatory reflex — and the stop-start technique — pausing sexual activity when arousal approaches the ejaculatory threshold and resuming when the threshold has subsided — were developed by Masters and Johnson and Semans respectively and remain the first-line behavioral interventions for early ejaculation, typically delivered within a structured sex therapy format that progresses from solo masturbation practice to partnered sexual activity. Pharmacological approaches — including off-label use of SSRIs, which delay ejaculation as a side effect, and on-demand dapoxetine — are available for cases where behavioral approaches alone are insufficient. The concurrent treatment of the relationship dimensions of early ejaculation — including partner distress, avoidance of sexual activity, and the shame and self-blame that often develop — is an important component of comprehensive sex therapy for this condition.</p>\n<p>Desire discrepancy — the experience of significantly different levels of sexual desire between partners — is one of the most common presentations in couples sex therapy and one that requires careful differential assessment to distinguish from individual sexual dysfunction in either partner. Desire discrepancy is not inherently a pathological condition: variation in sexual desire level across individuals is a normal feature of human sexual diversity, and two partners with different desire levels may be experiencing entirely normal desire levels individually while experiencing significant relationship distress from the mismatch between them. Clinical assessment should include individual assessment of each partner's sexual desire within their own context as well as assessment of the relationship dimensions — including the quality of intimacy and attachment, communication patterns, and conflict dynamics — that significantly shape the desire levels experienced within the partnership. Couples sex therapy for desire discrepancy typically addresses both individual components — including any individual desire disorder contributing to the discrepancy — and relational components, including communication skills, initiation and refusal patterns, and the development of a mutually satisfying sexual relationship that can accommodate the couple's different desire levels.</p>\n<p>Medications and medical conditions are among the most common contributors to sexual dysfunction in clinical populations, and the assessment of iatrogenic and medically-based sexual dysfunction requires specific clinical knowledge that mental health clinicians who do not receive medical training must develop through deliberate continuing education. Antidepressant medications — particularly SSRIs and SNRIs — are among the most commonly prescribed psychotropic medications and are associated with sexual side effects — including decreased desire, arousal difficulties, and delayed or absent orgasm — in 30–40% of individuals who take them, a rate that is frequently higher than is reported in clinical practice because patients are not specifically asked about sexual effects and because the sexual side effects develop gradually rather than immediately. The clinical implications of antidepressant sexual side effects include: reduced medication adherence; increased depression when medication-related sexual dysfunction adds to depressive symptomatology; and relationship distress when sexual difficulties affect intimate partnerships. Clinicians who assess sexual functioning as a standard component of medication monitoring, who provide psychoeducation about expected medication effects, and who facilitate discussion with prescribing providers about medication modifications when sexual side effects are significant are providing a clinically important dimension of care that is frequently absent.</p>",
+          "order": 2
+        },
+        {
+          "type": "text",
+          "content": "<p>Sensate focus exercises — the behavioral cornerstone of sex therapy developed by Masters and Johnson and subsequently refined by multiple clinicians and researchers — provide a structured framework for graduated physical intimacy that systematically addresses the performance anxiety, spectatoring, and avoidance that maintain most sexual dysfunctions. The foundational therapeutic mechanism of sensate focus is the explicit prohibition of sexual performance goals — including erection, orgasm, and intercourse — during initial exercises, creating a context in which physical intimacy can be experienced without the evaluative pressure that triggers performance anxiety. By redirecting attention from performance evaluation to present-moment sensory experience — the specific qualities of touch, temperature, texture, pressure, and pleasure — sensate focus disrupts the self-monitoring and anxiety cycle that impairs automatic sexual response and begins the process of rebuilding positive associations between physical intimacy and pleasurable experience. The graduated structure of sensate focus — beginning with non-genital touching, progressing to genital touching without intercourse goals, and eventually incorporating intercourse in ways that maintain the non-demand pleasuring orientation — allows systematic desensitization of the anxiety responses that have become conditioned to sexual situations.</p>\n<p>Cognitive-behavioral sex therapy integrates the cognitive restructuring approaches of CBT with the behavioral interventions that have constituted the classical sex therapy behavioral repertoire. Cognitive distortions about sexual performance — including catastrophizing about erectile difficulty, all-or-nothing thinking about orgasmic response, mind-reading about partner judgments, and the unrealistic sexual expectations promoted by pornography and cultural media — are both common contributors to sexual dysfunction and primary targets of cognitive restructuring interventions in sex therapy. Standard cognitive restructuring tools — thought records, Socratic questioning, behavioral experiments — apply directly to sexually-relevant cognitions when conducted by a clinician with sexual health knowledge to accurately evaluate the evidence regarding the client's specific distorted beliefs. Sex-specific cognitive interventions also include psychoeducation about normal sexual variation, the provision of accurate information about normative sexual functioning that corrects specific misinformation-based cognitive distortions, and the development of more flexible, reality-based sexual expectations.</p>\n<p>Mindfulness-based approaches to sex therapy have accumulated a growing evidence base over the past two decades, particularly for female sexual dysfunction. Mindfulness — the intentional, non-judgmental, present-moment awareness of experience — addresses the attentional dimension of sexual dysfunction that is captured in the concept of spectatoring: the withdrawal of attention from the immediate sensory experience of sexual activity to self-evaluative monitoring from an observer perspective. Spectatoring disrupts the physiological arousal process by redirecting neural resources away from erotic processing toward self-critical monitoring, explaining why performance anxiety impairs the very responses that the anxious monitoring is attempting to ensure. Brotto and colleagues' mindfulness-based sex therapy group program for women with FSIAD and for female cancer survivors with sexual health concerns has the strongest evidence base, with multiple RCTs documenting significant improvements in sexual desire, arousal, lubrication, and satisfaction. Mindfulness practices — including mindful awareness of sensory experience during solo and partnered sexual activity — provide both a self-regulatory tool for managing performance anxiety and a mechanism for building the embodied, present-moment sexual engagement that healthy sexual functioning requires.</p>\n<p>Communication and intimacy in sex therapy addresses the relational dimensions of sexual functioning that are separable from but interacting with the individual components of sexual response. Sexual functioning occurs within a relational context — the quality of attachment security, communication, conflict resolution, and emotional intimacy in the partnership provides the relational substrate within which individual sexual response either thrives or is impaired. Research by McCarthy and McCarthy documents the substantial impact of relational factors — including emotional intimacy, communication patterns, and the couple's 'GoodEnough Sex' model — on sexual satisfaction across the lifespan. Sex therapy that attends only to the individual components of sexual dysfunction without assessing and addressing the relational context will produce limited outcomes for clients whose dysfunction is substantially maintained by relational factors. Couples communication skills — including the development of explicit verbal communication about sexual preferences, boundaries, and experiences — are a standard component of sex therapy that provides both immediate clinical benefit and long-term relationship skills that sustain sexual health.</p>",
+          "order": 3
+        },
+        {
+          "type": "text",
+          "content": "<h2>Advanced Applications: LGBTQ+, Older Adults, and Referral Practice</h2>\n<p>Sex therapy for LGBTQ+ clients requires specific clinical adaptations that reflect the distinct dimensions of sexual health and sexual functioning within LGBTQ+ relationships. The sexual response cycle models derived from heterosexual cisgender samples may require adaptation for LGBTQ+ clients: for example, the specific physiological dimensions of sexual response in transgender clients who have undergone hormonal or surgical transition require the clinician's familiarity with gender-affirming medical care and its effects on sexual response. The relational dynamics of same-sex partnerships differ in specific ways from different-sex partnerships — including the absence of gender-based complementarity in sexual script expectations — in ways that affect the specific clinical presentations of desire discrepancy, communication challenges, and sexual functioning concerns. LGBTQ+ clients who present for sex therapy also carry the burden of minority stress and internalized stigma that may be contributing to their sexual concerns in ways that require affirming clinical attention alongside the specific sex therapy intervention.</p>\n<p>Sex therapy with older adults requires specific clinical knowledge about the normative changes in sexual response that accompany aging and about the medical, pharmacological, and relational factors that affect sexual health in later life. The normative changes in male sexual response with aging — including longer time to erection, reduced rigidity, longer refractory period, and reduced ejaculatory force — are frequently misinterpreted by older adult men as evidence of erectile disorder rather than as normative changes that may be accommodated through behavioral adjustments and realistic expectation modification. Genitourinary syndrome of menopause (GSM) — the umbrella term for the vulvovaginal and lower urinary tract changes associated with estrogen decline — affects approximately 50% of postmenopausal women and produces symptoms including vaginal dryness, tissue fragility, and dyspareunia that are both highly prevalent and highly treatable through local estrogen therapy, lubricants, and vaginal moisturizers. The failure to assess for and address GSM in postmenopausal women presenting with sexual pain is a clinically common oversight that reflects inadequate integration of sexual health assessment into clinical practice for this population.</p>\n<p>Referral to an AASECT-certified sex therapist represents an important component of the clinical competency of any mental health practitioner who encounters sexual health concerns in their clinical practice. The decision to refer involves clinical judgment about whether the complexity, treatment resistance, or specific clinical features of the sexual health presentation exceed the scope of what the referring clinician's training and competency can safely address. Clinical features that typically indicate referral to a sex therapy specialist include: complex or treatment-resistant sexual dysfunctions that have not responded to first-line clinical approaches; presentations involving significant relationship conflict or trauma that require the specific expertise of a clinician trained in both sex therapy and couples therapy; sexual health concerns with significant medical dimensions requiring coordination between mental health and medical sex therapy; presentations involving paraphilic interests or behaviors that require the specialized clinical knowledge of a certified sex therapist; and presentations that the referring clinician identifies as beyond their competency based on honest self-assessment. Warm referrals — in which the referring clinician personally facilitates the connection to the sex therapy specialist and maintains appropriate coordination — are more effective than cold referrals and are the standard of good clinical practice.</p>\n<p>The completion of this course provides a foundational framework for the integration of sexual health assessment and evidence-based sexual health interventions into general mental health clinical practice. Clinicians who have completed this training are equipped to: conduct sexual health assessments with genuine clinical ease; apply validated assessment instruments including the FSFI and IIEF; provide Permission and Limited Information level sexual health interventions for the full range of clients they serve; recognize when specific sexual health presentations require referral to an AASECT-certified sex therapist; and provide the culturally responsive, affirming, and evidence-based sexual health care that clients with sexual health concerns deserve. The ongoing professional development in sex therapy foundations — through additional continuing education, consultation with sex therapy specialists, and engagement with the growing sex therapy evidence base — will expand the depth and range of the clinician's sexual health clinical competency in ways that directly benefit the clients who present with these profoundly important clinical concerns.</p>",
+          "order": 4
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>David, 55, presents with erectile difficulty for two years. He reports moderate depression managed with sertraline (started three years ago), type 2 diabetes diagnosed four years ago, and increasing performance anxiety leading to sexual avoidance. Assessment distinguishes: biological contributors (diabetes vascular effects, SSRI sexual side effects); psychological (performance anxiety, catastrophizing, depression); relational (partner intimacy erosion). Plan: medical referral for vascular assessment; medication review with prescriber; individual sex therapy with sensate focus and cognitive restructuring; couples component addressing relational impact.</blockquote>",
+          "order": 5
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 2: sexual dysfunctions, evidence-based treatments, and advanced applications, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 6
+        },
+        {
+          "order": 7,
+          "type": "multiSelect",
+          "question": "Which are evidence-based components in treating female orgasmic difficulties? (Select all that apply)",
+          "options": [
+            {
+              "text": "Directed masturbation / guided self-exploration",
+              "isCorrect": true
+            },
+            {
+              "text": "Sensate focus and reducing performance pressure",
+              "isCorrect": true
+            },
+            {
+              "text": "Psychoeducation about arousal and the role of the clitoris",
+              "isCorrect": true
+            },
+            {
+              "text": "Requiring simultaneous orgasm as the treatment goal",
+              "isCorrect": false
+            },
+            {
+              "text": "Addressing relational and contextual factors",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Evidence-based care combines directed self-exploration, sensate focus, accurate psychoeducation, and attention to relational context. Simultaneous orgasm is not a clinical requirement and setting it as a goal adds performance pressure."
+        },
+        {
+          "type": "multipleChoice",
+          "question": "SSRIs and SNRIs are associated with sexual side effects in approximately:",
+          "options": [
+            {
+              "text": "5-10% of users",
+              "isCorrect": false
+            },
+            {
+              "text": "30-40% of users",
+              "isCorrect": true
+            },
+            {
+              "text": "60-70% of users",
+              "isCorrect": false
+            },
+            {
+              "text": "Less than 5% of users",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Sexual side effects from SSRIs/SNRIs — including decreased desire, arousal difficulties, and delayed orgasm — occur in approximately 30-40% of users, are frequently underreported, and significantly affect medication adherence.",
+          "showExplanation": true,
+          "order": 8
+        },
+        {
+          "order": 9,
+          "type": "sequencing",
+          "instructions": "Order the PLISSIT levels as a generalist moves through them, escalating to specialist referral last.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Permission — normalize the concern and invite discussion"
+            },
+            {
+              "order": 2,
+              "text": "Limited Information — provide accurate, targeted education"
+            },
+            {
+              "order": 3,
+              "text": "Specific Suggestions — offer concrete behavioral strategies within scope"
+            },
+            {
+              "order": 4,
+              "text": "Intensive Therapy — refer to specialized sex therapy when the concern exceeds generalist scope"
+            }
+          ],
+          "explanation": "PLISSIT escalates from low-intensity permission and information — where most generalist work happens — to specific suggestions, and finally to referral for intensive specialized treatment."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Classifying the Sexual Dysfunctions</h2>\n<p>The DSM-5-TR organizes sexual dysfunctions by the area of functioning affected, and a working knowledge of these categories supports accurate assessment and treatment planning. Across all categories, two requirements are essential: the difficulty must persist (generally for a minimum duration, typically about six months) and must cause clinically significant distress. This distress requirement is the safeguard that prevents the pathologizing of normal variation — a person whose sexual pattern differs from a supposed norm but who is not distressed does not have a disorder.</p>\n<h3>The Main Categories</h3>\n<p>The dysfunctions span desire concerns (such as male hypoactive sexual desire disorder and female sexual interest/arousal disorder), arousal concerns (such as erectile disorder), orgasm concerns (such as delayed ejaculation, early/premature ejaculation, and female orgasmic disorder), and genito-pelvic pain/penetration disorder. Each is further specified along the two clinical axes introduced earlier — lifelong versus acquired and generalized versus situational — which carry direct implications for likely cause and treatment.</p>\n<h3>Beyond the Categories</h3>\n<p>Diagnostic categories are a starting point, not the whole picture. Many clients present with concerns that cross categories, that are primarily relational, or that do not meet full diagnostic criteria yet cause real distress and deserve attention. The clinician uses the categories to organize understanding while remaining responsive to the individual's actual experience.</p>",
+          "order": 10
+        },
+        {
+          "type": "text",
+          "content": "<h2>Desire Concerns and Low Desire</h2>\n<p>Low or absent sexual desire is among the most common presentations in sex therapy, and also among the most multiply determined, which is why it requires careful biopsychosocial assessment rather than a single explanation.</p>\n<h3>Assessment</h3>\n<p>Assessment distinguishes lifelong from acquired and generalized from situational desire concerns, and surveys the full range of contributors: biological (hormonal status, medications — especially antidepressants, chronic illness, fatigue), psychological (depression, anxiety, body image, history of negative experiences), and relational (relationship satisfaction, conflict, attraction, the partner's behavior). Crucially, the clinician evaluates whether the concern reflects truly low desire or a mismatch with a partner, and whether the client's desire is responsive rather than spontaneous — since a person with responsive desire may interpret the absence of spontaneous desire as a disorder when it is simply their normal pattern.</p>\n<h3>Treatment</h3>\n<p>Because low desire is multiply determined, treatment is correspondingly multimodal: addressing biological contributors (including medication review with the prescriber), treating co-occurring depression or anxiety, working with relational factors, correcting beliefs and expectations, and — where relevant — reframing responsive desire as normal and building the conditions (intimacy, reduced stress, positive experiences) under which desire can emerge. Mindfulness-based approaches have a particularly notable evidence base for desire and arousal concerns.</p>",
+          "order": 11
+        },
+        {
+          "type": "text",
+          "content": "<h2>Desire Discrepancy Between Partners</h2>\n<p>Desire discrepancy — a difference between partners in desired frequency or type of sexual activity — is one of the most common reasons couples seek sex therapy, and it is frequently misframed by the couple as a dysfunction in the lower-desire partner.</p>\n<h3>Reframing the Problem</h3>\n<p>A central and frequently therapeutic intervention is to reframe desire discrepancy as a difference between two people rather than a deficiency in one. Almost all couples differ in desire to some degree, and the difference itself is normal; the distress arises from how the difference is interpreted and managed. Reframing relieves the lower-desire partner of the \"patient\" role and the higher-desire partner of feeling rejected, and it positions the discrepancy as a shared challenge to navigate together.</p>\n<h3>The Pursuer-Distancer Cycle</h3>\n<p>Desire discrepancy frequently settles into a self-reinforcing pursuer-distancer dynamic: the higher-desire partner pursues, the lower-desire partner feels pressured and withdraws, the pursuit intensifies, and the withdrawal deepens. Treatment helps the couple recognize and interrupt this cycle, improve communication about sex, reduce pressure, and find mutually satisfying ways to connect. Often, reducing the pressure itself allows desire in the lower-desire partner more room to emerge.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Arousal Difficulties: Erectile Disorder</h2>\n<p>Erectile difficulty is one of the most common male-presenting concerns and one of the most important to assess carefully, because of both its medical significance and the powerful role of anxiety.</p>\n<h3>The Cardiovascular Connection</h3>\n<p>Because erection is fundamentally a vascular event, erectile difficulty can be an early marker of cardiovascular disease — the same processes that impair coronary circulation impair erectile function, frequently earlier. New-onset erectile difficulty therefore warrants medical evaluation, both for the sexual concern and as a potential cardiovascular signal. A useful clinical clue is whether erections occur in some contexts (on waking, with self-stimulation) but not others, which points toward psychological and situational contributors rather than purely vascular ones.</p>\n<h3>The Anxiety Cycle and Treatment</h3>\n<p>Psychologically, the performance-anxiety cycle is central: a single difficult experience generates anxiety that makes the next more likely, and spectatoring (self-monitoring during sex) pulls attention away from arousal. Treatment combines, as appropriate, medical evaluation and management (including PDE5 inhibitors prescribed by a medical provider), anxiety reduction, sensate focus to remove performance demand, cognitive work on beliefs and expectations, and attention to relational factors. Sex therapy and medical treatment frequently work best in combination.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>Arousal Difficulties in Women</h2>\n<p>Reduced genital arousal and lubrication in women may reflect hormonal change (especially the genitourinary syndrome of menopause), medication, insufficient or mismatched stimulation, anxiety, or relationship factors, and assessment surveys each.</p>\n<h3>Arousal Non-Concordance</h3>\n<p>An especially important concept is arousal non-concordance — the common finding that genital response and subjective arousal do not always align. A woman may show genital arousal without subjective arousal, or experience subjective arousal without strong genital response. This is a normal feature of sexual response, not a sign of dysfunction or of dishonesty about one's feelings, and clients distressed by a perceived mismatch are frequently reassured to learn so. Recognizing non-concordance also prevents the clinician from treating genital response as a reliable proxy for desire or consent.</p>\n<h3>Treatment</h3>\n<p>Treatment addresses the relevant contributors: medical evaluation and management of hormonal or vascular factors (including treatment for the genitourinary syndrome of menopause), attention to the adequacy and type of stimulation, reduction of anxiety and spectatoring, mindfulness-based approaches, and relational work. As throughout sex therapy, the dual control framework is useful — frequently the issue is too much inhibition (stress, distraction, anxiety) rather than too little excitation.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Orgasm Concerns</h2>\n<p>Orgasm concerns include difficulty reaching orgasm (delayed or absent) and orgasm occurring sooner than desired (early/premature ejaculation), affecting clients of all genders.</p>\n<h3>Delayed and Absent Orgasm</h3>\n<p>Difficulty reaching orgasm has common contributors across genders: medication (SSRIs are a leading cause), anxiety and spectatoring, insufficient or mismatched stimulation, and relationship factors. Assessment distinguishes lifelong from acquired and generalized from situational, since a client who has never experienced orgasm requires a different approach than one who has lost a previously reliable capacity. Accurate education — about the role of adequate stimulation, the effects of anxiety, and the wide range of normal experience — is itself frequently therapeutic, and directed masturbation programs have strong evidence for lifelong female anorgasmia.</p>\n<h3>Early (Premature) Ejaculation</h3>\n<p>Early ejaculation involves ejaculation sooner than the person or couple desires, with associated distress. Performance anxiety frequently maintains it, in a self-reinforcing cycle. Many cases respond to behavioral techniques (such as the stop-start and squeeze methods that build awareness and tolerance of arousal), anxiety reduction, and reduced pressure; some respond to pharmacological approaches managed by a prescriber. As with all the dysfunctions, treatment is matched to the individual's particular pattern and contributors.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Genito-Pelvic Pain and Penetration Disorder</h2>\n<p>Genito-pelvic pain/penetration disorder encompasses pain during intercourse or attempted penetration, difficulty with penetration, fear or anxiety about pain, and tension of the pelvic floor muscles. It deserves particular care because it is common, frequently has treatable physiological contributors, and is too often dismissed or prematurely attributed to psychological causes.</p>\n<h3>The Cardinal Principle</h3>\n<p>Sexual pain always warrants medical evaluation alongside psychological assessment. Physiological contributors are numerous — pelvic floor dysfunction, the genitourinary syndrome of menopause, vulvodynia and related pain conditions, infections, dermatological conditions, and the after-effects of childbirth or surgery — and many respond well to targeted treatment. Pelvic floor physical therapy in particular is an essential and frequently overlooked resource.</p>\n<h3>The Pain-Fear-Tension Cycle</h3>\n<p>Physiological and psychological factors interact in a self-reinforcing cycle: pain produces anticipatory fear, fear produces muscle tension and reduced arousal, and tension and reduced arousal worsen pain. Effective treatment is therefore usually interdisciplinary, combining medical and physical-therapy management of the physiological contributors with psychological work on the fear, anxiety, and avoidance that maintain the cycle. Graduated approaches — including the careful, client-controlled use of dilators alongside anxiety reduction — can help, but the clinician never treats sexual pain as a purely psychological problem.</p>",
+          "order": 16
+        },
+        {
+          "order": 17,
+          "type": "fillInBlank",
+          "title": "Quick check — DSM-5-TR criteria",
+          "blanks": [
+            {
+              "prompt": "DSM-5-TR sexual dysfunctions generally require symptoms persist for at least this many months:",
+              "answer": "6",
+              "acceptAlternates": [
+                "six"
+              ]
+            },
+            {
+              "prompt": "Across categories, the diagnosis also requires clinically significant ___ to the individual:",
+              "answer": "distress",
+              "acceptAlternates": [
+                "distress or impairment"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>Sensate Focus in Depth</h2>\n<p>Sensate focus, developed by Masters and Johnson, remains one of the foundational behavioral techniques in sex therapy and a tool that clinicians with foundational training can use for a range of concerns.</p>\n<h3>What It Is and How It Works</h3>\n<p>Sensate focus is a structured series of touching exercises that partners do at home, beginning with non-genital touching and progressing gradually, over sessions, toward genital touching and eventually intercourse — but crucially, with an explicit prohibition, in the early stages, on intercourse and on any goal of arousal or orgasm. The partners take turns giving and receiving touch, focusing on sensation and on what feels pleasant rather than on performance or outcome.</p>\n<h3>Why the Performance Ban Matters</h3>\n<p>The genius of sensate focus is the removal of performance demand. Because so many sexual difficulties are maintained by performance anxiety and spectatoring, removing the demand to perform — to achieve erection, arousal, or orgasm — interrupts the anxiety cycle and allows natural response to re-emerge. The structured progression rebuilds positive sexual experience gradually and at the couple's pace, restores communication about touch and pleasure, and shifts the couple's focus from goal-oriented performance to shared sensory connection. Sensate focus is used for arousal and desire concerns, performance anxiety, and the rebuilding of sexual connection, and it is frequently combined with other interventions.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Cognitive-Behavioral Approaches to Sexual Concerns</h2>\n<p>Cognitive-behavioral sex therapy applies the principles of CBT to sexual problems, addressing the thoughts, beliefs, and behaviors that maintain them, and has a solid evidence base across a range of presentations.</p>\n<h3>The Cognitive Component</h3>\n<p>Sexual difficulties are frequently maintained by distorted or unhelpful cognitions: unrealistic expectations about how sex \"should\" work, catastrophic interpretations of normal variation, performance-related fears, negative beliefs about one's body or sexual adequacy, and rigid sexual scripts. Cognitive work identifies and challenges these beliefs, replacing them with more accurate and flexible alternatives. Addressing spectatoring — the anxious self-monitoring that pulls attention from sensation to evaluation — is a central cognitive-behavioral target across many sexual concerns.</p>\n<h3>The Behavioral Component</h3>\n<p>The behavioral component includes the structured techniques of sex therapy — sensate focus, the stop-start and squeeze methods, directed masturbation, graduated exposure for avoidance and pain-related fear — along with anxiety-reduction strategies and the scheduling of intimacy where avoidance has taken hold. Cognitive and behavioral elements work together: behavioral exercises generate new experiences that disconfirm distorted beliefs, and cognitive work supports engagement in the behavioral exercises.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Mindfulness-Based Approaches</h2>\n<p>Mindfulness-based interventions have emerged as a particularly well-supported approach in sex therapy, with a notable evidence base for women's desire and arousal concerns and growing application across presentations.</p>\n<h3>The Rationale</h3>\n<p>Many sexual difficulties involve distraction, anxiety, spectatoring, and disconnection from bodily sensation — precisely the patterns that mindfulness addresses. Mindfulness cultivates present-moment, non-judgmental awareness, which counters the self-monitoring and distraction that interfere with sexual response and helps clients reconnect with bodily sensation and pleasure. In dual-control terms, mindfulness reduces the activation of the \"brakes\" (anxiety, distraction, self-criticism) that inhibit response.</p>\n<h3>Application</h3>\n<p>Mindfulness-based sex therapy typically combines mindfulness training with sexual health education and behavioral practice, teaching clients to bring non-judgmental attention to bodily sensation during both daily life and sexual experience. It is especially useful for desire and arousal concerns, for spectatoring and performance anxiety, and for clients whose difficulties are maintained by self-criticism and distraction. The approach fits the affirming, non-prescriptive orientation of contemporary sex therapy, emphasizing awareness and acceptance over the forcing of a particular response.</p>",
+          "order": 20
+        },
+        {
+          "type": "text",
+          "content": "<h2>Medical Collaboration and Medication Effects</h2>\n<p>Because biological factors contribute to so many sexual concerns, collaboration with medical providers is a routine and essential part of sex therapy, even for clinicians who do not prescribe.</p>\n<h3>Medication Effects</h3>\n<p>Many common medications affect sexual function. Antidepressants, particularly SSRIs, frequently cause reduced desire, delayed or absent orgasm, and arousal difficulty across genders — an effect important to recognize, since clients may not connect a new sexual problem to a recent medication, and since prescribers have options (dose adjustment, timing, alternative agents, or augmentation) when made aware. Antihypertensives, hormonal agents, and other medications also affect sexual function. The clinician routinely reviews medications as part of assessment and coordinates with prescribers rather than working around a contributor that could be modified.</p>\n<h3>Coordinating Care</h3>\n<p>Effective collaboration involves recognizing when a medical evaluation is warranted (new-onset, physical, or illness-associated concerns; sexual pain; erectile difficulty as a potential cardiovascular marker), making appropriate referrals with the client's consent, and integrating medical and psychological treatment. Medical management — whether of vascular factors, hormonal status, or a contributing medication — frequently works best alongside the psychological and relational work of sex therapy, with each addressing dimensions the other cannot.</p>",
+          "order": 21
+        },
+        {
+          "order": 22,
+          "type": "cardSort",
+          "instructions": "Sort each intervention by its primary mechanism.",
+          "categories": [
+            "Behavioral",
+            "Cognitive",
+            "Mindfulness-based"
+          ],
+          "cards": [
+            {
+              "id": "sf",
+              "text": "Sensate focus exercises",
+              "correctCategory": "Behavioral"
+            },
+            {
+              "id": "dm",
+              "text": "Directed masturbation",
+              "correctCategory": "Behavioral"
+            },
+            {
+              "id": "cb",
+              "text": "Challenging performance-related beliefs",
+              "correctCategory": "Cognitive"
+            },
+            {
+              "id": "pe",
+              "text": "Psychoeducation correcting sexual myths",
+              "correctCategory": "Cognitive"
+            },
+            {
+              "id": "pm",
+              "text": "Nonjudgmental present-moment awareness during touch",
+              "correctCategory": "Mindfulness-based"
+            },
+            {
+              "id": "us",
+              "text": "Observing sensations and urges without reacting",
+              "correctCategory": "Mindfulness-based"
+            }
+          ],
+          "explanation": "Behavioral methods change what clients do; cognitive methods change unhelpful beliefs; mindfulness-based methods change the quality of attention during intimacy — and effective treatment frequently combines all three."
+        },
+        {
+          "type": "reflection",
+          "prompt": "Which of the foundational techniques — sensate focus, cognitive-behavioral methods, or mindfulness — fits most naturally with your current practice, and how might you begin integrating it?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 39
+        },
+        {
+          "type": "text",
+          "content": "<h2>Performance Anxiety and Spectatoring: The Common Thread</h2>\n<p>Across nearly all of the sexual dysfunctions runs a common maintaining factor — performance anxiety and the self-monitoring known as spectatoring — and understanding it unifies much of sex therapy.</p>\n<h3>The Mechanism</h3>\n<p>When a person becomes anxious about sexual performance, they begin to monitor and evaluate themselves during sex rather than attending to sensation and pleasure. This self-focused attention — spectatoring — pulls cognitive resources away from the very experience that produces arousal, and the anxiety itself activates the inhibitory \"brakes\" of the dual control system. The result is a self-reinforcing cycle: anxiety impairs response, the impaired response increases anxiety, and avoidance frequently follows.</p>\n<h3>Why It Unifies Treatment</h3>\n<p>Recognizing performance anxiety and spectatoring as a common thread explains why several different techniques work for several different problems. Sensate focus removes the performance demand; mindfulness redirects attention from self-monitoring to present sensation; cognitive work challenges the catastrophic beliefs that fuel the anxiety; and reducing pressure interrupts the cycle. Whatever the presenting dysfunction, addressing the performance-anxiety cycle is frequently central to its resolution.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>Treating Sexual Avoidance</h2>\n<p>Avoidance is a frequent and self-perpetuating consequence of sexual difficulty: a person who has had distressing sexual experiences begins to avoid sex, and avoidance prevents the new, corrective experiences that could resolve the problem while allowing anxiety and distance to grow.</p>\n<h3>Breaking the Avoidance Cycle</h3>\n<p>Treatment gently reverses avoidance through graduated, low-pressure re-engagement. Sensate focus is well suited to this, because its early prohibition on intercourse and arousal goals makes re-engagement safe and removes the very performance demand that drove the avoidance. The clinician helps the couple or individual rebuild positive experience step by step, at a tolerable pace, while addressing the anxiety and beliefs that maintain the avoidance. Scheduling intimacy — counterintuitive as it sounds — can help couples who have drifted into avoidance re-establish connection without the pressure of spontaneity.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Sexual Functioning and Chronic Medical Conditions</h2>\n<p>Chronic medical conditions affect sexual functioning through multiple pathways, and the clinician's awareness of these effects supports accurate formulation and appropriate collaboration.</p>\n<h3>Common Pathways</h3>\n<p>Conditions such as diabetes, cardiovascular disease, and neurological disorders directly impair the vascular and neural processes underlying arousal; many conditions cause fatigue, pain, and reduced wellbeing that dampen desire and activity; treatments and medications carry their own sexual side effects; and the psychological impact of illness — on body image, identity, and mood — further affects sexuality. Cancer and its treatments, in particular, frequently produce lasting sexual consequences that survivors are rarely helped to address.</p>\n<h3>The Clinical Response</h3>\n<p>The clinician raises sexuality as a legitimate part of living with illness, coordinates with medical providers regarding physiological contributors and medication effects, helps clients and partners adapt and renegotiate intimacy, and expands the definition of satisfying sexuality where prior function cannot be restored. As elsewhere, simply asking about the sexual impact of a condition — when no one else on the care team has — frequently allows a client to address a concern they assumed they had to endure in silence.</p>",
+          "order": 26
+        },
+        {
+          "order": 27,
+          "type": "multiSelect",
+          "question": "Why do performance anxiety and spectatoring matter across many sexual dysfunctions? (Select all that apply)",
+          "options": [
+            {
+              "text": "Spectatoring diverts attention from erotic cues and disrupts arousal",
+              "isCorrect": true
+            },
+            {
+              "text": "Anxiety activates inhibition in the dual control model",
+              "isCorrect": true
+            },
+            {
+              "text": "They maintain a self-perpetuating cycle of difficulty and worry",
+              "isCorrect": true
+            },
+            {
+              "text": "They are relevant only to erectile disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "Reducing performance pressure (e.g., sensate focus) targets them directly",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Performance anxiety and spectatoring are transdiagnostic: they disrupt arousal, increase inhibition, and sustain a self-reinforcing cycle across presentations — which is why pressure-reducing techniques like sensate focus are so widely useful."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Setting Goals and Measuring Progress</h2>\n<p>Effective sex therapy is goal-directed and collaborative, with goals set together with the client and progress monitored over time.</p>\n<h3>Collaborative, Client-Defined Goals</h3>\n<p>Goals are defined by the client's own vision of sexual wellbeing rather than by an external standard of \"normal\" function. For one client the goal may be resolving a specific dysfunction; for another, reducing distress, improving communication, or expanding a satisfying sexual repertoire within the constraints of illness or aging. Clarifying goals collaboratively keeps treatment focused and ensures it serves the client's actual priorities.</p>\n<h3>Tracking Change</h3>\n<p>Progress is monitored through the client's report, through change in the presenting concern and associated distress, and, where appropriate, through validated instruments used to measure change over treatment. Regularly reviewing progress against the agreed goals supports motivation, allows the plan to be adjusted, and clarifies when treatment goals have been met.</p>",
+          "order": 28
+        },
+        {
+          "type": "text",
+          "content": "<h2>Homework and Between-Session Practice</h2>\n<p>Much of the change in sex therapy happens between sessions, through the structured exercises and practice the clinician assigns, making the design and review of homework a core skill.</p>\n<h3>The Role of Homework</h3>\n<p>Behavioral assignments — sensate focus exercises, communication practice, mindfulness practice, graduated exposure, the stop-start or squeeze methods, directed masturbation — are where new experiences are generated and skills are built. The clinician designs assignments collaboratively, ensures they are clearly understood and matched to the client's readiness, anticipates obstacles, and reviews the results in the next session, using both successes and difficulties as material for the work.</p>\n<h3>Working with Non-Completion</h3>\n<p>When clients do not complete assignments, the clinician treats this as information rather than failure: it may reflect anxiety, an assignment pitched beyond readiness, relational obstacles, ambivalence, or practical barriers. Exploring non-completion curiously frequently reveals important maintaining factors and allows the plan to be recalibrated.</p>",
+          "order": 29
+        },
+        {
+          "type": "text",
+          "content": "<h2>When Sex Therapy Stalls: Common Obstacles</h2>\n<p>Treatment does not always proceed smoothly, and recognizing and addressing common obstacles is part of competent practice.</p>\n<h3>Frequent Sources of Impasse</h3>\n<p>Sex therapy may stall when an unaddressed medical contributor is impeding progress, when relationship distress overwhelms the sexual work and needs to be addressed first, when unrecognized trauma is driving the presentation, when anxiety or shame is too high for the current pace, when goals are mismatched between partners, or when the concern exceeds the clinician's competence. Attempting to push forward with behavioral techniques while one of these obstacles is operating is a frequent and counterproductive error.</p>\n<h3>Responding to Impasse</h3>\n<p>When progress stalls, the clinician steps back to reassess: Is a medical evaluation needed? Is relationship distress the primary issue? Is trauma involved? Is the pace too fast, or the alliance strained? Does the concern call for referral to a certified sex therapist or another specialist? Consultation is especially valuable at these moments. Impasse handled with reassessment and recalibration frequently becomes a turning point rather than an ending.</p>",
+          "order": 30
+        },
+        {
+          "order": 31,
+          "type": "sequencing",
+          "instructions": "Order the clinician’s steps when a client repeatedly does not complete between-session assignments.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Explore nonjudgmentally what got in the way, rather than assuming noncompliance"
+            },
+            {
+              "order": 2,
+              "text": "Reassess whether the assignment fit the client’s readiness, relationship, and context"
+            },
+            {
+              "order": 3,
+              "text": "Identify and address specific barriers (anxiety, partner dynamics, logistics, meaning)"
+            },
+            {
+              "order": 4,
+              "text": "Collaboratively adjust or rescale the assignment"
+            }
+          ],
+          "explanation": "Incomplete assignments are clinical information, not failure. The clinician first understands the barrier, reassesses fit, addresses what is in the way, and then recalibrates collaboratively."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Integrating Pharmacological and Psychological Treatment</h2>\n<p>For many sexual concerns, the most effective approach combines medical and psychological treatment, each addressing dimensions the other cannot, and the clinician's ability to integrate the two improves outcomes.</p>\n<h3>Why Integration Helps</h3>\n<p>Medical treatment can address physiological contributors — vascular, hormonal, or medication-related — while psychological and relational work addresses the anxiety, beliefs, communication, and relationship factors that medical treatment does not reach. For erectile difficulty, for example, a PDE5 inhibitor prescribed by a medical provider may restore function while sex therapy addresses the performance anxiety, avoidance, and relationship tension that the medication alone leaves untouched. Treating only one dimension frequently produces incomplete results.</p>\n<h3>Coordinating Effectively</h3>\n<p>Integration requires the clinician to recognize when medical evaluation is warranted, to refer and communicate with prescribers (with the client's consent), and to sequence and combine treatments thoughtfully. The client is best served when the providers communicate and align rather than working in isolation, with the sex therapist frequently serving as the integrating presence who helps the client make sense of the whole.</p>",
+          "order": 32
+        },
+        {
+          "type": "text",
+          "content": "<h2>Sexual Side Effects: Raising and Managing Them</h2>\n<p>Because so many medications affect sexual function, clinicians should raise the possibility of sexual side effects routinely rather than waiting for clients to connect a new sexual problem to a medication they are taking.</p>\n<h3>Proactive Inquiry</h3>\n<p>Clients frequently do not report sexual side effects — out of embarrassment, or because they do not realize the medication is the cause — and may discontinue an important medication on their own rather than raise the issue. The clinician who routinely asks about sexual function when medications are involved catches these effects, validates the client's experience, and opens the door to solutions. This is especially important with antidepressants, given both their frequency of use and their common sexual effects.</p>\n<h3>Pathways to Management</h3>\n<p>When a medication is contributing, the clinician coordinates with the prescriber, who may have options including dose adjustment, timing strategies, alternative agents, or augmentation. The clinician helps the client weigh the trade-offs and make informed, autonomous decisions, and supports continued adherence to needed medication by ensuring sexual side effects are addressed rather than silently endured. Attention to sexual side effects matters especially for clients working toward sexual recovery or wellbeing.</p>",
+          "order": 33
+        },
+        {
+          "type": "text",
+          "content": "<h2>Adjunctive Aids and Devices in Treatment</h2>\n<p>A range of practical aids has a legitimate place in sex therapy, and discussing them matter-of-factly and without embarrassment is part of comprehensive care.</p>\n<h3>Common Aids</h3>\n<p>Lubricants address dryness and discomfort and can improve comfort and pleasure across many situations, particularly with the genitourinary syndrome of menopause and other causes of reduced lubrication. Vibrators and other devices can aid arousal and orgasm and are useful in directed approaches to orgasm difficulties. Graduated dilators, used at the client's own pace and control, are an established tool in treating penetration difficulties and pain-related muscle guarding. Pelvic floor approaches, frequently guided by a physical therapist, address the muscular contributors to pain and penetration difficulties.</p>\n<h3>Discussing Them Well</h3>\n<p>The clinician introduces such aids without embarrassment, frames them as ordinary tools rather than as signs of failure, and tailors recommendations to the client's concern, comfort, and cultural context. Normalizing these aids removes shame and gives clients access to practical solutions they may not have known were available or acceptable.</p>",
+          "order": 34
+        }
+      ]
+    },
+    {
+      "title": "Module 3: Affirming, Relational, and Specialized Sex Therapy Practice",
+      "order": 2,
+      "estimatedTime": 25,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 3,
+          "title": "Module 3",
+          "subtitle": "Module 3: Affirming, Relational, and Specialized Sex Therapy Practice"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Couples and Relational Sex Therapy</h2>\n<p>Sexual concerns frequently arise and are maintained within relationships, and much of sex therapy is relational work — treating the couple system rather than an individual \"patient.\"</p>\n<h3>The Relational Frame</h3>\n<p>Even when one partner carries the presenting symptom, the concern usually involves and affects both partners, and the relational context is often where the difficulty is maintained and where change must happen. A relational frame reframes the problem as the couple's shared challenge rather than one partner's defect, which reduces blame and mobilizes both partners. It attends to the cycles partners fall into (such as the pursuer-distancer dynamic of desire discrepancy), to communication, to emotional intimacy and conflict, and to the meaning each partner attaches to the sexual relationship.</p>\n<h3>Integrating Individual and Relational Work</h3>\n<p>Effective sex therapy moves fluidly between the individual and relational levels — addressing, for example, one partner's performance anxiety and the couple's communication and the relationship tension that amplifies both. The behavioral techniques of sex therapy, such as sensate focus, are frequently delivered as couple exercises, making the relationship itself the site of treatment. Relationship distress that overwhelms the sexual concern may call for couples therapy first or concurrently, and recognizing when relational conflict is the primary issue is part of competent assessment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Sexual Communication Skills</h2>\n<p>Many sexual concerns are sustained not by dysfunction but by the absence of effective communication between partners, and helping clients communicate about sex is among the most broadly useful interventions in the field.</p>\n<h3>Why Sexual Communication Is Hard</h3>\n<p>Sexual communication is difficult for most people, who have rarely been taught how to do it and who fear that raising a concern will hurt or offend a partner. As a result, partners make consequential assumptions about each other's desires, satisfaction, and difficulties without ever checking them — assumptions that, when wrong, breed distance, resentment, and unaddressed problems. A great deal of sexual distress dissolves when partners learn to talk.</p>\n<h3>Building the Skill</h3>\n<p>The clinician helps by normalizing the difficulty, coaching clients to express desires and concerns directly and without blame, helping partners listen without defensiveness, and reframing sexual communication as an ongoing collaborative process rather than a single difficult conversation. Practicing these skills in session, and assigning structured communication exercises between sessions, builds capacity. Improved communication complements every other intervention, from reframing desire discrepancy to negotiating the touch involved in sensate focus.</p>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Affirming Sex Therapy with LGBTQ+ Clients</h2>\n<p>Affirming practice with sexual and gender minority clients is built from concrete skills, not a vague attitude, and it is essential given the minority stress these clients experience and the histories of harm many carry within healthcare.</p>\n<h3>Foundations of Affirming Care</h3>\n<p>Affirming care begins before the first session, in intake forms and environment that do not assume heterosexuality, monogamy, or a gender binary. The central clinical skill is disciplined non-assumption: not assuming the gender of a client's partners, the configuration of their relationships, the language they use for their body, or their sexual practices, but asking respectfully and using the client's own terms. For transgender and gender-diverse clients, this includes asking which words the client uses for their anatomy rather than imposing gendered or clinical terms that may cause distress.</p>\n<h3>Minority Stress and Competence Limits</h3>\n<p>Affirming sex therapy locates concerns within the minority stress framework where relevant — chronic stigma, rejection, and internalized negative messages contribute to shame, anxiety, and difficulty with intimacy — while avoiding the opposite error of attributing every concern to minority stress. It also requires honesty about the edge of one's competence: a clinician lacking specific training in gender-affirming care does not improvise it but provides a supportive, affirming relationship while connecting the client with appropriately trained providers. Affirming care is the standard for all clients, not a specialty reserved for some.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Trauma-Informed Sex Therapy</h2>\n<p>Sexual concerns and sexual trauma are frequently connected, and sex therapy must be conducted in a trauma-informed manner whether or not a trauma history is known.</p>\n<h3>How Trauma Shapes Sexual Concerns</h3>\n<p>A history of sexual trauma can underlie many presentations: sexual avoidance or aversion, dissociation during sexual activity, difficulty with arousal or pleasure, flashbacks triggered by sexual situations, genito-pelvic pain, or compulsive sexual behavior. The clinician remains alert to the possibility of trauma, screens sensitively, and recognizes that a sexual concern may be a manifestation of unprocessed trauma rather than a discrete dysfunction.</p>\n<h3>Principles and Scope</h3>\n<p>Trauma-informed sex therapy prioritizes safety, choice, and control throughout — pacing the work at the client's tolerance, never pressuring for disclosure or for sexual progress, and restoring the client's sense of agency over their own body and sexual experience. When sexual concerns are significantly rooted in trauma, the clinician determines whether specialized trauma treatment is indicated and coordinates or refers accordingly; sexual recovery work generally follows sufficient stabilization and trauma processing. A clinician without trauma training can still practice trauma-informed care and can collaborate with or refer to a trauma specialist while supporting the sexual dimension of recovery.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 5,
+          "question": "The central skill of affirming sex therapy with LGBTQ+ clients is:",
+          "options": [
+            {
+              "text": "Assuming the client wants their identity to be the focus of treatment",
+              "isCorrect": false
+            },
+            {
+              "text": "Disciplined non-assumption — asking about partners, language, and practices rather than inferring them",
+              "isCorrect": true
+            },
+            {
+              "text": "Attributing every concern to minority stress",
+              "isCorrect": false
+            },
+            {
+              "text": "Avoiding any discussion of sexuality",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Disciplined non-assumption — asking rather than inferring and using the client’s own language — is the core affirming skill; both over-attribution to minority stress and avoidance are errors.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Sexuality, Aging, Illness, and Disability</h2>\n<p>Sexuality persists across the lifespan and through illness and disability, yet these dimensions are frequently neglected by care systems, leaving an opening for the clinician who simply addresses them.</p>\n<h3>Aging</h3>\n<p>Sexual interest and activity continue into later life for many people, even as the body changes. Normal age-related changes — slower arousal, the genitourinary syndrome of menopause, changes in erectile function — are frequently misinterpreted as the end of sexuality rather than as adjustments to accommodate. The clinician counters ageist assumptions, provides accurate information, and helps older clients adapt and continue satisfying sexual lives.</p>\n<h3>Illness and Disability</h3>\n<p>Chronic illness, disability, and their treatments affect sexuality through direct physiological effects, fatigue and pain, body-image changes, medication side effects, and psychological impact — yet medical teams rarely address the sexual dimension of the conditions they treat. The clinician's task is to raise sexuality as a legitimate concern, to normalize adaptation, to help clients and partners communicate and renegotiate intimacy, and to expand the definition of satisfying sexuality beyond a narrow script when prior function cannot be restored. For people with disabilities, affirming practice rejects the assumption that they are asexual and supports their sexual rights and self-determination.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Cultural and Religious Context in Sexual Health</h2>\n<p>Sexuality is shaped powerfully by culture and religion, and clinicians regularly work with clients whose frameworks differ sharply from their own. Cultural humility means neither imposing the clinician's values nor abandoning clinical responsibility.</p>\n<h3>Faith and Sexuality</h3>\n<p>Clients from conservative religious backgrounds may experience conflict between sexual feelings or identities and deeply held beliefs, or carry shame rooted in religious teaching. The clinician's task is not to argue the client out of their faith or to validate self-rejection, but to help the client reduce shame and arrive at a resolution that is genuinely their own. For sexual and gender minority clients from such backgrounds, affirming care means supporting self-determination rather than steering toward any predetermined outcome.</p>\n<h3>Cross-Cultural Practice</h3>\n<p>Clients from diverse cultural backgrounds bring varying sexual scripts, gender roles, meanings of marriage and family, and norms about what may be discussed. Cultural humility means approaching each client as the expert on their own context, remaining curious rather than assuming, and attending to intersectionality — the way multiple identities combine to shape a particular person's experience. The clinician brackets their own sexual values so they do not become a basis for judgment, while retaining the responsibility to provide accurate information and to respond to genuine harm or coercion.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Sexual Diversity: Relationship Structures and Interests</h2>\n<p>Competent, affirming sex therapy neither assumes monogamy nor pathologizes consensual variation in relationship structure or sexual interest. The clinician's task is to understand and support the client's actual sexual life, whatever its configuration.</p>\n<h3>Relationship Structures</h3>\n<p>Many clients are monogamous; others are in consensually non-monogamous arrangements — open relationships, polyamory, and other negotiated structures — organized around honesty and mutual agreement. Consensual non-monogamy is a relationship choice, not a disorder or symptom, and research does not support interpreting it as pathology. The clinician asks about the structure and agreements of a client's relationships rather than assuming them, and supports the client in living according to their own values while addressing any genuine distress, coercion, or dishonesty.</p>\n<h3>Sexual Interests</h3>\n<p>The same non-pathologizing discipline extends to the range of consensual sexual interests and practices. The clinician distinguishes carefully between consensual sexual variation, which is not pathology, and non-consensual or harmful behavior, which is a clinical and sometimes legal concern. Working knowledgeably and without judgment with diverse sexual interests is part of affirming practice; the deeper clinical competencies of kink-aware and structured non-monogamy practice are developed in dedicated coursework, and clinicians refer to appropriately trained colleagues when a presentation exceeds their preparation.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 9,
+          "prompt": "Which client population or sexual health topic do you currently feel least prepared to work with affirmingly, and what learning would close that gap?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Body Image, Self-Esteem, and Sexual Wellbeing</h2>\n<p>Body image and sexual self-concept exert a powerful influence on sexual experience, and they intersect with nearly every theme of sex therapy — aging, illness, treatment effects, trauma, and cultural messages about bodies and desirability.</p>\n<h3>How Body Image Shapes Sexuality</h3>\n<p>Negative body image interferes with sexual experience through spectatoring (self-monitoring that pulls attention from pleasure), avoidance of sexual situations, and an undermined sense of being a desirable and sexual person. Cultural standards that equate sexual worth with a narrow appearance ideal, the bodily changes of aging and illness, and the effects of weight, disability, and difference all shape sexual self-concept, frequently generating distress disproportionate to anything about actual function.</p>\n<h3>The Clinical Focus</h3>\n<p>Addressing body image is an accessible and frequently powerful focus of sex therapy. Helping clients shift attention from self-monitoring to present-moment experience (a target shared with mindfulness-based approaches), challenging internalized standards, and supporting a more compassionate relationship with one's body frequently improves sexual wellbeing even when physical function does not change. This work is especially central for clients navigating the bodily changes of aging, illness, and treatment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Sexual Health Education as Intervention</h2>\n<p>A large share of sexual distress arises from straightforward gaps in accurate information — the legacy of sex education that was absent, abstinence-focused, fear-based, or incomplete. Education is therefore one of the most powerful and accessible interventions, and it falls within every clinician's scope as limited information.</p>\n<h3>Correcting the Information Deficit</h3>\n<p>Many clients carry misinformation about anatomy, about the range of normal function and variation, about how desire and arousal actually work, and about what consent requires. Correcting these misconceptions — explaining responsive desire, normalizing the diversity of sexual experience, clarifying the role of anxiety and adequate stimulation, accurately describing the effects of aging or medication — frequently resolves distress that had been experienced as a personal failing.</p>\n<h3>Education as Empowerment</h3>\n<p>Beyond correcting specific myths, education empowers clients to understand their own bodies and responses, to communicate with partners, and to make informed decisions. This educational stance is consistent with a sexual rights framework: clients have a right to accurate sexual information, and providing it is a core, high-impact dimension of sexual health care. In PLISSIT terms, much of this work occurs at the Permission and Limited Information levels — exactly where the generalist is most effective.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Ethics, Boundaries, and Professional Conduct</h2>\n<p>Sex therapy carries distinctive ethical responsibilities, and clear boundaries protect both clients and the integrity of the work.</p>\n<h3>The Absolute Boundary</h3>\n<p>The prohibition on any sexual contact between clinician and client is absolute, grounded in the recognition that the power differential makes genuine consent impossible and that such contact is among the most serious harms a clinician can inflict. Sex therapy is entirely talk-based; it never involves nudity, demonstration, or physical sexual contact. Clinicians must also manage erotic transference — clients' romantic or sexual feelings toward them — without shaming the client, maintaining clear boundaries, and using consultation to manage their own reactions.</p>\n<h3>Values, Competence, and Consultation</h3>\n<p>Ethical practice requires examining one's own sexual values so they do not distort care, practicing within one's competence and referring when concerns exceed it, and maintaining the confidentiality and informed consent that sensitive sexual material demands. Where a clinician's values genuinely prevent affirming care for a particular client or concern, the ethical response is appropriate referral rather than the imposition of those values. Ongoing consultation and supervision are essential supports for ethical, competent practice in this emotionally and ethically demanding area.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Telehealth and Sustaining Practice</h2>\n<p>Two practical matters round out a foundation in sex therapy: adapting the work to telehealth, and sustaining oneself as a competent practitioner over time.</p>\n<h3>Telehealth Considerations</h3>\n<p>Sexual health work translates to telehealth, which can lower barriers for clients who find it easier to discuss sensitive material from home, while raising specific considerations. The clinician confirms the client is in a private space where they can speak freely (and, where relevant, is safe from a partner within earshot), attends to the reduced access to nonverbal cues, and maintains the same standards of permission, normalization, and boundaries. Some behavioral assignments translate readily to remote delivery; others require adaptation.</p>\n<h3>Sustaining and Developing Practice</h3>\n<p>Competent sex therapy practice is sustained through ongoing education, consultation and supervision, continued self-reflection on one's own attitudes and reactions, and the deliberate building of knowledge and referral networks. The field continues to evolve — in its understanding of diversity, its evidence base, and its techniques — and staying current is part of competent practice. Clinicians who began at the foundational levels can extend their competence over time through training and supervision, moving further along the spectrum as their preparation grows.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 14,
+          "question": "A clinician’s values make it impossible to provide affirming care to a particular client. The ethical response is to:",
+          "options": [
+            {
+              "text": "Impose those values to guide the client",
+              "isCorrect": false
+            },
+            {
+              "text": "Refer the client to an appropriately affirming provider",
+              "isCorrect": true
+            },
+            {
+              "text": "Continue while concealing the disapproval",
+              "isCorrect": false
+            },
+            {
+              "text": "Refuse to acknowledge the conflict",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "When a clinician’s values genuinely prevent affirming care, appropriate referral — not imposition of values — is the ethical response.",
+          "showExplanation": true
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>Course Summary: Integrating Sexual Health Into Counseling Practice</h2>\n<p>This course has established a foundation in sex therapy for the general mental health clinician. Several principles unify the material.</p>\n<p>First, sexual health work exists on a spectrum, and every clinician can practice at the foundational levels — permission, limited information, and basic suggestions — which resolve a large share of concerns, while referring complex presentations to certified specialists. Second, sexual concerns are almost always multiply determined, and the biopsychosocial model, with its attention to biological, psychological, and relational contributors and its requirement of medical collaboration, is the organizing framework for assessment and treatment. Third, the foundational techniques — sensate focus, cognitive-behavioral methods, and mindfulness-based approaches — share a common logic of reducing the anxiety, performance demand, and distraction that maintain so many difficulties.</p>\n<p>Fourth, contemporary practice is affirming, culturally humble, trauma-informed, and non-pathologizing, meeting clients across the full diversity of identities, relationships, and bodies, and supporting each client's sexual wellbeing as they define it. And fifth, the clinician's own comfort, self-examination, ethical clarity, and ongoing development are as foundational as any technique. The clinician who carries these principles into practice will close the silence that surrounds sexual health and ensure that a fundamental dimension of human wellbeing is no longer the one their clients are left to navigate alone.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 33,
+          "prompt": "After this course, what is one concrete change you will make to how you address sexual health in your counseling practice?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Pregnancy, Postpartum, and Perinatal Sexuality</h2>\n<p>The perinatal period brings major and frequently unaddressed sexual changes, and clinicians working with expectant and new parents can offer an opening the broader care system rarely provides.</p>\n<h3>The Changes</h3>\n<p>Sexual desire and comfort vary widely across pregnancy, influenced by hormonal change, physical discomfort, fatigue, body-image shifts, and anxiety, and many clients carry unfounded fears that benefit from accurate information. The postpartum period brings physical recovery, hormonal shifts (especially with breastfeeding, which commonly reduces lubrication and desire), profound sleep disruption, and the reorganization of identity and relationship around the infant. Many couples experience a significant change in their sexual relationship that, when unspoken, breeds distress and disconnection.</p>\n<h3>The Clinical Opening</h3>\n<p>Because perinatal care focuses on the infant, the parents' sexual relationship is routinely neglected. Naming perinatal sexual changes as common and often temporary, giving couples permission to communicate about them, and helping them renegotiate intimacy prevents a normal transition from becoming a lasting rupture.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Pleasure, Satisfaction, and Sexual Wellbeing</h2>\n<p>Because the field has historically focused on dysfunction, it is easy to lose sight of the positive dimension at the center of sexual health: pleasure, satisfaction, intimacy, and the freedom to express one's sexuality safely and authentically.</p>\n<h3>Why the Positive Dimension Matters</h3>\n<p>Attending to sexual wellbeing, not only to dysfunction, changes the clinical conversation: it allows the clinician to help clients build satisfying sexual lives rather than only repairing deficits, and it recognizes that two people with identical \"function\" may have very different wellbeing depending on intimacy, communication, and meaning. Satisfaction is predicted more strongly by relational and emotional factors than by mechanical function, which is why interventions that improve communication and intimacy often improve satisfaction even when a physical difficulty persists.</p>\n<h3>The Reframing</h3>\n<p>A wellbeing-oriented clinician asks not only \"Is anything wrong?\" but \"What would a satisfying sexual life look like for you?\" This reframing is especially valuable for clients whose circumstances mean restoring prior function is not the goal; for them, the work is often expanding the definition of satisfying sexuality rather than restoring a narrow prior norm.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Common Sexual Myths and the Facts That Replace Them</h2>\n<p>Much sexual distress is generated not by dysfunction but by false beliefs about what sex is supposed to be, and correcting these myths is a high-yield, accessible intervention within every clinician's scope.</p>\n<h3>Pervasive Myths</h3>\n<p>Common myths include the belief that healthy desire is always spontaneous (distressing for the many people whose desire is responsive); that there is a \"normal\" frequency against which couples should measure themselves (when the only meaningful standard is mutual satisfaction); that sex must follow a particular script culminating in simultaneous orgasm (a performance standard that breeds anxiety); that aging means the end of sexuality; and that \"real\" sex is narrowly defined as penetrative intercourse (excluding much of human sexual experience and creating problems for those whose bodies, health, or preferences do not fit that script).</p>\n<h3>The Clinical Value of Correction</h3>\n<p>In each case, accurate information replaces a distressing standard with a realistic one, frequently resolving distress that the client had experienced as a personal failing. A broader, more accurate understanding of sexuality — as encompassing a wide range of pleasurable and intimate experiences and a wide range of normal variation — is both more inclusive and more clinically useful, particularly for clients managing illness, disability, or the changes of aging.</p>",
+          "order": 19
+        },
+        {
+          "type": "multipleChoice",
+          "question": "A wellbeing-oriented (rather than dysfunction-only) stance in sex therapy is especially valuable because:",
+          "options": [
+            {
+              "text": "It ignores client distress",
+              "isCorrect": false
+            },
+            {
+              "text": "Satisfaction is predicted more by relational and emotional factors than mechanical function, so intimacy and communication work can improve satisfaction even when a physical difficulty persists",
+              "isCorrect": true
+            },
+            {
+              "text": "It applies only to clients without any dysfunction",
+              "isCorrect": false
+            },
+            {
+              "text": "It replaces all medical evaluation",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Sexual satisfaction is driven more by relational and emotional factors than by mechanics; a wellbeing orientation lets the clinician improve satisfaction even when physical function cannot be fully restored.",
+          "showExplanation": true,
+          "order": 20
+        },
+        {
+          "type": "text",
+          "content": "<h2>Sexuality, Substance Use, and Recovery</h2>\n<p>Substance use intersects with sexual health in clinically important ways, and clinicians who work with substance use are well positioned to attend to this intersection.</p>\n<h3>Effects and Risks</h3>\n<p>Different substances affect sexual function differently — alcohol impairs arousal and performance despite reducing inhibition, opioids markedly suppress desire, stimulants and chronic use contribute to dysfunction over time — and intoxication impairs the capacity to negotiate consent and to make safe decisions. Recognizing these effects helps the clinician understand sexual concerns that coincide with substance use rather than attributing them solely to psychological causes.</p>\n<h3>Sexuality in Recovery</h3>\n<p>In recovery, sexuality presents distinctive challenges: people who have only experienced sex while using may face anxiety about sober sexual experience, and sexual situations can function as relapse triggers. Addressing sexuality as part of recovery — rather than treating it as separate or taboo — supports both sexual health and sustained recovery, and is an appropriate focus for clinicians working in this area.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Solo Sexuality and Work with Single Clients</h2>\n<p>Sex therapy is frequently framed around couples, but a great deal of sexual health work involves individuals, and solo sexuality is a legitimate and useful dimension of treatment.</p>\n<h3>Working with Single Clients</h3>\n<p>Single clients present with the full range of sexual concerns — desire, arousal, orgasm, pain, anxiety, and the effects of trauma, illness, or aging — and deserve the same comprehensive care as partnered clients. The clinician does not assume a client needs a partner to address sexual concerns, and supports single clients in understanding their own bodies and responses, building sexual self-knowledge and confidence, and preparing for future partnered sexuality where that is a goal.</p>\n<h3>Solo Sexuality as a Tool</h3>\n<p>Self-stimulation has specific clinical uses: directed masturbation programs have strong evidence for lifelong female anorgasmia, and self-exploration helps clients of all genders learn what produces arousal and pleasure, build confidence, and develop awareness they can later bring to partnered sex. The clinician discusses solo sexuality matter-of-factly and without judgment, as a normal part of human sexuality and a legitimate clinical tool.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>A Developmental View of Sexuality Across the Lifespan</h2>\n<p>Sexual health concerns arise at every stage of life, and a developmental perspective helps the clinician understand a concern in the context of the client's life stage.</p>\n<h3>Sexuality Changes Across Life</h3>\n<p>Sexuality is not static: it develops and changes from adolescence through young adulthood, the establishment and maintenance of long-term relationships, the perinatal period and parenthood, midlife and the menopausal transition, and later life. Each stage brings characteristic concerns, opportunities, and changes, and what is normal at one stage may differ at another. A long-term couple's shift from spontaneous to responsive desire, the perinatal reorganization of intimacy, and the adaptations of later life are developmental transitions rather than dysfunctions.</p>\n<h3>The Clinical Value</h3>\n<p>A developmental lens helps the clinician distinguish normal life-stage change from genuine dysfunction, normalize the changes clients experience, and tailor interventions to life stage. It also reinforces the affirming, non-pathologizing stance at the heart of contemporary practice: sexuality is a lifelong dimension of wellbeing that takes different forms across the life course.</p>",
+          "order": 23
+        },
+        {
+          "type": "text",
+          "content": "<h2>Maintaining Gains and Concluding Treatment</h2>\n<p>As sex therapy approaches its goals, attention turns to consolidating gains and preparing the client to sustain them, and to concluding treatment well.</p>\n<h3>Consolidating and Sustaining Change</h3>\n<p>Toward the end of treatment, the clinician helps the client consolidate the skills, understanding, and new experiences developed in the work, and anticipate and plan for future challenges — recognizing that sexual difficulties can recur with stress, illness, relationship change, or life transitions. Helping the client understand what produced the improvement, and how to apply the same principles if difficulties return, supports lasting change and a sense of self-efficacy.</p>\n<h3>Concluding Well</h3>\n<p>Concluding treatment involves reviewing progress against the original goals, affirming the client's gains and agency, clarifying when and how to return if needed, and addressing any remaining concerns or appropriate referrals. A thoughtful conclusion leaves the client not only improved but equipped to maintain and extend their sexual wellbeing on their own.</p>",
+          "order": 24
+        },
+        {
+          "order": 25,
+          "type": "matching",
+          "matchingInstructions": "Match each life stage to a central sexual-health consideration.",
+          "matchingPairs": [
+            {
+              "term": "Adolescence",
+              "definition": "Identity formation, education, consent, and first experiences"
+            },
+            {
+              "term": "Young adulthood",
+              "definition": "Partnership formation, intimacy skills, and family-building decisions"
+            },
+            {
+              "term": "Midlife",
+              "definition": "Hormonal and relational shifts, desire changes, and renegotiating intimacy"
+            },
+            {
+              "term": "Later life",
+              "definition": "Adapting to physiological change and illness while sexuality persists"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>Examining the Clinician's Own Sexual Values</h2>\n<p>Because affirming, non-judgmental practice requires clinicians to set aside their own values when those values would distort care, deliberate self-examination of one's sexual attitudes is itself a professional competency.</p>\n<h3>Why It Matters</h3>\n<p>Every clinician carries values, beliefs, and reactions about sexuality, shaped by culture, upbringing, religion, and experience. These become clinical problems when they operate unexamined — leaking into the room as judgment or discomfort, or subtly steering a client toward the clinician's own preferences. A clinician who has never examined their reactions to particular practices, identities, or relationship structures is more likely to communicate disapproval unintentionally and less able to recognize when their values are shaping their judgment.</p>\n<h3>The Work of Values Clarification</h3>\n<p>Useful self-examination involves honestly identifying the sexual topics, identities, and behaviors that evoke discomfort or judgment, understanding where those reactions come from, and developing the capacity to recognize them in the moment so they can be set aside in service of the client. The goal is not to erase one's values but to hold them with enough awareness that they do not govern one's conduct. Where values genuinely prevent affirming care for a particular client, appropriate referral — not imposition — is the ethical response. This ongoing reflection, supported by consultation, is part of competent, ethical practice.</p>",
+          "order": 26
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coordinating Care Across an Interdisciplinary Team</h2>\n<p>Because sexual health sits at the intersection of physical, psychological, relational, and social factors, effective care is frequently interdisciplinary, and the mental health clinician occupies a distinctive position on the team.</p>\n<h3>The Clinician's Contribution</h3>\n<p>Medical providers may address the biological dimension but frequently lack the time, training, or comfort to address the psychological and relational dimensions; the mental health clinician supplies exactly these. The clinician holds the integrated biopsychosocial formulation that no single discipline captures alone, addresses the meaning a concern holds for the client, works with relational and communication factors, and provides the permission-giving, supportive presence the medical encounter rarely affords.</p>\n<h3>Effective Coordination</h3>\n<p>Coordination requires appropriate consent and information-sharing, clear communication about respective roles, and a collaborative rather than siloed stance. The clinician frequently functions as the consistent presence who helps the client integrate the contributions of multiple providers — physician, pelvic floor physical therapist, prescriber, certified sex therapist — into a coherent whole. The clinician need not be expert in every dimension; they need to recognize the dimensions, ensure each is addressed by someone competent, and help the client make sense of the whole.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "content": "<h2>Resources, Referral Networks, and Staying Current</h2>\n<p>Competent sexual health practice is supported by good resources and an up-to-date referral network, and by ongoing engagement with a field that continues to evolve.</p>\n<h3>Building a Referral Network</h3>\n<p>Clinicians benefit from knowing the resources in their community and field: certified sex therapists for concerns beyond their scope, medical providers familiar with sexual health (including those who manage hormonal, vascular, and medication-related contributors), pelvic floor physical therapists, trauma specialists, and affirming providers for sexual and gender minority clients. A ready referral network allows the clinician to ensure each dimension of a client's concern is addressed by someone competent.</p>\n<h3>Staying Current</h3>\n<p>The field continues to evolve in its understanding of diversity, its evidence base, and its techniques, and staying current is part of competent practice. Ongoing education, consultation and supervision, and engagement with professional organizations and the literature keep the clinician's knowledge fresh and support the continued extension of competence over a career. The foundation built in this course is a starting point from which clinicians can continue to grow.</p>",
+          "order": 28
+        }
+      ]
+    }
+  ]
+};
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+async function main(){
+  await mongoose.connect(MONGODB_URI); console.log('Connected.');
+  const doc = await Course.findOne({ slug: COURSE_DATA.slug });
+  if(!doc){ console.error('CR-306 not found:', COURSE_DATA.slug); process.exit(1); }
+  for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
+  doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  await doc.save();
+  const fresh=await Course.findById(doc._id).lean();
+  console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);
+  await mongoose.disconnect(); console.log('Done.');
+}
+main().catch(e=>{console.error('ERROR:',e.message);process.exit(1);});

--- a/server/src/scripts/seedCR307-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR307-EXPANDED-canonical.js
@@ -1,0 +1,1679 @@
+/**
+ * Copyright (c) 2026 CounselorReady / GA Integrated Therapeutic Perspectives, LLC.
+ */
+import mongoose from 'mongoose';
+import { Course } from '../models/InteractiveCourse.js';
+import 'dotenv/config';
+
+// CR-307 EXPANDED — canonical sections[] shape; saves through the model (wordCount hook fires).
+const COURSE_DATA = {
+  "title": "Compulsive Sexual Behavior and Intimacy Disorders: Assessment and Treatment",
+  "slug": "compulsive-sexual-behavior-intimacy-disorders",
+  "courseCode": "CR-307",
+  "description": "A comprehensive 3-hour continuing education course for licensed mental health professionals. Meets NBCC ACEP standards with 18,238 words of graduate-level clinical content.",
+  "ceHours": 3,
+  "credits": 3,
+  "category": "Clinical",
+  "ceCategory": "Clinical",
+  "ceuHours": 3,
+  "ceuEligible": true,
+  "approvingBody": "NBCC",
+  "approvalNumber": "#7760",
+  "creditType": "NBCC",
+  "acepProvider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "number": "7760"
+  },
+  "instructor": "GA Integrated Therapeutic Perspectives LLC",
+  "targetAudience": [
+    "Licensed mental health professionals including LPCs, LCSWs, LMFTs, psychologists, and NCCs who encounter compulsive sexual behavior, problematic pornography use, and intimacy disorders in clinical practice."
+  ],
+  "accessType": "subscription",
+  "price": 59.99,
+  "pricingTier": "standard",
+  "status": "draft",
+  "isPublished": false,
+  "isActive": true,
+  "passingScore": 80,
+  "maxAttempts": 3,
+  "settings": {
+    "passingScore": 80,
+    "certificateEnabled": true,
+    "requireEvaluation": true,
+    "requireAttestation": true
+  },
+  "objectives": [
+    "Define compulsive sexual behavior disorder (CSBD) per ICD-11 criteria and distinguish it from sexual addiction models, paraphilic disorders, and normative high sexual desire.",
+    "Apply validated assessment instruments including the CSBI and SCS within a biopsychosocial framework for clinical evaluation of compulsive sexual behavior.",
+    "Identify the neurobiological, psychological, and interpersonal mechanisms that maintain compulsive sexual behavior and inform evidence-based treatment selection.",
+    "Describe cognitive-behavioral, ACT-based, and motivational approaches for compulsive sexual behavior that are supported by current clinical evidence.",
+    "Assess and address the specific clinical needs of clients with problematic pornography use, including its impacts on intimacy, relationships, and sexual functioning.",
+    "Identify intimacy disorders — including avoidant attachment, intimacy avoidance, and emotional intimacy deficits — and their relationship to compulsive sexual behavior and sexual dysfunction."
+  ],
+  "assessment": {
+    "isExam": true,
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
+      {
+        "question": "ICD-11 compulsive sexual behavior disorder (CSBD) is classified as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A sexual dysfunction",
+            "isCorrect": false
+          },
+          {
+            "text": "An addictive disorder analogous to gambling disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "An impulse control disorder",
+            "isCorrect": true
+          },
+          {
+            "text": "A paraphilic disorder",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "The correct answer is an impulse control disorder. The ICD-11 classifies CSBD under impulse control disorders (F63.8), reflecting a cautious, evidence-informed approach rather than adopting the addiction framework that lacks sufficient empirical validation. While the addiction model (option B) has been influential in treatment communities, neither the DSM-5 nor the ICD-11 validated it as a diagnostic category for sexual behavior."
+      },
+      {
+        "question": "AASECT's official position on sex addiction is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Sexual addiction is a well-validated diagnostic category requiring addiction-based treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "There is insufficient empirical evidence to support sex addiction as a clinical diagnosis",
+            "isCorrect": true
+          },
+          {
+            "text": "Sexual addiction affects approximately 6% of the adult population",
+            "isCorrect": false
+          },
+          {
+            "text": "Sex addiction treatment should follow the 12-step model exclusively",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that there is insufficient empirical evidence to support sex addiction as a clinical diagnosis. AASECT's official position statement explicitly states this, representing a competing perspective within the clinical field that challenges the addiction framework. Option A is incorrect because it directly contradicts AASECT's position, which questions the very validity of sexual addiction as a diagnostic category."
+      },
+      {
+        "question": "The primary distinguishing feature of compulsive sexual behavior disorder in ICD-11 is:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "High frequency of sexual activity regardless of distress",
+            "isCorrect": false
+          },
+          {
+            "text": "Persistent failure to control intense sexual urges causing marked distress or functional impairment",
+            "isCorrect": true
+          },
+          {
+            "text": "Sexual behavior that is inconsistent with cultural norms",
+            "isCorrect": false
+          },
+          {
+            "text": "Sexual behavior involving paraphilic interests",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is persistent failure to control intense sexual urges causing marked distress or functional impairment. The ICD-11 criteria require both subjective loss of control over sexual urges and clinically significant distress or impairment in functioning, persisting for at least six months. Option A (high frequency regardless of distress) is incorrect because frequency alone does not constitute CSBD; a person with high sexual desire who lacks subjective loss of control and distress does not meet criteria."
+      },
+      {
+        "question": "Which assessment instrument was specifically developed for hypersexual behavior in men:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Sexual Compulsivity Scale (SCS)",
+            "isCorrect": false
+          },
+          {
+            "text": "Hypersexual Behavior Inventory (HBI)",
+            "isCorrect": true
+          },
+          {
+            "text": "Female Sexual Function Index (FSFI)",
+            "isCorrect": false
+          },
+          {
+            "text": "Compulsive Sexual Behavior Inventory (CSBI)",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is the Hypersexual Behavior Inventory (HBI). The HBI is a 19-item measure developed specifically for assessing hypersexual behavior in men, as described in Reid and colleagues' (2011) psychometric development study. The Sexual Compulsivity Scale (option A) is a general 10-item sexual compulsivity measure not specifically designed for men, making it the most plausible but incorrect alternative."
+      },
+      {
+        "question": "The neurobiological model most supported by current research positions problematic sexual behavior as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A primary dopaminergic addiction indistinguishable from substance use disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Involving reward circuitry in ways that may parallel impulsive/compulsive mechanisms without meeting full addiction criteria",
+            "isCorrect": true
+          },
+          {
+            "text": "A purely psychological phenomenon with no neurobiological component",
+            "isCorrect": false
+          },
+          {
+            "text": "Exclusively a paraphilic disorder with different neurobiology from other compulsive behaviors",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that CSBD involves reward circuitry in ways that may parallel impulsive/compulsive mechanisms without meeting full addiction criteria. Neuroimaging research by Voon and colleagues (2014) found increased activation in the amygdala, ventral striatum, and dorsal anterior cingulate, but the field has not confirmed full addiction model criteria such as consistent tolerance and withdrawal phenomena. Option A is incorrect because research has identified important disanalogies with substance use disorders that prevent equating CSBD with a primary dopaminergic addiction."
+      },
+      {
+        "question": "Problematic pornography use is most accurately described as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "A clearly validated diagnostic category in DSM-5",
+            "isCorrect": false
+          },
+          {
+            "text": "A subcategory of CSBD in which pornography is the primary sexual behavior of concern",
+            "isCorrect": true
+          },
+          {
+            "text": "A form of sexual addiction requiring 12-step treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "A normal variation in sexual behavior that should never be pathologized",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is a subcategory of CSBD in which pornography is the primary sexual behavior of concern. Problematic pornography use is characterized by subjective loss of control, distress, and functional impairment related to pornography use, and it is clinically understood as a specific presentation within the broader CSBD framework. Option A is incorrect because problematic pornography use is not a validated diagnostic category in the DSM-5, which did not include any form of hypersexual or compulsive sexual behavior diagnosis."
+      },
+      {
+        "question": "Partner trauma — the distress experienced by partners of individuals with CSBD — most closely resembles:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Separation anxiety disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Adjustment disorder with anxious mood",
+            "isCorrect": false
+          },
+          {
+            "text": "Post-traumatic stress disorder in its symptom profile",
+            "isCorrect": true
+          },
+          {
+            "text": "Dependent personality disorder",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 2,
+        "explanation": "The correct answer is post-traumatic stress disorder in its symptom profile. Research by Steffens and Rennie (2006) documented that many partners of individuals with compulsive sexual behavior met PTSD criteria following disclosure, experiencing intrusive thoughts, hypervigilance, avoidance of intimacy, and significant trust disruption. Adjustment disorder (option B) is incorrect because the severity and specific trauma symptom profile observed in partners goes beyond what adjustment disorder captures, warranting trauma-informed clinical intervention."
+      },
+      {
+        "question": "Acceptance and Commitment Therapy (ACT) addresses compulsive sexual behavior through:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Behavioral extinction of sexual urges through abstinence",
+            "isCorrect": false
+          },
+          {
+            "text": "Values clarification and psychological flexibility to reduce experiential avoidance driving compulsive behavior",
+            "isCorrect": true
+          },
+          {
+            "text": "Cognitive restructuring of sexual addiction beliefs",
+            "isCorrect": false
+          },
+          {
+            "text": "Systematic desensitization of sexual urges",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is values clarification and psychological flexibility to reduce experiential avoidance driving compulsive behavior. ACT conceptualizes compulsive sexual behavior as an experiential avoidance strategy -- a behavioral escape from unwanted internal states such as loneliness, anxiety, and shame -- and builds psychological flexibility and values-driven behavioral alternatives. Option A (behavioral extinction through abstinence) is incorrect because ACT does not aim to extinguish urges through abstinence but rather develops the capacity to hold uncomfortable experiences without reacting through compulsive avoidance."
+      },
+      {
+        "question": "Intimacy avoidance as a clinical pattern is most directly associated with:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Insecure attachment — particularly dismissive-avoidant attachment style — developed through early relational experiences",
+            "isCorrect": true
+          },
+          {
+            "text": "Low sexual desire as the primary presenting concern",
+            "isCorrect": false
+          },
+          {
+            "text": "Antisocial personality as the underlying etiology",
+            "isCorrect": false
+          },
+          {
+            "text": "Sexual trauma as the only causal pathway",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "The correct answer is insecure attachment, particularly dismissive-avoidant attachment style, developed through early relational experiences. The course identifies dismissive-avoidant attachment as the pattern most directly associated with intimacy avoidance, as individuals who learned that emotional dependence is unsafe develop defensive self-reliance and deactivation of the attachment system in response to intimacy. Option D (sexual trauma as the only causal pathway) is incorrect because while trauma can contribute to intimacy avoidance, the attachment framework identifies multiple developmental pathways including consistent caregiver unavailability and rejection of attachment needs."
+      },
+      {
+        "question": "The ethical obligation regarding sex addiction terminology in clinical documentation is to:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Use ICD-11 CSBD criteria rather than 'sexual addiction' given lack of DSM-5/ICD-11 validation",
+            "isCorrect": true
+          },
+          {
+            "text": "Exclusively use the client's preferred terminology",
+            "isCorrect": false
+          },
+          {
+            "text": "Document both terms to cover all clinical and insurance requirements",
+            "isCorrect": false
+          },
+          {
+            "text": "Avoid documentation of sexual behavior concerns entirely",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "The correct answer is to use ICD-11 CSBD criteria rather than 'sexual addiction' given the lack of DSM-5/ICD-11 validation. Because 'sexual addiction' is not a validated diagnostic category in either the DSM-5 or ICD-11, clinicians have an ethical obligation to use evidence-based diagnostic terminology in clinical documentation rather than unsupported diagnostic labels. Option B (exclusively using the client's preferred terminology) is incorrect because while client language matters therapeutically, clinical documentation must adhere to validated diagnostic frameworks regardless of client preference."
+      },
+      {
+        "question": "Motivational interviewing is particularly valuable in compulsive sexual behavior clinical work because:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "It provides the behavioral extinction necessary for recovery",
+            "isCorrect": false
+          },
+          {
+            "text": "It addresses the ambivalence about behavior change that is common and clinically significant in this population",
+            "isCorrect": true
+          },
+          {
+            "text": "It is the only evidence-based approach with RCT support for CSBD",
+            "isCorrect": false
+          },
+          {
+            "text": "It is required by ethical guidelines for this population",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that MI addresses the ambivalence about behavior change that is common and clinically significant in this population. Ambivalence about change is nearly universal in CSBD because individuals may experience the behavior as partially ego-syntonic or may present under external pressure rather than internal motivation, and MI's non-judgmental, evocative stance creates conditions for internal motivation to develop. Option C is incorrect because MI is not required by ethical guidelines; rather, it is indicated by the clinical characteristics of the population."
+      },
+      {
+        "question": "The sexual double bind describes:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "The situation in which both partners experience sexual dysfunction simultaneously",
+            "isCorrect": false
+          },
+          {
+            "text": "The clinical dynamic in which sexual behavior is driven by both compulsive urges and shame about those urges",
+            "isCorrect": true
+          },
+          {
+            "text": "The paradox of recommending abstinence for sexual compulsivity",
+            "isCorrect": false
+          },
+          {
+            "text": "The situation in which treatment increases awareness of sexual urges temporarily",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is the clinical dynamic in which sexual behavior is driven by both compulsive urges and shame about those urges. The sexual double bind describes how the shame about sexual behavior paradoxically maintains the compulsive cycle, as both the urge and the shame are powerfully motivating forces that reinforce one another. Option C (the paradox of recommending abstinence) is incorrect because the sexual double bind refers specifically to the internal psychological dynamic between compulsive urges and shame, not to a treatment planning dilemma."
+      },
+      {
+        "question": "Intimacy disorder in the context of compulsive sexual behavior is best described as:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Absence of sexual desire for intimate partners",
+            "isCorrect": false
+          },
+          {
+            "text": "Deficits in emotional intimacy capacity that drive compulsive sexual behavior as a substitute for genuine connection",
+            "isCorrect": true
+          },
+          {
+            "text": "Sexual dysfunction that prevents intimate partner sexual activity",
+            "isCorrect": false
+          },
+          {
+            "text": "Personality disorder that precludes the formation of intimate relationships",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is deficits in emotional intimacy capacity that drive compulsive sexual behavior as a substitute for genuine connection. The course emphasizes that compulsive sexual behavior often substitutes for authentic emotional intimacy, providing a form of connection that avoids the vulnerability of genuine relational closeness, and that treating only the compulsive behavior without addressing underlying intimacy deficits produces incomplete recovery. Option A (absence of sexual desire for intimate partners) is incorrect because intimacy disorder in this context refers to emotional intimacy capacity deficits, not to sexual desire or dysfunction per se."
+      },
+      {
+        "question": "Relapse prevention in CSBD treatment is most effective when it:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Focuses exclusively on abstinence from all sexual behavior as the treatment goal",
+            "isCorrect": false
+          },
+          {
+            "text": "Addresses individual triggers, high-risk situations, and values-based behavioral alternatives alongside social support",
+            "isCorrect": true
+          },
+          {
+            "text": "Follows the 12-step model without adaptation to individual presentations",
+            "isCorrect": false
+          },
+          {
+            "text": "Focuses primarily on shame reduction without behavioral components",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is that relapse prevention addresses individual triggers, high-risk situations, and values-based behavioral alternatives alongside social support. The cognitive-behavioral relapse prevention model identifies specific high-risk situations -- including emotional states, interpersonal contexts, and environmental cues -- and develops individualized coping plans with practical strategies and accountability structures. Option A (focusing exclusively on abstinence from all sexual behavior) is incorrect because effective relapse prevention is individualized and values-based rather than requiring blanket abstinence from all sexual activity."
+      },
+      {
+        "question": "The clinical standard of care for couples affected by CSBD disclosure:",
+        "type": "multipleChoice",
+        "options": [
+          {
+            "text": "Requires immediate couples therapy as the primary treatment modality",
+            "isCorrect": false
+          },
+          {
+            "text": "Typically involves staged treatment: individual stabilization for the CSBD partner, crisis support for the affected partner, and couples work when both are ready",
+            "isCorrect": true
+          },
+          {
+            "text": "Prioritizes the CSBD partner's individual treatment without attention to partner needs",
+            "isCorrect": false
+          },
+          {
+            "text": "Requires assessment of both partners for addiction disorders",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The correct answer is staged treatment: individual stabilization for the CSBD partner, crisis support for the affected partner, and couples work when both are ready. The course describes a staged approach beginning with individual stabilization and partner crisis support, followed by couples work only after both partners have achieved sufficient individual stabilization. Option A (requiring immediate couples therapy) is incorrect because initiating couples work before individual stabilization risks overwhelming both partners and undermining the therapeutic process."
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Estimates of CSBD prevalence vary widely primarily because:",
+        "options": [
+          {
+            "text": "Researchers do not study it",
+            "isCorrect": false
+          },
+          {
+            "text": "Definitions vary — stricter impairment-based definitions yield lower estimates than broad self-report measures that may capture moral incongruence and high desire",
+            "isCorrect": true
+          },
+          {
+            "text": "It does not occur across cultures",
+            "isCorrect": false
+          },
+          {
+            "text": "It is identical to high desire",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Prevalence estimates depend heavily on definition; broad self-report measures capture moral incongruence and high desire, inflating estimates relative to strict impairment-based criteria.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "The \"triple-A\" features (accessibility, affordability, anonymity) of online sexual content are clinically relevant because they:",
+        "options": [
+          {
+            "text": "Make technology inherently harmful for everyone",
+            "isCorrect": false
+          },
+          {
+            "text": "Can intensify difficulty with control for those vulnerable to compulsive patterns, without making ordinary use pathological",
+            "isCorrect": true
+          },
+          {
+            "text": "Prove pornography is addictive",
+            "isCorrect": false
+          },
+          {
+            "text": "Are irrelevant to treatment",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The triple-A features can facilitate escalation for vulnerable individuals while most use remains unproblematic; the clinician addresses access patterns without moralizing technology itself.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "When a client trying to change has a lapse, the abstinence violation effect describes:",
+        "options": [
+          {
+            "text": "Automatic full recovery",
+            "isCorrect": false
+          },
+          {
+            "text": "Intense shame and a sense of total failure that can paradoxically trigger further behavior, which relapse prevention reframes as a single event to learn from",
+            "isCorrect": true
+          },
+          {
+            "text": "A medication side effect",
+            "isCorrect": false
+          },
+          {
+            "text": "The partner’s reaction only",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The abstinence violation effect is the shame-driven \"I’ve already failed\" spiral after a lapse; reframing the lapse as a learning event, met with self-compassion, prevents it from deepening.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Contemporary, evidence-informed practice regards a partner affected by a client’s compulsive sexual behavior as:",
+        "options": [
+          {
+            "text": "A \"co-addict\" responsible for the behavior",
+            "isCorrect": false
+          },
+          {
+            "text": "A person affected by another’s actions who deserves support and respect in their own right, not blamed for the client’s behavior",
+            "isCorrect": true
+          },
+          {
+            "text": "Irrelevant to treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Required to remain in the relationship",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Contemporary practice rejects blaming the partner (e.g., \"co-addict\" frameworks) and supports the partner as someone affected by another’s actions, entitled to their own support and decisions.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "A consistent, accepting therapeutic relationship is especially important in treating compulsive sexual behavior because it:",
+        "options": [
+          {
+            "text": "Increases the client’s shame",
+            "isCorrect": false
+          },
+          {
+            "text": "Counters the shame and isolation that drive the cycle and, for clients with avoidant patterns, provides a corrective experience of safe closeness",
+            "isCorrect": true
+          },
+          {
+            "text": "Replaces all other interventions",
+            "isCorrect": false
+          },
+          {
+            "text": "Is unnecessary if techniques are used",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The non-judgmental relationship counters the shame-compulsivity cycle and, for clients with avoidant attachment, offers a corrective experience of safe closeness central to change.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Self-compassion functions as an active clinical ingredient in treating compulsive sexual behavior because it:",
+        "options": [
+          {
+            "text": "Excuses the behavior and reduces motivation",
+            "isCorrect": false
+          },
+          {
+            "text": "Counters the shame that drives the compulsivity cycle and prevents the post-lapse shame spiral, supporting sustained change",
+            "isCorrect": true
+          },
+          {
+            "text": "Replaces all other interventions",
+            "isCorrect": false
+          },
+          {
+            "text": "Is only relevant for partners",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Self-compassion directly counters the shame that fuels the cycle and the post-lapse \"I’ve failed\" spiral; it supports, rather than undermines, values-driven change.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "A non-shaming therapeutic stance is clinically essential (not merely humane) in this area because:",
+        "options": [
+          {
+            "text": "Shame is an effective motivator",
+            "isCorrect": false
+          },
+          {
+            "text": "Shame both drives and results from the behavior, so increasing it tends to intensify the cycle rather than break it",
+            "isCorrect": true
+          },
+          {
+            "text": "It speeds up assessment",
+            "isCorrect": false
+          },
+          {
+            "text": "It is required only in couples work",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Shame fuels the compulsivity cycle; shaming or moralizing approaches tend to intensify the very behavior the client is trying to change, making a non-shaming stance clinically essential.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "An integrative treatment plan for compulsive sexual behavior is preferred because:",
+        "options": [
+          {
+            "text": "One technique addresses every dimension",
+            "isCorrect": false
+          },
+          {
+            "text": "The behavior is multiply determined and serves multiple functions, so combining CBT, acceptance/mindfulness, motivational, relapse-prevention, and relational approaches — tailored to the individual — works best",
+            "isCorrect": true
+          },
+          {
+            "text": "It avoids assessment",
+            "isCorrect": false
+          },
+          {
+            "text": "It guarantees abstinence",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Because compulsive sexual behavior is multiply determined, integrative, individualized treatment combining multiple evidence-informed approaches is generally most effective.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "ICD-11 classifies Compulsive Sexual Behaviour Disorder as:",
+        "options": [
+          {
+            "text": "A substance addiction",
+            "isCorrect": false
+          },
+          {
+            "text": "An impulse-control disorder, deliberately avoiding the contested addiction framing",
+            "isCorrect": true
+          },
+          {
+            "text": "A paraphilic disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "A marker of high sexual desire",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "ICD-11 recognizes CSBD as an impulse-control disorder — not an addiction, paraphilia, or marker of high desire — providing a category for genuine impairing loss of control while avoiding the contested addiction model.",
+        "showExplanation": true
+      },
+      {
+        "type": "multipleChoice",
+        "question": "Across treatment approaches, the unifying clinical stance toward compulsive sexual behavior is:",
+        "options": [
+          {
+            "text": "Moralizing and abstinence-enforcing",
+            "isCorrect": false
+          },
+          {
+            "text": "Non-judgmental, function-focused, evidence-informed, with collaborative goals and vigilance against pathologizing non-disordered sexuality",
+            "isCorrect": true
+          },
+          {
+            "text": "Confrontational",
+            "isCorrect": false
+          },
+          {
+            "text": "Focused only on the behavior’s frequency",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The unifying stance is non-shaming, function-focused, and evidence-informed, with collaborative goals and careful guarding against pathologizing sexuality that is not actually disordered.",
+        "showExplanation": true
+      },
+      {
+        "type": "trueFalse",
+        "question": "Per the ICD-11, distress arising entirely from moral or religious disapproval of one’s sexual behavior is, by itself, sufficient to diagnose CSBD.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "The ICD-11 specifies that moral incongruence alone does not warrant a CSBD diagnosis; the disorder requires genuine loss of control with distress or impairment."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Reflexively imposing abstinence is the recommended default goal for every client with compulsive sexual behavior.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Best practice sets collaborative, values-based goals; abstinence is not reflexively imposed, and harm-reduction or abstinence may be appropriate depending on the client."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Compulsive sexual behavior frequently functions as a form of emotion regulation, which is why building alternative coping is central to treatment.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "CSB frequently serves to regulate difficult emotional states; functional analysis identifies this so that alternative coping can be developed."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are accurate about partners affected by CSBD disclosure? (Select all that apply)",
+        "options": [
+          {
+            "text": "Their reaction can resemble betrayal trauma in its impact",
+            "isCorrect": true
+          },
+          {
+            "text": "They deserve support in their own right",
+            "isCorrect": true
+          },
+          {
+            "text": "They should be framed as “co-addicts” responsible for the behavior",
+            "isCorrect": false
+          },
+          {
+            "text": "Disclosure carries clinical considerations around timing and process",
+            "isCorrect": true
+          }
+        ],
+        "explanation": "Partner reactions can resemble betrayal trauma and warrant support in their own right; framing partners as “co-addicts” is inappropriate, and disclosure requires careful clinical handling."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are appropriate elements of a non-shaming, function-focused approach to CSBD? (Select all that apply)",
+        "options": [
+          {
+            "text": "Understanding the behavior’s function rather than only condemning it",
+            "isCorrect": true
+          },
+          {
+            "text": "Distinguishing CSBD from normative or minority sexuality",
+            "isCorrect": true
+          },
+          {
+            "text": "Collaborative, values-based goal-setting",
+            "isCorrect": true
+          },
+          {
+            "text": "Using shame as a motivator for change",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "A non-shaming, function-focused approach understands the behavior’s function, avoids pathologizing normal sexuality, and sets collaborative goals — shame is counterproductive, not a tool."
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "AASECT position on sex addiction. https://www.aasect.org",
+      "author": "American Association of Sexuality Educators, Counselors and Therapists",
+      "year": 2016,
+      "source": "6). AASECT position on sex addiction. https://www.aasect.org"
+    },
+    {
+      "title": "Sexual addiction, sexual compulsivity, sexual impulsivity, or what? Journal of Sex Research, 41(3), 225–234.",
+      "author": "Bancroft, J",
+      "year": 2004,
+      "source": "pulsivity, or what? Journal of Sex Research, 41(3), 225–234."
+    },
+    {
+      "title": "Out of the shadows: Understanding sexual addiction. CompCare Publications.",
+      "author": "Carnes, P",
+      "year": 1983,
+      "source": "dows: Understanding sexual addiction. CompCare Publications."
+    },
+    {
+      "title": "Is your patient suffering from compulsive sexual behavior? Psychiatric Annals, 22(6), 320–325.",
+      "author": "Coleman, E",
+      "year": 1992,
+      "source": "pulsive sexual behavior? Psychiatric Annals, 22(6), 320–325."
+    },
+    {
+      "title": "What's in a name? Terminology for designating a syndrome of driven sexual behavior. Sexual Addiction & Compulsivity, 8(",
+      "author": "Goodman, A",
+      "year": 2001,
+      "source": "behavior. Sexual Addiction & Compulsivity, 8(3–4), 191–213."
+    },
+    {
+      "title": "Hypersexual disorder: A proposed diagnosis for DSM-5. Archives of Sexual Behavior, 39(2), 377–400.",
+      "author": "Kafka, M",
+      "year": 2010,
+      "source": "osis for DSM-5. Archives of Sexual Behavior, 39(2), 377–400."
+    },
+    {
+      "title": "Hypersexuality and recidivism among sexual offenders. Sexual Addiction & Compulsivity, 20(1–2), 91–105.",
+      "author": "Kingston, D",
+      "year": 2013,
+      "source": "offenders. Sexual Addiction & Compulsivity, 20(1–2), 91–105."
+    },
+    {
+      "title": "Should compulsive sexual behavior be considered an addiction? Addiction, 111(12), 2097–2106.",
+      "author": "Kraus, S",
+      "year": 2016,
+      "source": "r be considered an addiction? Addiction, 111(12), 2097–2106."
+    },
+    {
+      "title": "Impulsive-compulsive sexual behavior. CNS Spectrums, 11(12), 944–955.",
+      "author": "Mick, T",
+      "year": 2006,
+      "source": "-compulsive sexual behavior. CNS Spectrums, 11(12), 944–955."
+    },
+    {
+      "title": "Data do not support sex as addictive. Lancet Psychiatry, 4(12), 899.",
+      "author": "Prause, N",
+      "year": 2017,
+      "source": "not support sex as addictive. Lancet Psychiatry, 4(12), 899."
+    },
+    {
+      "title": "Reliability, validity, and psychometric development of the Hypersexual Behavior Inventory in an outpatient sample of me",
+      "author": "Reid, R",
+      "year": 2011,
+      "source": "ample of men. Sexual Addiction & Compulsivity, 18(1), 30–51."
+    },
+    {
+      "title": "Current status and future directions in couple therapy. Annual Review of Psychology, 57, 317–344.",
+      "author": "Snyder, D",
+      "year": 2006,
+      "source": "in couple therapy. Annual Review of Psychology, 57, 317–344."
+    },
+    {
+      "title": "The traumatic nature of disclosure for wives of sexual addicts. Sexual Addiction & Compulsivity, 13(2–3), 247–267.",
+      "author": "Steffens, B",
+      "year": 2006,
+      "source": "addicts. Sexual Addiction & Compulsivity, 13(2–3), 247–267."
+    },
+    {
+      "title": "Hypersexuality: A critical review and introduction to the 'Sexhavior Cycle.' Archives of Sexual Behavior, 46(8), 2231–2",
+      "author": "Walton, M",
+      "year": 2017,
+      "source": "avior Cycle.' Archives of Sexual Behavior, 46(8), 2231–2251."
+    },
+    {
+      "title": "International classification of diseases (11th revision). https://icd.who.int",
+      "author": "World Health Organization",
+      "year": 2019,
+      "source": "ssification of diseases (11th revision). https://icd.who.int"
+    },
+    {
+      "title": "Hypersexual disorder: A more cautious approach. Archives of Sexual Behavior, 39(3), 594–596.",
+      "author": "Winters, J",
+      "year": 2010,
+      "source": "tious approach. Archives of Sexual Behavior, 39(3), 594–596."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module 1: Compulsive Sexual Behavior — Diagnosis, Neurobiology, and Assessment",
+      "order": 1,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 1,
+          "title": "Module 1",
+          "subtitle": "Module 1: Compulsive Sexual Behavior — Diagnosis, Neurobiology, and Assessment",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>Defining Compulsive Sexual Behavior: ICD-11, Controversies, and Biopsychosocial Etiology</h2>\n<h3>The Contested Diagnostic Landscape</h3>\n<p>Compulsive sexual behavior — characterized by persistent, distressing preoccupation with sexual thoughts, urges, and behaviors that the individual experiences as difficult or impossible to control — occupies a contested conceptual and diagnostic space in contemporary clinical practice, reflecting genuine scientific uncertainty about its nature, etiology, and optimal treatment. The most widely used lay term — sexual addiction — imports the addiction framework of substance use disorders into the sexual behavior domain, implying the same neurobiological mechanisms, the same progressive tolerance and withdrawal phenomena, and the same disease model that organizes substance use disorder treatment.</p>\n<p>This framework has been influential in treatment communities and has shaped public understanding of the condition, but it has not been validated by the empirical research base in ways that would justify its formal adoption as a clinical diagnosis. The DSM-5 did not include sexual addiction or hypersexual disorder as a diagnostic category — despite Kafka's (2010) proposal for the latter — citing insufficient empirical evidence. The ICD-11's classification of Compulsive Sexual Behavior Disorder (CSBD) as an impulse control disorder — not as an addictive disorder — reflects a more cautious, evidence-informed approach to the classification of this clinical phenomenon.</p>\n<h3>ICD-11 Diagnostic Criteria</h3>\n<p>ICD-11 Compulsive Sexual Behavior Disorder (F63.8) is defined by:</p>\n<ul>\n<li>A persistent pattern of failure to control intense, repetitive sexual impulses or urges</li>\n<li>Repetitive sexual behavior that becomes a central focus of the person's life to the point of neglecting health and personal care or other interests, activities, and responsibilities</li>\n<li>Continued repetitive sexual behavior despite adverse consequences or deriving little or no satisfaction from it</li>\n<li>Marked distress or significant impairment in personal, family, social, educational, occupational, or other important areas of functioning</li>\n</ul>\n<p>The ICD-11 criteria require that these features persist over an extended period — at least six months — and that they not be better explained by another mental disorder, the physiological effects of a substance or medication, or another medical condition. AASECT's official position statement — explicitly stating that there is insufficient empirical evidence to support sexual addiction or compulsive sexual behavior as a clinical diagnosis — reflects a competing perspective within the clinical field that clinicians should be aware of as they navigate this contested diagnostic terrain.</p>\n<h3>Distinguishing CSBD from Normative High Sexual Desire</h3>\n<p>The distinction between compulsive sexual behavior disorder and normative high sexual desire is a clinically essential assessment distinction that has direct implications for clinical formulation and treatment planning. Not all frequent sexual behavior, high sexual desire, or sexual behavior that others consider excessive constitutes CSBD.</p>\n<p>The diagnostic criteria require both the persistence of experienced loss of control over sexual urges and marked distress or functional impairment — meaning that a person with high sexual desire who engages in frequent sexual activity without subjective loss of control and without significant distress or functional impairment does not meet criteria for CSBD, regardless of the frequency or cultural unconventionality of their behavior. Conversely, a person who experiences intense distress about sexual urges and significant functional impairment from compulsive sexual behavior — even at levels of sexual activity that others might consider normative — may meet criteria. The clinical assessment must attend to subjective experience and functional impact rather than applying frequency or moral norms as diagnostic criteria.</p>\n<h3>CSBD and Paraphilic Disorders</h3>\n<p>The relationship between compulsive sexual behavior and paraphilic disorders requires specific clinical attention to avoid both the conflation and the erroneous separation of these distinct clinical phenomena. Paraphilic disorders — defined in DSM-5 as intense and persistent sexual interests in atypical objects, situations, or individuals that cause distress or functional impairment or that are acted upon with non-consenting individuals — are distinct from CSBD in their diagnostic basis: paraphilic disorders are defined by the specific content of sexual interests, while CSBD is defined by the behavioral pattern of compulsive engagement with sexual activity regardless of its specific content.</p>\n<p>These conditions can co-occur — a person can have both a paraphilic disorder and CSBD — or either can occur independently. Clinical assessment should address both the pattern of sexual behavior and the specific content of sexual interests, using the resulting information to guide formulation and treatment planning for each dimension of the presentation independently.</p>",
+          "order": 1
+        },
+        {
+          "type": "text",
+          "content": "<h2>Neurobiology, Psychological Factors, and Comprehensive Assessment</h2>\n<h3>Neurobiological Underpinnings</h3>\n<p>The neurobiological underpinnings of compulsive sexual behavior are an active area of research that has produced some findings suggesting parallels with substance use disorder neurobiology while also identifying important disanalogies that complicate the addiction framework. Neuroimaging studies have documented that exposure to sexual stimuli activates reward circuitry — including the ventral striatum and prefrontal cortex — in ways that share structural similarity with substance cue reactivity in addiction.</p>\n<p>Voon and colleagues' (2014) neuroimaging research found that individuals with CSBD showed increased activation in the amygdala, ventral striatum, and dorsal anterior cingulate in response to sexual cue exposure compared to controls — patterns similar to those seen in substance use disorders. However, other research has challenged the addiction model interpretation of these findings, noting that enhanced cue reactivity does not in itself validate addiction, that the behavioral escalation and tolerance phenomena central to the addiction model are not consistently documented in CSBD, and that subjective 'craving' in CSBD may not parallelize substance craving in the ways the addiction model requires.</p>\n<h3>Psychological and Developmental Factors</h3>\n<p>Psychological and developmental factors in the etiology of compulsive sexual behavior include:</p>\n<ul>\n<li>Attachment disruptions</li>\n<li>Early sexual trauma</li>\n<li>Shame-based sexual development</li>\n<li>The psychological functions that compulsive sexual behavior serves — including emotional regulation, dissociation from distressing affect, and the search for intimacy in substitute sexual encounters that cannot satisfy the underlying relational need</li>\n</ul>\n<p>The relationship between attachment insecurity — particularly dismissive-avoidant and anxious-preoccupied attachment patterns — and compulsive sexual behavior is clinically significant: individuals who have learned through early relational experiences that emotional intimacy is unsafe may develop sexual behavior as a substitute form of connection that provides physical closeness while avoiding the vulnerability of genuine emotional intimacy. This intimacy avoidance pattern — the chronic compromise of emotional closeness through the substitution of sexual activity, pornography use, or other sexually-mediated intimacy substitutes — is both a contributing etiological factor in many CSBD presentations and a treatment target that must be addressed for genuine recovery to occur.</p>\n<h3>Cultural and Sociocultural Context</h3>\n<p>The cultural and sociocultural context of compulsive sexual behavior deserves specific clinical attention because cultural factors significantly shape both the phenomenology of the behavior and the distress associated with it. Research by Prause, Janssen, and colleagues suggests that the subjective distress experienced in relation to sexual behavior is significantly predicted by religiosity and moral disapproval of the behavior — meaning that some portion of the distress attributed to 'compulsive' sexual behavior may more accurately reflect moral or religious incongruence between the behavior and the person's values rather than clinically meaningful compulsivity.</p>\n<p>This finding has direct clinical implications: clinicians must carefully distinguish between genuine compulsive sexual behavior — characterized by persistent subjective loss of control and functional impairment independent of moral evaluation — and moral distress about sexual behavior that is incongruent with the person's religious or moral values, which requires a different clinical response that includes attention to values clarification rather than behavioral disorder treatment.</p>\n<h3>Comprehensive Assessment</h3>\n<p>Assessment of compulsive sexual behavior requires a comprehensive, multi-modal approach that combines clinical interview with validated self-report instruments and attends to the full range of biopsychosocial factors contributing to the presentation. Validated instruments include:</p>\n<ul>\n<li>The <strong>Sexual Compulsivity Scale (SCS)</strong>, a 10-item self-report measure of sexual compulsivity</li>\n<li>The <strong>Hypersexual Behavior Inventory (HBI)</strong>, a 19-item measure developed specifically for hypersexual behavior in men</li>\n<li>The <strong>Compulsive Sexual Behavior Inventory (CSBI)</strong>, a 28-item measure assessing control over sexual behavior, abuse, and violence</li>\n</ul>\n<p>These instruments provide standardized, quantitative data that complement clinical interview findings and support treatment monitoring. Clinical interview should assess:</p>\n<ul>\n<li>The specific behaviors involved, their frequency and duration</li>\n<li>The degree of subjective loss of control</li>\n<li>The presence of craving, tolerance, and withdrawal-like phenomena</li>\n<li>Functional impact across occupational, relational, and health domains</li>\n<li>Comorbid conditions including depression, anxiety, substance use, and trauma</li>\n<li>Sexual development history including early sexual experiences and exposure to pornography</li>\n<li>Attachment history and current relational patterns</li>\n<li>Religious, cultural, and moral context for the behavior</li>\n</ul>",
+          "order": 2
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Robert, 38, presents at the request of his wife following her discovery of extensive pornography use and contact with escorts over six years. He acknowledges escalating frequency, work impairment, and intense shame alongside ongoing urges feeling 'outside my control.' Assessment: ICD-11 CSBD criteria evaluation; HBI administration; functional behavior assessment; comorbidity screening (depression, anxiety, attachment history); partner trauma assessment. Plan: individual CBT/ACT-based therapy; partner trauma support; staged couples work when both stabilized; ICD-11 CSBD framing rather than 'sex addiction'; values clarification as motivation foundation.</blockquote>",
+          "order": 3
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 1: compulsive sexual behavior — diagnosis, neurobiology, and assessment, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 4
+        },
+        {
+          "type": "multipleChoice",
+          "question": "ICD-11 classifies compulsive sexual behavior disorder as:",
+          "options": [
+            {
+              "text": "An addictive disorder analogous to gambling disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "A sexual dysfunction",
+              "isCorrect": false
+            },
+            {
+              "text": "An impulse control disorder",
+              "isCorrect": true
+            },
+            {
+              "text": "A paraphilic disorder",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "ICD-11 classifies CSBD as an impulse control disorder (F63.8) — not as an addictive disorder — reflecting a more cautious approach than the 'sexual addiction' framework that lacks DSM-5/ICD-11 validation.",
+          "showExplanation": true,
+          "order": 5
+        },
+        {
+          "order": 6,
+          "type": "multiSelect",
+          "question": "Which features distinguish CSBD from normative high sexual desire? (Select all that apply)",
+          "options": [
+            {
+              "text": "A persistent failure to control the behavior despite efforts",
+              "isCorrect": true
+            },
+            {
+              "text": "Marked distress or functional impairment",
+              "isCorrect": true
+            },
+            {
+              "text": "Simply having a high frequency of consensual sexual activity",
+              "isCorrect": false
+            },
+            {
+              "text": "Continued behavior despite adverse consequences",
+              "isCorrect": true
+            },
+            {
+              "text": "The behavior becoming a central focus that crowds out other interests",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "CSBD is defined by loss of control, distress/impairment, and persistence despite consequences — not by high desire or frequency alone, which is not itself disordered."
+        },
+        {
+          "type": "multipleChoice",
+          "question": "The sexual double bind in CSBD describes:",
+          "options": [
+            {
+              "text": "Situations where both partners experience compulsive sexual behavior simultaneously",
+              "isCorrect": false
+            },
+            {
+              "text": "The dynamic where both the sexual urge and the shame about it powerfully maintain the compulsive cycle",
+              "isCorrect": true
+            },
+            {
+              "text": "Treatment paradoxes involving simultaneous abstinence and exposure",
+              "isCorrect": false
+            },
+            {
+              "text": "Legal and ethical conflicts in mandatory reporting",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "The sexual double bind — in which shame about sexual urges paradoxically maintains them — requires clinical approaches that hold both compassionate understanding of the mechanisms driving behavior and values-based accountability.",
+          "showExplanation": true,
+          "order": 7
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Diagnostic Debate: Naming the Problem</h2>\n<p>Few areas of clinical practice are as conceptually contested as compulsive sexual behavior, and a clinician working in this area must understand the debate, because how the problem is framed shapes assessment, treatment, and the stance taken toward the client.</p>\n<h3>Competing Models</h3>\n<p>Several frameworks have been used to describe distressing, out-of-control sexual behavior: a sexual \"addiction\" model drawing analogy to substance addiction; a hypersexuality or sexual-desire-dysregulation model; an impulse-control model; and an obsessive-compulsive-spectrum model. Each carries different assumptions about cause, and each implies different treatment. The \"addiction\" framing in particular is popular in the public and in some treatment programs but is scientifically contested, as the evidence that this behavior functions like a substance addiction at the neurobiological level is mixed and incomplete.</p>\n<h3>Why DSM-5 Declined and ICD-11 Acted</h3>\n<p>The DSM-5 considered but ultimately did not include hypersexual disorder, citing insufficient evidence and concern about pathologizing normal sexual variation. The ICD-11 subsequently included {{callout:csbd}} Disorder (CSBD), but deliberately classified it as an impulse-control disorder rather than as an addiction or a paraphilia, reflecting a cautious, evidence-based stance. This history matters clinically: it counsels humility about etiology, caution about the \"addiction\" language, and great care not to pathologize sexual behavior that is simply frequent, unconventional, or in conflict with the client's or society's values.</p>",
+          "order": 8,
+          "callouts": {
+            "csbd": {
+              "label": "CSBD",
+              "type": "reference",
+              "body": "Compulsive Sexual Behaviour Disorder (ICD-11) — a persistent pattern of failure to control intense, repetitive sexual impulses causing marked distress or impairment; classified as an impulse-control disorder."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>ICD-11 Compulsive Sexual Behaviour Disorder in Depth</h2>\n<p>The ICD-11 criteria for CSBD provide the most authoritative current definition, and understanding them precisely is essential for accurate diagnosis and for avoiding overdiagnosis.</p>\n<h3>The Core Features</h3>\n<p>CSBD is characterized by a persistent pattern of failure to control intense, repetitive sexual impulses or urges, resulting in repetitive sexual behavior over an extended period (generally six months or more), with several hallmark features: the behavior becomes a central focus of the person's life to the neglect of health, self-care, and other interests and responsibilities; the person makes numerous unsuccessful efforts to control or reduce the behavior; the person continues despite adverse consequences or deriving little satisfaction from it; and the pattern causes marked distress or significant impairment in important areas of functioning.</p>\n<h3>The Crucial Exclusion</h3>\n<p>The ICD-11 includes a critical clarification: distress that is entirely related to moral judgments and disapproval about sexual impulses, urges, or behaviors is not sufficient to meet the diagnosis. In other words, a person who is distressed about their sexual behavior solely because it conflicts with their personal, religious, or cultural values — but whose behavior is not genuinely out of control by the other criteria — does not have CSBD. This exclusion is one of the most clinically important features of the diagnosis, and it directly shapes assessment.</p>",
+          "order": 9
+        },
+        {
+          "type": "text",
+          "content": "<h2>Moral Incongruence: The Central Clinical Distinction</h2>\n<p>Research over the past decade has established that a large proportion of people who self-identify as having a sexual behavior \"problem\" — particularly around pornography use — are experiencing what is termed {{callout:moral-incongruence}}: distress arising from the conflict between their behavior and their moral or religious values, rather than from genuine loss of control.</p>\n<h3>Why This Matters Enormously</h3>\n<p>Studies have found that self-perceived problematic sexual behavior, especially problematic pornography use, is frequently predicted more strongly by religiosity and moral disapproval than by the actual frequency or quantity of the behavior. A person may use pornography at a level that causes no objective impairment, yet experience intense distress and self-condemnation because the behavior violates deeply held beliefs. This is a fundamentally different clinical situation from genuine compulsivity, and treating it as an \"addiction\" can deepen shame, reinforce a sense of being diseased, and miss the actual source of suffering.</p>\n<h3>The Clinical Implication</h3>\n<p>The clinician must carefully distinguish genuine compulsivity (behavior that is truly out of control, persists despite serious consequences, and impairs functioning) from moral incongruence (distress driven primarily by value conflict). The two call for different approaches: genuine compulsivity may warrant the evidence-based treatments for CSBD, while moral incongruence is better addressed by helping the client explore and reconcile the conflict between their behavior and their values, reduce shame, and arrive at a resolution that is genuinely their own — which may involve changing the behavior, revising the belief, or finding an integration, as the client determines.</p>",
+          "order": 10,
+          "callouts": {
+            "moral-incongruence": {
+              "label": "Moral Incongruence",
+              "type": "definition",
+              "body": "Distress about one’s sexual behavior arising from conflict with personal moral or religious values; the ICD-11 specifies this alone does not warrant a CSBD diagnosis."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Distinguishing CSBD from Normative High Sexual Desire</h2>\n<p>One of the gravest errors in this clinical area is pathologizing high sexual desire or frequent consensual sexual behavior that is not actually disordered, and guarding against it is a core competency.</p>\n<h3>High Desire Is Not a Disorder</h3>\n<p>People vary enormously in sexual desire and activity, and a high level of sexual interest or frequent sexual behavior is, by itself, simply a point on the normal spectrum of human sexuality — not a disorder. The defining features of CSBD are loss of control, the central and life-dominating role of the behavior, continuation despite serious adverse consequences, and marked distress or impairment — not frequency as such. A person with a high libido who enjoys an active, consensual sexual life and experiences no loss of control or impairment does not have a disorder, regardless of how their frequency compares to others.</p>\n<h3>The Risk of Overdiagnosis</h3>\n<p>The history of this field includes the pathologizing of sexual behavior that was merely frequent, unconventional, or socially disapproved, and the contemporary clinician remains vigilant against repeating that error. Cultural and personal discomfort with a client's sexuality must never become the basis for a diagnosis. The clinician applies the criteria rigorously, attends to whether the behavior is genuinely out of control rather than merely frequent or disapproved, and respects the wide range of healthy sexual expression.</p>",
+          "order": 11
+        },
+        {
+          "type": "text",
+          "content": "<h2>Differential Diagnosis</h2>\n<p>Compulsive sexual behavior can resemble, co-occur with, or be better explained by other conditions, and careful differential diagnosis is essential to accurate formulation and treatment.</p>\n<h3>Conditions to Consider</h3>\n<p>Several conditions warrant consideration. <strong>Bipolar disorder</strong>: increased sexual behavior can be a feature of manic or hypomanic episodes, and behavior occurring only during mood episodes is better explained by the mood disorder. <strong>Substance use</strong>: sexual behavior driven by or occurring under the influence of substances, including in the context of chemsex, may reflect the substance use. <strong>Obsessive-compulsive disorder</strong>: intrusive sexual thoughts in OCD are ego-dystonic and not pleasurable, differing from the urges of CSBD. <strong>Paraphilic disorders</strong>: these involve atypical sexual interests and are a distinct category from CSBD, though they can co-occur. <strong>ADHD and other impulse-control problems</strong>, as well as the effects of certain medications (such as dopaminergic agents), can also contribute to disinhibited sexual behavior.</p>\n<h3>Co-Occurrence and Formulation</h3>\n<p>These conditions frequently co-occur with compulsive sexual behavior rather than simply ruling it in or out, and assessment determines what is driving the behavior and what conditions require treatment in their own right. A thorough differential prevents both the misattribution of mood- or substance-driven behavior to CSBD and the neglect of co-occurring conditions that must be addressed for treatment to succeed.</p>",
+          "order": 12
+        },
+        {
+          "order": 13,
+          "type": "fillInBlank",
+          "title": "Quick check — the central distinction",
+          "blanks": [
+            {
+              "prompt": "Distress arising entirely from conflict with one’s moral or religious values is called:",
+              "answer": "moral incongruence",
+              "acceptAlternates": [
+                "moral-incongruence"
+              ]
+            },
+            {
+              "prompt": "Per the ICD-11, moral incongruence alone is ___ sufficient to diagnose CSBD:",
+              "answer": "not",
+              "acceptAlternates": [
+                "insufficient"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "<h2>Neurobiological Considerations</h2>\n<p>Research has examined the neurobiology of compulsive sexual behavior, and the clinician benefits from understanding both what the evidence suggests and its limits.</p>\n<h3>What the Research Suggests</h3>\n<p>Studies have explored the role of brain reward systems, dopaminergic signaling, and circuits involved in impulse control and habit, with some findings paralleling those seen in addictive and impulse-control disorders. These lines of research inform the impulse-control framing of CSBD and suggest that, for some individuals with genuine compulsivity, dysregulation of reward and inhibitory systems may contribute to the difficulty controlling behavior.</p>\n<h3>Interpreting the Evidence Cautiously</h3>\n<p>At the same time, the neurobiological evidence is incomplete and contested, and it does not definitively establish that compulsive sexual behavior is neurobiologically equivalent to substance addiction. The clinician holds this knowledge with appropriate humility: neurobiological factors may contribute, particularly in genuine compulsivity, but they neither fully explain the behavior nor justify a reductive \"brain disease\" framing that can deepen shame or imply the behavior is beyond the client's capacity to change. A biopsychosocial formulation that integrates neurobiological, psychological, and social factors remains the most accurate and clinically useful framework.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Psychological, Developmental, and Trauma Factors</h2>\n<p>Compulsive sexual behavior frequently functions within a larger psychological context, and understanding the factors that drive and maintain it is essential to effective treatment.</p>\n<h3>Emotion Regulation and Coping</h3>\n<p>For many people, sexual behavior serves as a way of coping with difficult internal states — anxiety, depression, loneliness, boredom, shame, or the aftermath of trauma. The behavior provides temporary relief, escape, or soothing, which negatively reinforces it, and over time it can become a primary and increasingly automatic coping strategy. Understanding the function the behavior serves — what it does for the person, what states it manages — is frequently more clinically useful than focusing on the behavior in isolation.</p>\n<h3>Developmental and Trauma History</h3>\n<p>Histories of childhood trauma, including sexual abuse, neglect, and disrupted attachment, are common among people with compulsive sexual behavior, and the behavior may be linked to trauma in multiple ways — as a means of regulating trauma-related states, as a reenactment, or as a learned pattern. Early experiences also shape the beliefs about self, intimacy, and worth that underlie the behavior. A trauma-informed approach is therefore frequently essential, and unaddressed trauma is a common reason treatment focused only on behavior change fails.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Attachment and Intimacy in the Etiology</h2>\n<p>Attachment patterns formed in early relationships profoundly shape adult sexuality and intimacy, and they are central to understanding both compulsive sexual behavior and the intimacy disorders with which it frequently intertwines.</p>\n<h3>The Attachment Lens</h3>\n<p>Insecure attachment — particularly avoidant and disorganized patterns — is associated with difficulties in emotional intimacy, and for some individuals compulsive sexual behavior functions partly as a substitute for, or a defense against, genuine intimacy. Sexual behavior can provide connection or arousal without the vulnerability of emotional closeness, which can feel threatening to those with avoidant attachment histories. Understanding a client's attachment patterns illuminates why the behavior may serve to avoid intimacy even as it appears to seek connection.</p>\n<h3>Implications for Treatment</h3>\n<p>This attachment framing connects compulsive sexual behavior to the intimacy disorders addressed later in this course, and it implies that effective treatment frequently must address not only the behavior but the underlying capacity for emotional intimacy and the attachment-related fears and patterns that drive avoidance of it. For many clients, building the capacity for genuine intimacy is as central to recovery as reducing the problematic behavior.</p>",
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>Cultural, Religious, and Sociocultural Context</h2>\n<p>Cultural and religious context shapes both the experience of sexual behavior and its appraisal as problematic, and attending to this context is essential to accurate, non-judgmental assessment.</p>\n<h3>Context Shapes What Is \"Problematic\"</h3>\n<p>What is considered acceptable or problematic sexual behavior varies across cultures and religious traditions, and a client's appraisal of their own behavior is heavily shaped by these frameworks. As the research on moral incongruence demonstrates, religiosity and cultural disapproval strongly influence whether a person perceives their behavior as a problem, frequently more than the behavior's objective characteristics. The clinician must therefore understand the client's cultural and religious context to distinguish genuine compulsivity from value conflict and to avoid imposing either the clinician's own values or a pathologizing framework.</p>\n<h3>Working Respectfully With Values</h3>\n<p>Cultural humility here means neither dismissing the client's values nor enforcing them, but helping the client navigate their own framework. For a client whose distress is rooted in value conflict, the clinician supports exploration and self-determined resolution; for a client with genuine compulsivity, the clinician provides appropriate treatment while remaining respectful of the cultural and religious context that gives the behavior its meaning. Throughout, the clinician brackets personal values so they do not distort the work.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Comprehensive Assessment and Instruments</h2>\n<p>Assessment of compulsive sexual behavior is a careful, multidimensional process that distinguishes genuine compulsivity from moral incongruence and normative behavior, identifies contributing and co-occurring factors, and informs treatment.</p>\n<h3>The Assessment Process</h3>\n<p>Comprehensive assessment characterizes the behavior (its nature, frequency, contexts, and triggers), evaluates the hallmark features of genuine compulsivity (loss of control, life-dominating centrality, continuation despite consequences, distress and impairment), and explicitly assesses whether distress is driven by genuine loss of control or by moral incongruence. It surveys the biopsychosocial contributors — emotional and trauma history, attachment and intimacy, co-occurring conditions, relational context, and cultural and religious framework — and it assesses the consequences of the behavior across domains of the person's life. Safety considerations, including any behavior involving non-consent or legal risk, are evaluated.</p>\n<h3>Validated Instruments</h3>\n<p>Several validated instruments can supplement the clinical interview, including measures of compulsive sexual behavior and sexual compulsivity that help quantify the concern, structure assessment, and track change. As with all instruments, these supplement rather than replace clinical judgment, must be interpreted in light of the moral-incongruence distinction (since high scores may reflect distress driven by value conflict rather than genuine compulsivity), and should be used in a culturally responsive way. Used thoughtfully, they add rigor to an assessment that must remain nuanced and individualized.</p>",
+          "order": 18
+        },
+        {
+          "order": 19,
+          "type": "cardSort",
+          "instructions": "Sort each scenario by whether a CSBD diagnosis may apply or caution is warranted.",
+          "categories": [
+            "CSBD may apply",
+            "Caution — likely not CSBD"
+          ],
+          "cards": [
+            {
+              "id": "a",
+              "text": "Loss of control and impairment, distress not driven only by moral conflict",
+              "correctCategory": "CSBD may apply"
+            },
+            {
+              "id": "b",
+              "text": "Distress arising entirely from religious guilt about normative behavior",
+              "correctCategory": "Caution — likely not CSBD"
+            },
+            {
+              "id": "c",
+              "text": "High consensual sexual frequency with no distress or impairment",
+              "correctCategory": "Caution — likely not CSBD"
+            },
+            {
+              "id": "d",
+              "text": "Repeated failure to control behavior despite serious adverse consequences",
+              "correctCategory": "CSBD may apply"
+            },
+            {
+              "id": "e",
+              "text": "A sexual-minority client distressed mainly by internalized stigma",
+              "correctCategory": "Caution — likely not CSBD"
+            }
+          ],
+          "explanation": "CSBD requires genuine loss of control with distress/impairment not reducible to moral incongruence or stigma; high frequency without distress, or distress driven only by moral conflict or internalized stigma, calls for caution."
+        },
+        {
+          "type": "reflection",
+          "prompt": "How will you distinguish genuine compulsivity from moral incongruence in your own assessment process, and what questions would help you tell them apart?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 31
+        },
+        {
+          "type": "text",
+          "content": "<h2>Prevalence, Course, and Who Seeks Help</h2>\n<p>Compulsive sexual behavior occurs across genders, orientations, and cultures, though estimates of its prevalence vary widely depending on how it is defined — a direct consequence of the diagnostic debates discussed earlier. Stricter, impairment-based definitions yield lower estimates than broad self-report measures that may capture moral incongruence and high desire.</p>\n<h3>Patterns in Help-Seeking</h3>\n<p>Those who present for help are not a representative sample of those who might meet criteria. Help-seeking is shaped by shame, by relationship crises (discovery by a partner is a frequent precipitant), by moral and religious frameworks that lead some to label their behavior as addiction, and by the consequences the behavior has produced. Men present more frequently than women, which may reflect both genuine differences and the gendered ways sexuality is judged and labeled. The clinician keeps these patterns in mind, recognizing that the path to treatment shapes how a concern is presented and understood.</p>\n<h3>Course</h3>\n<p>The course of compulsive sexual behavior is variable. For some it is chronic and entrenched; for others it waxes and wanes with life stress, mood, and circumstance; and for many it improves substantially with treatment that addresses the underlying functions and co-occurring conditions. A single lapse does not mean treatment has failed, and improvement is frequently non-linear.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Screening: When and How to Assess</h2>\n<p>Because compulsive sexual behavior is frequently hidden behind shame and behind other presenting concerns, clinicians benefit from a thoughtful approach to when and how to screen.</p>\n<h3>When to Consider It</h3>\n<p>Indicators that warrant gentle exploration include a client's own concern about loss of control over sexual behavior, relationship crises involving sexual behavior, co-occurring conditions frequently associated with the pattern, and the use of sexual behavior to manage distress. The clinician raises the topic non-judgmentally and follows the client's lead, recognizing that shame makes spontaneous disclosure unlikely and that a calm, accepting inquiry is what makes honest discussion possible.</p>\n<h3>Screening Without Overpathologizing</h3>\n<p>Screening in this area carries a specific risk: framing ordinary or value-discordant sexual behavior as a potential disorder can itself induce shame and a false self-understanding. The clinician therefore screens in a way that assesses for genuine loss of control and impairment without implying that frequent or value-discordant sexual behavior is inherently pathological. The same careful distinction that governs diagnosis — genuine compulsivity versus high desire versus moral incongruence — governs screening.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>A Function-Focused Formulation: A Worked Example</h2>\n<p>Consider a client who presents, after a partner's discovery, distressed about compulsive use of online sexual content that has begun to interfere with work and with his relationship. A function-focused biopsychosocial formulation organizes the assessment and treatment.</p>\n<h3>Building the Formulation</h3>\n<p>Assessment reveals genuine loss of control (repeated failed efforts to cut down, use continuing despite clear adverse consequences) and real impairment — distinguishing this from moral incongruence. The behavior is found to function primarily as a way of managing chronic anxiety and a deep discomfort with emotional intimacy rooted in an avoidant attachment history; co-occurring depressive symptoms amplify the pattern, and shame about the behavior feeds a self-perpetuating cycle. Each of these is a point of intervention.</p>\n<h3>From Formulation to Plan</h3>\n<p>The plan follows directly: building emotion-regulation and urge-management skills (CBT, mindfulness, {{callout:urge-surfing}}) for the anxiety the behavior has managed; ACT work on values and on tolerating intimacy-related discomfort; treatment of the co-occurring depression; reduction of shame through a non-judgmental stance and self-compassion work; attention to the underlying intimacy and attachment difficulty; and, with the client's consent and readiness, couples work to support the partner and the relationship. No single intervention would suffice; the integrated, function-focused formulation is what turns an apparently overwhelming problem into a set of addressable targets.</p>",
+          "order": 23,
+          "callouts": {
+            "urge-surfing": {
+              "label": "Urge Surfing",
+              "type": "clinical",
+              "body": "A mindfulness technique of observing an urge rise, peak, and subside without acting on it — building tolerance of urges rather than suppression."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>The First Sessions: Engagement in a Shame-Laden Area</h2>\n<p>Few clinical areas are as saturated with shame as compulsive sexual behavior, and the opening sessions determine whether a client can be honest enough for treatment to work.</p>\n<h3>Establishing Safety</h3>\n<p>Clients frequently arrive expecting judgment, having internalized moralizing messages about their behavior, and may disclose only a fraction of what is occurring until they feel safe. The clinician's calm, matter-of-fact, explicitly non-judgmental stance in these first conversations is the foundational intervention: it communicates that the client will be helped rather than condemned, and that honesty is safe. Normalizing the difficulty, explaining the collaborative and non-moralizing nature of the work, and conveying that the goal is the client's own wellbeing all lower the barrier to honest engagement.</p>\n<h3>The Frame</h3>\n<p>Early sessions also establish the frame: confidentiality and its limits, the client's control over goals and pace, and the clarity that treatment serves the client's values rather than an imposed standard of conduct. For clients whose sexuality has been a source of secrecy and shame, the experience of being met with acceptance is itself the beginning of change.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>Integrating This Work Into General Practice</h2>\n<p>General mental health clinicians need not specialize in compulsive sexual behavior to provide valuable help, and integrating a basic competence into ordinary practice serves many clients who would otherwise go unhelped.</p>\n<h3>What the Generalist Can Do</h3>\n<p>The generalist can screen sensitively, conduct a careful initial assessment that distinguishes genuine compulsivity from moral incongruence and high desire, provide a non-judgmental relationship that reduces shame, deliver foundational interventions (psychoeducation, emotion-regulation and urge-management skills, motivational and acceptance-based strategies), address co-occurring conditions, and recognize when a presentation calls for specialized care. Much of what helps clients in this area — a non-shaming stance, accurate understanding, and attention to underlying functions — is within the generalist's reach.</p>\n<h3>Knowing the Limits</h3>\n<p>The generalist also recognizes the limits of their competence and refers appropriately: complex or entrenched presentations, significant co-occurring conditions beyond their scope, couples work requiring specialized skill, and any presentation involving non-consensual or illegal behavior that raises distinct frameworks. Referral is not abandonment; the generalist frequently continues to provide support alongside specialized care.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Integrating the Assessment: From Findings to Formulation</h2>\n<p>Pulling together the assessment, a biopsychosocial synthesis integrates the biological, psychological, and social-relational threads into a single working understanding that guides treatment.</p>\n<h3>The Pattern of Comorbidity</h3>\n<p>Compulsive sexual behavior commonly co-occurs with mood disorders, anxiety, substance use, trauma-related conditions, and the {{callout:compulsivity-impulsivity}} associated with certain other conditions, and these relationships are bidirectional and mutually reinforcing. A synthesis identifies which conditions are present, how they interact with the sexual behavior, and which are driving which — recognizing that the same behavior may serve different functions and arise from different sources in different clients.</p>\n<h3>An Individualized Formulation</h3>\n<p>The synthesis yields an individualized formulation: a working account of how this particular client's biology, psychological history and emotion-regulation patterns, attachment and intimacy capacities, co-occurring conditions, cultural and relational context, and the specific functions of the behavior fit together. This formulation, shared collaboratively with the client, replaces a generic \"addiction\" label with a personalized understanding that directly informs a tailored, multimodal treatment plan and supports the client's own sense-making and hope.</p>",
+          "order": 26,
+          "callouts": {
+            "compulsivity-impulsivity": {
+              "label": "Compulsivity vs. Impulsivity",
+              "type": "definition",
+              "body": "Impulsivity is acting on urges for anticipated reward; compulsivity is driven behavior aimed at relieving distress. CSBD involves features of both."
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Module 2: Evidence-Based Treatment, Intimacy Disorders, and Couples Practice",
+      "order": 2,
+      "estimatedTime": 20,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "sectionNumber": 2,
+          "title": "Module 2",
+          "subtitle": "Module 2: Evidence-Based Treatment, Intimacy Disorders, and Couples Practice",
+          "order": 0
+        },
+        {
+          "type": "text",
+          "content": "<h2>CBT, ACT, Motivational Interviewing, and Relapse Prevention</h2>\n<h3>Cognitive-Behavioral Approaches</h3>\n<p>Cognitive-behavioral approaches to the treatment of compulsive sexual behavior draw on the well-established CBT framework for impulsive and compulsive behaviors, adapting its core components — functional assessment of antecedents and consequences, cognitive restructuring, behavioral skill building, and {{callout:relapse-prevention}} planning — to the specific cognitive and behavioral patterns that maintain CSBD. Functional behavior assessment — identifying the specific triggers, thoughts, emotions, and behavioral consequences that constitute the individual's specific compulsive sexual behavior cycle — provides the foundation for an individualized treatment plan that addresses the specific maintaining mechanisms rather than applying generic CSBD treatment approaches to heterogeneous presentations that may differ substantially in their specific etiology and function.</p>\n<p>The CSBD behavioral cycle typically involves:</p>\n<ol>\n<li>A triggering situation or emotional state</li>\n<li>Cognitive events including intrusive sexual thoughts and permission-giving beliefs that allow the behavior</li>\n<li>The behavior itself</li>\n<li>Immediate reinforcing consequences including emotional relief, pleasure, or dissociative numbing</li>\n<li>Delayed consequences including shame, guilt, and functional impairment that maintain the shame-behavior cycle</li>\n</ol>\n<h3>The Sexual Double Bind</h3>\n<p>The sexual double bind — the clinical dynamic in which both the sexual urge and the shame about the urge are powerfully motivating forces that together maintain the compulsive cycle — is among the most important clinical concepts in CSBD treatment. The standard shame-reduction approach to many clinical conditions — normalizing the experience, reducing self-judgment — is insufficient in CSBD because the shame about the behavior is often ethically warranted: the person is engaging in behavior that genuinely violates their own values and that may harm others.</p>\n<p>Effective CSBD treatment must hold both dimensions: the compassionate acknowledgment of the psychological mechanisms driving the behavior, which reduces the shame that paradoxically maintains it, and the values-based engagement with the person's own ethical commitments that provides the motivational foundation for behavior change. This holding of both dimensions — compassion and accountability — requires clinical skill and conceptual clarity that distinguishes effective CSBD treatment from either pure shame reduction or shame-amplifying moral confrontation.</p>\n<h3>Acceptance and Commitment Therapy (ACT)</h3>\n<p>Acceptance and Commitment Therapy (ACT) provides a particularly well-suited therapeutic framework for CSBD because it addresses the experiential avoidance — the attempt to escape or suppress unwanted internal experiences including uncomfortable emotions, memories, and sexual urges — that is a primary driver of many compulsive behaviors. From an ACT perspective, compulsive sexual behavior functions as an experiential avoidance strategy: a behavioral escape from the discomfort of unwanted internal states — loneliness, anxiety, shame, boredom, depression — through the dissociative, pleasurable, or numbing properties of sexual activity.</p>\n<p>The ACT approach to CSBD involves:</p>\n<ul>\n<li>Identification and defusion from the thoughts that permission-give compulsive behavior</li>\n<li>Acceptance of the internal states that the behavior serves to avoid</li>\n<li>Clarification of personal values as the basis for values-driven behavior change</li>\n<li>Commitment to behavioral choices aligned with values rather than driven by avoidance</li>\n</ul>\n<p>ACT's emphasis on psychological flexibility — the capacity to hold uncomfortable experiences without reacting to them through behavioral avoidance — directly addresses the compulsive mechanism while building the values-based behavioral repertoire that sustained recovery requires.</p>\n<h3>Motivational Interviewing</h3>\n<p>Motivational interviewing is a clinically essential approach for the early stages of CSBD treatment because ambivalence about behavior change is nearly universal in this population and because the confrontational approaches that were historically used in addiction treatment — and that were sometimes applied to CSBD — are now well-documented to reduce rather than increase motivation for change.</p>\n<p>Many individuals presenting with CSBD are not certain they want to change the behavior — they may experience the behavior as ego-syntonic at least in part, may derive genuine pleasure and relief from it, and may be presenting for treatment under external pressure from a partner, employer, or legal system rather than from internal motivation. Motivational interviewing's non-judgmental, evocative, collaborative stance — exploring the individual's own ambivalence and eliciting their own reasons for change rather than providing the reasons from an external authoritative perspective — creates the clinical conditions in which motivation for change can develop and strengthen from within.</p>",
+          "order": 1,
+          "callouts": {
+            "relapse-prevention": {
+              "label": "Relapse Prevention",
+              "type": "clinical",
+              "body": "A structured approach identifying triggers and high-risk situations, building coping strategies, and treating lapses as learning opportunities rather than failures."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Problematic Pornography Use, Partner Trauma, and Relapse Prevention</h2>\n<h3>Problematic Pornography Use</h3>\n<p>Pornography use and its clinical management has emerged as a significant clinical concern in the past two decades, as internet pornography has become universally accessible and as the proportion of clients presenting with concerns about their pornography use has grown substantially. Problematic pornography use — defined by the experience of subjective loss of control over pornography use, distress about pornography use, and functional impairment related to pornography use — is distinguished from normative pornography use by these criteria rather than by frequency or content alone.</p>\n<p>The clinical assessment of problematic pornography use must attend to:</p>\n<ul>\n<li>The frequency, duration, and content of pornography use</li>\n<li>The degree of subjective control or loss of control</li>\n<li>The functional impact on occupational functioning, intimate relationships, and sexual functioning</li>\n<li>The presence of comorbid conditions including depression, anxiety, and social anxiety that may be contributing to pornography use as an avoidance behavior</li>\n<li>The cultural, religious, and moral context in which the pornography use is experienced as problematic</li>\n</ul>\n<h3>Impact on Relationships and Sexual Functioning</h3>\n<p>The impact of pornography use on intimate relationships and sexual functioning is a clinically complex topic about which the evidence is contested and evolving. Research suggests that high-frequency pornography use is associated with reduced sexual satisfaction, reduced sexual desire for intimate partners, and difficulties with sexual arousal to partnered sexual stimuli that may reflect the specific arousal properties of pornography — including novelty, variety, and absence of the relational dimensions of partnered sex.</p>\n<p>However, the causal direction of these associations — whether pornography use causes these outcomes or whether individuals with these characteristics are more likely to use pornography frequently — is not clearly established. Clinicians should approach clients' concerns about pornography's impact on their sexual functioning and relationships with a genuinely curious, non-judgmental clinical stance that neither dismisses the concerns as unfounded nor amplifies them beyond what the evidence supports, and that provides accurate clinical information about what is and is not known about pornography's effects.</p>\n<h3>Partner Trauma</h3>\n<p>Partner trauma — the distress experienced by partners who discover or are disclosed to about a significant other's compulsive sexual behavior — has been described as resembling post-traumatic stress in its symptom profile, including intrusive thoughts and images, hypervigilance about partner behavior, avoidance of intimacy, and significant disruptions in trust and safety. Research by Steffens and Rennie (2006) documented that many partners of self-identified 'sex addicts' met criteria for PTSD following disclosure, a finding that has been replicated in subsequent research and that has produced the concept of 'partner {{callout:betrayal-trauma}} trauma' as a clinical construct.</p>\n<p>Whether partner distress following CSBD disclosure constitutes genuine PTSD — or a subclinical but clinically significant trauma response — has clinical treatment implications: partners who meet PTSD criteria benefit from trauma-informed clinical approaches including psychoeducation about trauma responses, validation of the reality-based nature of their hypervigilance and distress, and the specific trauma-focused interventions with the strongest evidence for PTSD symptom reduction.</p>\n<h3>Relapse Prevention</h3>\n<p>Relapse prevention in CSBD treatment draws on the well-established cognitive-behavioral relapse prevention model developed for substance use disorders and adapts it to the specific features of sexual compulsive behavior. The relapse prevention model identifies high-risk situations — the specific circumstances, emotional states, cognitive patterns, and interpersonal contexts that increase vulnerability to compulsive sexual behavior — and develops individualized coping plans for each identified high-risk situation.</p>\n<p>High-risk situations for CSBD commonly include:</p>\n<ul>\n<li>Specific emotional states including loneliness, boredom, stress, and shame</li>\n<li>Specific interpersonal contexts including conflict with a partner</li>\n<li>Specific environmental cues including access to internet-enabled devices in private settings</li>\n<li>Specific times including late evenings after the family is asleep</li>\n<li>Specific internal states including sexual frustration within an intimate relationship</li>\n</ul>\n<p>Effective relapse prevention planning addresses each identified high-risk situation with specific, practical coping strategies and builds the social support and accountability structures that reduce both the likelihood and the impact of lapse experiences.</p>",
+          "order": 2,
+          "callouts": {
+            "betrayal-trauma": {
+              "label": "Betrayal Trauma",
+              "type": "definition",
+              "body": "The trauma-like impact on a partner following disclosure of CSBD-related behavior; resembles betrayal trauma and warrants partner support in its own right."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Intimacy Disorders, Attachment, and Couples Treatment</h2>\n<h3>The Intimacy-Compulsivity Dynamic</h3>\n<p>Intimacy disorders — clinical patterns characterized by significant deficits in the capacity for or engagement with emotional intimacy — are clinically intertwined with compulsive sexual behavior in ways that are often central to the etiology, maintenance, and treatment of both. The relationship between intimacy avoidance and compulsive sexual behavior is bidirectional and reinforcing:</p>\n<ul>\n<li>The compulsive sexual behavior substitutes for genuine emotional intimacy, providing a form of connection that avoids the vulnerability of authentic relational closeness</li>\n<li>The intimacy avoidance maintains the motivation for the compulsive behavior by preventing the development of genuine emotional connection that would reduce the need for its substitute</li>\n</ul>\n<p>Understanding this intimacy-compulsivity dynamic is clinically essential because treatment that addresses only the compulsive behavior dimension without attending to the underlying intimacy deficits will produce incomplete and unstable recovery.</p>\n<h3>Attachment Framework and Dismissive-Avoidant Patterns</h3>\n<p>The attachment framework — developed from Bowlby's (1969) foundational theory and subsequently elaborated through decades of empirical research — provides the most clinically comprehensive account of intimacy disorder development and maintenance. Dismissive-avoidant attachment — characterized by defensive self-reliance, suppression of attachment needs, and deactivation of the attachment system in response to intimacy — is the attachment pattern most directly associated with intimacy avoidance.</p>\n<p>Individuals with dismissive-avoidant attachment learned through early relational experiences that emotional dependence is unsafe — that caregivers were consistently unavailable, rejecting, or shaming of attachment needs — and developed the adaptive strategy of dismissing attachment needs and managing emotional regulation independently. In adulthood, this strategy produces difficulties with emotional intimacy, discomfort with vulnerability, and a preference for sexual or activity-based forms of connection that provide relational engagement without the vulnerability of emotional closeness. The compulsive sexual behavior of individuals with dismissive-avoidant attachment often serves exactly this function: it provides a form of connection and pleasure that satisfies the attachment need at a surface level while avoiding the vulnerability that deeper intimacy requires.</p>\n<h3>Treatment of Intimacy Disorders</h3>\n<p>The treatment of intimacy disorders in the context of CSBD requires clinical approaches that address the deep relational and attachment dimensions of the clinical presentation — dimensions that are not adequately addressed by behavioral approaches focused exclusively on the compulsive sexual behavior. Schema therapy — developed by Young and colleagues — provides a clinical framework for identifying and addressing the early maladaptive schemas that organize the intimacy avoidance pattern, including the specific abandonment, shame, emotional deprivation, and defectiveness schemas that are most commonly associated with intimacy disorders.</p>\n<p>Attachment-informed approaches — including the application of Emotionally Focused Therapy (EFT) principles to individual therapy and to couples work — address the attachment-level disruptions that underlie intimacy avoidance and build the secure attachment experiences that support genuine intimacy development. The therapeutic relationship itself, conducted with consistent attunement and explicit attention to the client's attachment-related responses to intimacy within the therapeutic relationship, provides a corrective relational experience that is directly relevant to the development of intimacy capacity.</p>\n<h3>Staged Couples Treatment</h3>\n<p>Couples treatment for compulsive sexual behavior typically involves a staged approach that addresses the needs of both the individual with CSBD and their partner while attending to the significant relational damage that CSBD-related behaviors and their discovery typically produce. The initial stage typically focuses on:</p>\n<ul>\n<li>Individual stabilization for the CSBD partner, including immediate behavioral management and engagement with an appropriate treatment modality</li>\n<li>Crisis support for the affected partner, including trauma-informed support for the acute distress of discovery and disclosure</li>\n<li>The development of a minimum safety plan for the relationship that specifies the conditions under which both partners can remain in the relationship while treatment proceeds</li>\n</ul>\n<p>Subsequent couples work — typically initiated when both partners have achieved sufficient individual stabilization — focuses on the relational repair dimensions of CSBD recovery: rebuilding trust through transparency and accountability; addressing the intimacy deficits that contributed to both the CSBD and to the partner's experience of disconnection; and rebuilding a mutually satisfying intimate and sexual relationship that meets both partners' needs.</p>",
+          "order": 3
+        },
+        {
+          "type": "text",
+          "content": "<blockquote class=\"cr-vignette\"><strong>Clinical Vignette</strong><br>Carla, 45, presents with anxiety, depression, and relationship difficulties. Assessment reveals a lifelong pattern of emotional intimacy avoidance — maintaining closeness through sexual engagement while avoiding emotional vulnerability. Her partner describes her as 'emotionally unavailable.' Formulation: dismissive-avoidant attachment as organizing pattern; compulsive sexual behavior serving intimacy-avoidance function. Plan: attachment-informed individual therapy addressing emotional deprivation and defectiveness schemas; graduated emotional vulnerability development; couples EFT adjunct; psychoeducation about responsive vs. avoidant intimacy.</blockquote>",
+          "order": 4
+        },
+        {
+          "type": "reflection",
+          "prompt": "After reviewing this module 2: evidence-based treatment, intimacy disorders, and couples practice, what aspect of your current clinical practice most needs updating or strengthening?",
+          "placeholder": "Take a moment to reflect on how this applies to your clinical practice...",
+          "order": 5
+        },
+        {
+          "order": 6,
+          "type": "matching",
+          "matchingInstructions": "Match each treatment modality to its primary mechanism in CSBD care.",
+          "matchingPairs": [
+            {
+              "term": "CBT",
+              "definition": "Identifying triggers and modifying thoughts and behavior patterns"
+            },
+            {
+              "term": "ACT",
+              "definition": "Accepting urges and committing to values-consistent action rather than control struggles"
+            },
+            {
+              "term": "Motivational Interviewing",
+              "definition": "Resolving ambivalence and strengthening the client’s own motivation"
+            },
+            {
+              "term": "Relapse Prevention",
+              "definition": "Anticipating high-risk situations and treating lapses as learning"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Partner trauma following CSBD disclosure most closely resembles in its symptom profile:",
+          "options": [
+            {
+              "text": "Separation anxiety disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "Adjustment disorder with depressed mood",
+              "isCorrect": false
+            },
+            {
+              "text": "Post-traumatic stress disorder",
+              "isCorrect": true
+            },
+            {
+              "text": "Dependent personality disorder",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 2,
+          "explanation": "Research by Steffens and Rennie (2006) documented that many partners of individuals with CSBD met PTSD criteria following disclosure, supporting trauma-informed clinical approaches for affected partners.",
+          "showExplanation": true,
+          "order": 7
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Motivational interviewing is indicated in CSBD treatment because:",
+          "options": [
+            {
+              "text": "It provides behavioral extinction of compulsive urges",
+              "isCorrect": false
+            },
+            {
+              "text": "It addresses the ambivalence about change that is common in this population",
+              "isCorrect": true
+            },
+            {
+              "text": "It is required by ethical guidelines for this clinical population",
+              "isCorrect": false
+            },
+            {
+              "text": "It is the only evidence-based approach with RCT support",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Ambivalence about behavior change is nearly universal in CSBD, and MI's non-judgmental evocative approach creates conditions for internal motivation development — contrasting with confrontational approaches that reduce motivation.",
+          "showExplanation": true,
+          "order": 8
+        },
+        {
+          "type": "text",
+          "content": "<h2>Principles of Treatment: Non-Shaming and Function-Focused</h2>\n<p>Before any specific technique, treatment of compulsive sexual behavior rests on a set of principles that distinguish effective, ethical care from the moralizing approaches that have historically harmed clients in this area.</p>\n<h3>Core Principles</h3>\n<p>Effective treatment is non-judgmental and non-shaming, recognizing that shame fuels rather than resolves compulsive patterns. It is function-focused, addressing what the behavior does for the person — the states it manages and needs it meets — rather than only the behavior's surface. It is individualized and client-centered, oriented to the client's own goals rather than to an externally imposed standard of sexual conduct. It addresses co-occurring conditions and underlying factors, since compulsive sexual behavior rarely exists in isolation. And it is evidence-informed, drawing on approaches with empirical support rather than on the contested assumptions of any single popular model.</p>\n<h3>Goals Defined With the Client</h3>\n<p>Crucially, treatment goals are set collaboratively. For some clients the goal is to stop a specific behavior; for others it is to regain a sense of control, to reduce distress, to align behavior with values, or to address the underlying emotional needs the behavior has been managing. The clinician does not assume that abstinence from all sexual activity is the goal, and helps the client define what recovery means for them.</p>",
+          "order": 9
+        },
+        {
+          "type": "text",
+          "content": "<h2>Cognitive-Behavioral Therapy for Compulsive Sexual Behavior</h2>\n<p>Cognitive-behavioral approaches are among the most established treatments for compulsive sexual behavior, targeting the triggers, thoughts, and behavioral patterns that maintain the cycle.</p>\n<h3>Understanding and Managing Triggers</h3>\n<p>CBT begins by helping the client identify the triggers — emotional states, situations, times, and cues — that precede the behavior, and the chain of events and thoughts that leads from trigger to behavior. With this map, the client develops strategies to manage triggers: avoiding or modifying high-risk situations where appropriate, interrupting the chain earlier, and developing alternative responses to the states that previously led to the behavior.</p>\n<h3>Cognitive and Behavioral Components</h3>\n<p>The cognitive component identifies and challenges the thoughts that permit or drive the behavior — rationalizations, permission-giving beliefs, and the distorted thinking that accompanies urges — and addresses the shame-laden beliefs that fuel the cycle. The behavioral component builds urge-management skills, develops alternative coping strategies for the emotional states the behavior has managed, restructures the environment to reduce cues, and establishes new routines. Because compulsive sexual behavior so often functions as emotion regulation, building healthier emotion-regulation skills is central to the behavioral work.</p>",
+          "order": 10
+        },
+        {
+          "type": "text",
+          "content": "<h2>Acceptance and Commitment Therapy</h2>\n<p>Acceptance and Commitment Therapy (ACT) has emerged as a particularly well-suited approach for compulsive sexual behavior, in part because its emphasis on values and acceptance addresses the shame and avoidance at the heart of the problem.</p>\n<h3>The ACT Approach</h3>\n<p>Rather than focusing on controlling or eliminating urges directly, ACT helps clients change their relationship to urges and difficult internal experiences. Through acceptance, clients learn to allow urges and uncomfortable feelings to be present without acting on them; through cognitive defusion, they learn to observe thoughts and urges without being controlled by them; and through values clarification, they connect with what genuinely matters to them and use those values to guide behavior. The central construct, psychological flexibility, is the capacity to act in line with one's values even in the presence of difficult internal experiences.</p>\n<h3>Why It Fits</h3>\n<p>ACT is well matched to compulsive sexual behavior for several reasons. It directly addresses the experiential avoidance — the attempt to escape painful internal states — that frequently drives the behavior. Its non-judgmental, acceptance-based stance counters the shame that fuels the compulsivity cycle, rather than adding to it. And its focus on values, rather than on rules or prohibitions, helps clients build a life that is meaningful and aligned with what they care about, which supports lasting change more durably than willpower or restriction alone.</p>",
+          "order": 11
+        },
+        {
+          "type": "text",
+          "content": "<h2>Mindfulness and Urge Surfing</h2>\n<p>Mindfulness-based strategies are a valuable component of treatment, giving clients a concrete way to experience urges without acting on them.</p>\n<h3>Urge Surfing</h3>\n<p>Urge surfing is a mindfulness technique in which the client learns to observe an urge as it rises, peaks, and falls — like a wave — without acting on it and without fighting it. The key insight is that urges, however intense, are temporary: they rise and pass if not acted upon. By observing the urge with curiosity and acceptance rather than panic or suppression, the client discovers experientially that they can tolerate the urge and that it will subside, weakening the automatic link between urge and behavior.</p>\n<h3>Broader Mindfulness Practice</h3>\n<p>Beyond urge surfing, mindfulness cultivates the present-moment, non-judgmental awareness that helps clients notice triggers and the early links in the behavioral chain, tolerate difficult emotional states without escaping into the behavior, and reduce the self-criticism that feeds the shame-compulsivity cycle. Mindfulness practice supports the emotion-regulation goals shared across CBT and ACT, and it gives clients a portable skill they can use in the moments when urges arise.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Motivational Interviewing and Ambivalence</h2>\n<p>Clients with compulsive sexual behavior are frequently ambivalent — they may want to change and also experience the behavior as meeting real needs or providing relief — and motivational interviewing provides a stance and a set of skills for working with this ambivalence.</p>\n<h3>Working With Ambivalence</h3>\n<p>Motivational interviewing recognizes ambivalence as a normal part of the change process rather than as resistance or denial. Through a collaborative, non-confrontational, empathic style, the clinician helps the client explore their own reasons for and against change, resolves ambivalence in the direction of the client's own values and goals, and strengthens the client's intrinsic motivation. Confrontational or shaming approaches — common in some traditional models — tend to increase defensiveness and are counterproductive; the motivational interviewing stance, by contrast, evokes the client's own motivation.</p>\n<h3>Engagement and Retention</h3>\n<p>Because shame and ambivalence are such powerful barriers in this area, the motivational interviewing spirit is valuable not only as a discrete technique but as an overall stance that supports engagement and retention in treatment. Meeting the client where they are, honoring their autonomy, and supporting their own reasons for change makes it possible for clients to remain in and benefit from treatment.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>Relapse Prevention and Managing Lapses</h2>\n<p>Relapse prevention, adapted from the treatment of addictive behaviors, helps clients maintain change over time and respond constructively to lapses.</p>\n<h3>Anticipating and Planning</h3>\n<p>Relapse prevention helps clients identify high-risk situations — the emotional states, contexts, and cues most likely to precipitate the behavior — and develop specific plans for managing them. It builds coping skills for high-risk moments, supports the lifestyle changes that reduce vulnerability (such as addressing stress, isolation, and unmet needs), and helps clients recognize the early warning signs that precede a lapse.</p>\n<h3>The Abstinence Violation Effect</h3>\n<p>A central concept is the abstinence violation effect: when a person who is trying to change has a lapse, they may experience intense shame, guilt, and a sense of total failure that paradoxically triggers further behavior — \"I've already failed, so it doesn't matter.\" Relapse prevention reframes a lapse as a single event to learn from rather than a catastrophic failure, helping the client respond to a lapse with self-compassion and recommitment rather than the shame spiral that would otherwise deepen it. This reframing is especially important given the central role of shame in compulsive sexual behavior.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Abstinence and Harm-Reduction Question</h2>\n<p>One of the most important — and frequently mishandled — questions in treating compulsive sexual behavior is what the goal should be, and the answer is neither automatic nor universal.</p>\n<h3>Beyond a Reflexive Abstinence Model</h3>\n<p>Some popular treatment models assume that the goal is abstinence, often modeled on substance-addiction recovery. But sexuality, unlike substance use, is a normal and healthy part of human life that most clients neither can nor should eliminate, and a blanket abstinence goal frequently makes little clinical sense. The goal is usually not to stop being sexual but to regain control, to align sexual behavior with one's values, to stop a specific problematic behavior, or to address the underlying needs the behavior has been managing.</p>\n<h3>Defining Goals With the Client</h3>\n<p>The appropriate goal is defined collaboratively with the client and depends on the specific behavior, its consequences, and the client's values and circumstances. For some behaviors and some clients, stopping a specific behavior entirely is the goal; for others, the goal is a healthier, more controlled, values-consistent relationship with sexuality. The clinician helps the client clarify what they actually want and what would genuinely serve their wellbeing, rather than imposing a one-size-fits-all abstinence framework that may not fit and may even deepen shame.</p>",
+          "order": 15
+        },
+        {
+          "order": 16,
+          "type": "multiSelect",
+          "question": "Which reflect best practice in setting treatment goals for compulsive sexual behavior? (Select all that apply)",
+          "options": [
+            {
+              "text": "Goals are set collaboratively with the client",
+              "isCorrect": true
+            },
+            {
+              "text": "Goals are grounded in the client’s own values",
+              "isCorrect": true
+            },
+            {
+              "text": "Reflexive, clinician-imposed abstinence is the default for everyone",
+              "isCorrect": false
+            },
+            {
+              "text": "Goals focus on function, wellbeing, and control rather than shame",
+              "isCorrect": true
+            },
+            {
+              "text": "Both abstinence and harm-reduction goals may be appropriate depending on the client",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Best practice sets collaborative, values-based, function-focused goals; abstinence is not reflexively imposed, and harm-reduction or abstinence may fit depending on the individual."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Treating Co-Occurring Conditions</h2>\n<p>Compulsive sexual behavior rarely occurs in isolation, and effective treatment addresses the co-occurring conditions that frequently accompany and maintain it.</p>\n<h3>Common Co-Occurrence</h3>\n<p>Depression, anxiety, substance use, trauma-related conditions, and other difficulties frequently co-occur with compulsive sexual behavior, and the relationship runs both ways: these conditions can drive the behavior (which functions to manage the associated distress), and the behavior and its consequences can worsen them. A client who uses sexual behavior to cope with depression or trauma will struggle to change the behavior while the underlying condition goes untreated.</p>\n<h3>Integrated Treatment</h3>\n<p>Effective care assesses for and treats co-occurring conditions in an integrated way rather than addressing the sexual behavior in isolation. This frequently means treating depression or anxiety, addressing trauma with appropriate trauma-focused care, coordinating substance-use treatment, and understanding how these conditions and the sexual behavior interact. Because so much compulsive sexual behavior functions as emotion regulation and as coping with underlying distress, treating the underlying conditions is often essential to lasting change in the behavior itself.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Pharmacological Adjuncts</h2>\n<p>While psychotherapy is the foundation of treatment, medication has an adjunctive role that clinicians should understand in order to coordinate care, even when they do not prescribe.</p>\n<h3>The Role of Medication</h3>\n<p>Medication is generally adjunctive rather than primary, and is most often used to treat co-occurring conditions — such as depression and anxiety — that drive or accompany the behavior. In some cases, agents that reduce sexual drive or target impulsivity have been used, and certain medications have been explored specifically for compulsive sexual behavior, though the evidence base is limited and such use requires specialized prescribing judgment. Notably, some medications (including certain antidepressants) have sexual side effects that may incidentally reduce the behavior, which carries its own considerations.</p>\n<h3>Coordinating Care</h3>\n<p>Non-prescribing clinicians contribute by recognizing when a medication consultation may help — particularly for co-occurring depression, anxiety, or significant impulsivity — referring to and coordinating with prescribers, and helping the client make informed decisions. As throughout, the client's autonomy and goals guide these decisions, and medication is integrated with the psychological and relational work rather than substituted for it.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Group Treatment and Peer Support</h2>\n<p>Group modalities and peer support play a significant role in this area, offering distinctive benefits while also raising considerations the clinician should weigh.</p>\n<h3>What Groups Offer</h3>\n<p>Because shame, secrecy, and isolation are so central to compulsive sexual behavior, group treatment and peer support can be powerfully therapeutic: the experience of being among others who understand, of reducing secrecy, and of mutual support can counter the shame and isolation that maintain the behavior. Process and skills-based groups can provide support, accountability, and a setting to practice new skills.</p>\n<h3>Considerations With Peer Models</h3>\n<p>Various peer-support and twelve-step-style programs exist for sexual behavior, and some clients find them helpful. The clinician approaches these with balanced judgment: they can offer valuable community and support, but some are built on the contested addiction and abstinence models, and some carry shame-based or moralizing elements that may be counterproductive for a given client. The clinician helps the client evaluate whether a particular program fits their needs and values, supports their autonomy in the choice, and remains alert to whether a program is reducing or inadvertently increasing shame.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Behavioral Activation and Lifestyle Foundations in Recovery</h2>\n<p>Treatment for compulsive sexual behavior frequently focuses on the behavior itself, but sustainable change rests substantially on the broader structure of a person's life. Attending to behavioral activation and lifestyle foundations strengthens treatment and addresses conditions that drive compulsive patterns.</p>\n<h3>Structure, Activity, and the Empty Hours</h3>\n<p>Compulsive sexual behavior frequently occupies the unstructured, isolated, or distressing hours of a person's life, serving to fill emptiness, escape difficult states, or manage boredom and loneliness. Helping clients build a fuller, more structured, and more rewarding daily life directly addresses these drivers. Behavioral activation — collaboratively increasing engagement in meaningful, pleasurable, and values-consistent activities — counters the isolation and emptiness that compulsive behavior frequently fills, and provides genuine sources of reward and meaning that the behavior had been substituting for. Building structure into the day, particularly around high-risk times, reduces the unstructured vulnerability in which urges escalate.</p>\n<h3>Sleep, Stress, and Physical Foundations</h3>\n<p>The physical foundations of self-regulation also matter. Poor sleep, chronic stress, and physical depletion erode the capacity to tolerate distress and resist urges, while attention to sleep, stress management, physical activity, and basic self-care strengthens it. These are not peripheral to treatment but part of building the regulatory capacity on which behavior change depends; a depleted, exhausted, chronically stressed person has fewer resources to bring to the difficult work of changing an entrenched pattern. Integrating attention to activity, structure, connection, and physical wellbeing into treatment — alongside the more targeted work on urges, triggers, and underlying factors — supports durable change by addressing the life conditions in which compulsive behavior takes hold, rather than treating the behavior in isolation from the life around it.</p>",
+          "order": 20,
+          "title": "Behavioral Activation and Lifestyle Foundations in Recovery"
+        },
+        {
+          "type": "multipleChoice",
+          "question": "Research on self-perceived pornography \"addiction\" indicates that distress is frequently driven by:",
+          "options": [
+            {
+              "text": "The objective quantity of use alone",
+              "isCorrect": false
+            },
+            {
+              "text": "Moral incongruence — conflict between use and the person’s moral/religious values — rather than genuine loss of control",
+              "isCorrect": true
+            },
+            {
+              "text": "Always genuine neurobiological addiction",
+              "isCorrect": false
+            },
+            {
+              "text": "Partner approval",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 1,
+          "explanation": "Studies show self-perceived pornography addiction is frequently driven by moral incongruence rather than by quantity of use or genuine compulsivity, which is why careful assessment must distinguish the two.",
+          "showExplanation": true,
+          "order": 21
+        },
+        {
+          "type": "reflection",
+          "prompt": "How might you respond differently to a client distressed about pornography use driven by moral incongruence versus one with genuine loss of control? What would change in your approach?",
+          "placeholder": "Reflect on your clinical practice...",
+          "order": 35
+        },
+        {
+          "type": "text",
+          "content": "<h2>Building Emotion-Regulation Skills</h2>\n<p>Because compulsive sexual behavior so frequently functions as a way of managing painful internal states, building the client's capacity to regulate emotion in other ways is central to lasting change across every treatment approach.</p>\n<h3>The Rationale</h3>\n<p>If sexual behavior is the client's primary tool for managing anxiety, loneliness, emptiness, or distress, simply removing the behavior leaves the underlying states unmanaged — which is why behavior-only approaches frequently fail or relapse. Effective treatment helps the client develop a broader repertoire for tolerating and regulating difficult emotions, so that the behavior becomes less necessary.</p>\n<h3>What This Involves</h3>\n<p>Emotion-regulation work includes helping the client identify and name internal states (many clients act on states they cannot yet recognize), tolerate distress without escaping into the behavior, soothe and regulate themselves through other means, and meet the underlying needs — for connection, soothing, stimulation, or relief — in healthier ways. Mindfulness, distress-tolerance skills, and the acceptance-based strategies of ACT all contribute. As the client's capacity to manage internal states grows, the pull of the compulsive behavior typically weakens.</p>",
+          "order": 23
+        },
+        {
+          "type": "text",
+          "content": "<h2>Technology, Accessibility, and the Modern Context</h2>\n<p>The contemporary technological environment has changed the landscape of sexual behavior, and understanding this context informs assessment and treatment.</p>\n<h3>The Role of Accessibility</h3>\n<p>Online sexual content and sexual contact are available with unprecedented ease, privacy, affordability, and variety. For most people this access is unproblematic, but for those vulnerable to compulsive patterns, the constant availability, novelty, and low barriers can intensify difficulty with control. The \"triple-A\" qualities frequently noted — accessibility, affordability, and anonymity — describe features of the online environment that can facilitate escalation for those who are vulnerable, without making the technology itself inherently harmful for the majority.</p>\n<h3>Clinical Implications</h3>\n<p>Understanding the technological context helps the clinician assess realistically and plan practically — for example, in addressing the environmental cues and access patterns that maintain the behavior — while avoiding the moralizing of technology use itself. The same careful distinction applies: most use is unproblematic, and the clinician guards against treating ordinary technology-mediated sexual behavior as pathological while attending to genuine loss of control where it exists.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>Measuring Progress and Defining Recovery</h2>\n<p>Because recovery in this area is individually defined rather than tied to a universal abstinence standard, measuring progress requires clarity about what the client is actually working toward.</p>\n<h3>What Progress Looks Like</h3>\n<p>Progress may include reduced frequency or cessation of a specific problematic behavior, a restored sense of control and choice, reduced distress, behavior brought into alignment with the client's values, improved emotion regulation, healthier intimacy and relationships, and the resolution of co-occurring conditions. The clinician and client define, collaboratively, what recovery means in this case, and track movement toward those goals rather than toward an external standard.</p>\n<h3>A Realistic, Compassionate View</h3>\n<p>Progress is frequently non-linear, with lapses and setbacks that — handled with the relapse-prevention reframe — become information and opportunities for learning rather than evidence of failure. A recovery-oriented, compassionate view sustains the client's motivation and counters the shame that would otherwise sabotage change. The measure of success is the client's genuine wellbeing and self-defined goals, not conformity to any predetermined model of sexual conduct.</p>",
+          "order": 25
+        },
+        {
+          "order": 26,
+          "type": "sequencing",
+          "instructions": "Order the steps of a functional analysis of a compulsive sexual behavior episode.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Identify the trigger or high-risk situation"
+            },
+            {
+              "order": 2,
+              "text": "Notice the emotional state or distress that arises"
+            },
+            {
+              "order": 3,
+              "text": "Observe the behavior used to regulate that state"
+            },
+            {
+              "order": 4,
+              "text": "Examine the short-term relief and longer-term consequences"
+            }
+          ],
+          "explanation": "Functional analysis traces trigger → emotion → behavior → consequence, revealing the emotion-regulation function the behavior serves — the target for building alternative coping."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Self-Compassion as a Clinical Tool</h2>\n<p>Given the central role of shame in compulsive sexual behavior, cultivating the client's self-compassion is not a soft add-on but a clinically active ingredient of change.</p>\n<h3>Why Self-Compassion Helps</h3>\n<p>Self-criticism and shame fuel the compulsivity cycle: they intensify the painful internal states the behavior is used to escape, and they drive the \"I've already failed\" spiral after lapses. Self-compassion — treating oneself with the kindness, understanding, and perspective one would offer a friend — directly counters this dynamic. It reduces the shame that drives the behavior, supports recovery from lapses without spiraling, and makes sustained change more possible.</p>\n<h3>Cultivating It</h3>\n<p>The clinician models self-compassion through their own non-judgmental stance and helps the client develop it explicitly: recognizing and softening harsh self-criticism, understanding their behavior with compassion rather than condemnation, and responding to setbacks with kindness and recommitment rather than self-attack. Far from excusing the behavior or reducing motivation, self-compassion frees the energy that shame consumes and supports the genuine, values-driven change the client seeks.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "content": "<h2>Aftercare and Maintaining Gains</h2>\n<p>As treatment approaches its goals, attention turns to consolidating gains and supporting the client to maintain them over time.</p>\n<h3>Consolidating Change</h3>\n<p>The clinician helps the client understand what produced their improvement — which skills, insights, and changes made the difference — so they can sustain and reapply them. Anticipating future challenges (stress, life transitions, relationship changes, and the high-risk situations identified in relapse prevention) and planning for them supports lasting change. The client leaves treatment not only improved but equipped with a framework for maintaining gains and responding to difficulties.</p>\n<h3>Responding to Setbacks</h3>\n<p>Clients are helped to understand that setbacks can occur and do not erase progress, and to respond to them with the relapse-prevention reframe and self-compassion rather than shame. Knowing when and how to return for support if needed, and having a plan for early warning signs, gives the client confidence and a safety net. A thoughtful conclusion affirms the client's gains and agency and supports their continued wellbeing beyond treatment.</p>",
+          "order": 28
+        },
+        {
+          "type": "text",
+          "content": "<h2>Combining Modalities: An Integrative Treatment Plan</h2>\n<p>Effective treatment of compulsive sexual behavior is typically integrative, combining elements from the approaches surveyed rather than applying any single method in isolation.</p>\n<h3>Why Integration</h3>\n<p>Because the behavior is multiply determined and serves multiple functions, no single modality addresses every dimension. A typical integrative plan might combine cognitive-behavioral skills for triggers and urges, acceptance- and mindfulness-based strategies for the relationship to urges and difficult states, motivational work for ambivalence, relapse-prevention planning, treatment of co-occurring conditions, attention to intimacy and attachment, and — where relevant — couples work and partner support. The clinician sequences and combines these according to the client's needs, readiness, and goals.</p>\n<h3>Tailoring the Plan</h3>\n<p>The integrative plan is tailored, not formulaic: it follows from the individualized formulation and is revised as treatment proceeds and as the clinician learns more about what helps this client. Throughout, the unifying threads remain constant — a non-shaming stance, a function-focused understanding, collaborative goals, and attention to the underlying needs and conditions that sustain the behavior.</p>",
+          "order": 29
+        },
+        {
+          "type": "text",
+          "content": "<h2>Common Pitfalls in Treatment</h2>\n<p>Several recurring pitfalls undermine treatment of compulsive sexual behavior, and awareness of them helps the clinician avoid them.</p>\n<h3>Frequent Errors</h3>\n<p>Common pitfalls include adopting a moralizing or shaming stance that intensifies the very cycle being treated; reflexively imposing an abstinence-on-an-addiction model that may not fit; pathologizing high desire, normative variation, or moral incongruence as disorder; treating the sexual behavior in isolation while ignoring co-occurring conditions and underlying functions; neglecting the intimacy and attachment difficulties that drive many cases; and mishandling the partner — either neglecting them or casting them in blaming frameworks. Each of these errors reflects a departure from the evidence-informed, non-judgmental, function-focused principles of sound practice.</p>\n<h3>Staying on Course</h3>\n<p>The clinician guards against these pitfalls through ongoing self-examination, consultation, and a steady return to first principles: careful differential assessment, a non-shaming stance, collaborative and individualized goals, attention to function and to co-occurring and underlying factors, and humility about a contested and evolving area. When treatment stalls, revisiting these principles — and considering whether an unaddressed factor or a misframed goal is the obstacle — frequently reveals the path forward.</p>",
+          "order": 30
+        }
+      ]
+    },
+    {
+      "title": "Module 3: Intimacy Disorders, Relationships, and Ethical Practice",
+      "order": 2,
+      "estimatedTime": 25,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 0,
+          "sectionNumber": 3,
+          "title": "Module 3",
+          "subtitle": "Module 3: Intimacy Disorders, Relationships, and Ethical Practice"
+        },
+        {
+          "type": "text",
+          "order": 1,
+          "content": "<h2>Intimacy Disorders: An Overview</h2>\n<p>Compulsive sexual behavior is frequently intertwined with difficulties in intimacy, and understanding these intimacy difficulties is essential to comprehensive assessment and treatment. \"Intimacy disorder\" is not a formal diagnostic category but a clinically useful way of describing persistent difficulty with genuine emotional closeness.</p>\n<h3>What Intimacy Difficulties Involve</h3>\n<p>Intimacy difficulties involve trouble forming or sustaining genuine emotional closeness — difficulty being vulnerable, trusting, and truly known by another person. They may manifest as avoidance of closeness, emotional distance even within ongoing relationships, difficulty tolerating the vulnerability that intimacy requires, and a pattern of substituting other experiences for genuine connection. These difficulties typically have roots in developmental experiences and attachment history.</p>\n<h3>Why They Matter Here</h3>\n<p>For many clients, sexual behavior and intimacy difficulties are connected: sex can become a way of obtaining a feeling of connection or relief without the vulnerability of genuine intimacy, or a way of avoiding closeness altogether. Recognizing and addressing the intimacy dimension frequently turns out to be central to lasting change, because treating the sexual behavior without addressing the underlying difficulty with closeness leaves the driving factor in place.</p>"
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>The Intimacy-Compulsivity Connection</h2>\n<p>One of the most clinically important insights in this area is the relationship between compulsive sexual behavior and difficulty with genuine intimacy.</p>\n<h3>Sex as a Substitute for Intimacy</h3>\n<p>For many clients, compulsive sexual behavior provides a counterfeit of intimacy — the physical and emotional sensations associated with closeness without the vulnerability, mutuality, and risk that genuine intimacy requires. Sexual behavior can deliver a temporary sense of connection, validation, or soothing while protecting the person from the exposure of being truly known. Paradoxically, the behavior that seems to seek connection frequently functions to avoid it.</p>\n<h3>The Avoidance Function</h3>\n<p>Understood this way, compulsive sexual behavior often serves as an avoidance of intimacy: it manages the anxiety that closeness provokes, fills the emptiness left by its absence, and substitutes for the connection the person both wants and fears. This is why purely behavioral approaches that target only the sexual behavior frequently fall short — the behavior is meeting a need and managing a fear that remain unaddressed. Effective treatment helps the client develop the capacity for genuine intimacy, so that the counterfeit becomes less necessary.</p>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Attachment Theory and Sexual Behavior</h2>\n<p>Attachment theory provides a powerful framework for understanding the intimacy difficulties that frequently underlie compulsive sexual behavior.</p>\n<h3>Attachment Patterns</h3>\n<p>Early relationships with caregivers shape internal working models of self and others and characteristic patterns of relating in close relationships. Secure attachment supports the capacity for intimacy — the ability to depend on others, tolerate vulnerability, and sustain closeness. Insecure attachment patterns, by contrast, involve characteristic difficulties: avoidant or dismissive patterns involve discomfort with closeness and a tendency to maintain distance and self-reliance, while anxious patterns involve fear of abandonment and difficulty feeling secure in relationships.</p>\n<h3>Attachment and Compulsive Sexual Behavior</h3>\n<p>Insecure attachment, particularly patterns involving avoidance of genuine emotional intimacy, is frequently associated with compulsive sexual behavior. For a person with a dismissive-avoidant pattern, sexual behavior may provide connection-like experiences while maintaining the emotional distance the person is comfortable with; for a person with an anxious pattern, it may provide reassurance and soothe fears of inadequacy or abandonment. Understanding a client's attachment pattern illuminates the function the sexual behavior serves and points toward treatment that addresses the underlying relational template, not just the behavior.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Working With Avoidant and Dismissive Patterns</h2>\n<p>Because dismissive-avoidant patterns are so frequently associated with compulsive sexual behavior and intimacy difficulties, working with these patterns is a common clinical task.</p>\n<h3>The Clinical Picture</h3>\n<p>Clients with dismissive-avoidant patterns may present as self-sufficient and uncomfortable with emotional closeness, minimizing the importance of relationships and intimacy, and struggling to access or express vulnerable feelings. They may not initially recognize intimacy difficulty as relevant to their sexual behavior, and the therapeutic relationship itself may evoke the discomfort with closeness that characterizes the pattern.</p>\n<h3>Treatment Considerations</h3>\n<p>Working with these patterns requires patience and attunement. The therapeutic relationship — consistent, accepting, and safe — itself becomes a vehicle for developing the capacity for closeness, offering a different experience of being known. Treatment gradually helps the client access and tolerate vulnerable feelings, recognize the costs of emotional distance, and develop the capacity for genuine intimacy. This work is typically slower and more relationally focused than purely behavioral intervention, and it addresses the underlying template that the sexual behavior has been serving.</p>"
+        },
+        {
+          "order": 5,
+          "type": "multiSelect",
+          "question": "Which statements about the relationship between compulsive sexual behavior and intimacy are accurate? (Select all that apply)",
+          "options": [
+            {
+              "text": "Compulsive behavior frequently coexists with difficulty in genuine intimacy",
+              "isCorrect": true
+            },
+            {
+              "text": "For some, the behavior substitutes for or avoids vulnerable connection",
+              "isCorrect": true
+            },
+            {
+              "text": "Addressing underlying intimacy and attachment difficulties is often part of treatment",
+              "isCorrect": true
+            },
+            {
+              "text": "Intimacy difficulties are irrelevant to CSBD treatment",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "CSBD frequently coexists with intimacy and attachment difficulties, sometimes substituting for vulnerable connection; addressing these is often integral to treatment."
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Relationship Impact and Betrayal</h2>\n<p>Compulsive sexual behavior frequently occurs within committed relationships and can have a profound impact on partners, who deserve clinical attention and support in their own right.</p>\n<h3>The Partner's Experience</h3>\n<p>When a partner discovers compulsive sexual behavior — particularly behavior that was hidden, or that involved infidelity or deception — they frequently experience significant distress: shock, betrayal, anger, grief, damaged self-esteem, and difficulty trusting. Some clinicians describe this experience using the language of betrayal trauma, noting that the discovery and the deception can produce trauma-like responses including intrusive thoughts, hypervigilance, and emotional dysregulation. The partner's distress is real and significant regardless of the framework used to describe it.</p>\n<h3>Holding the Framing Carefully</h3>\n<p>The clinician holds the conceptual framing with care. The betrayal-trauma framework can validate and help partners, and the partner's pain is genuine and deserves support; at the same time, some applications of the framework are tied to the contested addiction model and to assumptions that may not fit every couple. The clinician supports the partner's actual experience and needs rather than imposing a predetermined narrative, and remains attentive to the specific dynamics of the particular relationship rather than applying a fixed template.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Supporting the Partner</h2>\n<p>Partners affected by a loved one's compulsive sexual behavior need and deserve support in their own right, distinct from their role in the couple's treatment.</p>\n<h3>The Partner's Own Care</h3>\n<p>Partners benefit from their own space to process the distress, betrayal, and disruption they have experienced, to attend to their own wellbeing and safety (including sexual health concerns where relevant), and to make their own decisions about the relationship free from pressure. Individual support for the partner — whether through their own therapy or through partner-focused work — recognizes that the partner is not merely an adjunct to the client's treatment but a person with their own needs and their own process.</p>\n<h3>Avoiding Harmful Frameworks</h3>\n<p>Historically, some models cast partners in unhelpful roles — as \"co-addicts\" or as contributors to the behavior — frameworks that can be invalidating and harmful. Contemporary, evidence-informed practice rejects blaming the partner for the client's behavior and instead supports the partner as someone affected by another's actions and entitled to support and respect. The clinician helps the partner attend to their own needs and decisions while avoiding any framework that holds them responsible for the client's compulsive behavior.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Couples Treatment: A Staged Approach</h2>\n<p>When a couple chooses to work on the relationship in the context of compulsive sexual behavior, treatment typically proceeds in stages, with stabilization preceding the deeper work of rebuilding.</p>\n<h3>Stabilization First</h3>\n<p>The early stage focuses on stabilization: managing the acute crisis that frequently accompanies discovery, attending to both partners' immediate emotional needs and safety, establishing enough stability and safety in the relationship to allow further work, and beginning to address the compulsive behavior itself. Attempting to rebuild trust or intimacy before this stabilization is in place generally fails, much as trauma processing fails without prior stabilization.</p>\n<h3>Rebuilding and Growth</h3>\n<p>Later stages, entered when stabilization allows, focus on rebuilding trust, repairing and deepening the relationship, addressing the intimacy difficulties that frequently underlie the behavior, and supporting the growth of genuine closeness. This work integrates the individual treatment of the compulsive behavior with the relational work, and it proceeds at a pace both partners can sustain. Throughout, the clinician supports each partner's autonomy, including the possibility that a partner may decide the relationship cannot continue.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Disclosure: Clinical Considerations</h2>\n<p>The question of disclosure — what a client tells a partner about their sexual behavior, and how — is a significant and sometimes contested element of couples work in this area.</p>\n<h3>The Role of Disclosure</h3>\n<p>Where there has been hidden behavior or deception, disclosure is frequently important to the possibility of rebuilding trust, because trust cannot be rebuilt on continued concealment. Some approaches use a structured therapeutic disclosure process, in which the client shares relevant information with the partner in a prepared, facilitated way intended to support honesty while minimizing gratuitous harm. The aim is honesty in service of the relationship's possible repair and the partner's right to make informed decisions.</p>\n<h3>Handling Disclosure Thoughtfully</h3>\n<p>Disclosure is also genuinely complex, and practices vary. Questions about timing, scope, and the level of detail that is helpful versus harmful are matters of clinical judgment and ongoing debate. Excessive or poorly handled detail can be retraumatizing for a partner, while concealment undermines repair. The clinician approaches disclosure thoughtfully and individually — attending to the needs of both partners, the specific situation, and the goal of honesty in service of the partner's autonomy and the relationship's possible healing — rather than applying a rigid formula.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 10,
+          "prompt": "How comfortable are you working with the partner’s experience and with couples affected by compulsive sexual behavior? Where would your competence benefit from further training or consultation?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Rebuilding Trust and Intimacy</h2>\n<p>For couples who choose to rebuild, the restoration of trust and the development of genuine intimacy are central and gradual tasks.</p>\n<h3>Trust as a Gradual Process</h3>\n<p>Trust, once damaged, rebuilds slowly and through consistent, demonstrated trustworthiness over time rather than through promises alone. The clinician helps the couple understand that rebuilding trust is a process, supports the behavior change and transparency that make it possible, and helps the partner navigate the gradual and non-linear recovery of their ability to trust. Both partners need realistic expectations: setbacks and waves of distress are normal parts of the process rather than signs of failure.</p>\n<h3>Developing Genuine Intimacy</h3>\n<p>Because intimacy difficulties so frequently underlie compulsive sexual behavior, rebuilding often involves developing a kind of genuine closeness the couple may never have had. This includes building emotional intimacy and vulnerability, improving communication, and addressing the patterns that kept the couple distant. For many couples, the crisis becomes, painful as it is, an occasion for developing a deeper and more honest relationship than existed before — though this outcome is never guaranteed and is never the clinician's to promise.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Sexual Functioning and Compulsive Behavior</h2>\n<p>Compulsive sexual behavior intersects with sexual functioning in both partners, and attending to this dimension is part of comprehensive care.</p>\n<h3>Effects on the Client's Sexuality</h3>\n<p>Compulsive patterns can shape and distort a person's sexuality in various ways: a reliance on particular stimuli or escalating novelty, a disconnection of sex from intimacy and relationship, and, in some cases, difficulty with partnered sexual functioning. Some clients experience difficulty with arousal or response in partnered sex relative to solitary compulsive behavior. Recovery frequently involves not only reducing the compulsive behavior but reintegrating sexuality into intimacy and rebuilding a satisfying partnered sexual life.</p>\n<h3>Effects on the Couple's Sexuality</h3>\n<p>The couple's sexual relationship is frequently affected — by the partner's distress and difficulty with sexual closeness after a betrayal, by the disruption of trust, and by the work of rebuilding. Renegotiating sexual intimacy at a pace both partners can manage, with attention to the partner's needs and autonomy, is part of the rebuilding process. As elsewhere, the clinician restores choice and control and proceeds at the couple's pace, and refers to or collaborates with sexual health expertise where the sexual difficulties exceed their competence.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Special Populations and the Risk of Stigma</h2>\n<p>Work in this area requires particular attention to the populations who have historically been harmed by the pathologizing of sexuality, and to the role of stigma in presentation and care.</p>\n<h3>Sexual and Gender Minorities</h3>\n<p>Sexual and gender minority clients warrant particular care. The history of pathologizing LGBTQ+ sexuality means that affirming practice must be vigilant against mislabeling minority sexuality as compulsive. Minority stress, internalized stigma, and the conflict between identity and a non-affirming environment can produce distress and shame that may be misread as compulsivity. The clinician applies the same careful distinction — genuine loss of control and impairment versus value-based or stigma-driven distress — with heightened attention to the ways stigma can distort both the client's self-perception and the clinician's judgment.</p>\n<h3>Stigma and Help-Seeking</h3>\n<p>Across populations, stigma and shame shape who seeks help, what they disclose, and how they understand their own behavior. The clinician's non-judgmental, affirming, culturally humble stance is what makes honest engagement possible, and remains the foundation of competent care. Recognizing the role of stigma also guards against the clinician's own assumptions and protects clients from the harm of being pathologized for difference rather than helped for genuine impairment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Ethics and the Risk of Pathologizing</h2>\n<p>More than perhaps any other area of sexual health practice, work with compulsive sexual behavior carries a central ethical risk: the pathologizing of sexuality that is not actually disordered. Competent, ethical practice is organized around guarding against this risk.</p>\n<h3>The Central Ethical Tension</h3>\n<p>The clinician must hold two truths simultaneously: some clients genuinely experience impairing loss of control over sexual behavior and deserve effective, compassionate help; and the field has a long, harmful history of labeling normal sexual variation, high desire, and value-discordant behavior as pathology — disproportionately harming women, sexual minorities, and people whose sexuality differs from a dominant norm. Ethical practice neither dismisses genuine suffering nor manufactures disorder where there is only difference or moral conflict.</p>\n<h3>Practicing Ethically</h3>\n<p>This means applying diagnostic criteria carefully (including the moral-incongruence exclusion), maintaining a non-judgmental and non-moralizing stance, examining one's own sexual values so they do not become a clinical standard, setting goals collaboratively rather than imposing a standard of sexual conduct, and using approaches that reduce rather than amplify shame. It also means practicing within one's competence and referring complex presentations to clinicians with specialized training, and remaining humble about a contested and evolving area of knowledge. The clinician's guiding aim is the client's genuine wellbeing as the client defines it.</p>"
+        },
+        {
+          "order": 15,
+          "type": "multiSelect",
+          "question": "Which are central ethical risks specific to working with compulsive sexual behavior? (Select all that apply)",
+          "options": [
+            {
+              "text": "Pathologizing normative or minority sexuality as “compulsive”",
+              "isCorrect": true
+            },
+            {
+              "text": "Imposing the clinician’s moral judgments on the client",
+              "isCorrect": true
+            },
+            {
+              "text": "Reflexively diagnosing distress driven only by moral incongruence",
+              "isCorrect": true
+            },
+            {
+              "text": "Affirming the client’s autonomy and values",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "The central ethical risks are pathologizing normal or minority sexuality, imposing moral judgments, and over-diagnosing moral-incongruence distress — not respecting the client’s autonomy, which is appropriate."
+        },
+        {
+          "type": "text",
+          "order": 31,
+          "content": "<h2>Sustaining Practice and Course Summary</h2>\n<p>This course has provided a foundation for understanding and treating compulsive sexual behavior and the intimacy difficulties so often associated with it. Several principles unify the material.</p>\n<p>First, compulsive sexual behavior is defined by genuine loss of control and impairment, not by the frequency or content of sexual behavior, and the ICD-11 framing of CSBD as an impulse-control disorder — distinct from the contested addiction model — orients responsible practice. Second, careful assessment must distinguish genuine compulsivity from normative high desire and, crucially, from moral incongruence, guarding against the pathologizing of sexuality that the field's history demands vigilance against. Third, shame both drives and results from compulsive sexual behavior, so non-shaming, function-focused, evidence-informed treatment — drawing on CBT, ACT, mindfulness, motivational, and relapse-prevention approaches — is essential. Fourth, intimacy difficulties and attachment patterns frequently underlie the behavior, and addressing them, along with co-occurring conditions and the impact on partners and relationships, is often central to lasting change.</p>\n<p>And finally, this is an area that demands ongoing humility, self-examination, and development. The clinician sustains competent practice through consultation and supervision, continued learning in an evolving field, attention to their own values and reactions, and a steady commitment to the client's genuine wellbeing over any imposed standard. The clinician who carries these principles forward can offer real help to clients who are suffering, while protecting against the harm of pathologizing what is simply human.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 32,
+          "prompt": "After this course, what is one change you will make to how you assess or treat compulsive sexual behavior — and how will you guard against the risk of pathologizing sexuality that is not disordered?",
+          "placeholder": "Reflect on your clinical practice..."
+        },
+        {
+          "type": "text",
+          "content": "<h2>Adolescents and Developmental Considerations</h2>\n<p>Work with adolescents around sexual behavior requires particular developmental sensitivity and even greater caution about pathologizing, given the normal upheavals of adolescent sexual development.</p>\n<h3>Normal Development Versus Genuine Concern</h3>\n<p>Adolescence involves emerging sexuality, exploration, curiosity, and the use of online sexual content — much of which is a normal part of development rather than a disorder. The threshold for considering a sexual behavior genuinely problematic in an adolescent is high and must account for developmental norms; behavior that would be unremarkable is too easily mislabeled when viewed through an anxious or moralizing lens. At the same time, genuine difficulties — including behavior driven by trauma, used compulsively to manage distress, or causing real impairment — do occur and deserve careful, developmentally appropriate help.</p>\n<h3>The Clinical Approach</h3>\n<p>Work with adolescents attends to developmental stage, involves the family and care system appropriately while protecting the adolescent's appropriate confidentiality, and remains especially vigilant against pathologizing normal sexual development. As with adults, a non-judgmental, function-focused stance — and careful attention to any underlying trauma, distress, or co-occurring difficulty — guides assessment and treatment. The clinician also remains alert to safety and to the possibility that an adolescent's sexual behavior reflects victimization or risk requiring protective response.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>Telehealth in Treating Compulsive Sexual Behavior</h2>\n<p>Treatment of compulsive sexual behavior translates to telehealth, which can expand access while raising specific considerations.</p>\n<h3>Opportunities and Safeguards</h3>\n<p>For many clients, the privacy and reduced stigma of engaging from home lower the barrier to seeking help for a concern surrounded by shame. The clinician confirms the client is in a private space where they can speak freely, attends to the reduced access to nonverbal cues, and maintains the same non-judgmental, function-focused approach. Where couples work is involved, the clinician manages the particular dynamics of having both partners present remotely, including attention to safety and to each partner's ability to speak freely.</p>\n<h3>Maintaining Standards</h3>\n<p>The core principles — careful assessment, non-shaming stance, evidence-informed treatment, attention to co-occurring conditions and intimacy difficulties — apply identically in telehealth. The clinician adapts implementation to the medium while preserving the quality and the ethical care that work in this sensitive area requires.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documentation, Confidentiality, and Legal Awareness</h2>\n<p>The sensitive and sometimes legally relevant nature of sexual behavior makes thoughtful documentation and confidentiality especially important in this area.</p>\n<h3>Documentation</h3>\n<p>The clinician documents factually and professionally — the clinical picture, assessment, formulation, and plan — without unnecessary graphic detail, distinguishing the client's report from clinical observation. Given that sexual behavior can intersect with legal matters and with relationship disputes, the clinician is mindful that records may in some circumstances be accessed, and documents accurately and discreetly in a way that serves the client's care while protecting privacy.</p>\n<h3>Confidentiality and Its Limits</h3>\n<p>Clients need to understand both the confidentiality of the work and its limits, including mandated-reporting obligations that vary by jurisdiction. This is particularly salient if any disclosed behavior involves non-consensual conduct, minors, or other reportable matters — which, as noted, raise separate clinical, ethical, and legal frameworks distinct from CSBD itself. In couples work, the clinician clarifies in advance how individually shared information will be handled. Clarity about these matters protects the client, the partner where relevant, and the integrity of the work.</p>",
+          "order": 20
+        },
+        {
+          "order": 21,
+          "type": "multiSelect",
+          "question": "In assessing possible compulsive sexual behavior in an adolescent, the clinician should: (Select all that apply)",
+          "options": [
+            {
+              "text": "Account for normative adolescent sexual development",
+              "isCorrect": true
+            },
+            {
+              "text": "Be cautious about pathologizing developmentally typical behavior",
+              "isCorrect": true
+            },
+            {
+              "text": "Apply adult CSBD criteria directly without developmental context",
+              "isCorrect": false
+            },
+            {
+              "text": "Attend to safety, exploitation risk, and access to age-appropriate education",
+              "isCorrect": true
+            }
+          ],
+          "explanation": "Adolescent assessment requires developmental context and caution against pathologizing typical behavior, while attending to genuine safety and exploitation concerns — not direct application of adult criteria."
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Clinician's Self-Care and Values</h2>\n<p>Working with compulsive sexual behavior places particular demands on the clinician, both emotionally and in terms of the self-examination the work requires.</p>\n<h3>Examining One's Own Values</h3>\n<p>Because this area is so saturated with cultural and moral judgment, clinicians must examine their own sexual values, reactions, and assumptions with particular rigor. A clinician who has not done this work is at risk of subtly moralizing, of mislabeling difference or value-discordant behavior as pathology, or of communicating judgment that deepens client shame. Ongoing values-clarification, supported by consultation, is essential to providing the non-judgmental care this work requires, and recognizing when one's own values prevent affirming care for a particular client — and referring accordingly — is part of ethical practice.</p>\n<h3>Sustaining Oneself</h3>\n<p>The work also exposes clinicians to intense material — clients' shame and distress, the impact of betrayal on partners, and emotionally demanding couples work. Clinicians sustain themselves through consultation and supervision (for both clinical guidance and emotional support), manageable caseloads, attention to their own wellbeing and boundaries, and ongoing learning in an evolving field. A depleted or unexamined clinician cannot provide the steady, non-judgmental presence this work requires.</p>",
+          "order": 22
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coordinating Care and Building Referral Networks</h2>\n<p>Comprehensive care for compulsive sexual behavior frequently involves multiple providers, and the clinician's ability to coordinate care and refer well strengthens treatment.</p>\n<h3>The Interdisciplinary Picture</h3>\n<p>A given client may benefit from individual therapy, couples work, treatment of co-occurring conditions, psychiatric consultation for medication, partner support, and — for some — peer support or group treatment. The clinician helps integrate these elements, communicating with other providers (with appropriate consent) and helping the client make sense of a coordinated plan rather than a set of disconnected interventions.</p>\n<h3>Building the Network</h3>\n<p>Clinicians benefit from knowing the resources in their community and field: clinicians with specialized training in compulsive sexual behavior, trauma specialists, prescribers, affirming providers for sexual and gender minority clients, sexual health and couples specialists, and reputable support resources for clients and partners. A ready, vetted referral network allows the clinician to ensure each dimension of a client's situation is addressed by someone competent, and to refer well when a presentation exceeds their own scope.</p>",
+          "order": 23
+        },
+        {
+          "type": "text",
+          "content": "<h2>Supporting Clients and Partners With Resources</h2>\n<p>Beyond direct treatment, clinicians help clients and partners by connecting them with appropriate resources, chosen with the same care that governs the rest of the work.</p>\n<h3>Choosing Resources Wisely</h3>\n<p>A range of books, programs, online resources, and support communities exists in this area, of widely varying quality and orientation. Some are evidence-informed and non-shaming; others are built on the contested addiction model or carry moralizing, shame-based messages that may be counterproductive. The clinician helps clients and partners evaluate resources, steering them toward those consistent with an evidence-informed, non-judgmental approach and away from those that may deepen shame or impose a false framework.</p>\n<h3>Resources for Partners</h3>\n<p>Partners, in particular, benefit from resources and support tailored to their own experience and needs — recognizing them as people affected by another's behavior who deserve their own support, rather than positioning them within frameworks that assign them responsibility for it. Connecting partners with appropriate individual support is frequently among the most valuable things the clinician can do for the couple as a whole.</p>",
+          "order": 24
+        },
+        {
+          "type": "text",
+          "content": "<h2>When to Refer to a Specialist</h2>\n<p>Recognizing the limits of one's competence and referring well is a core part of ethical practice in this area, as in all sexual health work.</p>\n<h3>Indicators for Referral</h3>\n<p>A presentation may exceed general competence when the compulsive behavior is severe, entrenched, or unresponsive to foundational intervention; when significant co-occurring conditions require specialized treatment; when substantial trauma underlies the pattern and calls for specialized trauma care; when couples work requires skills beyond the clinician's training; when the presentation involves complex intimacy and attachment difficulties needing in-depth relational work; or when any disclosed behavior is non-consensual or illegal and raises distinct clinical, ethical, and legal frameworks. In each case, referral to or collaboration with an appropriately trained specialist serves the client.</p>\n<h3>Referral as Good Care</h3>\n<p>Referral is an act of competent, ethical care rather than a failure, and it need not mean withdrawal: the generalist frequently continues to provide a supportive relationship alongside specialized treatment, and serves as the integrating presence across providers. Knowing one's scope, building a referral network, and referring well ensure that each client's needs are met by someone competent to meet them.</p>",
+          "order": 25
+        },
+        {
+          "type": "text",
+          "content": "<h2>Hope, Recovery, and the Possibility of Change</h2>\n<p>Amid the careful attention to diagnosis, controversy, and the avoidance of harm, it is important to hold a realistic and grounded hope: clients who genuinely struggle with compulsive sexual behavior can and do improve.</p>\n<h3>Change Is Possible</h3>\n<p>With treatment that addresses the underlying functions, the co-occurring conditions, the shame, and the intimacy difficulties — and that sets collaborative, values-consistent goals — many clients regain a sense of control, reduce distress, align their behavior with their values, and build healthier relationships and more genuine intimacy. The path is frequently non-linear, with lapses along the way, but improvement is the common outcome of good treatment rather than the exception.</p>\n<h3>The Clinician's Hopeful Realism</h3>\n<p>The clinician holds this hope realistically: neither minimizing the genuine difficulty of change nor falling into pessimism, and neither promising outcomes nor doubting that improvement is possible. Communicating grounded hope — that the client's situation is understandable and workable, and that change is achievable — counters the despair and shame that clients so often carry, and supports the engagement and persistence that recovery requires.</p>",
+          "order": 26
+        },
+        {
+          "type": "text",
+          "content": "<h2>Key Takeaways for Practice</h2>\n<p>Several practical takeaways distill this course into principles the clinician can carry into the next session with a client struggling with sexual behavior.</p>\n<h3>What to Remember</h3>\n<p>Assess carefully and distinguish genuine compulsivity from high desire and from moral incongruence before applying any disorder label. Lead with a non-judgmental, non-shaming stance, recognizing that shame fuels rather than resolves the pattern. Understand the behavior's function — what states it manages and needs it meets — and build other ways to meet those needs. Set goals collaboratively, oriented to the client's values rather than to an imposed standard, and do not assume abstinence is the aim. Address co-occurring conditions and the intimacy and attachment difficulties that frequently underlie the behavior. Support partners as people affected in their own right. And guard, always, against the field's persistent risk of pathologizing sexuality that is not actually disordered.</p>\n<h3>The Underlying Commitment</h3>\n<p>Beneath all of these is a single commitment: to the client's genuine wellbeing as the client defines it, pursued with humility in a contested and evolving area, and with steady vigilance against causing the very harm the history of this field cautions against. The clinician who holds this commitment offers real help to people who are suffering while honoring the diversity and dignity of human sexuality.</p>",
+          "order": 27
+        }
+      ]
+    }
+  ]
+};
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+async function main(){
+  await mongoose.connect(MONGODB_URI); console.log('Connected.');
+  const doc = await Course.findOne({ slug: COURSE_DATA.slug });
+  if(!doc){ console.error('CR-307 not found:', COURSE_DATA.slug); process.exit(1); }
+  for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
+  doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  await doc.save();
+  const fresh=await Course.findById(doc._id).lean();
+  console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);
+  await mongoose.disconnect(); console.log('Done.');
+}
+main().catch(e=>{console.error('ERROR:',e.message);process.exit(1);});


### PR DESCRIPTION
Adds 5 enriched sexual-health CE course seed scripts. Each upserts ONE course by slug into canonical `sections[]` via the Course model (wordCount pre-save hook recomputes), and leaves `status: draft`. Block-level callout pills + varied knowledge-check types (multiSelect/matching/fillInBlank/cardSort/sequencing).

### This change = exactly 5 new files
My single commit (`77fde92`) adds only:
- `server/src/scripts/seedCR303-EXPANDED-canonical.js`
- `server/src/scripts/seedCR304-EXPANDED-canonical.js`
- `server/src/scripts/seedCR305-EXPANDED-canonical.js`
- `server/src/scripts/seedCR306-EXPANDED-canonical.js`
- `server/src/scripts/seedCR307-EXPANDED-canonical.js`

`git show --stat HEAD` → 5 files changed, 8235 insertions(+). No viewer, route, model, or other course files touched.

### ⚠️ Note on the diff-vs-`main`
This branch was cut from the active dev branch `claude/funny-clarke-0xzzxe` (per task instructions), which is ~26 commits ahead of `main` and **not yet on GitHub / not merged to main**. Because GitHub only has `main` to diff against, the PR's file list shows those pre-existing dev commits too. Those are **not** part of this change. **Do not merge this PR into `main` as-is** — it is here to support deploying/reviewing the seed branch. The base should be `claude/funny-clarke-0xzzxe` once that branch lands on GitHub.

### Pre-flight gates (all pass)
- `node --check` OK on all 5
- `grep -c "modules:"` = 0 on all 5 (canonical sections, no modules trap)
- `accessType` present (2 each)

Courses remain `status: draft`. Seeding has NOT been run — awaiting confirmation that Render has deployed the branch.

https://claude.ai/code/session_01TN1G78V1cc3vxm5xC9US9b