### PR TITLE
CR-401/402: Tier-2 rebuild — clear CE floor + callout pills + varied KC + wordCount fix (draft)

### DIFF
--- a/server/src/scripts/seedCR401_The_Elephant_in_the_Room_Navigating_Difficul-18038words.js
+++ b/server/src/scripts/seedCR401_The_Elephant_in_the_Room_Navigating_Difficul-18038words.js
@@ -6,2184 +6,2425 @@
 
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import { countCourseWords } from '../utils/courseWordCount.js';
 dotenv.config();
 if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 await mongoose.connect(process.env.MONGODB_URI);
 const col = mongoose.connection.db.collection('interactivecourses');
 
 const course = {
-  courseCode: 'CR-401',
-  slug: 'elephant-in-the-room-difficult-conversations',
-  title: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-  subtitle: `A Comprehensive 3-Hour CE Course for Licensed Mental Health Professionals`,
-  description: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-  ceHours: 3,
-  ceuHours: 3,
-  accessType: 'subscription',
-  status: 'draft',
-  isPublished: false,
-  category: 'Clinical Skills',
-  nbccContentAreas: ['Counseling Theory/Practice'],
-  targetAudience: ['Licensed Professional Counselors','Licensed Clinical Social Workers','Licensed Marriage and Family Therapists','National Certified Counselors'],
-  objectives: [    `Identify common "elephants" in therapy across five categories and recognize personal patterns of avoidance through structured self-reflection.`,
-    `Apply the COMPASS framework systematically for preparing, initiating, and navigating difficult conversations with clients.`,
-    `Utilize specific language patterns and sentence stems that promote openness while minimizing defensiveness in challenging clinical situations.`,
-    `Address treatment-interfering behaviors directly using a stance of curious compassion while maintaining therapeutic alliance.`,
-    `Navigate conversations about lack of progress, treatment failure, and termination with honesty, care, and appropriate referral practices.`,
-    `Discuss cultural differences, power dynamics, and identity with authenticity and cultural humility, including repair of cultural missteps.`,
-    `Repair therapeutic alliance ruptures using Safran and Muran's evidence-based strategies for both withdrawal and confrontation ruptures.`,
-    `Manage personal anxiety and countertransference when approaching difficult topics through centering techniques and professional self-care.`],
-  provider: { name: 'GA Integrated Therapeutic Perspectives LLC', shortName: 'GAITP LLC', acepNumber: '7760', approvalBody: 'NBCC' },
-  presenter: { name: 'Kejuiana Johnson', credentials: 'MA, LPC, NCC, CPCS, BC-TMH', degree: 'MA', licenseNumber: 'LPC009587', licenseState: 'Georgia', licenseType: 'LPC' },
-  approvals: [{ body: 'NBCC', providerNumber: '7760', approvalStatus: 'approved', hourBreakdown: [{ label: 'core', hours: 3 }] }],
-  assessment: {
-    passingScore: 80, maxAttempts: 3, showExplanations: false,
-    questions: [
+  "courseCode": "CR-401",
+  "slug": "elephant-in-the-room-difficult-conversations",
+  "title": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+  "subtitle": "A Comprehensive 3-Hour CE Course for Licensed Mental Health Professionals",
+  "description": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+  "ceHours": 3,
+  "ceuHours": 3,
+  "accessType": "subscription",
+  "status": "draft",
+  "isPublished": false,
+  "category": "Clinical Skills",
+  "nbccContentAreas": [
+    "Counseling Theory/Practice"
+  ],
+  "targetAudience": [
+    "Licensed Professional Counselors",
+    "Licensed Clinical Social Workers",
+    "Licensed Marriage and Family Therapists",
+    "National Certified Counselors"
+  ],
+  "objectives": [
+    "Identify common \"elephants\" in therapy across five categories and recognize personal patterns of avoidance through structured self-reflection.",
+    "Apply the COMPASS framework systematically for preparing, initiating, and navigating difficult conversations with clients.",
+    "Utilize specific language patterns and sentence stems that promote openness while minimizing defensiveness in challenging clinical situations.",
+    "Address treatment-interfering behaviors directly using a stance of curious compassion while maintaining therapeutic alliance.",
+    "Navigate conversations about lack of progress, treatment failure, and termination with honesty, care, and appropriate referral practices.",
+    "Discuss cultural differences, power dynamics, and identity with authenticity and cultural humility, including repair of cultural missteps.",
+    "Repair therapeutic alliance ruptures using Safran and Muran's evidence-based strategies for both withdrawal and confrontation ruptures.",
+    "Manage personal anxiety and countertransference when approaching difficult topics through centering techniques and professional self-care."
+  ],
+  "provider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "shortName": "GAITP LLC",
+    "acepNumber": "7760",
+    "approvalBody": "NBCC"
+  },
+  "presenter": {
+    "name": "Kejuiana Johnson",
+    "credentials": "MA, LPC, NCC, CPCS, BC-TMH",
+    "degree": "MA",
+    "licenseNumber": "LPC009587",
+    "licenseState": "Georgia",
+    "licenseType": "LPC"
+  },
+  "approvals": [
+    {
+      "body": "NBCC",
+      "providerNumber": "7760",
+      "approvalStatus": "approved",
+      "hourBreakdown": [
+        {
+          "label": "core",
+          "hours": 3
+        }
+      ]
+    }
+  ],
+  "assessment": {
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
       {
-        type: "multipleChoice",
-        question: `According to the course, "elephants in the room" in therapy refer to:`,
-        options: [
-          { text: `Decorative elements in the therapy office`, isCorrect: false },
-          { text: `Obvious issues that everyone recognizes but nobody addresses`, isCorrect: true },
-          { text: `Symbolic representations in client dreams`, isCorrect: false },
-          { text: `Large emotional reactions`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to the course, \"elephants in the room\" in therapy refer to:",
+        "options": [
+          {
+            "text": "Decorative elements in the therapy office",
+            "isCorrect": false
+          },
+          {
+            "text": "Obvious issues that everyone recognizes but nobody addresses",
+            "isCorrect": true
+          },
+          {
+            "text": "Symbolic representations in client dreams",
+            "isCorrect": false
+          },
+          {
+            "text": "Large emotional reactions",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Elephants are obvious issues that everyone recognizes but nobody addresses.`
+        "correctAnswer": 1,
+        "explanation": "Elephants are obvious issues that everyone recognizes but nobody addresses."
       },
       {
-        type: "multipleChoice",
-        question: `Which is NOT a common reason therapists avoid difficult conversations?`,
-        options: [
-          { text: `Fear of damaging the therapeutic relationship`, isCorrect: false },
-          { text: `Uncertainty about how to proceed`, isCorrect: false },
-          { text: `Excessive confidence in their confrontation skills`, isCorrect: true },
-          { text: `Countertransference making certain topics uncomfortable`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which is NOT a common reason therapists avoid difficult conversations?",
+        "options": [
+          {
+            "text": "Fear of damaging the therapeutic relationship",
+            "isCorrect": false
+          },
+          {
+            "text": "Uncertainty about how to proceed",
+            "isCorrect": false
+          },
+          {
+            "text": "Excessive confidence in their confrontation skills",
+            "isCorrect": true
+          },
+          {
+            "text": "Countertransference making certain topics uncomfortable",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Excessive confidence is not a common reason for avoidance; most therapists avoid due to discomfort and uncertainty.`
+        "correctAnswer": 2,
+        "explanation": "Excessive confidence is not a common reason for avoidance; most therapists avoid due to discomfort and uncertainty."
       },
       {
-        type: "multipleChoice",
-        question: `In the COMPASS framework, what does the "C" represent?`,
-        options: [
-          { text: `Confront the client directly`, isCorrect: false },
-          { text: `Center yourself before the conversation`, isCorrect: true },
-          { text: `Criticize behavior immediately`, isCorrect: false },
-          { text: `Close the session early`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "In the COMPASS framework, what does the \"C\" represent?",
+        "options": [
+          {
+            "text": "Confront the client directly",
+            "isCorrect": false
+          },
+          {
+            "text": "Center yourself before the conversation",
+            "isCorrect": true
+          },
+          {
+            "text": "Criticize behavior immediately",
+            "isCorrect": false
+          },
+          {
+            "text": "Close the session early",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `C represents centering yourself before the conversation.`
+        "correctAnswer": 1,
+        "explanation": "C represents centering yourself before the conversation."
       },
       {
-        type: "multipleChoice",
-        question: `According to the course, when clients sense therapist avoidance:`,
-        options: [
-          { text: `They appreciate the therapist's sensitivity`, isCorrect: false },
-          { text: `Trust may erode due to inauthenticity`, isCorrect: true },
-          { text: `Treatment outcomes improve`, isCorrect: false },
-          { text: `The therapeutic alliance strengthens`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to the course, when clients sense therapist avoidance:",
+        "options": [
+          {
+            "text": "They appreciate the therapist's sensitivity",
+            "isCorrect": false
+          },
+          {
+            "text": "Trust may erode due to inauthenticity",
+            "isCorrect": true
+          },
+          {
+            "text": "Treatment outcomes improve",
+            "isCorrect": false
+          },
+          {
+            "text": "The therapeutic alliance strengthens",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Trust may erode due to perceived inauthenticity when clients sense avoidance.`
+        "correctAnswer": 1,
+        "explanation": "Trust may erode due to perceived inauthenticity when clients sense avoidance."
       },
       {
-        type: "multipleChoice",
-        question: `Treatment-interfering behaviors include all EXCEPT:`,
-        options: [
-          { text: `Missing sessions`, isCorrect: false },
-          { text: `Not completing homework`, isCorrect: false },
-          { text: `Active engagement in treatment`, isCorrect: true },
-          { text: `Showing up intoxicated`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Treatment-interfering behaviors include all EXCEPT:",
+        "options": [
+          {
+            "text": "Missing sessions",
+            "isCorrect": false
+          },
+          {
+            "text": "Not completing homework",
+            "isCorrect": false
+          },
+          {
+            "text": "Active engagement in treatment",
+            "isCorrect": true
+          },
+          {
+            "text": "Showing up intoxicated",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Active engagement is not treatment-interfering; it's the desired behavior.`
+        "correctAnswer": 2,
+        "explanation": "Active engagement is not treatment-interfering; it's the desired behavior."
       },
       {
-        type: "multipleChoice",
-        question: `The recommended stance for addressing treatment-interfering behaviors is:`,
-        options: [
-          { text: `Judgmental confrontation`, isCorrect: false },
-          { text: `Curious compassion`, isCorrect: true },
-          { text: `Ignoring the behavior until it stops`, isCorrect: false },
-          { text: `Immediate termination`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The recommended stance for addressing treatment-interfering behaviors is:",
+        "options": [
+          {
+            "text": "Judgmental confrontation",
+            "isCorrect": false
+          },
+          {
+            "text": "Curious compassion",
+            "isCorrect": true
+          },
+          {
+            "text": "Ignoring the behavior until it stops",
+            "isCorrect": false
+          },
+          {
+            "text": "Immediate termination",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Curious compassion is the recommended stance for addressing problematic behaviors.`
+        "correctAnswer": 1,
+        "explanation": "Curious compassion is the recommended stance for addressing problematic behaviors."
       },
       {
-        type: "multipleChoice",
-        question: `Which opening is MOST effective for a difficult conversation?`,
-        options: [
-          { text: `"We need to talk about your problem."`, isCorrect: false },
-          { text: `"I've noticed something I'd like to understand better. Is this a good time to discuss something that might be uncomfortable?"`, isCorrect: true },
-          { text: `"You're doing something wrong."`, isCorrect: false },
-          { text: `"Other clients don't have this issue."`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which opening is MOST effective for a difficult conversation?",
+        "options": [
+          {
+            "text": "\"We need to talk about your problem.\"",
+            "isCorrect": false
+          },
+          {
+            "text": "\"I've noticed something I'd like to understand better. Is this a good time to discuss something that might be uncomfortable?\"",
+            "isCorrect": true
+          },
+          {
+            "text": "\"You're doing something wrong.\"",
+            "isCorrect": false
+          },
+          {
+            "text": "\"Other clients don't have this issue.\"",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `This opening signals importance, frames collaboratively, and seeks permission.`
+        "correctAnswer": 1,
+        "explanation": "This opening signals importance, frames collaboratively, and seeks permission."
       },
       {
-        type: "multipleChoice",
-        question: `When addressing lack of treatment progress, the therapist should:`,
-        options: [
-          { text: `Blame the client for not trying hard enough`, isCorrect: false },
-          { text: `Avoid the topic to prevent discouragement`, isCorrect: false },
-          { text: `Open dialogue about what's not working and explore alternatives together`, isCorrect: true },
-          { text: `Continue the same approach indefinitely`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When addressing lack of treatment progress, the therapist should:",
+        "options": [
+          {
+            "text": "Blame the client for not trying hard enough",
+            "isCorrect": false
+          },
+          {
+            "text": "Avoid the topic to prevent discouragement",
+            "isCorrect": false
+          },
+          {
+            "text": "Open dialogue about what's not working and explore alternatives together",
+            "isCorrect": true
+          },
+          {
+            "text": "Continue the same approach indefinitely",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Open dialogue and explore alternatives together when treatment isn't progressing.`
+        "correctAnswer": 2,
+        "explanation": "Open dialogue and explore alternatives together when treatment isn't progressing."
       },
       {
-        type: "multipleChoice",
-        question: `Cultural humility involves all EXCEPT:`,
-        options: [
-          { text: `Lifelong learning about cultural differences`, isCorrect: false },
-          { text: `Self-reflection on one's own biases`, isCorrect: false },
-          { text: `Claiming expertise in all cultures`, isCorrect: true },
-          { text: `Recognizing power imbalances`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Cultural humility involves all EXCEPT:",
+        "options": [
+          {
+            "text": "Lifelong learning about cultural differences",
+            "isCorrect": false
+          },
+          {
+            "text": "Self-reflection on one's own biases",
+            "isCorrect": false
+          },
+          {
+            "text": "Claiming expertise in all cultures",
+            "isCorrect": true
+          },
+          {
+            "text": "Recognizing power imbalances",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Claiming expertise in all cultures contradicts cultural humility, which emphasizes ongoing learning.`
+        "correctAnswer": 2,
+        "explanation": "Claiming expertise in all cultures contradicts cultural humility, which emphasizes ongoing learning."
       },
       {
-        type: "multipleChoice",
-        question: `When a client provides feedback about a cultural misstep, the therapist should:`,
-        options: [
-          { text: `Defend their intentions immediately`, isCorrect: false },
-          { text: `Listen non-defensively, acknowledge impact, and commit to doing better`, isCorrect: true },
-          { text: `Explain why the client misunderstood`, isCorrect: false },
-          { text: `Change the subject`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When a client provides feedback about a cultural misstep, the therapist should:",
+        "options": [
+          {
+            "text": "Defend their intentions immediately",
+            "isCorrect": false
+          },
+          {
+            "text": "Listen non-defensively, acknowledge impact, and commit to doing better",
+            "isCorrect": true
+          },
+          {
+            "text": "Explain why the client misunderstood",
+            "isCorrect": false
+          },
+          {
+            "text": "Change the subject",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Listen non-defensively, acknowledge impact, and commit to doing better.`
+        "correctAnswer": 1,
+        "explanation": "Listen non-defensively, acknowledge impact, and commit to doing better."
       },
       {
-        type: "multipleChoice",
-        question: `According to Safran and Muran, withdrawal ruptures involve:`,
-        options: [
-          { text: `The client becoming hostile and confrontational`, isCorrect: false },
-          { text: `The client becoming distant, compliant, or disengaged`, isCorrect: true },
-          { text: `The therapist ending treatment abruptly`, isCorrect: false },
-          { text: `Physical violence`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to Safran and Muran, withdrawal ruptures involve:",
+        "options": [
+          {
+            "text": "The client becoming hostile and confrontational",
+            "isCorrect": false
+          },
+          {
+            "text": "The client becoming distant, compliant, or disengaged",
+            "isCorrect": true
+          },
+          {
+            "text": "The therapist ending treatment abruptly",
+            "isCorrect": false
+          },
+          {
+            "text": "Physical violence",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Withdrawal ruptures involve the client becoming distant or disengaged.`
+        "correctAnswer": 1,
+        "explanation": "Withdrawal ruptures involve the client becoming distant or disengaged."
       },
       {
-        type: "multipleChoice",
-        question: `The rupture-repair sequence is therapeutically valuable because:`,
-        options: [
-          { text: `It shows clients that relationships cannot survive conflict`, isCorrect: false },
-          { text: `It demonstrates that conflict doesn't destroy relationship and alliance can strengthen`, isCorrect: true },
-          { text: `It proves the therapist is always right`, isCorrect: false },
-          { text: `It ends treatment faster`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The rupture-repair sequence is therapeutically valuable because:",
+        "options": [
+          {
+            "text": "It shows clients that relationships cannot survive conflict",
+            "isCorrect": false
+          },
+          {
+            "text": "It demonstrates that conflict doesn't destroy relationship and alliance can strengthen",
+            "isCorrect": true
+          },
+          {
+            "text": "It proves the therapist is always right",
+            "isCorrect": false
+          },
+          {
+            "text": "It ends treatment faster",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Rupture-repair demonstrates that relationships can survive conflict and strengthens alliance.`
+        "correctAnswer": 1,
+        "explanation": "Rupture-repair demonstrates that relationships can survive conflict and strengthens alliance."
       },
       {
-        type: "multipleChoice",
-        question: `Which statement about addressing elephants is TRUE?`,
-        options: [
-          { text: `Clients are usually unaware of the issues therapists avoid`, isCorrect: false },
-          { text: `The elephant is always visible to the client too`, isCorrect: true },
-          { text: `Avoidance has no impact on treatment`, isCorrect: false },
-          { text: `Only experienced therapists should attempt difficult conversations`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which statement about addressing elephants is TRUE?",
+        "options": [
+          {
+            "text": "Clients are usually unaware of the issues therapists avoid",
+            "isCorrect": false
+          },
+          {
+            "text": "The elephant is always visible to the client too",
+            "isCorrect": true
+          },
+          {
+            "text": "Avoidance has no impact on treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Only experienced therapists should attempt difficult conversations",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `The elephant is always visible to the client too; naming it creates relief.`
+        "correctAnswer": 1,
+        "explanation": "The elephant is always visible to the client too; naming it creates relief."
       },
       {
-        type: "multipleChoice",
-        question: `Treatment-interfering behaviors should be understood as:`,
-        options: [
-          { text: `Deliberate attempts to sabotage therapy`, isCorrect: false },
-          { text: `Communication that may reveal important patterns`, isCorrect: true },
-          { text: `Character flaws requiring punishment`, isCorrect: false },
-          { text: `Reasons for immediate termination`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Treatment-interfering behaviors should be understood as:",
+        "options": [
+          {
+            "text": "Deliberate attempts to sabotage therapy",
+            "isCorrect": false
+          },
+          {
+            "text": "Communication that may reveal important patterns",
+            "isCorrect": true
+          },
+          {
+            "text": "Character flaws requiring punishment",
+            "isCorrect": false
+          },
+          {
+            "text": "Reasons for immediate termination",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Treatment-interfering behaviors are communication that may reveal important patterns.`
+        "correctAnswer": 1,
+        "explanation": "Treatment-interfering behaviors are communication that may reveal important patterns."
       },
       {
-        type: "multipleChoice",
-        question: `When initiating difficult conversations about progress, the therapist should:`,
-        options: [
-          { text: `Present conclusions without seeking client perspective`, isCorrect: false },
-          { text: `Wait until the client brings it up`, isCorrect: false },
-          { text: `Open dialogue and collaboratively explore what's happening`, isCorrect: true },
-          { text: `Immediately recommend termination`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When initiating difficult conversations about progress, the therapist should:",
+        "options": [
+          {
+            "text": "Present conclusions without seeking client perspective",
+            "isCorrect": false
+          },
+          {
+            "text": "Wait until the client brings it up",
+            "isCorrect": false
+          },
+          {
+            "text": "Open dialogue and collaboratively explore what's happening",
+            "isCorrect": true
+          },
+          {
+            "text": "Immediately recommend termination",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Open dialogue and collaboratively explore what's happening.`
+        "correctAnswer": 2,
+        "explanation": "Open dialogue and collaboratively explore what's happening."
       },
       {
-        type: "multipleChoice",
-        question: `In the COMPASS framework, "Pause and listen" follows:`,
-        options: [
-          { text: `Strengthening connection`, isCorrect: false },
-          { text: `Making observations`, isCorrect: true },
-          { text: `Aligning on understanding`, isCorrect: false },
-          { text: `Strategizing together`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "In the COMPASS framework, \"Pause and listen\" follows:",
+        "options": [
+          {
+            "text": "Strengthening connection",
+            "isCorrect": false
+          },
+          {
+            "text": "Making observations",
+            "isCorrect": true
+          },
+          {
+            "text": "Aligning on understanding",
+            "isCorrect": false
+          },
+          {
+            "text": "Strategizing together",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Pause and listen follows making observations in the COMPASS framework.`
+        "correctAnswer": 1,
+        "explanation": "Pause and listen follows making observations in the COMPASS framework."
       },
       {
-        type: "multipleChoice",
-        question: `Regarding therapist discomfort with difficult conversations:`,
-        options: [
-          { text: `Discomfort should always be avoided`, isCorrect: false },
-          { text: `Discomfort often signals something important needs attention`, isCorrect: true },
-          { text: `Only uncomfortable therapists should address difficult topics`, isCorrect: false },
-          { text: `Discomfort indicates the conversation shouldn't happen`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Regarding therapist discomfort with difficult conversations:",
+        "options": [
+          {
+            "text": "Discomfort should always be avoided",
+            "isCorrect": false
+          },
+          {
+            "text": "Discomfort often signals something important needs attention",
+            "isCorrect": true
+          },
+          {
+            "text": "Only uncomfortable therapists should address difficult topics",
+            "isCorrect": false
+          },
+          {
+            "text": "Discomfort indicates the conversation shouldn't happen",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Discomfort often signals something important needs attention.`
+        "correctAnswer": 1,
+        "explanation": "Discomfort often signals something important needs attention."
       },
       {
-        type: "multipleChoice",
-        question: `According to the course, surviving difficult conversations in therapy:`,
-        options: [
-          { text: `Weakens the therapeutic alliance`, isCorrect: false },
-          { text: `Can strengthen alliance and provide corrective emotional experience`, isCorrect: true },
-          { text: `Should be avoided whenever possible`, isCorrect: false },
-          { text: `Always leads to termination`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to the course, surviving difficult conversations in therapy:",
+        "options": [
+          {
+            "text": "Weakens the therapeutic alliance",
+            "isCorrect": false
+          },
+          {
+            "text": "Can strengthen alliance and provide corrective emotional experience",
+            "isCorrect": true
+          },
+          {
+            "text": "Should be avoided whenever possible",
+            "isCorrect": false
+          },
+          {
+            "text": "Always leads to termination",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Surviving difficult conversations can strengthen alliance and provide corrective emotional experience.`
+        "correctAnswer": 1,
+        "explanation": "Surviving difficult conversations can strengthen alliance and provide corrective emotional experience."
       },
       {
-        type: "multipleChoice",
-        question: `The course recommends building skill in difficult conversations by:`,
-        options: [
-          { text: `Avoiding all uncomfortable topics`, isCorrect: false },
-          { text: `Starting with smaller elephants and building capacity`, isCorrect: true },
-          { text: `Only addressing major crises`, isCorrect: false },
-          { text: `Reading about conversations without practicing`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The course recommends building skill in difficult conversations by:",
+        "options": [
+          {
+            "text": "Avoiding all uncomfortable topics",
+            "isCorrect": false
+          },
+          {
+            "text": "Starting with smaller elephants and building capacity",
+            "isCorrect": true
+          },
+          {
+            "text": "Only addressing major crises",
+            "isCorrect": false
+          },
+          {
+            "text": "Reading about conversations without practicing",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 1,
-        explanation: `Start with smaller elephants and build capacity through practice.`
+        "correctAnswer": 1,
+        "explanation": "Start with smaller elephants and build capacity through practice."
       },
       {
-        type: "multipleChoice",
-        question: `When discussing power dynamics in therapy, therapists should:`,
-        options: [
-          { text: `Pretend power differences don't exist`, isCorrect: false },
-          { text: `Use power to control the client`, isCorrect: false },
-          { text: `Name power dynamics and navigate them in service of the client`, isCorrect: true },
-          { text: `Avoid the topic entirely`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When discussing power dynamics in therapy, therapists should:",
+        "options": [
+          {
+            "text": "Pretend power differences don't exist",
+            "isCorrect": false
+          },
+          {
+            "text": "Use power to control the client",
+            "isCorrect": false
+          },
+          {
+            "text": "Name power dynamics and navigate them in service of the client",
+            "isCorrect": true
+          },
+          {
+            "text": "Avoid the topic entirely",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 2,
-        explanation: `Name power dynamics and navigate them in service of the client.`
+        "correctAnswer": 2,
+        "explanation": "Name power dynamics and navigate them in service of the client."
+      },
+      {
+        "type": "trueFalse",
+        "question": "In the COMPASS framework, making an observation means describing the client’s behavior rather than interpreting their motives.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "“Make observations” calls for specific, behavioral, non-judgmental description; interpreting motives invites defensiveness."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Alliance ruptures are signs of clinician failure that should be avoided rather than worked through.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "Ruptures are common and expected; their skillful repair is associated with good outcomes, making them opportunities rather than failures."
+      },
+      {
+        "type": "trueFalse",
+        "question": "Treatment-interfering behaviors are best met with a stance of curious compassion rather than punishment.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "These behaviors are understood as communication to be explored with curious compassion, not misconduct to be punished."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are costs of avoiding difficult conversations in therapy? (Select all that apply)",
+        "options": [
+          {
+            "text": "Treatment effectiveness erodes as the real obstacle goes unexamined",
+            "isCorrect": true
+          },
+          {
+            "text": "The clinician’s inauthenticity registers with the client",
+            "isCorrect": true
+          },
+          {
+            "text": "The clinician may accumulate resentment",
+            "isCorrect": true
+          },
+          {
+            "text": "The therapeutic relationship reliably deepens",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "Avoidance erodes effectiveness, signals inauthenticity, and breeds resentment; it is engagement, not avoidance, that deepens the relationship."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which support effective repair of an alliance rupture? (Select all that apply)",
+        "options": [
+          {
+            "text": "Noticing and naming the rupture",
+            "isCorrect": true
+          },
+          {
+            "text": "Listening non-defensively",
+            "isCorrect": true
+          },
+          {
+            "text": "Acknowledging one’s own contribution",
+            "isCorrect": true
+          },
+          {
+            "text": "Defending one’s intentions to reassure oneself",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "Repair depends on noticing/naming, non-defensive listening, and owning one’s part — not on defending intentions, which centers the clinician over the client."
       }
     ]
   },
-  references: [    { citation: `Ackerman, S. J., & Hilsenroth, M. J. (2001). A review of therapist characteristics and techniques negatively impacting the therapeutic alliance. Psychotherapy, 38(2), 171-185.` },
-    { citation: `American Counseling Association. (2014). 2014 ACA Code of Ethics. Alexandria, VA: Author.` },
-    { citation: `Bordin, E. S. (1979). The generalizability of the psychoanalytic concept of the working alliance. Psychotherapy: Theory, Research & Practice, 16(3), 252-260.` },
-    { citation: `Eubanks, C. F., Muran, J. C., & Safran, J. D. (2018). Alliance rupture repair: A meta-analysis. Psychotherapy, 55(4), 508-519.` },
-    { citation: `Hays, P. A. (2016). Addressing cultural complexities in practice: Assessment, diagnosis, and therapy (3rd ed.). American Psychological Association.` },
-    { citation: `Hook, J. N., Davis, D. E., Owen, J., Worthington, E. L., & Utsey, S. O. (2013). Cultural humility: Measuring openness to culturally diverse clients. Journal of Counseling Psychology, 60(3), 353-366.` },
-    { citation: `Kanter, J. W., Rosen, D. C., Manbeck, K. E., Marquis, H. M. S., et al. (2020). Addressing microaggressions in racially charged patient-provider interactions. BMC Medical Education, 20, Article 88.` },
-    { citation: `Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.` },
-    { citation: `Norcross, J. C., & Lambert, M. J. (2018). Psychotherapy relationships that work III. Psychotherapy, 55(4), 303-315.` },
-    { citation: `Owen, J., Tao, K. W., Imel, Z. E., Wampold, B. E., & Rodolfa, E. (2014). Addressing racial and ethnic microaggressions in therapy. Professional Psychology: Research and Practice, 45(4), 283-290.` },
-    { citation: `Patterson, K., Grenny, J., McMillan, R., & Switzler, A. (2012). Crucial conversations: Tools for talking when stakes are high (2nd ed.). McGraw-Hill.` },
-    { citation: `Safran, J. D., & Muran, J. C. (2000). Negotiating the therapeutic alliance: A relational treatment guide. Guilford Press.` },
-    { citation: `Safran, J. D., Muran, J. C., & Eubanks-Carter, C. (2011). Repairing alliance ruptures. Psychotherapy, 48(1), 80-87.` },
-    { citation: `Stone, D., Patton, B., & Heen, S. (2010). Difficult conversations: How to discuss what matters most. Penguin Books.` },
-    { citation: `Sue, D. W. (2010). Microaggressions in everyday life: Race, gender, and sexual orientation. John Wiley & Sons.` },
-    { citation: `Sue, D. W., & Sue, D. (2016). Counseling the culturally diverse: Theory and practice (7th ed.). John Wiley & Sons.` },
-    { citation: `Tervalon, M., & Murray-García, J. (1998). Cultural humility versus cultural competence: A critical distinction in defining physician training outcomes in multicultural education. Journal of Health Care for the Poor and Underserved, 9(2), 117-125.` },
-    { citation: `Wachtel, P. L. (2011). Therapeutic communication: Knowing what to say when (2nd ed.). Guilford Press.` },
-    { citation: `Zilcha-Mano, S., & Errázuriz, P. (2015). One size does not fit all: Examining heterogeneity and identifying moderators. Journal of Counseling Psychology, 62(4), 579-591.` }],
-  sections: [
+  "references": [
     {
-      order: 1,
-      title: `Module 1: UNDERSTANDING AVOIDANCE`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 1: UNDERSTANDING AVOIDANCE`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 1,
+      "citation": "Ackerman, S. J., & Hilsenroth, M. J. (2001). A review of therapist characteristics and techniques negatively impacting the therapeutic alliance. Psychotherapy, 38(2), 171-185."
+    },
+    {
+      "citation": "American Counseling Association. (2014). 2014 ACA Code of Ethics. Alexandria, VA: Author."
+    },
+    {
+      "citation": "Bordin, E. S. (1979). The generalizability of the psychoanalytic concept of the working alliance. Psychotherapy: Theory, Research & Practice, 16(3), 252-260."
+    },
+    {
+      "citation": "Eubanks, C. F., Muran, J. C., & Safran, J. D. (2018). Alliance rupture repair: A meta-analysis. Psychotherapy, 55(4), 508-519."
+    },
+    {
+      "citation": "Hays, P. A. (2016). Addressing cultural complexities in practice: Assessment, diagnosis, and therapy (3rd ed.). American Psychological Association."
+    },
+    {
+      "citation": "Hook, J. N., Davis, D. E., Owen, J., Worthington, E. L., & Utsey, S. O. (2013). Cultural humility: Measuring openness to culturally diverse clients. Journal of Counseling Psychology, 60(3), 353-366."
+    },
+    {
+      "citation": "Kanter, J. W., Rosen, D. C., Manbeck, K. E., Marquis, H. M. S., et al. (2020). Addressing microaggressions in racially charged patient-provider interactions. BMC Medical Education, 20, Article 88."
+    },
+    {
+      "citation": "Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press."
+    },
+    {
+      "citation": "Norcross, J. C., & Lambert, M. J. (2018). Psychotherapy relationships that work III. Psychotherapy, 55(4), 303-315."
+    },
+    {
+      "citation": "Owen, J., Tao, K. W., Imel, Z. E., Wampold, B. E., & Rodolfa, E. (2014). Addressing racial and ethnic microaggressions in therapy. Professional Psychology: Research and Practice, 45(4), 283-290."
+    },
+    {
+      "citation": "Patterson, K., Grenny, J., McMillan, R., & Switzler, A. (2012). Crucial conversations: Tools for talking when stakes are high (2nd ed.). McGraw-Hill."
+    },
+    {
+      "citation": "Safran, J. D., & Muran, J. C. (2000). Negotiating the therapeutic alliance: A relational treatment guide. Guilford Press."
+    },
+    {
+      "citation": "Safran, J. D., Muran, J. C., & Eubanks-Carter, C. (2011). Repairing alliance ruptures. Psychotherapy, 48(1), 80-87."
+    },
+    {
+      "citation": "Stone, D., Patton, B., & Heen, S. (2010). Difficult conversations: How to discuss what matters most. Penguin Books."
+    },
+    {
+      "citation": "Sue, D. W. (2010). Microaggressions in everyday life: Race, gender, and sexual orientation. John Wiley & Sons."
+    },
+    {
+      "citation": "Sue, D. W., & Sue, D. (2016). Counseling the culturally diverse: Theory and practice (7th ed.). John Wiley & Sons."
+    },
+    {
+      "citation": "Tervalon, M., & Murray-García, J. (1998). Cultural humility versus cultural competence: A critical distinction in defining physician training outcomes in multicultural education. Journal of Health Care for the Poor and Underserved, 9(2), 117-125."
+    },
+    {
+      "citation": "Wachtel, P. L. (2011). Therapeutic communication: Knowing what to say when (2nd ed.). Guilford Press."
+    },
+    {
+      "citation": "Zilcha-Mano, S., & Errázuriz, P. (2015). One size does not fit all: Examining heterogeneity and identifying moderators. Journal of Counseling Psychology, 62(4), 579-591."
+    }
+  ],
+  "sections": [
+    {
+      "order": 1,
+      "title": "Module 1: UNDERSTANDING AVOIDANCE",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 1: UNDERSTANDING AVOIDANCE",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 1
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Identify at least three elephants from each of five major categories</li>\n<li>Recognize their personal patterns of avoidance across different conversation types</li>\n<li>Articulate the costs of avoidance and benefits of addressing difficult topics</li>\n<li>Apply a self-assessment framework to identify their avoidance triggers</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Common Elephants in Therapy</h2>\n<p>Let's systematically name the common elephants that populate therapy rooms. By categorizing them, we can begin to recognize patterns in what we tend to avoid.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Category 1: Treatment-Interfering Behaviors</h2>\n<p>These are client behaviors that directly interfere with the therapy process. DBT explicitly names these as a treatment target, but all orientations encounter them:</p>\n<p><strong>Attendance issues:</strong> Chronic lateness, frequent cancellations, no-shows, early departures. Each of these patterns communicates something and interferes with treatment continuity.</p>\n<p><strong>Payment problems:</strong> Unpaid balances, bounced checks, credit card declines, requests for extended free sessions. Money is already difficult to discuss; when problems arise, the difficulty multiplies.</p>\n<p><strong>Homework non-completion:</strong> Clients who agree to between-session tasks but consistently don't complete them. The pattern often repeats week after week without being addressed.</p>\n<p><strong>Session-behavior problems:</strong> Showing up intoxicated, bringing uninvited family members, violating confidentiality agreements, recording sessions without permission.</p>\n<p><strong>Dishonesty:</strong> Clients who minimize substance use, hide self-harm, lie about medication compliance, or are otherwise not honest about important information.</p>\n<p><strong>Between-session contact:</strong> Excessive calls, texts, or emails that exceed appropriate boundaries but that we accommodate rather than address.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Category 2: Therapeutic Relationship Issues</h2>\n<p>These elephants live in the space between therapist and client:</p>\n<p><strong>Alliance strain:</strong> Something has shifted. The client seems withdrawn, annoyed, or disengaged. There's tension we can feel but haven't named.</p>\n<p><strong>Client anger at therapist:</strong> The client is upset with us—something we said, didn't say, did, didn't do. They may be expressing it indirectly, but we haven't addressed it directly.</p>\n<p><strong>Therapist frustration with client:</strong> We're feeling frustrated, annoyed, or burned out with a particular client. We haven't examined this or addressed what's driving it.</p>\n<p><strong>Attraction:</strong> Either the client has expressed attraction to us, or we're experiencing attraction to the client. Either direction creates an elephant that typically goes unaddressed.</p>\n<p><strong>Overdependence:</strong> The client relies on us too much, contacts us too frequently, attributes too much power to us. We sense this is problematic but avoid addressing it.</p>\n<p><strong>Therapist mistakes:</strong> We made a mistake—double-booked a session, forgot something important, said something insensitive. We haven't acknowledged or apologized.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Category 3: Treatment Effectiveness Issues</h2>\n<p>These elephants concern whether what we're doing is actually working:</p>\n<p><strong>Lack of progress:</strong> The client isn't getting better. Symptoms persist. Functioning hasn't improved. But we keep doing what we're doing without examining its effectiveness.</p>\n<p><strong>Deterioration:</strong> The client is actually getting worse. This is particularly difficult to name, but failing to do so is clinically negligent.</p>\n<p><strong>Wrong approach:</strong> We're increasingly suspecting that our theoretical approach or intervention strategy isn't right for this client, but we continue anyway.</p>\n<p><strong>Missed diagnosis:</strong> We're beginning to think there's something we missed diagnostically—perhaps a personality disorder, a trauma history, a medical condition, or substance use we didn't fully assess.</p>\n<p><strong>Need for referral:</strong> The client needs something we can't provide—a different modality, a specialist, medication evaluation, a higher level of care. But we haven't broached this.</p>\n<p><strong>Client not invested:</strong> The client doesn't seem to actually want to change. They're going through the motions but not really engaged in the work.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Category 4: Sensitive Client Issues</h2>\n<p>These elephants involve personal characteristics or behaviors that are genuinely delicate to address:</p>\n<p><strong>Hygiene problems:</strong> Body odor, bad breath, unkempt appearance that may be symptoms of mental illness but still affect the therapy environment and relationship.</p>\n<p><strong>Weight concerns:</strong> Client weight that's affecting health, that has changed dramatically, or that seems related to disordered eating.</p>\n<p><strong>Substance use minimization:</strong> The client acknowledges using substances but minimizes the amount, frequency, or impact—and we suspect the reality is more serious.</p>\n<p><strong>Relationship problems the client doesn't see:</strong> The client's relationship patterns are clearly problematic, but they present themselves as the victim without examining their contribution.</p>\n<p><strong>Infidelity or secrets:</strong> We know or suspect the client is hiding something significant—an affair, financial problems, undisclosed behaviors.</p>\n<p><strong>Parenting concerns:</strong> The client's parenting behaviors concern us, but don't rise to the level of reportable abuse or neglect.</p>\n<p><strong>Financial irresponsibility:</strong> The client makes financial decisions that undermine their stated goals and wellbeing, but we haven't addressed this.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Category 5: Identity, Culture, and Power</h2>\n<p>These elephants involve differences between therapist and client:</p>\n<p><strong>Racial differences:</strong> The elephant of racial difference—a white therapist and a client of color, or vice versa—and how this might affect the therapy.</p>\n<p><strong>Cultural disconnection:</strong> We sense we're missing something cultural about the client's experience, values, or worldview, but we haven't explored this.</p>\n<p><strong>Socioeconomic disparity:</strong> The gap between our socioeconomic position and the client's creates dynamics we don't address.</p>\n<p><strong>Religious or political differences:</strong> Client beliefs that differ significantly from ours and create internal reactions we haven't examined.</p>\n<p><strong>Privilege dynamics:</strong> How our privilege or the client's impacts the therapeutic relationship.</p>\n<p><strong>Microaggressions:</strong> Times when we may have committed a microaggression—or when the client has—that went unaddressed.</p>"
+        },
+        {
+          "type": "callout",
+          "order": 9,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: The Accumulating Elephants",
+          "content": "<p>Dr. Sarah Chen has been seeing Michael, a 34-year-old accountant, for four months for depression and anxiety. Consider the elephants that have accumulated:</p>\n<p><strong>Session 3:</strong> Michael mentioned in passing that he drinks \"a few beers most nights\" to relax. Sarah made a mental note but didn't explore further. <em>(Elephant: possible substance minimization)</em></p>\n<p><strong>Session 6:</strong> Michael arrived 20 minutes late with a vague explanation. Sarah said nothing, just compressed the session. This happened again in sessions 8 and 11. <em>(Elephant: chronic lateness)</em></p>\n<p><strong>Session 9:</strong> Sarah noticed Michael's depression scores weren't improving. She thought about mentioning this but worried it would discourage him. <em>(Elephant: lack of progress)</em></p>\n<p><strong>Session 12:</strong> Michael made a comment that seemed racially insensitive—he's white, Sarah is Asian American. Sarah felt a flash of reaction but let it pass. <em>(Elephant: racial dynamics/microaggression)</em></p>\n<p><strong>Session 14:</strong> Michael said something about finding Sarah \"really easy to talk to, unlike other women.\" Sarah felt uncomfortable but moved on. <em>(Elephant: possible boundary issue)</em></p>\n<p>By session 16, Sarah dreads seeing Michael. She's not sure exactly why—there are so many unaddressed issues that she can't sort them out. The therapy room is crowded with elephants, and neither Sarah nor Michael can move freely. Treatment has stalled, and Sarah is considering termination, though she hasn't examined why.</p>\n<p>This accumulation is common. One unaddressed elephant invites another. The therapy becomes increasingly constrained until someone—usually the client through dropout—ends it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Why We Avoid: A Deeper Look</h2>\n<p>Understanding our avoidance patterns requires honest self-examination. Several factors drive avoidance, often in combination:</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Temperamental Factors</h2>\n<p>Many counselors are conflict-avoidant by temperament. Research suggests that helping professions attract individuals who score higher on agreeableness—which includes a tendency to avoid conflict. We entered these fields to help, not to confront. The thought of a tense conversation triggers our nervous system's threat response.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Relational Fears</h2>\n<p>We fear damaging relationships we've worked hard to build. This fear has some basis—poorly handled {{callout:confrontation-rupture}} can damage alliance. But the fear is often disproportionate to the actual risk. Research consistently shows that {{callout:alliance-rupture}} that are addressed and repaired actually strengthen the relationship. The fear is of rupture; the reality is that repair is possible and beneficial.</p>",
+          "callouts": {
+            "alliance-rupture": {
+              "label": "Alliance Rupture",
+              "type": "definition",
+              "body": "A strain, tension, or breakdown in the therapeutic alliance; common rather than aberrant, and an opportunity for repair that is associated with good outcomes."
             },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Identify at least three elephants from each of five major categories</li>
-<li>Recognize their personal patterns of avoidance across different conversation types</li>
-<li>Articulate the costs of avoidance and benefits of addressing difficult topics</li>
-<li>Apply a self-assessment framework to identify their avoidance triggers</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Common Elephants in Therapy</h2>
-<p>Let's systematically name the common elephants that populate therapy rooms. By categorizing them, we can begin to recognize patterns in what we tend to avoid.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Category 1: Treatment-Interfering Behaviors</h2>
-<p>These are client behaviors that directly interfere with the therapy process. DBT explicitly names these as a treatment target, but all orientations encounter them:</p>
-<p><strong>Attendance issues:</strong> Chronic lateness, frequent cancellations, no-shows, early departures. Each of these patterns communicates something and interferes with treatment continuity.</p>
-<p><strong>Payment problems:</strong> Unpaid balances, bounced checks, credit card declines, requests for extended free sessions. Money is already difficult to discuss; when problems arise, the difficulty multiplies.</p>
-<p><strong>Homework non-completion:</strong> Clients who agree to between-session tasks but consistently don't complete them. The pattern often repeats week after week without being addressed.</p>
-<p><strong>Session-behavior problems:</strong> Showing up intoxicated, bringing uninvited family members, violating confidentiality agreements, recording sessions without permission.</p>
-<p><strong>Dishonesty:</strong> Clients who minimize substance use, hide self-harm, lie about medication compliance, or are otherwise not honest about important information.</p>
-<p><strong>Between-session contact:</strong> Excessive calls, texts, or emails that exceed appropriate boundaries but that we accommodate rather than address.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Category 2: Therapeutic Relationship Issues</h2>
-<p>These elephants live in the space between therapist and client:</p>
-<p><strong>Alliance strain:</strong> Something has shifted. The client seems withdrawn, annoyed, or disengaged. There's tension we can feel but haven't named.</p>
-<p><strong>Client anger at therapist:</strong> The client is upset with us—something we said, didn't say, did, didn't do. They may be expressing it indirectly, but we haven't addressed it directly.</p>
-<p><strong>Therapist frustration with client:</strong> We're feeling frustrated, annoyed, or burned out with a particular client. We haven't examined this or addressed what's driving it.</p>
-<p><strong>Attraction:</strong> Either the client has expressed attraction to us, or we're experiencing attraction to the client. Either direction creates an elephant that typically goes unaddressed.</p>
-<p><strong>Overdependence:</strong> The client relies on us too much, contacts us too frequently, attributes too much power to us. We sense this is problematic but avoid addressing it.</p>
-<p><strong>Therapist mistakes:</strong> We made a mistake—double-booked a session, forgot something important, said something insensitive. We haven't acknowledged or apologized.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Category 3: Treatment Effectiveness Issues</h2>
-<p>These elephants concern whether what we're doing is actually working:</p>
-<p><strong>Lack of progress:</strong> The client isn't getting better. Symptoms persist. Functioning hasn't improved. But we keep doing what we're doing without examining its effectiveness.</p>
-<p><strong>Deterioration:</strong> The client is actually getting worse. This is particularly difficult to name, but failing to do so is clinically negligent.</p>
-<p><strong>Wrong approach:</strong> We're increasingly suspecting that our theoretical approach or intervention strategy isn't right for this client, but we continue anyway.</p>
-<p><strong>Missed diagnosis:</strong> We're beginning to think there's something we missed diagnostically—perhaps a personality disorder, a trauma history, a medical condition, or substance use we didn't fully assess.</p>
-<p><strong>Need for referral:</strong> The client needs something we can't provide—a different modality, a specialist, medication evaluation, a higher level of care. But we haven't broached this.</p>
-<p><strong>Client not invested:</strong> The client doesn't seem to actually want to change. They're going through the motions but not really engaged in the work.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Category 4: Sensitive Client Issues</h2>
-<p>These elephants involve personal characteristics or behaviors that are genuinely delicate to address:</p>
-<p><strong>Hygiene problems:</strong> Body odor, bad breath, unkempt appearance that may be symptoms of mental illness but still affect the therapy environment and relationship.</p>
-<p><strong>Weight concerns:</strong> Client weight that's affecting health, that has changed dramatically, or that seems related to disordered eating.</p>
-<p><strong>Substance use minimization:</strong> The client acknowledges using substances but minimizes the amount, frequency, or impact—and we suspect the reality is more serious.</p>
-<p><strong>Relationship problems the client doesn't see:</strong> The client's relationship patterns are clearly problematic, but they present themselves as the victim without examining their contribution.</p>
-<p><strong>Infidelity or secrets:</strong> We know or suspect the client is hiding something significant—an affair, financial problems, undisclosed behaviors.</p>
-<p><strong>Parenting concerns:</strong> The client's parenting behaviors concern us, but don't rise to the level of reportable abuse or neglect.</p>
-<p><strong>Financial irresponsibility:</strong> The client makes financial decisions that undermine their stated goals and wellbeing, but we haven't addressed this.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Category 5: Identity, Culture, and Power</h2>
-<p>These elephants involve differences between therapist and client:</p>
-<p><strong>Racial differences:</strong> The elephant of racial difference—a white therapist and a client of color, or vice versa—and how this might affect the therapy.</p>
-<p><strong>Cultural disconnection:</strong> We sense we're missing something cultural about the client's experience, values, or worldview, but we haven't explored this.</p>
-<p><strong>Socioeconomic disparity:</strong> The gap between our socioeconomic position and the client's creates dynamics we don't address.</p>
-<p><strong>Religious or political differences:</strong> Client beliefs that differ significantly from ours and create internal reactions we haven't examined.</p>
-<p><strong>Privilege dynamics:</strong> How our privilege or the client's impacts the therapeutic relationship.</p>
-<p><strong>Microaggressions:</strong> Times when we may have committed a microaggression—or when the client has—that went unaddressed.</p>`,
-            },
-{
-              type: "callout",
-              order: 9,
-              calloutType: "clinical",
-              title: `Clinical Vignette: The Accumulating Elephants`,
-              content: `<p>Dr. Sarah Chen has been seeing Michael, a 34-year-old accountant, for four months for depression and anxiety. Consider the elephants that have accumulated:</p>
-<p><strong>Session 3:</strong> Michael mentioned in passing that he drinks "a few beers most nights" to relax. Sarah made a mental note but didn't explore further. <em>(Elephant: possible substance minimization)</em></p>
-<p><strong>Session 6:</strong> Michael arrived 20 minutes late with a vague explanation. Sarah said nothing, just compressed the session. This happened again in sessions 8 and 11. <em>(Elephant: chronic lateness)</em></p>
-<p><strong>Session 9:</strong> Sarah noticed Michael's depression scores weren't improving. She thought about mentioning this but worried it would discourage him. <em>(Elephant: lack of progress)</em></p>
-<p><strong>Session 12:</strong> Michael made a comment that seemed racially insensitive—he's white, Sarah is Asian American. Sarah felt a flash of reaction but let it pass. <em>(Elephant: racial dynamics/microaggression)</em></p>
-<p><strong>Session 14:</strong> Michael said something about finding Sarah "really easy to talk to, unlike other women." Sarah felt uncomfortable but moved on. <em>(Elephant: possible boundary issue)</em></p>
-<p>By session 16, Sarah dreads seeing Michael. She's not sure exactly why—there are so many unaddressed issues that she can't sort them out. The therapy room is crowded with elephants, and neither Sarah nor Michael can move freely. Treatment has stalled, and Sarah is considering termination, though she hasn't examined why.</p>
-<p>This accumulation is common. One unaddressed elephant invites another. The therapy becomes increasingly constrained until someone—usually the client through dropout—ends it.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Why We Avoid: A Deeper Look</h2>
-<p>Understanding our avoidance patterns requires honest self-examination. Several factors drive avoidance, often in combination:</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Temperamental Factors</h2>
-<p>Many counselors are conflict-avoidant by temperament. Research suggests that helping professions attract individuals who score higher on agreeableness—which includes a tendency to avoid conflict. We entered these fields to help, not to confront. The thought of a tense conversation triggers our nervous system's threat response.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Relational Fears</h2>
-<p>We fear damaging relationships we've worked hard to build. This fear has some basis—poorly handled confrontation can damage alliance. But the fear is often disproportionate to the actual risk. Research consistently shows that alliance ruptures that are addressed and repaired actually strengthen the relationship. The fear is of rupture; the reality is that repair is possible and beneficial.</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>Skills Gaps</h2>
-<p>Sometimes we avoid because we genuinely don't know how. We weren't taught specific language for these conversations. We don't have scripts. We can imagine starting the conversation but can't envision how to navigate what comes next. This skills gap is addressable—and addressing it is a major goal of this course.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Cognitive Distortions About Confrontation</h2>
-<p>We tell ourselves stories that justify avoidance:</p>
-<p><strong>Minimization:</strong> "It's not that big a deal." "It will probably resolve on its own."</p>
-<p><strong>Mind reading:</strong> "They would be devastated if I said something." "They're not ready to hear this."</p>
-<p><strong>Catastrophizing:</strong> "If I bring this up, they'll quit therapy." "This will destroy the relationship."</p>
-<p><strong>Rationalization:</strong> "It's not my place." "That's not what we're working on." "There are more important things to address."</p>
-<p>These cognitive distortions keep us stuck. They deserve examination just as our clients' cognitive distortions do.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Countertransference</h2>
-<p>Our personal histories shape which elephants we most want to avoid. The therapist who grew up with an angry parent may avoid any conversation that could evoke client anger. The therapist who experienced shaming may be hypervigilant about avoiding anything that feels like criticism. The therapist who learned that conflict leads to abandonment may unconsciously believe that addressing elephants will make clients leave.</p>
-<p>Examining our countertransference reveals our particular avoidance patterns. Common profiles include:</p>
-<p><strong>The Peacekeeper:</strong> Avoids anything that might create conflict or tension. Prioritizes harmony over honesty.</p>
-<p><strong>The Protector:</strong> Avoids anything that might cause the client distress. Conflates temporary discomfort with harm.</p>
-<p><strong>The Perfectionist:</strong> Avoids conversations they might not handle perfectly. Paralyzed by uncertainty about outcome.</p>
-<p><strong>The People-Pleaser:</strong> Avoids anything that might make the client like them less. Overly invested in being liked.</p>
-<p>Which profile resonates with you? Most of us have elements of several.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Power Concerns</h2>
-<p>We recognize that we hold power in the therapeutic relationship. We're conscious of the potential for harm, for imposing values, for misusing our position. This ethical awareness is important and appropriate. However, it can become an excuse for avoidance. Sometimes the most ethical action is honest feedback delivered with care—and withholding that feedback is the true misuse of power.</p>`,
-            },
-{
-              type: "reflection",
-              order: 17,
-              prompt: `Reflection Exercise: Your Avoidance Pattern`,
-              content: `<p>Take a moment to reflect on your personal avoidance patterns:</p>
-<ol>
-<li><strong>From the five categories above, which elephants do you most commonly avoid?</strong></li>
-</ol>
-<ol>
-<li><strong>What stories do you tell yourself that justify avoidance?</strong></li>
-</ol>
-<ol>
-<li><strong>When you imagine having a difficult conversation with a client, what physical sensations do you notice? Where do you feel them in your body?</strong></li>
-</ol>
-<ol>
-<li><strong>What experiences from your personal history might contribute to your avoidance patterns?</strong></li>
-</ol>
-<ol>
-<li><strong>Think of a specific current client where there's an unaddressed elephant. What has stopped you from addressing it?</strong></li>
-</ol>`,
-            },
-{
-              type: "multipleChoice",
-              order: 18,
-              question: `Which of the following is NOT a category of common elephants in therapy?`,
-              options: [
-                { text: `Treatment-interfering behaviors`, isCorrect: true },
-                { text: `Theoretical orientation differences`, isCorrect: false },
-                { text: `Therapeutic relationship issues`, isCorrect: false },
-                { text: `Treatment effectiveness issues`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 19,
-              question: `According to the course, avoidance of difficult conversations:`,
-              options: [
-                { text: `Is usually the safest choice`, isCorrect: true },
-                { text: `Has real costs for clients, therapists, and treatment`, isCorrect: false },
-                { text: `Is appropriate when the client seems fragile`, isCorrect: false },
-                { text: `Typically leads to natural resolution`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 20,
-              question: `The "Peacekeeper" avoidance profile is characterized by:`,
-              options: [
-                { text: `Fear of making mistakes`, isCorrect: true },
-                { text: `Prioritizing harmony over honesty`, isCorrect: false },
-                { text: `Concern about client distress`, isCorrect: false },
-                { text: `Need to be liked`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 21,
-              question: `When elephants accumulate in therapy without being addressed:`,
-              options: [
-                { text: `They typically resolve on their own`, isCorrect: true },
-                { text: `The therapy becomes increasingly constrained`, isCorrect: false },
-                { text: `Clients don't notice`, isCorrect: false },
-                { text: `Alliance automatically strengthens`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 22,
-              question: `Which factor does NOT typically contribute to therapist avoidance of difficult conversations?`,
-              options: [
-                { text: `Temperamental conflict avoidance`, isCorrect: true },
-                { text: `Countertransference from personal history`, isCorrect: false },
-                { text: `Lack of specific language and skills`, isCorrect: false },
-                { text: `Excessive confrontation in training`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+            "confrontation-rupture": {
+              "label": "Confrontation Rupture",
+              "type": "definition",
+              "body": "A rupture in which the client moves against the clinician — expressing anger, criticism, or dissatisfaction directly."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Skills Gaps</h2>\n<p>Sometimes we avoid because we genuinely don't know how. We weren't taught specific language for these conversations. We don't have scripts. We can imagine starting the conversation but can't envision how to navigate what comes next. This skills gap is addressable—and addressing it is a major goal of this course.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Cognitive Distortions About Confrontation</h2>\n<p>We tell ourselves stories that justify avoidance:</p>\n<p><strong>Minimization:</strong> \"It's not that big a deal.\" \"It will probably resolve on its own.\"</p>\n<p><strong>Mind reading:</strong> \"They would be devastated if I said something.\" \"They're not ready to hear this.\"</p>\n<p><strong>Catastrophizing:</strong> \"If I bring this up, they'll quit therapy.\" \"This will destroy the relationship.\"</p>\n<p><strong>Rationalization:</strong> \"It's not my place.\" \"That's not what we're working on.\" \"There are more important things to address.\"</p>\n<p>These cognitive distortions keep us stuck. They deserve examination just as our clients' cognitive distortions do.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Countertransference</h2>\n<p>Our personal histories shape which elephants we most want to avoid. The therapist who grew up with an angry parent may avoid any conversation that could evoke client anger. The therapist who experienced shaming may be hypervigilant about avoiding anything that feels like criticism. The therapist who learned that conflict leads to abandonment may unconsciously believe that addressing elephants will make clients leave.</p>\n<p>Examining our {{callout:countertransference}} reveals our particular avoidance patterns. Common profiles include:</p>\n<p><strong>The Peacekeeper:</strong> Avoids anything that might create conflict or tension. Prioritizes harmony over honesty.</p>\n<p><strong>The Protector:</strong> Avoids anything that might cause the client distress. Conflates temporary discomfort with harm.</p>\n<p><strong>The Perfectionist:</strong> Avoids conversations they might not handle perfectly. Paralyzed by uncertainty about outcome.</p>\n<p><strong>The People-Pleaser:</strong> Avoids anything that might make the client like them less. Overly invested in being liked.</p>\n<p>Which profile resonates with you? Most of us have elements of several.</p>",
+          "callouts": {
+            "countertransference": {
+              "label": "Countertransference",
+              "type": "clinical",
+              "body": "The clinician’s emotional reactions to the client; when unexamined, it can quietly drive avoidance or distort the work."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Power Concerns</h2>\n<p>We recognize that we hold power in the therapeutic relationship. We're conscious of the potential for harm, for imposing values, for misusing our position. This ethical awareness is important and appropriate. However, it can become an excuse for avoidance. Sometimes the most ethical action is honest feedback delivered with care—and withholding that feedback is the true misuse of power.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Avoidance Profiles: Recognizing Your Own Pattern</h2>\n<p>Clinicians tend to avoid difficult conversations in characteristic ways, and recognizing one’s own pattern is the first step toward changing it. These profiles are not rigid types but habitual tendencies that intensify under stress.</p>\n<h3>Common Patterns</h3>\n<p>The <strong>Peacekeeper</strong> prizes harmony above all and reads any tension as a threat to the relationship, so concerns go unspoken to preserve a surface calm. The <strong>Over-Explainer</strong> does eventually raise the issue but buries it in so much qualification, reassurance, and apology that the actual message is lost. The <strong>Postponer</strong> always intends to address the elephant — next session, when the timing is better — and the postponement becomes permanent. The <strong>Minimizer</strong> talks themselves out of the conversation by deciding the issue isn’t important enough to risk discomfort. And the <strong>Bulldozer</strong>, often overcorrecting for a history of avoidance, raises issues so bluntly that the client becomes defensive and the message cannot land.</p>\n<h3>Working With Your Pattern</h3>\n<p>Each pattern has a cost: the Peacekeeper’s harmony is hollow, the Over-Explainer’s message is diluted, the Postponer’s elephant grows, the Minimizer’s issues compound, and the Bulldozer’s candor ruptures the alliance. Naming one’s own tendency — particularly noticing how it sharpens under anxiety — allows the clinician to anticipate it and to lean deliberately toward the balance of honesty and care that effective conversations require. The goal is not to eliminate the temperament but to keep it from running the clinical decision.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Weighing the Costs: Engagement Versus Avoidance</h2>\n<p>Avoidance frequently feels like the safer choice in the moment, which is precisely why a clear-eyed accounting of its costs and benefits matters. The discomfort of the conversation is immediate and vivid; the costs of avoiding it are gradual and easy to discount.</p>\n<h3>The Hidden Costs of Avoidance</h3>\n<p>When an elephant goes unaddressed, the unspoken issue does not disappear — it shapes the work from the background. Treatment effectiveness quietly erodes as the real obstacle goes unexamined. The clinician’s inauthenticity registers with the client, even if neither names it, and the relationship loses some of its honesty. The clinician may accumulate resentment toward the client for a behavior they have never actually raised. And the client misses something therapeutic: the experience of a relationship in which a hard truth can be spoken and survived.</p>\n<h3>The Returns on Engagement</h3>\n<p>Addressing the elephant, by contrast, tends to improve treatment by removing a hidden obstacle, to deepen the relationship by demonstrating that it can hold difficulty, and to model courage and directness that many clients have rarely witnessed. The conversation itself becomes a {{callout:corrective-experience}} experience. Framed this way, the choice is not between comfort and discomfort but between a brief, bounded discomfort now and a diffuse, compounding cost later — a trade that consistently favors engagement.</p>",
+          "order": 18,
+          "callouts": {
+            "corrective-experience": {
+              "label": "Corrective Emotional Experience",
+              "type": "reference",
+              "body": "A new relational experience — such as a hard truth spoken and met with care — that disconfirms a client’s expectations and is itself therapeutic."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Avoidance and the Clinician’s Own History</h2>\n<p>A clinician’s reluctance to raise difficult issues often has roots that predate any particular client. Our own relationship to conflict, formed long before we trained, quietly shapes which conversations we are willing to have.</p>\n<h3>What We Bring to the Room</h3>\n<p>A clinician raised where conflict meant danger, or where harmony was kept by silence, may carry an unexamined conviction that directness ruptures relationships. One who learned to manage anxiety by smoothing things over will feel a strong pull to do the same with clients. These histories operate beneath awareness, presenting themselves as clinical judgment — “now isn’t the right time” — when they are in fact personal discomfort wearing professional clothing.</p>\n<h3>Turning Insight Into Freedom</h3>\n<p>Recognizing one’s own history with conflict — through reflection, consultation, or personal therapy — loosens its grip. The clinician can notice the familiar pull toward avoidance, name it internally as their own pattern rather than a clinical truth, and choose differently. This self-knowledge is not a detour from clinical skill but a foundation of it, since the clinician’s capacity to have hard conversations with clients is bounded by their capacity to tolerate the discomfort those conversations stir in themselves.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Naming the Elephant for Yourself First</h2>\n<p>Before a clinician can name an elephant to a client, they must first name it clearly to themselves — and this internal step is frequently where avoidance quietly succeeds.</p>\n<h3>From Vague Unease to Clear Issue</h3>\n<p>Elephants often live as a diffuse discomfort rather than a defined problem: a low-grade dread before a session, a flatness in the work, a topic the clinician notices themselves steering around. The first task is to convert that unease into a specific, nameable issue — not “something feels off” but “we have not addressed that the client missed our last three sessions, and I have been relieved rather than concerned.” Naming it precisely, if only in a note or to a consultant, makes it actionable.</p>\n<h3>Why the Internal Step Matters</h3>\n<p>An issue left vague stays unaddressable; the clinician cannot raise what they have not articulated. Clarifying the elephant for oneself also surfaces one’s own stake in it — the relief, the irritation, the fear — which is frequently part of why it went unspoken. This internal honesty is the precondition for the external conversation, and it is a discipline worth practicing deliberately rather than assuming it happens on its own.</p>",
+          "order": 20
+        },
+        {
+          "type": "reflection",
+          "order": 21,
+          "prompt": "Reflection Exercise: Your Avoidance Pattern",
+          "content": "<p>Take a moment to reflect on your personal avoidance patterns:</p>\n<ol>\n<li><strong>From the five categories above, which elephants do you most commonly avoid?</strong></li>\n</ol>\n<ol>\n<li><strong>What stories do you tell yourself that justify avoidance?</strong></li>\n</ol>\n<ol>\n<li><strong>When you imagine having a difficult conversation with a client, what physical sensations do you notice? Where do you feel them in your body?</strong></li>\n</ol>\n<ol>\n<li><strong>What experiences from your personal history might contribute to your avoidance patterns?</strong></li>\n</ol>\n<ol>\n<li><strong>Think of a specific current client where there's an unaddressed elephant. What has stopped you from addressing it?</strong></li>\n</ol>"
+        },
+        {
+          "order": 22,
+          "type": "cardSort",
+          "instructions": "Sort each example into its category of “elephant.”",
+          "categories": [
+            "Treatment-interfering",
+            "Relationship",
+            "Identity/culture/power"
+          ],
+          "cards": [
+            {
+              "id": "l",
+              "text": "Chronic lateness or missed sessions",
+              "correctCategory": "Treatment-interfering"
+            },
+            {
+              "id": "h",
+              "text": "Not completing agreed homework",
+              "correctCategory": "Treatment-interfering"
+            },
+            {
+              "id": "a",
+              "text": "Unspoken strain in the alliance",
+              "correctCategory": "Relationship"
+            },
+            {
+              "id": "ang",
+              "text": "Client’s anger at the therapist",
+              "correctCategory": "Relationship"
+            },
+            {
+              "id": "r",
+              "text": "Unaddressed racial difference in the dyad",
+              "correctCategory": "Identity/culture/power"
+            },
+            {
+              "id": "p",
+              "text": "Privilege and power dynamics between clinician and client",
+              "correctCategory": "Identity/culture/power"
+            }
+          ],
+          "explanation": "Elephants cluster into treatment-interfering behaviors, relationship issues, and matters of identity, culture, and power — each calling for a caring, direct conversation."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 23,
+          "question": "According to the course, avoidance of difficult conversations:",
+          "options": [
+            {
+              "text": "Is usually the safest choice",
+              "isCorrect": true
+            },
+            {
+              "text": "Has real costs for clients, therapists, and treatment",
+              "isCorrect": false
+            },
+            {
+              "text": "Is appropriate when the client seems fragile",
+              "isCorrect": false
+            },
+            {
+              "text": "Typically leads to natural resolution",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 24,
+          "type": "matching",
+          "matchingInstructions": "Match each clinician avoidance profile to its description.",
+          "matchingPairs": [
+            {
+              "term": "Peacekeeper",
+              "definition": "Prizes harmony and leaves concerns unspoken to preserve calm"
+            },
+            {
+              "term": "Over-Explainer",
+              "definition": "Raises the issue but buries the message in qualification and apology"
+            },
+            {
+              "term": "Postponer",
+              "definition": "Always intends to address it next time — and the postponement becomes permanent"
+            },
+            {
+              "term": "Bulldozer",
+              "definition": "Raises issues so bluntly that the client becomes defensive"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 25,
+          "question": "When elephants accumulate in therapy without being addressed:",
+          "options": [
+            {
+              "text": "They typically resolve on their own",
+              "isCorrect": true
+            },
+            {
+              "text": "The therapy becomes increasingly constrained",
+              "isCorrect": false
+            },
+            {
+              "text": "Clients don't notice",
+              "isCorrect": false
+            },
+            {
+              "text": "Alliance automatically strengthens",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 26,
+          "question": "Which factor does NOT typically contribute to therapist avoidance of difficult conversations?",
+          "options": [
+            {
+              "text": "Temperamental conflict avoidance",
+              "isCorrect": true
+            },
+            {
+              "text": "Countertransference from personal history",
+              "isCorrect": false
+            },
+            {
+              "text": "Lack of specific language and skills",
+              "isCorrect": false
+            },
+            {
+              "text": "Excessive confrontation in training",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 2,
-      title: `Module 2: THE COMPASS FRAMEWORK FOR DIFFICULT CONVERSATIONS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 2: THE COMPASS FRAMEWORK FOR DIFFICULT CONVERSATIONS`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 2,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Describe each component of the COMPASS framework</li>
-<li>Apply centering techniques before difficult conversations</li>
-<li>Craft effective opening statements that reduce defensiveness</li>
-<li>Use behavioral observation language without judgment</li>
-<li>Navigate client responses with curiosity and collaboration</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Introducing the COMPASS Framework</h2>
-<p>Having a framework reduces the uncertainty that drives avoidance. When you know what steps to take, difficult conversations become more manageable. The COMPASS framework provides a structured approach:</p>
-<p><strong>C - Center Yourself</strong> <strong>O - Open with Care</strong> <strong>M - Make Observations</strong> <strong>P - Pause and Listen</strong> <strong>A - Align on Understanding</strong> <strong>S - Strategize Together</strong> <strong>S - Strengthen Connection</strong></p>
-<p>Let's explore each component in depth, with specific language and examples.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>C - Center Yourself</h2>
-<p>Before the difficult conversation, you must center yourself. This isn't optional preparation—it's essential groundwork that determines how the conversation will go.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Notice Your Anxiety</h2>
-<p>Difficult conversations trigger our nervous system. Notice what happens in your body when you anticipate the conversation:</p>
-<ul>
-<li>Tightness in your chest or throat</li>
-<li>Butterflies or churning in your stomach</li>
-<li>Shallow breathing</li>
-<li>Racing thoughts</li>
-<li>Urge to postpone or avoid</li>
-</ul>
-<p>These sensations are normal. They're not signs that you shouldn't have the conversation—they're signs that you're human. Acknowledge them without letting them drive your behavior.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Ground Yourself</h2>
-<p>Use whatever grounding techniques work for you:</p>
-<p><strong>Breath:</strong> Take several slow, deep breaths. Extend your exhale longer than your inhale. This activates the parasympathetic nervous system.</p>
-<p><strong>Body awareness:</strong> Feel your feet on the floor. Feel your seat in the chair. Notice the sensation of your clothes on your skin.</p>
-<p><strong>Brief mindfulness:</strong> Spend even 30 seconds being present before the session.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Clarify Your Intention</h2>
-<p>Ask yourself: <strong>What is the caring purpose behind this conversation?</strong></p>
-<p>This question is crucial. It reframes the conversation from confrontation to care. You're not having this conversation to punish, to vent, to prove you're right, or to discharge your frustration. You're having it because something important needs to be addressed for the benefit of the client and the treatment.</p>
-<p>Write down your caring intention before the conversation:</p>
-<ul>
-<li>"I care about Michael's recovery, and his drinking may be interfering."</li>
-<li>"I want our work together to be effective, and we need to talk about what's getting in the way."</li>
-<li>"I want Jennifer to experience a relationship where difficult things can be named."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Examine Your Motivation</h2>
-<p>Be honest with yourself about what's driving you. Are you:</p>
-<ul>
-<li>Addressing this for the client's benefit?</li>
-<li>Discharging your own frustration?</li>
-<li>Trying to prove something?</li>
-<li>Reacting to your own triggers?</li>
-</ul>
-<p>If your motivation is contaminated by frustration or self-interest, take time to process those feelings before the conversation—perhaps in supervision or consultation. The conversation will go better if you can approach it from genuine care rather than accumulated resentment.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Anticipate Responses</h2>
-<p>Think through how the client might respond:</p>
-<ul>
-<li>What if they become defensive?</li>
-<li>What if they become tearful?</li>
-<li>What if they become angry?</li>
-<li>What if they deny or minimize?</li>
-<li>What if they leave?</li>
-</ul>
-<p>Having thought through possible responses reduces the chance of being caught off guard. For each possible response, consider how you might navigate it while maintaining connection.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Choose Timing</h2>
-<p>Consider when to have this conversation:</p>
-<ul>
-<li>Is there enough time in the session? (Don't start a major conversation with 10 minutes left.)</li>
-<li>Is the client stable enough to handle this discussion?</li>
-<li>Is this the right session, or should you prepare the client first?</li>
-<li>Are you in the right state to have this conversation today?</li>
-</ul>
-<p>Sometimes the right answer is "not today, but soon." Just don't let "soon" become "never."</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>O - Open with Care</h2>
-<p>The opening of a difficult conversation matters enormously. The first thirty seconds set the tone for everything that follows. A poor opening triggers defensiveness; a skillful opening creates collaboration.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>What to Avoid</h2>
-<p><strong>Accusatory openings:</strong> "We need to talk about your lateness problem." This puts the client on the defensive immediately.</p>
-<p><strong>Buried ledes:</strong> Starting with so much preamble that the client is confused and anxious before you get to the point.</p>
-<p><strong>Hedging that feels dishonest:</strong> "I don't know if this is even important, but..."—when you clearly think it's important.</p>
-<p><strong>Judgment-laden language:</strong> "I've noticed you're not taking this seriously."</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>Effective Opening Patterns</h2>
-<p>Here are sentence stems for opening difficult conversations:</p>
-<p><strong>Pattern 1: Naming the difficulty</strong> "I've been thinking about how to bring something up that I care about. Can we talk about something that might be uncomfortable but I think is important?"</p>
-<p>This pattern names that the conversation will be uncomfortable, which paradoxically reduces discomfort. It asks permission, which gives the client agency. It frames your motivation as caring.</p>
-<p><strong>Pattern 2: Naming your hesitation</strong> "I've been hesitant to bring something up, and I realize that hesitation probably means it's important. Can I share something I've been noticing?"</p>
-<p>This pattern uses your hesitation as evidence of importance. It models honesty about discomfort.</p>
-<p><strong>Pattern 3: Alliance-first framing</strong> "I care about our work together, and there's something I think we need to address for that work to be as helpful as possible."</p>
-<p>This pattern leads with alliance, frames the conversation as serving treatment, and implies collaboration.</p>
-<p><strong>Pattern 4: Direct acknowledgment</strong> "There's something I've noticed that I haven't said anything about, and I want to be more honest with you about what I'm observing."</p>
-<p>This pattern names the avoidance directly and commits to greater honesty.</p>`,
-            },
-{
-              type: "callout",
-              order: 14,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Opening Variations`,
-              content: `<p>Dr. Chen is preparing to address Michael's lateness pattern. Here are variations of how she might open:</p>
-<p><strong>Version 1 (Naming the difficulty):</strong> "Michael, I've been thinking about how to bring up something that I care about. It might be a little uncomfortable, but I think it's important for our work. Is now a good time?"</p>
-<p><strong>Version 2 (Naming hesitation):</strong> "I realize I've been hesitating to mention something for a few weeks now, and my hesitation tells me it matters. Can I share something I've been noticing?"</p>
-<p><strong>Version 3 (Alliance-first):</strong> "I want our time together to be as useful as possible for you. There's a pattern I've noticed that I think is getting in the way. Can we talk about it?"</p>
-<p>Each of these openings:</p>
-<ul>
-<li>Signals importance without alarm</li>
-<li>Frames the conversation as collaborative</li>
-<li>Establishes caring intention</li>
-<li>Seeks permission</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>M - Make Observations</h2>
-<p>After opening, share your observations using careful, nonjudgmental language.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Behavioral Description vs. Interpretation</h2>
-<p>Describe observable behavior, not your interpretation of what it means:</p>
-<p><strong>Interpretation (avoid):</strong> "You don't seem to take our sessions seriously."</p>
-<p><strong>Observation (better):</strong> "I've noticed that over the past month, you've arrived 15-20 minutes late to each of our sessions."</p>
-<p><strong>Interpretation (avoid):</strong> "You're resistant to doing the homework."</p>
-<p><strong>Observation (better):</strong> "The last three weeks, we've agreed on things to practice between sessions, and each week you've mentioned that you didn't do them."</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>The Formula: "I've noticed..."</h2>
-<p>The phrase "I've noticed" is your friend. It signals observation rather than accusation:</p>
-<ul>
-<li>"I've noticed that our last four sessions have been cut short by late arrivals."</li>
-<li>"I've noticed that when I ask about alcohol, you change the subject."</li>
-<li>"I've noticed something seems different between us the last couple of weeks."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>Staying Descriptive</h2>
-<p>Describe:</p>
-<ul>
-<li>Frequency ("three out of the last four sessions")</li>
-<li>Timing ("the past month")</li>
-<li>Specific behaviors ("arriving after the scheduled start time")</li>
-<li>Observable patterns ("you look away when this topic comes up")</li>
-</ul>
-<p>Avoid:</p>
-<ul>
-<li>Labels ("You're being avoidant")</li>
-<li>Mind-reading ("You must be scared of...")</li>
-<li>Global statements ("You always..." "You never...")</li>
-<li>Interpretations disguised as observations</li>
-</ul>`,
-            },
-{
-              type: "callout",
-              order: 19,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Observations About Lateness`,
-              content: `<p>Dr. Chen continues her conversation with Michael:</p>
-<p>"I've noticed a pattern over the past six weeks. You've arrived between 10 and 20 minutes late to five of our last six sessions. That means we've lost about an hour of our therapy time over that period. I'm not saying this to criticize you—I'm bringing it up because I want to understand what's happening, and because I think it might be important."</p>
-<p>Notice how this observation:</p>
-<ul>
-<li>Is specific (six weeks, 10-20 minutes, five of six sessions, about an hour)</li>
-<li>Is behavioral (arrived late, lost time)</li>
-<li>Avoids interpretation (doesn't say why Michael is late)</li>
-<li>Disclaims punitive intent (not to criticize)</li>
-<li>States purpose (want to understand, think it's important)</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>P - Pause and Listen</h2>
-<p>After sharing your observation, stop talking. This is harder than it sounds. Our anxiety makes us want to fill silence, qualify what we said, soften the impact, or move quickly to solutions. Resist these urges.</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>Create Space</h2>
-<p>Pause. Let there be silence. Give the client time to take in what you've said and formulate a response.</p>
-<p>Count to ten silently if you need to. The pause communicates that you're genuinely interested in their response, not just waiting to deliver more of your message.</p>`,
-            },
-{
-              type: "text",
-              order: 22,
-              content: `<h2>Listen Without Defending</h2>
-<p>Whatever the client says, listen to understand rather than to defend. Common responses to difficult conversations include:</p>
-<p><strong>Defensiveness:</strong> "I'm not that late! It's just a few minutes." <em>Listen. Don't argue about the data.</em></p>
-<p><strong>Minimization:</strong> "I don't think it's a big deal. We still have time to talk." <em>Listen. You'll address this, but first understand their perspective.</em></p>
-<p><strong>Counterattack:</strong> "Well, you started late last week too." <em>Listen. Don't defend. Acknowledge what's true in their response.</em></p>
-<p><strong>Deflection:</strong> "I've just had so much going on at work." <em>Listen. There may be important information here.</em></p>
-<p><strong>Vulnerability:</strong> "You're right. I've been avoiding coming here." <em>Listen. This may open important territory.</em></p>`,
-            },
-{
-              type: "text",
-              order: 23,
-              content: `<h2>Verbal and Nonverbal Listening</h2>
-<p>Demonstrate listening through:</p>
-<ul>
-<li>Eye contact (culturally appropriate)</li>
-<li>Nodding</li>
-<li>Brief verbal acknowledgments ("Mm-hmm," "I see")</li>
-<li>Body language that communicates openness</li>
-<li>Not interrupting</li>
-</ul>
-<p>Don't:</p>
-<ul>
-<li>Argue with their response</li>
-<li>Defend yourself</li>
-<li>Correct their perceptions immediately</li>
-<li>Jump to problem-solving</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 24,
-              content: `<h2>A - Align on Understanding</h2>
-<p>After listening, work toward shared understanding. This isn't about proving you're right—it's about developing a mutual view of what's happening and why it matters.</p>`,
-            },
-{
-              type: "text",
-              order: 25,
-              content: `<h2>Reflect What You Heard</h2>
-<p>Start by reflecting what the client said: "So it sounds like the lateness is connected to how stressful work has been—getting out the door is harder when you're this depleted."</p>
-<p>"I hear you saying that the lateness doesn't feel like a big deal to you—we still have time to cover what we need to."</p>`,
-            },
-{
-              type: "text",
-              order: 26,
-              content: `<h2>Seek Their Perspective</h2>
-<p>Ask questions that invite deeper exploration:</p>
-<ul>
-<li>"Help me understand more about what's happening on those mornings."</li>
-<li>"What's your sense of what the pattern is about?"</li>
-<li>"How do you think about the lateness—does it mean something to you?"</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 27,
-              content: `<h2>Share Your Perspective (Gently)</h2>
-<p>After hearing them, share your perspective—not as the truth, but as your view: "From my perspective, the lateness matters for a couple of reasons. One is practical—we're losing therapy time. The other is that patterns often mean something. I'm curious whether the lateness is telling us something important about your relationship to therapy, or to change, or to me."</p>`,
-            },
-{
-              type: "text",
-              order: 28,
-              content: `<h2>Work Toward Shared Understanding</h2>
-<p>The goal is to arrive at a shared understanding of what's happening: "So it sounds like we both see that there's a pattern. You're seeing it as mostly about work stress, and I'm wondering if there's also something about ambivalence toward therapy. Does that ring true at all, or does it feel off?"</p>`,
-            },
-{
-              type: "text",
-              order: 29,
-              content: `<h2>S - Strategize Together</h2>
-<p>Once you have shared understanding, collaborate on next steps. This is a joint problem-solving process, not you imposing solutions.</p>`,
-            },
-{
-              type: "text",
-              order: 30,
-              content: `<h2>Collaborative Language</h2>
-<ul>
-<li>"What do you think might help?"</li>
-<li>"What ideas do you have?"</li>
-<li>"How should we handle this going forward?"</li>
-<li>"What would you like to try?"</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 31,
-              content: `<h2>Offer Options</h2>
-<p>If the client doesn't have ideas, offer options rather than commands: "I have a few thoughts about what might help. Would you like to hear them?"</p>
-<p>Then present options:</p>
-<ul>
-<li>"We could move your appointment to a different time that might be easier for you to make."</li>
-<li>"We could address the lateness each time it happens, in the moment."</li>
-<li>"We could explore what the lateness is communicating about your relationship to therapy."</li>
-<li>"Some combination of these."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 32,
-              content: `<h2>Make Agreements</h2>
-<p>End with clear agreements:</p>
-<ul>
-<li>"So we're agreeing to try the 3pm slot instead, and if the lateness continues, we'll look more at what it means."</li>
-<li>"And if you arrive late, I'm going to bring it up directly rather than letting it go. Does that feel okay?"</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 33,
-              content: `<h2>S - Strengthen Connection</h2>
-<p>End the conversation by reinforcing the relationship. The client took a risk by engaging in this conversation. Acknowledge that.</p>`,
-            },
-{
-              type: "text",
-              order: 34,
-              content: `<h2>Express Appreciation</h2>
-<ul>
-<li>"Thank you for being willing to talk about this with me."</li>
-<li>"I appreciate your openness."</li>
-<li>"I know that wasn't easy. I'm grateful you hung in there with me."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 35,
-              content: `<h2>Reaffirm Commitment</h2>
-<ul>
-<li>"I'm committed to our work together. Conversations like this are part of how we make the therapy as helpful as possible."</li>
-<li>"My goal is always for this to be useful for you. Sometimes that means having uncomfortable conversations."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 36,
-              content: `<h2>Normalize</h2>
-<ul>
-<li>"These kinds of conversations are normal in good therapy. They don't mean something's wrong—they mean we're being honest with each other."</li>
-</ul>`,
-            },
-{
-              type: "multipleChoice",
-              order: 37,
-              question: `In the COMPASS framework, the "C" represents:`,
-              options: [
-                { text: `Confront directly`, isCorrect: true },
-                { text: `Center yourself`, isCorrect: false },
-                { text: `Clarify the problem`, isCorrect: false },
-                { text: `Consider consequences`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 38,
-              question: `Which is the most effective opening for a difficult conversation?`,
-              options: [
-                { text: `"We need to talk about your problem with lateness."`, isCorrect: true },
-                { text: `"I've noticed something I'd like to understand better. Is this a good time?"`, isCorrect: false },
-                { text: `"Don't take this personally, but..."`, isCorrect: false },
-                { text: `"I've been meaning to mention that you're always late."`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 39,
-              question: `"I've noticed you've arrived after the scheduled time for four of our last five sessions" is an example of:`,
-              options: [
-                { text: `Interpretation`, isCorrect: true },
-                { text: `Judgment`, isCorrect: false },
-                { text: `Behavioral observation`, isCorrect: false },
-                { text: `Mind-reading`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 40,
-              question: `After making an observation, the recommended next step is to:`,
-              options: [
-                { text: `Immediately offer solutions`, isCorrect: true },
-                { text: `Defend your observation`, isCorrect: false },
-                { text: `Pause and listen to the client's response`, isCorrect: false },
-                { text: `Provide additional evidence`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 41,
-              question: `The final "S" in COMPASS (Strengthen Connection) involves:`,
-              options: [
-                { text: `Summarizing everything discussed`, isCorrect: true },
-                { text: `Expressing appreciation and reaffirming commitment`, isCorrect: false },
-                { text: `Setting consequences for non-compliance`, isCorrect: false },
-                { text: `Scheduling a follow-up appointment`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+      "order": 2,
+      "title": "Module 2: THE COMPASS FRAMEWORK FOR DIFFICULT CONVERSATIONS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 2: THE COMPASS FRAMEWORK FOR DIFFICULT CONVERSATIONS",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 2
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Describe each component of the {{callout:compass}} framework</li>\n<li>Apply centering techniques before difficult conversations</li>\n<li>Craft effective opening statements that reduce defensiveness</li>\n<li>Use behavioral observation language without judgment</li>\n<li>Navigate client responses with curiosity and collaboration</li>\n</ol>",
+          "callouts": {
+            "compass": {
+              "label": "COMPASS",
+              "type": "reference",
+              "body": "A seven-step framework for difficult conversations: Center, Open with care, Make observations, Pause and listen, Align on understanding, Strategize together, Strengthen connection."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Introducing the COMPASS Framework</h2>\n<p>Having a framework reduces the uncertainty that drives avoidance. When you know what steps to take, difficult conversations become more manageable. The COMPASS framework provides a structured approach:</p>\n<p><strong>C - Center Yourself</strong> <strong>O - Open with Care</strong> <strong>M - Make Observations</strong> <strong>P - Pause and Listen</strong> <strong>A - Align on Understanding</strong> <strong>S - Strategize Together</strong> <strong>S - Strengthen Connection</strong></p>\n<p>Let's explore each component in depth, with specific language and examples.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>C - Center Yourself</h2>\n<p>Before the difficult conversation, you must center yourself. This isn't optional preparation—it's essential groundwork that determines how the conversation will go.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Notice Your Anxiety</h2>\n<p>Difficult conversations trigger our nervous system. Notice what happens in your body when you anticipate the conversation:</p>\n<ul>\n<li>Tightness in your chest or throat</li>\n<li>Butterflies or churning in your stomach</li>\n<li>Shallow breathing</li>\n<li>Racing thoughts</li>\n<li>Urge to postpone or avoid</li>\n</ul>\n<p>These sensations are normal. They're not signs that you shouldn't have the conversation—they're signs that you're human. Acknowledge them without letting them drive your behavior.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Ground Yourself</h2>\n<p>Use whatever grounding techniques work for you:</p>\n<p><strong>Breath:</strong> Take several slow, deep breaths. Extend your exhale longer than your inhale. This activates the parasympathetic nervous system.</p>\n<p><strong>Body awareness:</strong> Feel your feet on the floor. Feel your seat in the chair. Notice the sensation of your clothes on your skin.</p>\n<p><strong>Brief mindfulness:</strong> Spend even 30 seconds being present before the session.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Clarify Your Intention</h2>\n<p>Ask yourself: <strong>What is the caring purpose behind this conversation?</strong></p>\n<p>This question is crucial. It reframes the conversation from confrontation to care. You're not having this conversation to punish, to vent, to prove you're right, or to discharge your frustration. You're having it because something important needs to be addressed for the benefit of the client and the treatment.</p>\n<p>Write down your caring intention before the conversation:</p>\n<ul>\n<li>\"I care about Michael's recovery, and his drinking may be interfering.\"</li>\n<li>\"I want our work together to be effective, and we need to talk about what's getting in the way.\"</li>\n<li>\"I want Jennifer to experience a relationship where difficult things can be named.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Examine Your Motivation</h2>\n<p>Be honest with yourself about what's driving you. Are you:</p>\n<ul>\n<li>Addressing this for the client's benefit?</li>\n<li>Discharging your own frustration?</li>\n<li>Trying to prove something?</li>\n<li>Reacting to your own triggers?</li>\n</ul>\n<p>If your motivation is contaminated by frustration or self-interest, take time to process those feelings before the conversation—perhaps in supervision or consultation. The conversation will go better if you can approach it from genuine care rather than accumulated resentment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Anticipate Responses</h2>\n<p>Think through how the client might respond:</p>\n<ul>\n<li>What if they become defensive?</li>\n<li>What if they become tearful?</li>\n<li>What if they become angry?</li>\n<li>What if they deny or minimize?</li>\n<li>What if they leave?</li>\n</ul>\n<p>Having thought through possible responses reduces the chance of being caught off guard. For each possible response, consider how you might navigate it while maintaining connection.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Choose Timing</h2>\n<p>Consider when to have this conversation:</p>\n<ul>\n<li>Is there enough time in the session? (Don't start a major conversation with 10 minutes left.)</li>\n<li>Is the client stable enough to handle this discussion?</li>\n<li>Is this the right session, or should you prepare the client first?</li>\n<li>Are you in the right state to have this conversation today?</li>\n</ul>\n<p>Sometimes the right answer is \"not today, but soon.\" Just don't let \"soon\" become \"never.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>O - Open with Care</h2>\n<p>The opening of a difficult conversation matters enormously. The first thirty seconds set the tone for everything that follows. A poor opening triggers defensiveness; a skillful opening creates collaboration.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>What to Avoid</h2>\n<p><strong>Accusatory openings:</strong> \"We need to talk about your lateness problem.\" This puts the client on the defensive immediately.</p>\n<p><strong>Buried ledes:</strong> Starting with so much preamble that the client is confused and anxious before you get to the point.</p>\n<p><strong>Hedging that feels dishonest:</strong> \"I don't know if this is even important, but...\"—when you clearly think it's important.</p>\n<p><strong>Judgment-laden language:</strong> \"I've noticed you're not taking this seriously.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Effective Opening Patterns</h2>\n<p>Here are sentence stems for opening difficult conversations:</p>\n<p><strong>Pattern 1: Naming the difficulty</strong> \"I've been thinking about how to bring something up that I care about. Can we talk about something that might be uncomfortable but I think is important?\"</p>\n<p>This pattern names that the conversation will be uncomfortable, which paradoxically reduces discomfort. It asks permission, which gives the client agency. It frames your motivation as caring.</p>\n<p><strong>Pattern 2: Naming your hesitation</strong> \"I've been hesitant to bring something up, and I realize that hesitation probably means it's important. Can I share something I've been noticing?\"</p>\n<p>This pattern uses your hesitation as evidence of importance. It models honesty about discomfort.</p>\n<p><strong>Pattern 3: Alliance-first framing</strong> \"I care about our work together, and there's something I think we need to address for that work to be as helpful as possible.\"</p>\n<p>This pattern leads with alliance, frames the conversation as serving treatment, and implies collaboration.</p>\n<p><strong>Pattern 4: Direct acknowledgment</strong> \"There's something I've noticed that I haven't said anything about, and I want to be more honest with you about what I'm observing.\"</p>\n<p>This pattern names the avoidance directly and commits to greater honesty.</p>"
+        },
+        {
+          "type": "callout",
+          "order": 14,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Opening Variations",
+          "content": "<p>Dr. Chen is preparing to address Michael's lateness pattern. Here are variations of how she might open:</p>\n<p><strong>Version 1 (Naming the difficulty):</strong> \"Michael, I've been thinking about how to bring up something that I care about. It might be a little uncomfortable, but I think it's important for our work. Is now a good time?\"</p>\n<p><strong>Version 2 (Naming hesitation):</strong> \"I realize I've been hesitating to mention something for a few weeks now, and my hesitation tells me it matters. Can I share something I've been noticing?\"</p>\n<p><strong>Version 3 (Alliance-first):</strong> \"I want our time together to be as useful as possible for you. There's a pattern I've noticed that I think is getting in the way. Can we talk about it?\"</p>\n<p>Each of these openings:</p>\n<ul>\n<li>Signals importance without alarm</li>\n<li>Frames the conversation as collaborative</li>\n<li>Establishes caring intention</li>\n<li>Seeks permission</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>M - Make Observations</h2>\n<p>After opening, share your observations using careful, nonjudgmental language.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Behavioral Description vs. Interpretation</h2>\n<p>Describe observable behavior, not your interpretation of what it means:</p>\n<p><strong>Interpretation (avoid):</strong> \"You don't seem to take our sessions seriously.\"</p>\n<p><strong>Observation (better):</strong> \"I've noticed that over the past month, you've arrived 15-20 minutes late to each of our sessions.\"</p>\n<p><strong>Interpretation (avoid):</strong> \"You're resistant to doing the homework.\"</p>\n<p><strong>Observation (better):</strong> \"The last three weeks, we've agreed on things to practice between sessions, and each week you've mentioned that you didn't do them.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>The Formula: \"I've noticed...\"</h2>\n<p>The phrase \"I've noticed\" is your friend. It signals observation rather than accusation:</p>\n<ul>\n<li>\"I've noticed that our last four sessions have been cut short by late arrivals.\"</li>\n<li>\"I've noticed that when I ask about alcohol, you change the subject.\"</li>\n<li>\"I've noticed something seems different between us the last couple of weeks.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Staying Descriptive</h2>\n<p>Describe:</p>\n<ul>\n<li>Frequency (\"three out of the last four sessions\")</li>\n<li>Timing (\"the past month\")</li>\n<li>Specific behaviors (\"arriving after the scheduled start time\")</li>\n<li>Observable patterns (\"you look away when this topic comes up\")</li>\n</ul>\n<p>Avoid:</p>\n<ul>\n<li>Labels (\"You're being avoidant\")</li>\n<li>Mind-reading (\"You must be scared of...\")</li>\n<li>Global statements (\"You always...\" \"You never...\")</li>\n<li>Interpretations disguised as observations</li>\n</ul>"
+        },
+        {
+          "type": "callout",
+          "order": 19,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Observations About Lateness",
+          "content": "<p>Dr. Chen continues her conversation with Michael:</p>\n<p>\"I've noticed a pattern over the past six weeks. You've arrived between 10 and 20 minutes late to five of our last six sessions. That means we've lost about an hour of our therapy time over that period. I'm not saying this to criticize you—I'm bringing it up because I want to understand what's happening, and because I think it might be important.\"</p>\n<p>Notice how this observation:</p>\n<ul>\n<li>Is specific (six weeks, 10-20 minutes, five of six sessions, about an hour)</li>\n<li>Is behavioral (arrived late, lost time)</li>\n<li>Avoids interpretation (doesn't say why Michael is late)</li>\n<li>Disclaims punitive intent (not to criticize)</li>\n<li>States purpose (want to understand, think it's important)</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>P - Pause and Listen</h2>\n<p>After sharing your observation, stop talking. This is harder than it sounds. Our anxiety makes us want to fill silence, qualify what we said, soften the impact, or move quickly to solutions. Resist these urges.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Create Space</h2>\n<p>Pause. Let there be silence. Give the client time to take in what you've said and formulate a response.</p>\n<p>Count to ten silently if you need to. The pause communicates that you're genuinely interested in their response, not just waiting to deliver more of your message.</p>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>Listen Without Defending</h2>\n<p>Whatever the client says, listen to understand rather than to defend. Common responses to difficult conversations include:</p>\n<p><strong>Defensiveness:</strong> \"I'm not that late! It's just a few minutes.\" <em>Listen. Don't argue about the data.</em></p>\n<p><strong>Minimization:</strong> \"I don't think it's a big deal. We still have time to talk.\" <em>Listen. You'll address this, but first understand their perspective.</em></p>\n<p><strong>Counterattack:</strong> \"Well, you started late last week too.\" <em>Listen. Don't defend. Acknowledge what's true in their response.</em></p>\n<p><strong>Deflection:</strong> \"I've just had so much going on at work.\" <em>Listen. There may be important information here.</em></p>\n<p><strong>Vulnerability:</strong> \"You're right. I've been avoiding coming here.\" <em>Listen. This may open important territory.</em></p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Verbal and Nonverbal Listening</h2>\n<p>Demonstrate listening through:</p>\n<ul>\n<li>Eye contact (culturally appropriate)</li>\n<li>Nodding</li>\n<li>Brief verbal acknowledgments (\"Mm-hmm,\" \"I see\")</li>\n<li>Body language that communicates openness</li>\n<li>Not interrupting</li>\n</ul>\n<p>Don't:</p>\n<ul>\n<li>Argue with their response</li>\n<li>Defend yourself</li>\n<li>Correct their perceptions immediately</li>\n<li>Jump to problem-solving</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>A - Align on Understanding</h2>\n<p>After listening, work toward shared understanding. This isn't about proving you're right—it's about developing a mutual view of what's happening and why it matters.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Reflect What You Heard</h2>\n<p>Start by reflecting what the client said: \"So it sounds like the lateness is connected to how stressful work has been—getting out the door is harder when you're this depleted.\"</p>\n<p>\"I hear you saying that the lateness doesn't feel like a big deal to you—we still have time to cover what we need to.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>Seek Their Perspective</h2>\n<p>Ask questions that invite deeper exploration:</p>\n<ul>\n<li>\"Help me understand more about what's happening on those mornings.\"</li>\n<li>\"What's your sense of what the pattern is about?\"</li>\n<li>\"How do you think about the lateness—does it mean something to you?\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 27,
+          "content": "<h2>Share Your Perspective (Gently)</h2>\n<p>After hearing them, share your perspective—not as the truth, but as your view: \"From my perspective, the lateness matters for a couple of reasons. One is practical—we're losing therapy time. The other is that patterns often mean something. I'm curious whether the lateness is telling us something important about your relationship to therapy, or to change, or to me.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Work Toward Shared Understanding</h2>\n<p>The goal is to arrive at a shared understanding of what's happening: \"So it sounds like we both see that there's a pattern. You're seeing it as mostly about work stress, and I'm wondering if there's also something about ambivalence toward therapy. Does that ring true at all, or does it feel off?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 29,
+          "content": "<h2>S - Strategize Together</h2>\n<p>Once you have shared understanding, collaborate on next steps. This is a joint problem-solving process, not you imposing solutions.</p>"
+        },
+        {
+          "type": "text",
+          "order": 30,
+          "content": "<h2>Collaborative Language</h2>\n<ul>\n<li>\"What do you think might help?\"</li>\n<li>\"What ideas do you have?\"</li>\n<li>\"How should we handle this going forward?\"</li>\n<li>\"What would you like to try?\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 31,
+          "content": "<h2>Offer Options</h2>\n<p>If the client doesn't have ideas, offer options rather than commands: \"I have a few thoughts about what might help. Would you like to hear them?\"</p>\n<p>Then present options:</p>\n<ul>\n<li>\"We could move your appointment to a different time that might be easier for you to make.\"</li>\n<li>\"We could address the lateness each time it happens, in the moment.\"</li>\n<li>\"We could explore what the lateness is communicating about your relationship to therapy.\"</li>\n<li>\"Some combination of these.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>Make Agreements</h2>\n<p>End with clear agreements:</p>\n<ul>\n<li>\"So we're agreeing to try the 3pm slot instead, and if the lateness continues, we'll look more at what it means.\"</li>\n<li>\"And if you arrive late, I'm going to bring it up directly rather than letting it go. Does that feel okay?\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 33,
+          "content": "<h2>S - Strengthen Connection</h2>\n<p>End the conversation by reinforcing the relationship. The client took a risk by engaging in this conversation. Acknowledge that.</p>"
+        },
+        {
+          "type": "text",
+          "order": 34,
+          "content": "<h2>Express Appreciation</h2>\n<ul>\n<li>\"Thank you for being willing to talk about this with me.\"</li>\n<li>\"I appreciate your openness.\"</li>\n<li>\"I know that wasn't easy. I'm grateful you hung in there with me.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 35,
+          "content": "<h2>Reaffirm Commitment</h2>\n<ul>\n<li>\"I'm committed to our work together. Conversations like this are part of how we make the therapy as helpful as possible.\"</li>\n<li>\"My goal is always for this to be useful for you. Sometimes that means having uncomfortable conversations.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 36,
+          "content": "<h2>Normalize</h2>\n<ul>\n<li>\"These kinds of conversations are normal in good therapy. They don't mean something's wrong—they mean we're being honest with each other.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>COMPASS in Action: A Worked Example</h2>\n<p>The COMPASS framework is best understood through a concrete sequence. Consider a clinician addressing a client’s chronic lateness, moving through the stages rather than blurting the concern.</p>\n<h3>Walking the Stages</h3>\n<p>The clinician first <strong>centers</strong>, noticing their own irritation and grounding before the session so the conversation comes from care rather than frustration. They <strong>open with care</strong>: “There’s something I’ve been wanting to bring up because I care about your progress here.” They <strong>make an observation</strong> behaviorally and without judgment: “I’ve noticed that over the last several weeks, we’ve started ten or fifteen minutes after our scheduled time.” Then they <strong>pause and listen</strong>, resisting the urge to fill the silence or defend, which gives the client room to respond honestly — perhaps revealing a work conflict, or ambivalence about therapy itself.</p>\n<h3>Toward a Shared Plan</h3>\n<p>From there the clinician <strong>aligns on understanding</strong>, reflecting what they heard and offering their own perspective gently, so both arrive at a shared picture of what the lateness means. They <strong>strategize together</strong>, generating options collaboratively rather than imposing a rule — adjusting the session time, problem-solving the commute, or exploring the ambivalence directly. Finally they <strong>strengthen connection</strong>, appreciating the client’s openness and reaffirming the shared commitment. The same behavior that might have festered as resentment becomes a productive, alliance-deepening conversation.</p>",
+          "order": 37
+        },
+        {
+          "type": "text",
+          "content": "<h2>Common Pitfalls at Each Stage</h2>\n<p>Each stage of COMPASS has a characteristic failure mode, and anticipating these helps the clinician stay on track when a conversation gets difficult.</p>\n<h3>Where Conversations Go Wrong</h3>\n<p>At <strong>Center</strong>, the pitfall is skipping it entirely — launching the conversation while still activated, so the client receives the clinician’s frustration rather than their care. At <strong>Open</strong>, the error is an alarming or accusatory frame (“We need to talk”) that primes defensiveness before a word of substance. At <strong>Make Observations</strong>, clinicians frequently slide from description into interpretation — “you don’t seem to care about this work” rather than “we’ve started late several times” — which invites argument about motives. At <strong>Pause</strong>, the temptation is to rush past the silence or to defend, foreclosing the client’s response.</p>\n<h3>Staying the Course</h3>\n<p>At <strong>Align</strong>, clinicians sometimes insist on their own reading rather than genuinely seeking the client’s perspective, turning a dialogue into a verdict. At <strong>Strategize</strong>, the pitfall is imposing a solution rather than building one together, which undermines the collaboration the framework depends on. And at <strong>Strengthen</strong>, the conversation simply ends without repair or appreciation, leaving the client unsure whether the relationship is still intact. Knowing these failure points lets the clinician notice when they are drifting and return to the stance the conversation needs.</p>",
+          "order": 38
+        },
+        {
+          "type": "text",
+          "content": "<h2>When the Client Raises the Elephant First</h2>\n<p>Sometimes it is the client, not the clinician, who names the difficult thing — a complaint about the therapy, a confession, a challenge to the clinician. How the clinician receives these moments determines whether they become ruptures or breakthroughs.</p>\n<h3>Receiving It Well</h3>\n<p>The instinctive responses — defending, explaining, reassuring too quickly — all foreclose the opening the client has bravely created. The skillful response is closer to the COMPASS stance in reverse: center oneself against the flush of defensiveness, genuinely listen, validate the client’s courage in raising it, and explore rather than rebut. A client who criticizes the therapy or the clinician is, frequently, deeply engaged — trusting the relationship enough to test it.</p>\n<h3>The Opportunity</h3>\n<p>When a clinician meets a client’s difficult disclosure with non-defensive curiosity, the client experiences something potentially corrective: a relationship in which hard truths can be spoken and are met with care rather than retaliation or collapse. Treating these moments as gifts rather than threats — and saying so explicitly, thanking the client for raising them — reinforces the honesty the whole approach depends on.</p>",
+          "order": 39
+        },
+        {
+          "type": "text",
+          "content": "<h2>Adapting the Approach to Telehealth and Brief Formats</h2>\n<p>Difficult conversations unfold differently over video and within time-limited treatment, and the clinician adapts the approach to these now-common formats.</p>\n<h3>Difficult Conversations Over Video</h3>\n<p>Telehealth thins the nonverbal channel — subtle cues are harder to read, silences feel longer and more awkward, and a client can disengage by simply looking away or citing a connection problem. The clinician compensates by being more explicit: naming what they observe, checking in more directly about how a comment landed, and tolerating the screen’s amplified silences rather than rushing to fill them. Privacy also matters more, since a client may not be alone or safe to speak freely.</p>\n<h3>When Time Is Short</h3>\n<p>In brief or time-limited treatment, the clinician cannot wait indefinitely for the ideal moment; elephants must be raised earlier and more economically, because the window to repair and benefit from the conversation is itself short. This argues for addressing issues sooner rather than later — the very tendency that avoidance resists — and for trusting that a well-framed, caring conversation does not require abundant time to be worthwhile.</p>",
+          "order": 40
+        },
+        {
+          "type": "text",
+          "content": "<h2>Pacing and the Question of the Right Moment</h2>\n<p>“Waiting for the right moment” is both genuine clinical wisdom and the most common rationalization for avoidance, and distinguishing the two is a clinical skill in itself.</p>\n<h3>Timing That Serves the Client</h3>\n<p>There are real reasons to wait: a client in acute crisis may not have the bandwidth for a conversation about lateness; an alliance too new to bear weight may need strengthening first; the end of a session is no time to open something large. Genuine timing judgment asks what the client can use right now and sequences the conversation to serve them.</p>\n<h3>When “Not Yet” Means “Never”</h3>\n<p>But timing becomes avoidance when “not yet” has no end — when every session offers a fresh reason to postpone and the elephant simply grows. The honest test is whether the clinician can name what specifically would make a later moment better, and whether that condition is actually approaching. If the answer is vague, the right moment is probably now, approached with care. Most clients are more ready for honest conversation than clinicians fear.</p>",
+          "order": 41
+        },
+        {
+          "order": 42,
+          "type": "matching",
+          "matchingInstructions": "Match each COMPASS letter to what it stands for.",
+          "matchingPairs": [
+            {
+              "term": "C",
+              "definition": "Center yourself — notice anxiety, ground, clarify intention"
+            },
+            {
+              "term": "O",
+              "definition": "Open with care — frame the conversation around the relationship"
+            },
+            {
+              "term": "M",
+              "definition": "Make observations — describe behavior without judgment"
+            },
+            {
+              "term": "P",
+              "definition": "Pause and listen — create space and listen non-defensively"
+            },
+            {
+              "term": "A",
+              "definition": "Align on understanding — seek a shared picture"
+            },
+            {
+              "term": "S / S",
+              "definition": "Strategize together, then Strengthen connection"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 43,
+          "question": "Which is the most effective opening for a difficult conversation?",
+          "options": [
+            {
+              "text": "\"We need to talk about your problem with lateness.\"",
+              "isCorrect": true
+            },
+            {
+              "text": "\"I've noticed something I'd like to understand better. Is this a good time?\"",
+              "isCorrect": false
+            },
+            {
+              "text": "\"Don't take this personally, but...\"",
+              "isCorrect": false
+            },
+            {
+              "text": "\"I've been meaning to mention that you're always late.\"",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 44,
+          "type": "multiSelect",
+          "question": "What makes “I’ve noticed you’ve arrived after our start time for four of the last five sessions” an effective observation? (Select all that apply)",
+          "options": [
+            {
+              "text": "It describes behavior rather than interpreting motive",
+              "isCorrect": true
+            },
+            {
+              "text": "It is specific and factual",
+              "isCorrect": true
+            },
+            {
+              "text": "It avoids judgment and blame",
+              "isCorrect": true
+            },
+            {
+              "text": "It diagnoses why the client is late",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "An effective observation is specific, behavioral, and non-judgmental — describing what happened without interpreting the client’s motives."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 45,
+          "question": "After making an observation, the recommended next step is to:",
+          "options": [
+            {
+              "text": "Immediately offer solutions",
+              "isCorrect": true
+            },
+            {
+              "text": "Defend your observation",
+              "isCorrect": false
+            },
+            {
+              "text": "Pause and listen to the client's response",
+              "isCorrect": false
+            },
+            {
+              "text": "Provide additional evidence",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 46,
+          "question": "The final \"S\" in COMPASS (Strengthen Connection) involves:",
+          "options": [
+            {
+              "text": "Summarizing everything discussed",
+              "isCorrect": true
+            },
+            {
+              "text": "Expressing appreciation and reaffirming commitment",
+              "isCorrect": false
+            },
+            {
+              "text": "Setting consequences for non-compliance",
+              "isCorrect": false
+            },
+            {
+              "text": "Scheduling a follow-up appointment",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 3,
-      title: `Module 3: ADDRESSING TREATMENT-INTERFERING BEHAVIORS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 3: ADDRESSING TREATMENT-INTERFERING BEHAVIORS`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 3,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Define treatment-interfering behaviors and explain their clinical significance</li>
-<li>Adopt a stance of curious compassion when addressing problematic client behaviors</li>
-<li>Apply specific language patterns for common treatment-interfering behaviors</li>
-<li>Distinguish between limit-setting and punishment in clinical responses</li>
-<li>Follow through consistently after addressing behaviors</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>🎯 Pre-Module Pulse Check</h2>
-<p>Before exploring this topic, rate your comfort (1 = very uncomfortable, 5 = very comfortable):</p><table class="cr-table">
-<tr><th>Situation</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th></tr>
-<tr><td>Addressing chronic client lateness</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td>Discussing payment issues</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td>Confronting homework non-completion</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td>Setting limits on between-session contact</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td>Addressing a client who arrives intoxicated</td><td></td><td></td><td></td><td></td><td></td></tr>
-</table>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>What Are Treatment-Interfering Behaviors?</h2>
-<p>Dialectical Behavior Therapy (DBT) gives us the useful concept of "therapy-interfering behaviors"—any behaviors by client or therapist that interfere with the client receiving effective treatment. While DBT addresses these within a specific treatment hierarchy, the concept applies across theoretical orientations.</p>
-<p>Treatment-interfering behaviors include:</p>
-<p><strong>Attendance behaviors:</strong></p>
-<ul>
-<li>Missing sessions (no-shows)</li>
-<li>Canceling with short or no notice</li>
-<li>Chronic lateness</li>
-<li>Leaving sessions early</li>
-<li>Coming to session in a state that prevents productive work (intoxicated, highly dissociated)</li>
-</ul>
-<p><strong>Engagement behaviors:</strong></p>
-<ul>
-<li>Not completing agreed-upon homework or between-session tasks</li>
-<li>Not honestly reporting symptoms, behaviors, or life events</li>
-<li>Refusing to discuss important topics</li>
-<li>Being chronically silent or superficial in sessions</li>
-</ul>
-<p><strong>Boundary behaviors:</strong></p>
-<ul>
-<li>Excessive or inappropriate contact between sessions</li>
-<li>Attempting to change the therapeutic relationship (gift-giving, personal questions, social media connection)</li>
-<li>Recording sessions without permission</li>
-<li>Violating confidentiality agreements</li>
-</ul>
-<p><strong>Financial behaviors:</strong></p>
-<ul>
-<li>Not paying bills</li>
-<li>Bouncing checks or declined payments</li>
-<li>Requesting ongoing reduced fees without discussion</li>
-<li>Disputing legitimate charges</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Why These Behaviors Matter</h2>
-<p>Failing to address treatment-interfering behaviors has consequences:</p>
-<p><strong>Treatment is undermined:</strong> Therapy can't work if the client isn't there, isn't honest, isn't doing the work between sessions, or isn't engaged during sessions.</p>
-<p><strong>Patterns go unexamined:</strong> Treatment-interfering behaviors often parallel problems in the client's life outside therapy. The client who is chronically late to therapy may be chronically late elsewhere. The client who avoids topics in therapy may avoid them in other relationships too. By not addressing these patterns, we miss opportunities to work on them in vivo.</p>
-<p><strong>Resentment builds:</strong> When we don't address problematic behaviors, we often feel resentful. This resentment leaks into the therapy in indirect ways that harm the relationship more than honest conversation would.</p>
-<p><strong>Modeling occurs:</strong> When we tolerate problematic behavior without comment, we implicitly teach that boundaries aren't important, that avoidance works, that consequences can be avoided.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>The Stance: Curious Compassion</h2>
-<p>The key to addressing treatment-interfering behaviors is curious compassion—not judgment, not punishment, not angry confrontation.</p>
-<p><strong>Curiosity:</strong> The behavior means something. It communicates something. Our job is to understand what. "What is this behavior telling us?"</p>
-<p><strong>Compassion:</strong> The client is not trying to be difficult. They're doing the best they can with the resources they have. The behavior that interferes with treatment may be the same behavior that interferes with the client's life—the very thing they came to work on.</p>
-<p>When you approach treatment-interfering behaviors with curious compassion, you're saying:</p>
-<ul>
-<li>"I see this behavior."</li>
-<li>"I want to understand it."</li>
-<li>"I believe it means something."</li>
-<li>"I'm not punishing you for it."</li>
-<li>"And we do need to address it because it's getting in the way."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>What Curious Compassion Sounds Like</h2>
-<p><strong>Not this (judgment):</strong> "You need to start taking therapy seriously."</p>
-<p><strong>This (curious compassion):</strong> "I notice you've missed three sessions this month. I'm not trying to criticize you—I genuinely want to understand what's getting in the way of you being here."</p>
-<p><strong>Not this (punishment):</strong> "If you keep canceling, I'll have to terminate treatment."</p>
-<p><strong>This (curious compassion):</strong> "Missing sessions makes it hard for therapy to help you. What's happening that's making it difficult to be here consistently?"</p>
-<p><strong>Not this (enabling):</strong> Saying nothing and continuing to accommodate.</p>
-<p><strong>This (curious compassion):</strong> "I haven't said anything about the pattern of cancellations, and I realize that's not fair to you. You deserve to know what I'm observing and to talk about what's happening."</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Behavior Is Communication</h2>
-<p>Always remember: behavior is communication. The client who is chronically late may be communicating:</p>
-<ul>
-<li>Ambivalence about treatment</li>
-<li>Passive resistance to something in the therapy</li>
-<li>Difficulty with transitions</li>
-<li>Testing whether you'll enforce boundaries</li>
-<li>Parallel patterns that occur in other relationships</li>
-<li>Actual logistical challenges</li>
-<li>Anxiety about sessions</li>
-<li>A recreation of patterns from early relationships</li>
-</ul>
-<p>Your job isn't to assume which of these is true—it's to explore with curiosity.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Specific Language for Common Situations</h2>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Chronic Lateness</h2>
-<p><strong>Opening:</strong> "I've noticed a pattern I want to understand better. Over the past month, you've arrived 15-20 minutes late to each session. I'm not bringing this up to criticize you—I'm bringing it up because I want to understand what's happening, and because the lateness is affecting how much time we have together. Can we talk about it?"</p>
-<p><strong>Exploring:</strong> "What's your sense of what's happening? Do you notice the pattern too?" "What's going on when it gets close to our session time? Help me understand the experience." "I wonder if the lateness might be telling us something about your relationship to therapy. What do you think?"</p>
-<p><strong>Following through:</strong> "Going forward, I'd like us to pay attention to this pattern together. If you're late, I may bring it up directly rather than just letting it go. And I'm curious—if you notice yourself running late, what's happening in that moment?"</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Missed Sessions/Cancellations</h2>
-<p><strong>Opening:</strong> "You've cancelled or not shown up for several sessions recently. I want to make sure I understand what's happening. I'm not angry or trying to make you feel guilty—I'm genuinely concerned about how to help you when we're not meeting consistently."</p>
-<p><strong>Exploring:</strong> "What's getting in the way of you being here?" "When you think about coming to session, what comes up?" "Sometimes people miss therapy when something about the therapy isn't working. I wonder if there's anything about our work together that's not feeling right?"</p>
-<p><strong>Following through:</strong> "We need to figure out how to move forward. If weekly sessions aren't sustainable right now, let's talk about that. But if we're going to continue, I need you here as consistently as possible."</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Homework Non-Completion</h2>
-<p><strong>Opening:</strong> "I've noticed that we've agreed on things to try between sessions several times now, and those things haven't happened. I'm curious about that. I'm not asking to criticize you—I'm asking because the between-session work is important for therapy to be effective."</p>
-<p><strong>Exploring:</strong> "What happens when you think about the homework during the week?" "Is there something about the tasks themselves that doesn't feel right?" "Sometimes when people don't do therapy homework, it means the tasks aren't right for them, or something else is getting in the way. What's your sense?"</p>
-<p><strong>Following through:</strong> "Let's think together about what would actually be doable. I'd rather have you do something small consistently than agree to things that aren't happening."</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>Payment Issues</h2>
-<p><strong>Opening:</strong> "I want to talk about something I've been avoiding, which is your account balance. It's now [amount] past due. I know money can be uncomfortable to discuss, but this is affecting our work, and I'd rather talk about it directly than have it sit between us."</p>
-<p><strong>Exploring:</strong> "What's happening with the bills? Is it a financial constraint, or something else?" "I wonder if there are feelings about paying for therapy that would be worth exploring." "What would help us figure this out?"</p>
-<p><strong>Following through:</strong> "Let's make a plan. If the fee is genuinely too much right now, we can talk about that. But I need us to have an agreement we both stick to."</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Showing Up Intoxicated</h2>
-<p><strong>Opening:</strong> "I notice you seem like you may have been drinking before session today. I want to check in about that directly. Can you tell me what's happening?"</p>
-<p><strong>Exploring:</strong> "What led to drinking before session?" "This is the second time this has happened. What do you think that pattern is about?" "Showing up impaired makes it hard to do the work we're trying to do. What would help?"</p>
-<p><strong>Following through:</strong> "I can't work with you effectively when you're impaired. Going forward, if this happens, we'll need to reschedule rather than continue. And I want to talk more about what the drinking is about."</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Between-Session Contact</h2>
-<p><strong>Opening:</strong> "I've noticed that you've been calling/texting/emailing more frequently between sessions lately. I want to talk about that pattern—not to criticize you, but because I want to understand what's happening and because I think it might be important."</p>
-<p><strong>Exploring:</strong> "What's coming up between sessions that leads to reaching out?" "What happens after you contact me? Does it help?" "I wonder if the between-session contact might be telling us something about what you need that we're not addressing in our sessions."</p>
-<p><strong>Following through:</strong> "I care about you, and I also want to help you build your own capacity to manage difficult moments. Contacting me every time you're distressed doesn't actually build that capacity. Let's talk about what would."</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Limit-Setting vs. Punishment</h2>
-<p>There's an important distinction between limit-setting and punishment:</p>
-<p><strong>Punishment</strong> is retaliatory and aims to cause discomfort: "Since you missed two sessions, I'm not going to schedule you for three weeks."</p>
-<p><strong>Limit-setting</strong> maintains necessary structure while remaining collaborative: "We need sessions to happen consistently for therapy to work. If you miss two sessions without 24 hours notice, we'll need to discuss whether this therapy format is working for you."</p>
-<p>Limits are about maintaining the conditions necessary for effective treatment. They're stated clearly and in advance. They're not designed to punish but to protect the therapy frame.</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>Natural Consequences vs. Imposed Consequences</h2>
-<p>Natural consequences flow directly from the behavior:</p>
-<ul>
-<li>If you're 20 minutes late, we have 20 fewer minutes to work.</li>
-<li>If you don't do the homework, we have less material to work with.</li>
-<li>If you don't pay, I can't continue providing services.</li>
-</ul>
-<p>Imposed consequences are penalties unrelated to the behavior:</p>
-<ul>
-<li>If you're late three times, I won't see you anymore.</li>
-<li>If you don't do homework, I'll give you more homework.</li>
-</ul>
-<p>Generally, natural consequences are more effective and less damaging to the relationship.</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>Following Through</h2>
-<p>Addressing a treatment-interfering behavior once isn't enough. Following through is essential:</p>
-<p><strong>Consistency:</strong> Apply the same standard over time. If lateness matters, it matters every time.</p>
-<p><strong>Remembering:</strong> In subsequent sessions, check in: "How did the week go with what we talked about?"</p>
-<p><strong>Addressing recurrence:</strong> If the behavior continues, name that: "I notice the same pattern is happening. Let's talk about what's getting in the way of change."</p>
-<p><strong>Adjusting if needed:</strong> If your approach isn't working, try something different. Maybe the agreed-upon solution wasn't right. Reassess collaboratively.</p>`,
-            },
-{
-              type: "callout",
-              order: 19,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Treatment-Interfering Behavior in Context`,
-              content: `<p>Marcus, a 29-year-old graduate student, has been in therapy for depression for four months. His therapist, Dr. Williams, has noticed a pattern: Marcus agrees enthusiastically to between-session tasks but never completes them.</p>
-<p><strong>Session 14 - Addressing the Pattern:</strong></p>
-<p>Dr. Williams: "Marcus, I want to bring up something I've noticed. Over the past two months, we've identified things to try between sessions maybe eight or ten times. Each time, you've seemed motivated and agreed they were good ideas. And each time, when you come back, they haven't happened. I'm not bringing this up to criticize you—I'm genuinely curious about what's happening."</p>
-<p>Marcus (defensive): "I've been really busy. It's not like I'm not trying."</p>
-<p>Dr. Williams: "I hear that. And I'm not questioning your effort. I'm more curious about the pattern. What happens when the week goes by? Do you think about the tasks?"</p>
-<p>Marcus: "Honestly? Not really. I mean, I think about them right after session, but then life takes over."</p>
-<p>Dr. Williams: "So they don't stay present. That's helpful to know. I wonder if that tells us something. What's your sense?"</p>
-<p>Marcus (pausing): "I guess... maybe part of me doesn't really believe anything will help? Like, what's the point?"</p>
-<p>Dr. Williams: "That sounds important. The hopelessness about whether anything can help might make it hard to invest in trying things. Is that what depression does—makes it hard to believe effort will pay off?"</p>
-<p>Marcus: "Yeah. That's exactly it."</p>
-<p>Dr. Williams: "So the homework non-completion isn't about being lazy or not caring—it's a symptom of the depression itself. That's useful to understand. And it puts us in a bind, right? The things that might help feel pointless, so they don't happen, so you don't get evidence that things can help."</p>
-<p>Marcus: "Right."</p>
-<p>Dr. Williams: "Let's think together about what might be different. What would help the between-session work actually happen?"</p>
-<p>Notice how Dr. Williams:</p>
-<ul>
-<li>Named the pattern without judgment</li>
-<li>Explored with curiosity</li>
-<li>Discovered that the behavior was a symptom of the presenting problem</li>
-<li>Reframed understanding collaboratively</li>
-<li>Moved toward problem-solving together</li>
-</ul>`,
-            },
-{
-              type: "multipleChoice",
-              order: 20,
-              question: `Treatment-interfering behaviors are best understood as:`,
-              options: [
-                { text: `Evidence of client resistance`, isCorrect: true },
-                { text: `Character flaws requiring confrontation`, isCorrect: false },
-                { text: `Communication that often parallels problems in the client's life`, isCorrect: false },
-                { text: `Reasons to terminate treatment`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 21,
-              question: `The recommended stance for addressing treatment-interfering behaviors is:`,
-              options: [
-                { text: `Stern authority`, isCorrect: true },
-                { text: `Curious compassion`, isCorrect: false },
-                { text: `Detached objectivity`, isCorrect: false },
-                { text: `Sympathetic tolerance`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 22,
-              question: `When a client is chronically late, the therapist should first:`,
-              options: [
-                { text: `Implement consequences immediately`, isCorrect: true },
-                { text: `Explore what the lateness might be communicating`, isCorrect: false },
-                { text: `Extend the session to make up the time`, isCorrect: false },
-                { text: `Reduce the fee proportionally`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 23,
-              question: `The difference between limit-setting and punishment is:`,
-              options: [
-                { text: `There is no meaningful difference`, isCorrect: true },
-                { text: `Limit-setting maintains necessary structure; punishment is retaliatory`, isCorrect: false },
-                { text: `Punishment is more effective for change`, isCorrect: false },
-                { text: `Limit-setting is only used in DBT`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 24,
-              question: `After addressing a treatment-interfering behavior, the therapist should:`,
-              options: [
-                { text: `Never mention it again`, isCorrect: true },
-                { text: `Follow through consistently and check in about changes`, isCorrect: false },
-                { text: `Wait for the client to bring it up`, isCorrect: false },
-                { text: `Document and move on`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+      "order": 3,
+      "title": "Module 3: ADDRESSING TREATMENT-INTERFERING BEHAVIORS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 3: ADDRESSING TREATMENT-INTERFERING BEHAVIORS",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 3
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Define {{callout:tib}}s and explain their clinical significance</li>\n<li>Adopt a stance of curious compassion when addressing problematic client behaviors</li>\n<li>Apply specific language patterns for common treatment-interfering behaviors</li>\n<li>Distinguish between limit-setting and punishment in clinical responses</li>\n<li>Follow through consistently after addressing behaviors</li>\n</ol>",
+          "callouts": {
+            "tib": {
+              "label": "Treatment-Interfering Behavior",
+              "type": "clinical",
+              "body": "Client behaviors (e.g., lateness, missed sessions, non-completion of homework) that obstruct the work; understood as communication to be explored, not misconduct to be punished."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>🎯 Pre-Module Pulse Check</h2>\n<p>Before exploring this topic, rate your comfort (1 = very uncomfortable, 5 = very comfortable):</p><table class=\"cr-table\">\n<tr><th>Situation</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th></tr>\n<tr><td>Addressing chronic client lateness</td><td></td><td></td><td></td><td></td><td></td></tr>\n<tr><td>Discussing payment issues</td><td></td><td></td><td></td><td></td><td></td></tr>\n<tr><td>Confronting homework non-completion</td><td></td><td></td><td></td><td></td><td></td></tr>\n<tr><td>Setting limits on between-session contact</td><td></td><td></td><td></td><td></td><td></td></tr>\n<tr><td>Addressing a client who arrives intoxicated</td><td></td><td></td><td></td><td></td><td></td></tr>\n</table>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>What Are Treatment-Interfering Behaviors?</h2>\n<p>Dialectical Behavior Therapy (DBT) gives us the useful concept of \"therapy-interfering behaviors\"—any behaviors by client or therapist that interfere with the client receiving effective treatment. While DBT addresses these within a specific treatment hierarchy, the concept applies across theoretical orientations.</p>\n<p>Treatment-interfering behaviors include:</p>\n<p><strong>Attendance behaviors:</strong></p>\n<ul>\n<li>Missing sessions (no-shows)</li>\n<li>Canceling with short or no notice</li>\n<li>Chronic lateness</li>\n<li>Leaving sessions early</li>\n<li>Coming to session in a state that prevents productive work (intoxicated, highly dissociated)</li>\n</ul>\n<p><strong>Engagement behaviors:</strong></p>\n<ul>\n<li>Not completing agreed-upon homework or between-session tasks</li>\n<li>Not honestly reporting symptoms, behaviors, or life events</li>\n<li>Refusing to discuss important topics</li>\n<li>Being chronically silent or superficial in sessions</li>\n</ul>\n<p><strong>Boundary behaviors:</strong></p>\n<ul>\n<li>Excessive or inappropriate contact between sessions</li>\n<li>Attempting to change the therapeutic relationship (gift-giving, personal questions, social media connection)</li>\n<li>Recording sessions without permission</li>\n<li>Violating confidentiality agreements</li>\n</ul>\n<p><strong>Financial behaviors:</strong></p>\n<ul>\n<li>Not paying bills</li>\n<li>Bouncing checks or declined payments</li>\n<li>Requesting ongoing reduced fees without discussion</li>\n<li>Disputing legitimate charges</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Why These Behaviors Matter</h2>\n<p>Failing to address treatment-interfering behaviors has consequences:</p>\n<p><strong>Treatment is undermined:</strong> Therapy can't work if the client isn't there, isn't honest, isn't doing the work between sessions, or isn't engaged during sessions.</p>\n<p><strong>Patterns go unexamined:</strong> Treatment-interfering behaviors often parallel problems in the client's life outside therapy. The client who is chronically late to therapy may be chronically late elsewhere. The client who avoids topics in therapy may avoid them in other relationships too. By not addressing these patterns, we miss opportunities to work on them in vivo.</p>\n<p><strong>Resentment builds:</strong> When we don't address problematic behaviors, we often feel resentful. This resentment leaks into the therapy in indirect ways that harm the relationship more than honest conversation would.</p>\n<p><strong>Modeling occurs:</strong> When we tolerate problematic behavior without comment, we implicitly teach that boundaries aren't important, that avoidance works, that consequences can be avoided.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>The Stance: Curious Compassion</h2>\n<p>The key to addressing treatment-interfering behaviors is curious compassion—not judgment, not punishment, not angry confrontation.</p>\n<p><strong>Curiosity:</strong> The behavior means something. It communicates something. Our job is to understand what. \"What is this behavior telling us?\"</p>\n<p><strong>Compassion:</strong> The client is not trying to be difficult. They're doing the best they can with the resources they have. The behavior that interferes with treatment may be the same behavior that interferes with the client's life—the very thing they came to work on.</p>\n<p>When you approach treatment-interfering behaviors with curious compassion, you're saying:</p>\n<ul>\n<li>\"I see this behavior.\"</li>\n<li>\"I want to understand it.\"</li>\n<li>\"I believe it means something.\"</li>\n<li>\"I'm not punishing you for it.\"</li>\n<li>\"And we do need to address it because it's getting in the way.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>What Curious Compassion Sounds Like</h2>\n<p><strong>Not this (judgment):</strong> \"You need to start taking therapy seriously.\"</p>\n<p><strong>This (curious compassion):</strong> \"I notice you've missed three sessions this month. I'm not trying to criticize you—I genuinely want to understand what's getting in the way of you being here.\"</p>\n<p><strong>Not this (punishment):</strong> \"If you keep canceling, I'll have to terminate treatment.\"</p>\n<p><strong>This (curious compassion):</strong> \"Missing sessions makes it hard for therapy to help you. What's happening that's making it difficult to be here consistently?\"</p>\n<p><strong>Not this (enabling):</strong> Saying nothing and continuing to accommodate.</p>\n<p><strong>This (curious compassion):</strong> \"I haven't said anything about the pattern of cancellations, and I realize that's not fair to you. You deserve to know what I'm observing and to talk about what's happening.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Behavior Is Communication</h2>\n<p>Always remember: behavior is communication. The client who is chronically late may be communicating:</p>\n<ul>\n<li>Ambivalence about treatment</li>\n<li>Passive resistance to something in the therapy</li>\n<li>Difficulty with transitions</li>\n<li>Testing whether you'll enforce boundaries</li>\n<li>Parallel patterns that occur in other relationships</li>\n<li>Actual logistical challenges</li>\n<li>Anxiety about sessions</li>\n<li>A recreation of patterns from early relationships</li>\n</ul>\n<p>Your job isn't to assume which of these is true—it's to explore with curiosity.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Specific Language for Common Situations</h2>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Chronic Lateness</h2>\n<p><strong>Opening:</strong> \"I've noticed a pattern I want to understand better. Over the past month, you've arrived 15-20 minutes late to each session. I'm not bringing this up to criticize you—I'm bringing it up because I want to understand what's happening, and because the lateness is affecting how much time we have together. Can we talk about it?\"</p>\n<p><strong>Exploring:</strong> \"What's your sense of what's happening? Do you notice the pattern too?\" \"What's going on when it gets close to our session time? Help me understand the experience.\" \"I wonder if the lateness might be telling us something about your relationship to therapy. What do you think?\"</p>\n<p><strong>Following through:</strong> \"Going forward, I'd like us to pay attention to this pattern together. If you're late, I may bring it up directly rather than just letting it go. And I'm curious—if you notice yourself running late, what's happening in that moment?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Missed Sessions/Cancellations</h2>\n<p><strong>Opening:</strong> \"You've cancelled or not shown up for several sessions recently. I want to make sure I understand what's happening. I'm not angry or trying to make you feel guilty—I'm genuinely concerned about how to help you when we're not meeting consistently.\"</p>\n<p><strong>Exploring:</strong> \"What's getting in the way of you being here?\" \"When you think about coming to session, what comes up?\" \"Sometimes people miss therapy when something about the therapy isn't working. I wonder if there's anything about our work together that's not feeling right?\"</p>\n<p><strong>Following through:</strong> \"We need to figure out how to move forward. If weekly sessions aren't sustainable right now, let's talk about that. But if we're going to continue, I need you here as consistently as possible.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Homework Non-Completion</h2>\n<p><strong>Opening:</strong> \"I've noticed that we've agreed on things to try between sessions several times now, and those things haven't happened. I'm curious about that. I'm not asking to criticize you—I'm asking because the between-session work is important for therapy to be effective.\"</p>\n<p><strong>Exploring:</strong> \"What happens when you think about the homework during the week?\" \"Is there something about the tasks themselves that doesn't feel right?\" \"Sometimes when people don't do therapy homework, it means the tasks aren't right for them, or something else is getting in the way. What's your sense?\"</p>\n<p><strong>Following through:</strong> \"Let's think together about what would actually be doable. I'd rather have you do something small consistently than agree to things that aren't happening.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>Payment Issues</h2>\n<p><strong>Opening:</strong> \"I want to talk about something I've been avoiding, which is your account balance. It's now [amount] past due. I know money can be uncomfortable to discuss, but this is affecting our work, and I'd rather talk about it directly than have it sit between us.\"</p>\n<p><strong>Exploring:</strong> \"What's happening with the bills? Is it a financial constraint, or something else?\" \"I wonder if there are feelings about paying for therapy that would be worth exploring.\" \"What would help us figure this out?\"</p>\n<p><strong>Following through:</strong> \"Let's make a plan. If the fee is genuinely too much right now, we can talk about that. But I need us to have an agreement we both stick to.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Showing Up Intoxicated</h2>\n<p><strong>Opening:</strong> \"I notice you seem like you may have been drinking before session today. I want to check in about that directly. Can you tell me what's happening?\"</p>\n<p><strong>Exploring:</strong> \"What led to drinking before session?\" \"This is the second time this has happened. What do you think that pattern is about?\" \"Showing up impaired makes it hard to do the work we're trying to do. What would help?\"</p>\n<p><strong>Following through:</strong> \"I can't work with you effectively when you're impaired. Going forward, if this happens, we'll need to reschedule rather than continue. And I want to talk more about what the drinking is about.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Between-Session Contact</h2>\n<p><strong>Opening:</strong> \"I've noticed that you've been calling/texting/emailing more frequently between sessions lately. I want to talk about that pattern—not to criticize you, but because I want to understand what's happening and because I think it might be important.\"</p>\n<p><strong>Exploring:</strong> \"What's coming up between sessions that leads to reaching out?\" \"What happens after you contact me? Does it help?\" \"I wonder if the between-session contact might be telling us something about what you need that we're not addressing in our sessions.\"</p>\n<p><strong>Following through:</strong> \"I care about you, and I also want to help you build your own capacity to manage difficult moments. Contacting me every time you're distressed doesn't actually build that capacity. Let's talk about what would.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Limit-Setting vs. Punishment</h2>\n<p>There's an important distinction between limit-setting and punishment:</p>\n<p><strong>Punishment</strong> is retaliatory and aims to cause discomfort: \"Since you missed two sessions, I'm not going to schedule you for three weeks.\"</p>\n<p><strong>Limit-setting</strong> maintains necessary structure while remaining collaborative: \"We need sessions to happen consistently for therapy to work. If you miss two sessions without 24 hours notice, we'll need to discuss whether this therapy format is working for you.\"</p>\n<p>Limits are about maintaining the conditions necessary for effective treatment. They're stated clearly and in advance. They're not designed to punish but to protect the therapy frame.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Natural Consequences vs. Imposed Consequences</h2>\n<p>Natural consequences flow directly from the behavior:</p>\n<ul>\n<li>If you're 20 minutes late, we have 20 fewer minutes to work.</li>\n<li>If you don't do the homework, we have less material to work with.</li>\n<li>If you don't pay, I can't continue providing services.</li>\n</ul>\n<p>Imposed consequences are penalties unrelated to the behavior:</p>\n<ul>\n<li>If you're late three times, I won't see you anymore.</li>\n<li>If you don't do homework, I'll give you more homework.</li>\n</ul>\n<p>Generally, natural consequences are more effective and less damaging to the relationship.</p>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Following Through</h2>\n<p>Addressing a treatment-interfering behavior once isn't enough. Following through is essential:</p>\n<p><strong>Consistency:</strong> Apply the same standard over time. If lateness matters, it matters every time.</p>\n<p><strong>Remembering:</strong> In subsequent sessions, check in: \"How did the week go with what we talked about?\"</p>\n<p><strong>Addressing recurrence:</strong> If the behavior continues, name that: \"I notice the same pattern is happening. Let's talk about what's getting in the way of change.\"</p>\n<p><strong>Adjusting if needed:</strong> If your approach isn't working, try something different. Maybe the agreed-upon solution wasn't right. Reassess collaboratively.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Treatment-Interfering Behaviors in Couples and Group Settings</h2>\n<p>Treatment-interfering behaviors take on added complexity in couples and group work, where a behavior affects not only the individual’s progress but the shared therapeutic space and the other members.</p>\n<h3>The Multiplied Stakes</h3>\n<p>In couples work, one partner’s lateness, disengagement, or between-session escalation affects the other partner and the couple’s fragile trust in the process. In group settings, behaviors such as monopolizing, chronic absence, side conversations, or hostility ripple outward, shaping safety and cohesion for everyone. The clinician must therefore weigh the individual’s needs against the group’s, and address behavior in a way that protects the shared space without scapegoating any one member.</p>\n<h3>Addressing It in the Room</h3>\n<p>The same curious, non-punitive stance applies, but the clinician also attends to the systemic meaning — what the behavior communicates about the couple’s dynamic or the group’s stage of development — and to the impact on others. Some conversations are best held individually to avoid shaming; others belong in the shared room because the behavior is the group’s to process. Judging which is which, and protecting the safety of all members while still addressing the behavior directly, is a distinctive skill of multi-person work.</p>",
+          "order": 19
+        },
+        {
+          "type": "text",
+          "content": "<h2>Culture, Context, and Limit-Setting</h2>\n<p>What counts as a treatment-interfering behavior, and how a limit is best set, is shaped by culture and context, and the clinician applies limits with {{callout:cultural-humility}} rather than as universal rules.</p>\n<h3>Reading Behavior in Context</h3>\n<p>Behaviors such as lateness, the involvement of family in decisions, expectations about between-session contact, or styles of emotional expression carry different meanings across cultures, and a behavior that looks “interfering” through one cultural lens may be ordinary or even respectful through another. Practical realities — unreliable transportation, inflexible work, caregiving demands, or financial strain — also produce behaviors that can be misread as resistance. The clinician assesses the meaning and the constraints before assuming the behavior is about the therapy.</p>\n<h3>Setting Limits With Humility</h3>\n<p>Limits remain necessary — the frame protects the work — but they are set collaboratively and with attention to the client’s context, distinguishing genuine treatment-interfering patterns from cultural difference or structural barrier. The clinician holds the boundary that the work requires while remaining curious about what the behavior means to this particular client, adjusting the practical frame where the obstacle is circumstantial rather than psychological.</p>",
+          "order": 20,
+          "callouts": {
+            "cultural-humility": {
+              "label": "Cultural Humility",
+              "type": "reference",
+              "body": "An ongoing, self-reflective stance of openness and learning about the client’s culture — distinct from “competence” as a fixed achievement — attentive to power and one’s own limits."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>When a Behavior Signals Risk</h2>\n<p>Some treatment-interfering behaviors are not merely frame issues but signals of risk, and the clinician must distinguish a boundary problem from a safety concern.</p>\n<h3>Reading the Signal</h3>\n<p>Showing up intoxicated, escalating between-session contact, sudden disengagement, or hostility can reflect ordinary ambivalence — or can mark deterioration, crisis, substance relapse, or danger. The clinician assesses rather than assumes, holding the behavior’s possible meanings open and attending to context: what else is happening in the client’s life, what the behavior departs from, what it might be communicating about a worsening state.</p>\n<h3>Responding to Both Frame and Safety</h3>\n<p>Where risk is present, the safety concern takes precedence over the frame issue: the clinician addresses the danger, mobilizes appropriate support, and documents carefully, while still — in time — understanding the behavior compassionately. The skill is in not collapsing the two, neither treating a safety signal as mere rule-breaking nor treating every frame violation as an emergency. Curious compassion and clear-eyed risk assessment operate together.</p>",
+          "order": 21
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documenting Difficult Conversations</h2>\n<p>Difficult conversations and the behaviors that prompt them belong in the clinical record, and documenting them well protects the client, the work, and the clinician.</p>\n<h3>What and How to Document</h3>\n<p>The clinician records the behavior or concern objectively, the conversation held, the client’s response, and any plan or agreement reached, in factual and non-pejorative language. Notes describe behavior rather than character — “arrived twenty minutes late to three of the last four sessions; discussed impact on the work; agreed to a later start time” — capturing the clinical reasoning without editorializing. Conversations about risk, limits, referral, or termination especially warrant clear documentation.</p>\n<h3>Why It Matters</h3>\n<p>Good documentation creates continuity, supports the clinical reasoning behind difficult decisions, and provides a record should questions later arise. It also disciplines the clinician’s own thinking, since articulating the behavior, the conversation, and the plan in writing clarifies whether the issue was addressed substantively or merely worried about. The record should reflect care and sound judgment, not blame.</p>",
+          "order": 22
+        },
+        {
+          "type": "callout",
+          "order": 23,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Treatment-Interfering Behavior in Context",
+          "content": "<p>Marcus, a 29-year-old graduate student, has been in therapy for depression for four months. His therapist, Dr. Williams, has noticed a pattern: Marcus agrees enthusiastically to between-session tasks but never completes them.</p>\n<p><strong>Session 14 - Addressing the Pattern:</strong></p>\n<p>Dr. Williams: \"Marcus, I want to bring up something I've noticed. Over the past two months, we've identified things to try between sessions maybe eight or ten times. Each time, you've seemed motivated and agreed they were good ideas. And each time, when you come back, they haven't happened. I'm not bringing this up to criticize you—I'm genuinely curious about what's happening.\"</p>\n<p>Marcus (defensive): \"I've been really busy. It's not like I'm not trying.\"</p>\n<p>Dr. Williams: \"I hear that. And I'm not questioning your effort. I'm more curious about the pattern. What happens when the week goes by? Do you think about the tasks?\"</p>\n<p>Marcus: \"Honestly? Not really. I mean, I think about them right after session, but then life takes over.\"</p>\n<p>Dr. Williams: \"So they don't stay present. That's helpful to know. I wonder if that tells us something. What's your sense?\"</p>\n<p>Marcus (pausing): \"I guess... maybe part of me doesn't really believe anything will help? Like, what's the point?\"</p>\n<p>Dr. Williams: \"That sounds important. The hopelessness about whether anything can help might make it hard to invest in trying things. Is that what depression does—makes it hard to believe effort will pay off?\"</p>\n<p>Marcus: \"Yeah. That's exactly it.\"</p>\n<p>Dr. Williams: \"So the homework non-completion isn't about being lazy or not caring—it's a symptom of the depression itself. That's useful to understand. And it puts us in a bind, right? The things that might help feel pointless, so they don't happen, so you don't get evidence that things can help.\"</p>\n<p>Marcus: \"Right.\"</p>\n<p>Dr. Williams: \"Let's think together about what might be different. What would help the between-session work actually happen?\"</p>\n<p>Notice how Dr. Williams:</p>\n<ul>\n<li>Named the pattern without judgment</li>\n<li>Explored with curiosity</li>\n<li>Discovered that the behavior was a symptom of the presenting problem</li>\n<li>Reframed understanding collaboratively</li>\n<li>Moved toward problem-solving together</li>\n</ul>"
+        },
+        {
+          "order": 24,
+          "type": "fillInBlank",
+          "title": "Quick check — the stance",
+          "blanks": [
+            {
+              "prompt": "Treatment-interfering behaviors are best understood not as misconduct but as a form of:",
+              "answer": "communication",
+              "acceptAlternates": [
+                "communicating"
+              ]
+            },
+            {
+              "prompt": "The recommended therapist stance toward them is curious:",
+              "answer": "compassion",
+              "acceptAlternates": [
+                "curious compassion"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 25,
+          "question": "The recommended stance for addressing treatment-interfering behaviors is:",
+          "options": [
+            {
+              "text": "Stern authority",
+              "isCorrect": true
+            },
+            {
+              "text": "Curious compassion",
+              "isCorrect": false
+            },
+            {
+              "text": "Detached objectivity",
+              "isCorrect": false
+            },
+            {
+              "text": "Sympathetic tolerance",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 26,
+          "question": "When a client is chronically late, the therapist should first:",
+          "options": [
+            {
+              "text": "Implement consequences immediately",
+              "isCorrect": true
+            },
+            {
+              "text": "Explore what the lateness might be communicating",
+              "isCorrect": false
+            },
+            {
+              "text": "Extend the session to make up the time",
+              "isCorrect": false
+            },
+            {
+              "text": "Reduce the fee proportionally",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 27,
+          "type": "multiSelect",
+          "question": "What distinguishes limit-setting from punishment? (Select all that apply)",
+          "options": [
+            {
+              "text": "Limits protect the work and the relationship; punishment expresses frustration",
+              "isCorrect": true
+            },
+            {
+              "text": "Limits are set collaboratively and transparently where possible",
+              "isCorrect": true
+            },
+            {
+              "text": "Limits rely on natural consequences rather than imposed penalties",
+              "isCorrect": true
+            },
+            {
+              "text": "Punishment is the recommended response to repeated lateness",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "Limit-setting protects the work, is collaborative and transparent, and favors natural over imposed consequences; punishment, driven by frustration, is not the therapeutic stance."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 28,
+          "question": "After addressing a treatment-interfering behavior, the therapist should:",
+          "options": [
+            {
+              "text": "Never mention it again",
+              "isCorrect": true
+            },
+            {
+              "text": "Follow through consistently and check in about changes",
+              "isCorrect": false
+            },
+            {
+              "text": "Wait for the client to bring it up",
+              "isCorrect": false
+            },
+            {
+              "text": "Document and move on",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 4,
-      title: `Module 4: CONVERSATIONS ABOUT PROGRESS AND TERMINATION`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 4: CONVERSATIONS ABOUT PROGRESS AND TERMINATION`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 4,
+      "order": 4,
+      "title": "Module 4: CONVERSATIONS ABOUT PROGRESS AND TERMINATION",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 4: CONVERSATIONS ABOUT PROGRESS AND TERMINATION",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 4
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Identify signs that treatment may not be progressing</li>\n<li>Initiate conversations about lack of progress using collaborative language</li>\n<li>Navigate termination discussions with honesty and appropriate referral</li>\n<li>Address situations where clients want to terminate prematurely</li>\n<li>Handle conversations about treatment failure with integrity</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Addressing Lack of Progress</h2>\n<p>One of the most avoided elephants is treatment that isn't working. We continue sessions week after week, even when symptoms aren't improving and functioning isn't changing. Why?</p>\n<ul>\n<li>We hope things will shift eventually</li>\n<li>We're not sure what else to try</li>\n<li>We don't want to discourage the client</li>\n<li>We feel like failures if treatment doesn't work</li>\n<li>We've invested time and care in this client</li>\n</ul>\n<p>But continuing ineffective treatment harms clients. It costs them time, money, and hope. It may prevent them from getting help that would actually work.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Signs of Insufficient Progress</h2>\n<p>Watch for these indicators:</p>\n<p><strong>Objective measures:</strong> Standardized assessment scores (PHQ-9, GAD-7, etc.) aren't improving or are worsening.</p>\n<p><strong>Subjective reports:</strong> Client reports same complaints session after session with no meaningful change.</p>\n<p><strong>Functioning:</strong> No improvement in work, relationships, daily activities, or self-care.</p>\n<p><strong>Same patterns repeating:</strong> You're having the same conversations repeatedly without movement.</p>\n<p><strong>Your gut:</strong> Something tells you this isn't working, even if you can't articulate exactly why.</p>\n<p><strong>Treatment length:</strong> The client has been in treatment longer than expected with less progress than expected.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Opening the Conversation</h2>\n<p>When progress isn't occurring, the conversation might go:</p>\n<p>\"I want to check in with you about how you feel our work is going. From my perspective, I've been noticing that despite our efforts, things don't seem to be shifting the way I'd hoped. Your depression scores are similar to when we started four months ago, and you're describing the same struggles. What's your sense?\"</p>\n<p>Key elements:</p>\n<ul>\n<li>Invites client perspective first</li>\n<li>Uses data (scores, time frame)</li>\n<li>Owns your observation (\"from my perspective\")</li>\n<li>Is honest without blaming</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Exploring Together</h2>\n<p>After opening, explore collaboratively:</p>\n<p>\"What do you think is getting in the way?\" \"Is there something about our approach that doesn't feel right for you?\" \"Are there things you've wanted to try that we haven't?\" \"Is something outside of therapy interfering that we haven't addressed?\"</p>\n<p>You're looking for:</p>\n<ul>\n<li>Diagnostic issues (missed diagnosis, comorbidity)</li>\n<li>Treatment match issues (wrong modality, wrong focus)</li>\n<li>External barriers (circumstances undermining progress)</li>\n<li>Therapeutic relationship issues (problems in the alliance)</li>\n<li>Client factors (ambivalence, secondary gain, not doing the work)</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Making Changes</h2>\n<p>Based on your exploration, changes might include:</p>\n<ul>\n<li>Reassessing the diagnosis</li>\n<li>Trying a different treatment approach</li>\n<li>Adding adjunctive treatment (medication, group, specialized service)</li>\n<li>Addressing barriers that have emerged</li>\n<li>Intensifying treatment</li>\n<li>Referring to a specialist</li>\n<li>Referring to a different therapist</li>\n</ul>\n<p>Some of these conversations are harder than others. Referring to a different therapist can feel like admitting failure. But sometimes the best thing for the client is someone else—different style, different specialty, better fit.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Measurement-Based Care: Catching Stalls Early</h2>\n<p>One reason a lack of progress goes unaddressed is that it goes unnoticed until it is severe. Measurement-based care — the routine use of brief validated measures to track symptoms and functioning — surfaces stalls early, while there is still time to adjust.</p>\n<h3>Making Progress Visible</h3>\n<p>Administering a short outcome or alliance measure at regular intervals gives both clinician and client an external read on whether the work is helping, rather than relying on impression alone. Flat or worsening scores become a shared, neutral piece of information — a prompt for the very conversation clinicians tend to avoid — and improving scores affirm the direction of the work. Tracking the alliance specifically can reveal strain the client has not voiced, opening the door to repair before a rupture deepens.</p>\n<h3>From Data to Conversation</h3>\n<p>The measure does not replace clinical judgment; it informs the conversation. “I’ve been looking at how things have been tracking, and I notice we haven’t seen much movement over the last several weeks — I’d like us to think together about that” turns a vague unease into a concrete, collaborative inquiry. Used transparently and with the client rather than on them, measurement-based care makes the progress conversation routine rather than confrontational.</p>",
+          "order": 8
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Discussing Termination</h2>\n<p>Termination conversations come in several varieties:</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Successful Termination</h2>\n<p>When treatment goals are met, termination is positive but still requires conversation:</p>\n<p>\"We've been working together for eight months, and I've noticed significant changes. Your depression scores are in the minimal range now, you're functioning well at work and in relationships, and you've developed solid coping skills. I'm wondering if it might be time to start thinking about wrapping up our work. What's your sense?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Therapist-Initiated Termination</h2>\n<p>Sometimes we need to end treatment, even when the client doesn't want to. This might be due to:</p>\n<ul>\n<li>Scope limitations (client needs something we don't provide)</li>\n<li>Countertransference that interferes with effectiveness</li>\n<li>Ethical issues (dual relationship emerging, etc.)</li>\n<li>Client needs that exceed our competence</li>\n<li>Persistent treatment-interfering behaviors</li>\n<li>Client deterioration requiring higher level of care</li>\n</ul>\n<p>Opening this conversation:</p>\n<p>\"I've been thinking a lot about our work together, and I've come to a difficult conclusion that I want to share with you honestly. I don't think I'm the right therapist for what you need right now. This isn't about you doing anything wrong—it's about making sure you get the best possible help.\"</p>\n<p>Essential elements:</p>\n<ul>\n<li>Clear explanation of reasoning</li>\n<li>Care for the client's emotional response</li>\n<li>Adequate notice (not sudden termination)</li>\n<li>Concrete referrals</li>\n<li>Transition support</li>\n<li>Leaving the door open when appropriate</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Client Wants to Terminate Prematurely</h2>\n<p>Sometimes clients want to end treatment before they're ready. This is delicate—clients have the right to end treatment, and we shouldn't be coercive. But we can be honest.</p>\n<p>\"I want to respect your decision about your own treatment—it's absolutely your choice. And I also want to share my honest perspective, which is that I'm concerned about ending now. You've made progress, and I worry that without continued support, some of that progress might be vulnerable. Can we talk about what's driving this decision?\"</p>\n<p>Explore:</p>\n<ul>\n<li>What's prompting the decision?</li>\n<li>Are there problems in the therapy we haven't addressed?</li>\n<li>Is there financial or logistical pressure?</li>\n<li>Is the client avoiding something?</li>\n<li>Is there something I've done that's made therapy feel unhelpful?</li>\n</ul>\n<p>Sometimes exploration resolves the issue. Sometimes the client has good reasons you hadn't understood. Sometimes they'll leave anyway. Your job is to make sure they're making an informed decision with all perspectives on the table.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>When Treatment Has Failed</h2>\n<p>Sometimes we need to acknowledge that treatment hasn't worked. This is humbling but important.</p>\n<p>\"I want to be honest with you about something. We've been working together for a year, and I don't see the progress I hoped for. I think I need to acknowledge that what we've been doing isn't working well enough for you. That's not your fault—it may be that my approach isn't the right fit, or that you need something I can't provide. But I don't want to keep going without acknowledging this.\"</p>\n<p>Then explore what's next—usually a referral to someone with different expertise or a different approach.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Termination Process: A Closer Look</h2>\n<p>Termination is itself a clinical intervention, not merely the administrative end of treatment, and handling it well can consolidate gains and provide a corrective experience of ending.</p>\n<h3>Ending as Part of the Work</h3>\n<p>Good termination is anticipated and prepared for rather than abrupt: the clinician names the approaching end, reviews the work and the client’s growth, anticipates challenges ahead and how the client will meet them, and leaves the door open for return. Spacing out final sessions can ease the transition. The clinician also attends to the meaning of ending for this particular client, since endings frequently activate earlier experiences of loss, abandonment, or relief.</p>\n<h3>Honoring What the Relationship Was</h3>\n<p>For many clients, the therapeutic relationship has been a uniquely safe and honest one, and ending it deserves acknowledgment rather than a brisk handshake. Naming what the work has meant, marking the client’s progress explicitly, and allowing space for the feelings the ending brings — gratitude, sadness, pride, ambivalence — turns termination into a final, integrating experience rather than a loose thread.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Processing the Emotional Meaning of Ending</h2>\n<p>Endings carry emotional weight for both client and clinician, and naming that weight is part of a good termination rather than a digression from it.</p>\n<h3>For the Client</h3>\n<p>Termination can stir grief, anxiety about managing alone, pride in progress, or relief, and for clients with histories of abrupt or painful endings it can reactivate old wounds. The clinician invites these feelings rather than rushing past them, framing the ending as an opportunity to experience a loss that is acknowledged, prepared for, and held with care — a different template from the endings the client may have known.</p>\n<h3>For the Clinician</h3>\n<p>Clinicians have feelings about endings too — attachment to clients, doubt about whether enough was accomplished, sadness, or relief — and these can quietly drive avoidance of the termination conversation or, conversely, a premature push toward the door. Recognizing one’s own reactions, ideally with consultation, keeps the clinician’s feelings from distorting the client’s ending and allows the clinician to be genuinely present for it.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "content": "<h2>Referral and Continuity of Care</h2>\n<p>When a client’s needs exceed what the clinician or the current treatment can provide, a thoughtful referral is an ethical obligation and itself a difficult conversation worth handling well.</p>\n<h3>Referring Without Abandoning</h3>\n<p>A referral can feel to a client like rejection, so the framing matters: the clinician presents it as a way to get the client the most appropriate help rather than as a dismissal, names the specific reason honestly and without blame, and stays involved enough to support a real handoff rather than a cold drop. Providing concrete options, helping the client navigate access, and — where appropriate and with consent — communicating with the receiving provider all protect continuity.</p>\n<h3>Protecting the Client Through the Gap</h3>\n<p>Continuity of care means the client is not left unsupported between providers. The clinician clarifies what to do in the interim, attends to any safety considerations, and avoids ending the relationship before the next is in place when the client’s needs require it. Done well, a referral conveys that the clinician is acting in the client’s interest, preserving trust even as the clinical relationship changes hands.</p>",
+          "order": 16
+        },
+        {
+          "type": "text",
+          "content": "<h2>Recognizing When You Are the Obstacle</h2>\n<p>When treatment stalls, the most uncomfortable possibility — and frequently the most important to consider — is that the clinician is part of what is stuck.</p>\n<h3>The Clinician’s Contribution</h3>\n<p>A lack of progress can reflect a poor fit between the clinician’s approach and the client’s needs, an unaddressed rupture the client has not voiced, the clinician’s own countertransference quietly steering the work, or simply the limits of the clinician’s competence with a particular issue. None of these is a moral failing, but all are easy to overlook because attending to them requires the clinician to question their own role rather than the client’s motivation.</p>\n<h3>Looking Honestly</h3>\n<p>Consultation, outcome and alliance measures, and direct inquiry with the client (“I want to check whether the way we’re working is fitting for you”) all help the clinician see their contribution. Sometimes the most therapeutic move is to name one’s own possible part in the stall, to adjust the approach, or to refer the client to someone better suited. The willingness to consider oneself as the obstacle — rather than reflexively locating the problem in the client — is a mark of clinical maturity.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Difficult Conversations About Diagnosis</h2>\n<p>Sharing or revisiting a diagnosis is among the more delicate difficult conversations, carrying weight for the client’s identity, hope, and self-understanding.</p>\n<h3>Holding Weight With Care</h3>\n<p>A diagnosis can land as relief, as stigma, as a life sentence, or as a long-awaited explanation, and the same words mean different things to different clients. The clinician shares diagnostic understanding honestly but with care — framing it as a useful description rather than a fixed identity, attending to the client’s reaction, and leaving room for the client’s own meaning-making. Where a prior diagnosis appears mistaken, revisiting it requires similar care, since the client may have built significant self-understanding around it.</p>\n<h3>Diagnosis as Collaboration</h3>\n<p>Presented well, a diagnostic conversation is collaborative rather than pronouncing: the clinician offers their formulation, invites the client’s perspective, and arrives at a shared understanding that serves the work. The aim is to give the client a framework that opens possibilities for help and self-understanding, not a label that forecloses them — which means attending as much to how the diagnosis is received as to its accuracy.</p>",
+          "order": 18
+        },
+        {
+          "type": "callout",
+          "order": 19,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Lack of Progress",
+          "content": "<p>Dr. Garcia has been seeing Robert, a 52-year-old man with depression, for eight months using cognitive-behavioral therapy. Despite consistent attendance and apparent engagement, Robert's depression has not improved.</p>\n<p><strong>Session 32 - Addressing Lack of Progress:</strong></p>\n<p>Dr. Garcia: \"Robert, I want to check in about how you're feeling about our work together. We've been meeting for eight months now, and I've been noticing something that concerns me.\"</p>\n<p>Robert: \"What's that?\"</p>\n<p>Dr. Garcia: \"Your PHQ-9 scores have stayed in the moderately severe range this whole time. When we started, you were at 17; last week you were at 16. And I hear you describing the same struggles—the low energy, the difficulty enjoying things, the sense of going through the motions. I guess I want to be honest that I hoped we'd see more movement by now. What's your sense of how things are going?\"</p>\n<p>Robert: \"I don't know. I guess I hoped I'd be better by now too. But I think therapy is helping. I feel like I understand more about why I'm depressed.\"</p>\n<p>Dr. Garcia: \"Understanding is valuable. And I'm not sure understanding alone is creating the change we're hoping for. I want to think with you about what might help things shift more. Are there things about our work that don't feel right? Or things we haven't addressed that might be important?\"</p>\n<p>Robert: \"I guess... I don't know if I've told you this, but I drink more than I probably should. A few drinks most nights. Maybe more than a few.\"</p>\n<p>Dr. Garcia: \"That feels important. You haven't mentioned that before. Can you tell me more?\"</p>\n<p>Robert: \"I guess I didn't want you to judge me. And I didn't think it was related to the depression.\"</p>\n<p>Dr. Garcia: \"I appreciate you telling me now. Alcohol is actually a depressant, and regular use can definitely maintain depression even when you're doing therapy. This might be a really important piece we've been missing.\"</p>\n<p>Notice how Dr. Garcia:</p>\n<ul>\n<li>Named the lack of progress directly</li>\n<li>Used data (PHQ-9 scores, time frame)</li>\n<li>Explored collaboratively</li>\n<li>Uncovered crucial missing information</li>\n<li>Didn't blame Robert for withholding</li>\n</ul>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 20,
+          "question": "When treatment isn't progressing, the therapist should:",
+          "options": [
+            {
+              "text": "Wait indefinitely for change to occur",
+              "isCorrect": true
             },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Identify signs that treatment may not be progressing</li>
-<li>Initiate conversations about lack of progress using collaborative language</li>
-<li>Navigate termination discussions with honesty and appropriate referral</li>
-<li>Address situations where clients want to terminate prematurely</li>
-<li>Handle conversations about treatment failure with integrity</li>
-</ol>`,
+            {
+              "text": "Address the lack of progress directly and explore reasons collaboratively",
+              "isCorrect": false
             },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Addressing Lack of Progress</h2>
-<p>One of the most avoided elephants is treatment that isn't working. We continue sessions week after week, even when symptoms aren't improving and functioning isn't changing. Why?</p>
-<ul>
-<li>We hope things will shift eventually</li>
-<li>We're not sure what else to try</li>
-<li>We don't want to discourage the client</li>
-<li>We feel like failures if treatment doesn't work</li>
-<li>We've invested time and care in this client</li>
-</ul>
-<p>But continuing ineffective treatment harms clients. It costs them time, money, and hope. It may prevent them from getting help that would actually work.</p>`,
+            {
+              "text": "Terminate immediately",
+              "isCorrect": false
             },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Signs of Insufficient Progress</h2>
-<p>Watch for these indicators:</p>
-<p><strong>Objective measures:</strong> Standardized assessment scores (PHQ-9, GAD-7, etc.) aren't improving or are worsening.</p>
-<p><strong>Subjective reports:</strong> Client reports same complaints session after session with no meaningful change.</p>
-<p><strong>Functioning:</strong> No improvement in work, relationships, daily activities, or self-care.</p>
-<p><strong>Same patterns repeating:</strong> You're having the same conversations repeatedly without movement.</p>
-<p><strong>Your gut:</strong> Something tells you this isn't working, even if you can't articulate exactly why.</p>
-<p><strong>Treatment length:</strong> The client has been in treatment longer than expected with less progress than expected.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Opening the Conversation</h2>
-<p>When progress isn't occurring, the conversation might go:</p>
-<p>"I want to check in with you about how you feel our work is going. From my perspective, I've been noticing that despite our efforts, things don't seem to be shifting the way I'd hoped. Your depression scores are similar to when we started four months ago, and you're describing the same struggles. What's your sense?"</p>
-<p>Key elements:</p>
-<ul>
-<li>Invites client perspective first</li>
-<li>Uses data (scores, time frame)</li>
-<li>Owns your observation ("from my perspective")</li>
-<li>Is honest without blaming</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Exploring Together</h2>
-<p>After opening, explore collaboratively:</p>
-<p>"What do you think is getting in the way?" "Is there something about our approach that doesn't feel right for you?" "Are there things you've wanted to try that we haven't?" "Is something outside of therapy interfering that we haven't addressed?"</p>
-<p>You're looking for:</p>
-<ul>
-<li>Diagnostic issues (missed diagnosis, comorbidity)</li>
-<li>Treatment match issues (wrong modality, wrong focus)</li>
-<li>External barriers (circumstances undermining progress)</li>
-<li>Therapeutic relationship issues (problems in the alliance)</li>
-<li>Client factors (ambivalence, secondary gain, not doing the work)</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Making Changes</h2>
-<p>Based on your exploration, changes might include:</p>
-<ul>
-<li>Reassessing the diagnosis</li>
-<li>Trying a different treatment approach</li>
-<li>Adding adjunctive treatment (medication, group, specialized service)</li>
-<li>Addressing barriers that have emerged</li>
-<li>Intensifying treatment</li>
-<li>Referring to a specialist</li>
-<li>Referring to a different therapist</li>
-</ul>
-<p>Some of these conversations are harder than others. Referring to a different therapist can feel like admitting failure. But sometimes the best thing for the client is someone else—different style, different specialty, better fit.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Discussing Termination</h2>
-<p>Termination conversations come in several varieties:</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Successful Termination</h2>
-<p>When treatment goals are met, termination is positive but still requires conversation:</p>
-<p>"We've been working together for eight months, and I've noticed significant changes. Your depression scores are in the minimal range now, you're functioning well at work and in relationships, and you've developed solid coping skills. I'm wondering if it might be time to start thinking about wrapping up our work. What's your sense?"</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Therapist-Initiated Termination</h2>
-<p>Sometimes we need to end treatment, even when the client doesn't want to. This might be due to:</p>
-<ul>
-<li>Scope limitations (client needs something we don't provide)</li>
-<li>Countertransference that interferes with effectiveness</li>
-<li>Ethical issues (dual relationship emerging, etc.)</li>
-<li>Client needs that exceed our competence</li>
-<li>Persistent treatment-interfering behaviors</li>
-<li>Client deterioration requiring higher level of care</li>
-</ul>
-<p>Opening this conversation:</p>
-<p>"I've been thinking a lot about our work together, and I've come to a difficult conclusion that I want to share with you honestly. I don't think I'm the right therapist for what you need right now. This isn't about you doing anything wrong—it's about making sure you get the best possible help."</p>
-<p>Essential elements:</p>
-<ul>
-<li>Clear explanation of reasoning</li>
-<li>Care for the client's emotional response</li>
-<li>Adequate notice (not sudden termination)</li>
-<li>Concrete referrals</li>
-<li>Transition support</li>
-<li>Leaving the door open when appropriate</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Client Wants to Terminate Prematurely</h2>
-<p>Sometimes clients want to end treatment before they're ready. This is delicate—clients have the right to end treatment, and we shouldn't be coercive. But we can be honest.</p>
-<p>"I want to respect your decision about your own treatment—it's absolutely your choice. And I also want to share my honest perspective, which is that I'm concerned about ending now. You've made progress, and I worry that without continued support, some of that progress might be vulnerable. Can we talk about what's driving this decision?"</p>
-<p>Explore:</p>
-<ul>
-<li>What's prompting the decision?</li>
-<li>Are there problems in the therapy we haven't addressed?</li>
-<li>Is there financial or logistical pressure?</li>
-<li>Is the client avoiding something?</li>
-<li>Is there something I've done that's made therapy feel unhelpful?</li>
-</ul>
-<p>Sometimes exploration resolves the issue. Sometimes the client has good reasons you hadn't understood. Sometimes they'll leave anyway. Your job is to make sure they're making an informed decision with all perspectives on the table.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>When Treatment Has Failed</h2>
-<p>Sometimes we need to acknowledge that treatment hasn't worked. This is humbling but important.</p>
-<p>"I want to be honest with you about something. We've been working together for a year, and I don't see the progress I hoped for. I think I need to acknowledge that what we've been doing isn't working well enough for you. That's not your fault—it may be that my approach isn't the right fit, or that you need something I can't provide. But I don't want to keep going without acknowledging this."</p>
-<p>Then explore what's next—usually a referral to someone with different expertise or a different approach.</p>`,
-            },
-{
-              type: "callout",
-              order: 13,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Lack of Progress`,
-              content: `<p>Dr. Garcia has been seeing Robert, a 52-year-old man with depression, for eight months using cognitive-behavioral therapy. Despite consistent attendance and apparent engagement, Robert's depression has not improved.</p>
-<p><strong>Session 32 - Addressing Lack of Progress:</strong></p>
-<p>Dr. Garcia: "Robert, I want to check in about how you're feeling about our work together. We've been meeting for eight months now, and I've been noticing something that concerns me."</p>
-<p>Robert: "What's that?"</p>
-<p>Dr. Garcia: "Your PHQ-9 scores have stayed in the moderately severe range this whole time. When we started, you were at 17; last week you were at 16. And I hear you describing the same struggles—the low energy, the difficulty enjoying things, the sense of going through the motions. I guess I want to be honest that I hoped we'd see more movement by now. What's your sense of how things are going?"</p>
-<p>Robert: "I don't know. I guess I hoped I'd be better by now too. But I think therapy is helping. I feel like I understand more about why I'm depressed."</p>
-<p>Dr. Garcia: "Understanding is valuable. And I'm not sure understanding alone is creating the change we're hoping for. I want to think with you about what might help things shift more. Are there things about our work that don't feel right? Or things we haven't addressed that might be important?"</p>
-<p>Robert: "I guess... I don't know if I've told you this, but I drink more than I probably should. A few drinks most nights. Maybe more than a few."</p>
-<p>Dr. Garcia: "That feels important. You haven't mentioned that before. Can you tell me more?"</p>
-<p>Robert: "I guess I didn't want you to judge me. And I didn't think it was related to the depression."</p>
-<p>Dr. Garcia: "I appreciate you telling me now. Alcohol is actually a depressant, and regular use can definitely maintain depression even when you're doing therapy. This might be a really important piece we've been missing."</p>
-<p>Notice how Dr. Garcia:</p>
-<ul>
-<li>Named the lack of progress directly</li>
-<li>Used data (PHQ-9 scores, time frame)</li>
-<li>Explored collaboratively</li>
-<li>Uncovered crucial missing information</li>
-<li>Didn't blame Robert for withholding</li>
-</ul>`,
-            },
-{
-              type: "multipleChoice",
-              order: 14,
-              question: `When treatment isn't progressing, the therapist should:`,
-              options: [
-                { text: `Wait indefinitely for change to occur`, isCorrect: true },
-                { text: `Address the lack of progress directly and explore reasons collaboratively`, isCorrect: false },
-                { text: `Terminate immediately`, isCorrect: false },
-                { text: `Avoid the topic to protect the client's hope`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 15,
-              question: `Signs that treatment may not be effective include:`,
-              options: [
-                { text: `Client expressing occasional frustration`, isCorrect: true },
-                { text: `Standardized scores not improving and same patterns repeating`, isCorrect: false },
-                { text: `Client questioning the therapist's approach`, isCorrect: false },
-                { text: `Normal therapeutic challenges`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 16,
-              question: `When a client wants to terminate prematurely, the therapist should:`,
-              options: [
-                { text: `Accept immediately without discussion`, isCorrect: true },
-                { text: `Refuse to allow termination`, isCorrect: false },
-                { text: `Share honest concerns while respecting client autonomy`, isCorrect: false },
-                { text: `Express disappointment in the client`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 17,
-              question: `Therapist-initiated termination is appropriate when:`,
-              options: [
-                { text: `The client is difficult to work with`, isCorrect: true },
-                { text: `The therapist needs the caseload slot`, isCorrect: false },
-                { text: `The client needs services outside the therapist's competence`, isCorrect: false },
-                { text: `The client disagrees with the therapist`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 18,
-              question: `When treatment has failed, the ethical response is to:`,
-              options: [
-                { text: `Continue the same approach indefinitely`, isCorrect: true },
-                { text: `Blame the client for lack of progress`, isCorrect: false },
-                { text: `Acknowledge the failure honestly and explore alternatives including referral`, isCorrect: false },
-                { text: `Pretend progress is occurring`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+            {
+              "text": "Avoid the topic to protect the client's hope",
+              "isCorrect": false
             }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 21,
+          "type": "multiSelect",
+          "question": "Which can be signs that treatment may not be progressing? (Select all that apply)",
+          "options": [
+            {
+              "text": "Flat or worsening outcome measures over time",
+              "isCorrect": true
+            },
+            {
+              "text": "Recurring sessions that feel stuck or repetitive",
+              "isCorrect": true
+            },
+            {
+              "text": "The client’s goals no longer seem to be moving",
+              "isCorrect": true
+            },
+            {
+              "text": "A single difficult session early in treatment",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "Stalled measures, a persistent stuck quality, and goals that stop moving can all signal a lack of progress; a single hard session is not by itself a sign of ineffective treatment."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 22,
+          "question": "When a client wants to terminate prematurely, the therapist should:",
+          "options": [
+            {
+              "text": "Accept immediately without discussion",
+              "isCorrect": true
+            },
+            {
+              "text": "Refuse to allow termination",
+              "isCorrect": false
+            },
+            {
+              "text": "Share honest concerns while respecting client autonomy",
+              "isCorrect": false
+            },
+            {
+              "text": "Express disappointment in the client",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 23,
+          "question": "Therapist-initiated termination is appropriate when:",
+          "options": [
+            {
+              "text": "The client is difficult to work with",
+              "isCorrect": true
+            },
+            {
+              "text": "The therapist needs the caseload slot",
+              "isCorrect": false
+            },
+            {
+              "text": "The client needs services outside the therapist's competence",
+              "isCorrect": false
+            },
+            {
+              "text": "The client disagrees with the therapist",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 24,
+          "question": "When treatment has failed, the ethical response is to:",
+          "options": [
+            {
+              "text": "Continue the same approach indefinitely",
+              "isCorrect": true
+            },
+            {
+              "text": "Blame the client for lack of progress",
+              "isCorrect": false
+            },
+            {
+              "text": "Acknowledge the failure honestly and explore alternatives including referral",
+              "isCorrect": false
+            },
+            {
+              "text": "Pretend progress is occurring",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 5,
-      title: `Module 5: NAVIGATING CULTURE, IDENTITY, AND POWER`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 5: NAVIGATING CULTURE, IDENTITY, AND POWER`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 5,
+      "order": 5,
+      "title": "Module 5: NAVIGATING CULTURE, IDENTITY, AND POWER",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 5: NAVIGATING CULTURE, IDENTITY, AND POWER",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 5
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Identify common elephants related to cultural difference and power</li>\n<li>Apply cultural humility principles to conversations about identity</li>\n<li>Use specific language to open discussions about racial and cultural dynamics</li>\n<li>Respond non-defensively to feedback about cultural missteps</li>\n<li>Name power dynamics in service of the therapeutic relationship</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>The Elephants of Difference</h2>\n<p>Some of the most common—and most avoided—elephants involve identity, culture, and power. These conversations require particular care because of historical harm, ongoing systemic issues, and real power differentials.</p>\n<p>Common avoided topics include:</p>\n<p><strong>Racial difference:</strong> The fact that therapist and client come from different racial backgrounds, and what that might mean for the therapy.</p>\n<p><strong>Cultural disconnection:</strong> The sense that we're missing something about the client's cultural context, values, worldview, or experience.</p>\n<p><strong>Socioeconomic disparity:</strong> The gap between therapist's class position and client's, and how that shapes understanding and access.</p>\n<p><strong>Religious or spiritual differences:</strong> When client's religious beliefs or practices differ significantly from therapist's.</p>\n<p><strong>Gender, sexuality, and identity:</strong> When these dimensions differ between therapist and client in ways that may affect understanding.</p>\n<p><strong>Immigration and documentation status:</strong> When this is part of the client's experience and creates particular vulnerabilities.</p>\n<p><strong>Disability:</strong> When physical or cognitive differences are present and unaddressed.</p>\n<p><strong>Microaggressions:</strong> Times when we may have committed a microaggression, or times when the client has said something problematic.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Why These Are Particularly Difficult</h2>\n<p>These elephants carry extra weight because:</p>\n<p><strong>History:</strong> There are long histories of harm—oppression, discrimination, cultural imperialism—that provide context for these conversations.</p>\n<p><strong>Ongoing harm:</strong> These aren't just historical issues. Racism, discrimination, and marginalization continue to affect clients' lives.</p>\n<p><strong>Power:</strong> Therapists typically hold power in the therapeutic relationship, and this power may be amplified by other forms of privilege.</p>\n<p><strong>Fear of making it worse:</strong> Many therapists, particularly those from dominant groups, fear that naming difference will be offensive, will center themselves, or will damage the relationship.</p>\n<p><strong>Lack of training:</strong> Many therapists received little training in having these conversations skillfully.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Cultural Humility as Framework</h2>\n<p>Cultural humility provides a framework for approaching these conversations. Developed by Tervalon and Murray-García, cultural humility involves:</p>\n<p><strong>Lifelong learning and self-reflection:</strong> Recognizing that we never \"arrive\" at cultural competence. We're always learning, always examining our biases, always developing.</p>\n<p><strong>Recognizing and challenging power imbalances:</strong> Being aware of how power operates in our relationships and actively working to address it.</p>\n<p><strong>Institutional accountability:</strong> Working to address systemic issues, not just individual interactions.</p>\n<p><strong>Client as expert:</strong> Positioning ourselves as learners about the client's experience, rather than experts on their culture.</p>\n<p>Cultural humility differs from \"cultural competence\" in important ways. Competence implies mastery—that we can learn enough about various cultures to be \"competent\" with any client. Humility recognizes that each client's cultural experience is unique, that we can never fully understand another's experience, and that ongoing learning and self-examination are required.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Opening Conversations About Difference</h2>\n<p>When racial or cultural difference is an elephant in the room, naming it can create relief and open important territory. Here are language patterns for different situations:</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Naming Racial Difference</h2>\n<p>\"I'm aware that I'm a white therapist and you're a Black man, and I want to acknowledge that this difference is real and might affect our work. I don't want to pretend not to notice. I'm curious whether you've had thoughts about working with a white therapist, and whether there are things I should know about how to be helpful to you.\"</p>\n<p>Key elements:</p>\n<ul>\n<li>Names the specific difference</li>\n<li>Acknowledges potential impact</li>\n<li>Invites client's perspective</li>\n<li>Positions yourself as learner</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Acknowledging Limits of Understanding</h2>\n<p>\"You're describing experiences with discrimination that I haven't experienced personally. I want to understand as best I can, but I also want to acknowledge the limits of my understanding. Please tell me when I'm missing something or when my responses don't feel right.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Checking for Cultural Fit</h2>\n<p>\"We come from different cultural backgrounds, and I want to make sure I'm understanding your experience through your cultural lens, not just through mine. Are there cultural values or perspectives that are important to you that I should know about?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Naming Privilege</h2>\n<p>\"I'm aware of the privilege I carry as someone who hasn't faced the kind of discrimination you're describing. I don't want that privilege to make me blind to your experience. I want to learn from you and be careful not to minimize what you've faced.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Inviting Ongoing Feedback</h2>\n<p>\"I want to create space for you to tell me if I say or do something that doesn't land right culturally. I'd rather you tell me and let me learn than have it sit between us.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Responding to Feedback About Missteps</h2>\n<p>Despite our best efforts, we will make cultural missteps. We'll say things that land wrong, miss important dimensions of the client's experience, commit microaggressions. How we respond to feedback matters enormously.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>What Not to Do</h2>\n<p><strong>Don't become defensive:</strong> \"That's not what I meant\" or \"I didn't intend to be offensive\" centers your intention rather than the client's experience.</p>\n<p><strong>Don't explain away:</strong> Long explanations of what you really meant come across as minimizing the impact.</p>\n<p><strong>Don't require the client to comfort you:</strong> Your guilt or discomfort shouldn't become their burden.</p>\n<p><strong>Don't challenge their perception:</strong> \"I don't think that was racist\" denies their experience.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>What to Do</h2>\n<p><strong>Listen fully before responding.</strong> Let the client finish. Don't interrupt to defend.</p>\n<p><strong>Thank them for the feedback.</strong> \"Thank you for telling me that. I appreciate you being willing to share that with me.\"</p>\n<p><strong>Acknowledge the impact.</strong> \"I can hear that what I said landed as dismissive of your experience.\"</p>\n<p><strong>Don't excuse with intention.</strong> \"That wasn't my intent, but intent doesn't erase impact.\"</p>\n<p><strong>Commit to doing better.</strong> \"I want to be more careful about that going forward.\"</p>\n<p><strong>Follow through.</strong> Actually do better. Bring it up again if relevant.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Example Response</h2>\n<p>Client: \"You know, when you said that thing about my neighborhood, it felt like a stereotype. Like you don't expect much from people who live there.\"</p>\n<p>Therapist: \"Thank you for telling me that. I can hear that what I said landed as stereotyping—like I have assumptions about your neighborhood that I'm applying to you. I'm sorry. That wasn't what I intended, but I hear how it came across, and that matters more than my intention. I want to be more careful about assumptions I might carry.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Naming Power Dynamics</h2>\n<p>Power is always present in the therapeutic relationship. The therapist has positional power (the one with the license, the one defining the frame), knowledge power (expertise about mental health), and often other forms of privilege.</p>\n<p>Naming power can be helpful:</p>\n<p>\"I want to acknowledge something about our relationship. I'm the one with the license, the one writing the notes, the one setting the frame. That gives me a kind of power in our relationship. I want us to be aware of that power and think together about how it shows up and how to navigate it in ways that serve you.\"</p>\n<p>\"You're navigating multiple systems right now—child welfare, legal, and now mental health. Each of those puts you in a one-down position. I'm aware that I'm another person in a system with power over you. I want to be different where I can.\"</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Intersectionality in the Therapy Dyad</h2>\n<p>Difference in the therapy room is rarely a single dimension. Clinician and client each hold multiple identities — race, gender, class, sexuality, disability, religion, immigration status — and these intersect to shape the relationship in ways no single category captures.</p>\n<h3>Multiple Differences at Once</h3>\n<p>A given dyad may share some identities while differing on others, and the salient difference may shift across the work. A clinician who shares a client’s race but differs in class, or shares gender but differs in religion, holds a mixed position of connection and distance. Power, too, is distributed unevenly across these dimensions — the clinician holds professional authority, but the client may hold social advantages the clinician does not. Treating difference as a single axis misses this complexity.</p>\n<h3>Holding Complexity With Humility</h3>\n<p>Rather than trying to master every dimension, the clinician stays curious about how this particular client’s intersecting identities shape their experience, including their experience of the therapy and of the clinician. This means remaining open to the client’s own account of what matters, noticing one’s assumptions, and recognizing that the relationship’s dynamics of connection and power are layered rather than reducible to any one difference.</p>",
+          "order": 17
+        },
+        {
+          "type": "text",
+          "content": "<h2>Microaggressions, Repair, and Earned Trust</h2>\n<p>Even well-intentioned clinicians commit microaggressions — subtle slights or invalidations that communicate bias — and how the clinician responds when this happens shapes whether trust is damaged or, paradoxically, strengthened.</p>\n<h3>When You Get It Wrong</h3>\n<p>A microaggression in session — an assumption, a dismissive response to a client’s experience of discrimination, a moment of defensiveness — can rupture the alliance, particularly for clients who carry histories of being misunderstood or harmed in helping relationships. The damage is compounded when the clinician, confronted, becomes defensive, minimizes, or centers their own intentions over the client’s experience.</p>\n<h3>Repair That Builds Trust</h3>\n<p>The repair that works does the opposite: the clinician listens non-defensively, takes the feedback seriously without demanding reassurance, acknowledges the impact regardless of intent, and demonstrates changed behavior over time. Handled this way, a misstep can become a corrective experience — evidence that this relationship can absorb a rupture around difference and survive it. Trust across difference is not assumed; it is earned, frequently precisely through the honest repair of inevitable mistakes.</p>",
+          "order": 18
+        },
+        {
+          "type": "text",
+          "content": "<h2>When the Clinician Holds Less Social Power</h2>\n<p>Discussions of power in therapy frequently assume the clinician holds more of it, but the picture is more complex: the clinician holds professional authority while the client may hold social advantages the clinician lacks.</p>\n<h3>A More Honest Map of Power</h3>\n<p>A clinician may be younger, from a marginalized group, an immigrant, or of lower social status than a client who holds racial, economic, or institutional privilege. The clinician retains the authority of the role, but the dynamics of the room are shaped by both — and a client may, consciously or not, draw on social power in ways that affect the work, from subtle dismissiveness to overt challenge to the clinician’s competence or belonging.</p>\n<h3>Holding the Role With Steadiness</h3>\n<p>The clinician’s task is to hold their professional authority and the frame steadily without either overcompensating through rigidity or collapsing into deference, while remaining honest about the layered power in the room. Naming difference and power remains appropriate, but the clinician does so from a clear-eyed sense that power is distributed across several dimensions, not concentrated simply on the professional side of the dyad.</p>",
+          "order": 19
+        },
+        {
+          "type": "callout",
+          "order": 20,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Navigating Cultural Difference",
+          "content": "<p>Dr. Okonkwo, a Black female therapist, has been working with Maria, a first-generation Mexican-American woman, for three months. Maria has mentioned her family's immigration story several times but always briefly, and Dr. Okonkwo senses there's more that isn't being said.</p>\n<p><strong>Session 12 - Opening the Conversation:</strong></p>\n<p>Dr. Okonkwo: \"Maria, I've noticed that when your family's immigration comes up, you mention it briefly and then move on. I want to check in about that. I don't want to push into anything you're not ready to discuss, and I also don't want you to feel like that part of your experience isn't welcome here. What feels right to you?\"</p>\n<p>Maria: \"I guess... I don't know if you'd understand. It's a Mexican thing.\"</p>\n<p>Dr. Okonkwo: \"I appreciate you being honest about that. You're right that I don't share your specific cultural experience. I can't fully understand what it's like to be from a Mexican-American family with that immigration history. And I want to learn, if you're willing to teach me. But I also understand if you'd prefer working with someone who shares that background.\"</p>\n<p>Maria: \"No, it's not that. I like working with you. I guess I just assume people don't get it.\"</p>\n<p>Dr. Okonkwo: \"That makes sense. You've probably had a lot of experiences of people not getting it. I want to try to get it as best I can, knowing I'll have limits. And I want you to tell me when I'm missing something. Can we agree that you'll let me know when I say something that doesn't land right or when I'm not understanding something important?\"</p>\n<p>Maria: \"Okay. That helps actually. Just knowing you want to understand.\"</p>\n<p>Dr. Okonkwo: \"I do want to understand. Tell me more about your family's immigration story, if you're open to it.\"</p>"
+        },
+        {
+          "order": 21,
+          "type": "multiSelect",
+          "question": "How does cultural humility differ from cultural competence? (Select all that apply)",
+          "options": [
+            {
+              "text": "It is an ongoing, lifelong stance rather than a fixed achievement",
+              "isCorrect": true
             },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Identify common elephants related to cultural difference and power</li>
-<li>Apply cultural humility principles to conversations about identity</li>
-<li>Use specific language to open discussions about racial and cultural dynamics</li>
-<li>Respond non-defensively to feedback about cultural missteps</li>
-<li>Name power dynamics in service of the therapeutic relationship</li>
-</ol>`,
+            {
+              "text": "It emphasizes self-reflection and openness to the client as expert on their experience",
+              "isCorrect": true
             },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>The Elephants of Difference</h2>
-<p>Some of the most common—and most avoided—elephants involve identity, culture, and power. These conversations require particular care because of historical harm, ongoing systemic issues, and real power differentials.</p>
-<p>Common avoided topics include:</p>
-<p><strong>Racial difference:</strong> The fact that therapist and client come from different racial backgrounds, and what that might mean for the therapy.</p>
-<p><strong>Cultural disconnection:</strong> The sense that we're missing something about the client's cultural context, values, worldview, or experience.</p>
-<p><strong>Socioeconomic disparity:</strong> The gap between therapist's class position and client's, and how that shapes understanding and access.</p>
-<p><strong>Religious or spiritual differences:</strong> When client's religious beliefs or practices differ significantly from therapist's.</p>
-<p><strong>Gender, sexuality, and identity:</strong> When these dimensions differ between therapist and client in ways that may affect understanding.</p>
-<p><strong>Immigration and documentation status:</strong> When this is part of the client's experience and creates particular vulnerabilities.</p>
-<p><strong>Disability:</strong> When physical or cognitive differences are present and unaddressed.</p>
-<p><strong>Microaggressions:</strong> Times when we may have committed a microaggression, or times when the client has said something problematic.</p>`,
+            {
+              "text": "It attends to power imbalances in the relationship",
+              "isCorrect": true
             },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Why These Are Particularly Difficult</h2>
-<p>These elephants carry extra weight because:</p>
-<p><strong>History:</strong> There are long histories of harm—oppression, discrimination, cultural imperialism—that provide context for these conversations.</p>
-<p><strong>Ongoing harm:</strong> These aren't just historical issues. Racism, discrimination, and marginalization continue to affect clients' lives.</p>
-<p><strong>Power:</strong> Therapists typically hold power in the therapeutic relationship, and this power may be amplified by other forms of privilege.</p>
-<p><strong>Fear of making it worse:</strong> Many therapists, particularly those from dominant groups, fear that naming difference will be offensive, will center themselves, or will damage the relationship.</p>
-<p><strong>Lack of training:</strong> Many therapists received little training in having these conversations skillfully.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Cultural Humility as Framework</h2>
-<p>Cultural humility provides a framework for approaching these conversations. Developed by Tervalon and Murray-García, cultural humility involves:</p>
-<p><strong>Lifelong learning and self-reflection:</strong> Recognizing that we never "arrive" at cultural competence. We're always learning, always examining our biases, always developing.</p>
-<p><strong>Recognizing and challenging power imbalances:</strong> Being aware of how power operates in our relationships and actively working to address it.</p>
-<p><strong>Institutional accountability:</strong> Working to address systemic issues, not just individual interactions.</p>
-<p><strong>Client as expert:</strong> Positioning ourselves as learners about the client's experience, rather than experts on their culture.</p>
-<p>Cultural humility differs from "cultural competence" in important ways. Competence implies mastery—that we can learn enough about various cultures to be "competent" with any client. Humility recognizes that each client's cultural experience is unique, that we can never fully understand another's experience, and that ongoing learning and self-examination are required.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Opening Conversations About Difference</h2>
-<p>When racial or cultural difference is an elephant in the room, naming it can create relief and open important territory. Here are language patterns for different situations:</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Naming Racial Difference</h2>
-<p>"I'm aware that I'm a white therapist and you're a Black man, and I want to acknowledge that this difference is real and might affect our work. I don't want to pretend not to notice. I'm curious whether you've had thoughts about working with a white therapist, and whether there are things I should know about how to be helpful to you."</p>
-<p>Key elements:</p>
-<ul>
-<li>Names the specific difference</li>
-<li>Acknowledges potential impact</li>
-<li>Invites client's perspective</li>
-<li>Positions yourself as learner</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Acknowledging Limits of Understanding</h2>
-<p>"You're describing experiences with discrimination that I haven't experienced personally. I want to understand as best I can, but I also want to acknowledge the limits of my understanding. Please tell me when I'm missing something or when my responses don't feel right."</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Checking for Cultural Fit</h2>
-<p>"We come from different cultural backgrounds, and I want to make sure I'm understanding your experience through your cultural lens, not just through mine. Are there cultural values or perspectives that are important to you that I should know about?"</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Naming Privilege</h2>
-<p>"I'm aware of the privilege I carry as someone who hasn't faced the kind of discrimination you're describing. I don't want that privilege to make me blind to your experience. I want to learn from you and be careful not to minimize what you've faced."</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Inviting Ongoing Feedback</h2>
-<p>"I want to create space for you to tell me if I say or do something that doesn't land right culturally. I'd rather you tell me and let me learn than have it sit between us."</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Responding to Feedback About Missteps</h2>
-<p>Despite our best efforts, we will make cultural missteps. We'll say things that land wrong, miss important dimensions of the client's experience, commit microaggressions. How we respond to feedback matters enormously.</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>What Not to Do</h2>
-<p><strong>Don't become defensive:</strong> "That's not what I meant" or "I didn't intend to be offensive" centers your intention rather than the client's experience.</p>
-<p><strong>Don't explain away:</strong> Long explanations of what you really meant come across as minimizing the impact.</p>
-<p><strong>Don't require the client to comfort you:</strong> Your guilt or discomfort shouldn't become their burden.</p>
-<p><strong>Don't challenge their perception:</strong> "I don't think that was racist" denies their experience.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>What to Do</h2>
-<p><strong>Listen fully before responding.</strong> Let the client finish. Don't interrupt to defend.</p>
-<p><strong>Thank them for the feedback.</strong> "Thank you for telling me that. I appreciate you being willing to share that with me."</p>
-<p><strong>Acknowledge the impact.</strong> "I can hear that what I said landed as dismissive of your experience."</p>
-<p><strong>Don't excuse with intention.</strong> "That wasn't my intent, but intent doesn't erase impact."</p>
-<p><strong>Commit to doing better.</strong> "I want to be more careful about that going forward."</p>
-<p><strong>Follow through.</strong> Actually do better. Bring it up again if relevant.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Example Response</h2>
-<p>Client: "You know, when you said that thing about my neighborhood, it felt like a stereotype. Like you don't expect much from people who live there."</p>
-<p>Therapist: "Thank you for telling me that. I can hear that what I said landed as stereotyping—like I have assumptions about your neighborhood that I'm applying to you. I'm sorry. That wasn't what I intended, but I hear how it came across, and that matters more than my intention. I want to be more careful about assumptions I might carry."</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Naming Power Dynamics</h2>
-<p>Power is always present in the therapeutic relationship. The therapist has positional power (the one with the license, the one defining the frame), knowledge power (expertise about mental health), and often other forms of privilege.</p>
-<p>Naming power can be helpful:</p>
-<p>"I want to acknowledge something about our relationship. I'm the one with the license, the one writing the notes, the one setting the frame. That gives me a kind of power in our relationship. I want us to be aware of that power and think together about how it shows up and how to navigate it in ways that serve you."</p>
-<p>"You're navigating multiple systems right now—child welfare, legal, and now mental health. Each of those puts you in a one-down position. I'm aware that I'm another person in a system with power over you. I want to be different where I can."</p>`,
-            },
-{
-              type: "callout",
-              order: 17,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Navigating Cultural Difference`,
-              content: `<p>Dr. Okonkwo, a Black female therapist, has been working with Maria, a first-generation Mexican-American woman, for three months. Maria has mentioned her family's immigration story several times but always briefly, and Dr. Okonkwo senses there's more that isn't being said.</p>
-<p><strong>Session 12 - Opening the Conversation:</strong></p>
-<p>Dr. Okonkwo: "Maria, I've noticed that when your family's immigration comes up, you mention it briefly and then move on. I want to check in about that. I don't want to push into anything you're not ready to discuss, and I also don't want you to feel like that part of your experience isn't welcome here. What feels right to you?"</p>
-<p>Maria: "I guess... I don't know if you'd understand. It's a Mexican thing."</p>
-<p>Dr. Okonkwo: "I appreciate you being honest about that. You're right that I don't share your specific cultural experience. I can't fully understand what it's like to be from a Mexican-American family with that immigration history. And I want to learn, if you're willing to teach me. But I also understand if you'd prefer working with someone who shares that background."</p>
-<p>Maria: "No, it's not that. I like working with you. I guess I just assume people don't get it."</p>
-<p>Dr. Okonkwo: "That makes sense. You've probably had a lot of experiences of people not getting it. I want to try to get it as best I can, knowing I'll have limits. And I want you to tell me when I'm missing something. Can we agree that you'll let me know when I say something that doesn't land right or when I'm not understanding something important?"</p>
-<p>Maria: "Okay. That helps actually. Just knowing you want to understand."</p>
-<p>Dr. Okonkwo: "I do want to understand. Tell me more about your family's immigration story, if you're open to it."</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 18,
-              question: `Cultural humility differs from cultural competence in that:`,
-              options: [
-                { text: `Cultural humility assumes mastery is possible`, isCorrect: true },
-                { text: `Cultural humility recognizes ongoing learning and the client as expert on their own experience`, isCorrect: false },
-                { text: `Cultural humility is less important than cultural competence`, isCorrect: false },
-                { text: `They are essentially the same concept`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 19,
-              question: `When naming racial difference, the therapist should:`,
-              options: [
-                { text: `Pretend not to notice to avoid making the client uncomfortable`, isCorrect: true },
-                { text: `Name the difference and invite the client's perspective`, isCorrect: false },
-                { text: `Assume the client wants a therapist of their own race`, isCorrect: false },
-                { text: `Wait for the client to bring it up`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 20,
-              question: `When receiving feedback about a cultural misstep, the therapist should:`,
-              options: [
-                { text: `Defend their intentions immediately`, isCorrect: true },
-                { text: `Explain what they really meant`, isCorrect: false },
-                { text: `Thank the client, acknowledge impact, and commit to doing better`, isCorrect: false },
-                { text: `Challenge the client's perception`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 21,
-              question: `Naming power dynamics in therapy:`,
-              options: [
-                { text: `Is inappropriate and destabilizing`, isCorrect: true },
-                { text: `Can be helpful and is done in service of the client`, isCorrect: false },
-                { text: `Should only happen if the client brings it up`, isCorrect: false },
-                { text: `Undermines the therapist's authority`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 22,
-              question: `Which statement reflects cultural humility?`,
-              options: [
-                { text: `"I've studied your culture extensively and understand it well."`, isCorrect: true },
-                { text: `"I want to learn from you about your experience, knowing my understanding has limits."`, isCorrect: false },
-                { text: `"Culture doesn't really affect therapy."`, isCorrect: false },
-                { text: `"I treat everyone the same regardless of culture."`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+            {
+              "text": "It assumes the clinician can fully master any culture",
+              "isCorrect": false
             }
+          ],
+          "explanation": "Cultural humility is an ongoing, self-reflective, power-aware stance that treats the client as the expert on their own experience."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 22,
+          "question": "When naming racial difference, the therapist should:",
+          "options": [
+            {
+              "text": "Pretend not to notice to avoid making the client uncomfortable",
+              "isCorrect": true
+            },
+            {
+              "text": "Name the difference and invite the client's perspective",
+              "isCorrect": false
+            },
+            {
+              "text": "Assume the client wants a therapist of their own race",
+              "isCorrect": false
+            },
+            {
+              "text": "Wait for the client to bring it up",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 23,
+          "question": "When receiving feedback about a cultural misstep, the therapist should:",
+          "options": [
+            {
+              "text": "Defend their intentions immediately",
+              "isCorrect": true
+            },
+            {
+              "text": "Explain what they really meant",
+              "isCorrect": false
+            },
+            {
+              "text": "Thank the client, acknowledge impact, and commit to doing better",
+              "isCorrect": false
+            },
+            {
+              "text": "Challenge the client's perception",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 24,
+          "question": "Naming power dynamics in therapy:",
+          "options": [
+            {
+              "text": "Is inappropriate and destabilizing",
+              "isCorrect": true
+            },
+            {
+              "text": "Can be helpful and is done in service of the client",
+              "isCorrect": false
+            },
+            {
+              "text": "Should only happen if the client brings it up",
+              "isCorrect": false
+            },
+            {
+              "text": "Undermines the therapist's authority",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 25,
+          "question": "Which statement reflects cultural humility?",
+          "options": [
+            {
+              "text": "\"I've studied your culture extensively and understand it well.\"",
+              "isCorrect": true
+            },
+            {
+              "text": "\"I want to learn from you about your experience, knowing my understanding has limits.\"",
+              "isCorrect": false
+            },
+            {
+              "text": "\"Culture doesn't really affect therapy.\"",
+              "isCorrect": false
+            },
+            {
+              "text": "\"I treat everyone the same regardless of culture.\"",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 6,
-      title: `Module 6: REPAIRING RUPTURES`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 6: REPAIRING RUPTURES`,
-              subtitle: `The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice`,
-              sectionNumber: 6,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Define therapeutic alliance ruptures and explain their clinical significance</li>
-<li>Distinguish between withdrawal and confrontation ruptures</li>
-<li>Detect ruptures using verbal, nonverbal, and intuitive cues</li>
-<li>Apply a systematic approach to rupture repair</li>
-<li>Articulate why rupture-repair sequences are therapeutically valuable</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>What Are Alliance Ruptures?</h2>
-<p>Alliance ruptures are moments of tension, breach, or disconnection in the therapeutic relationship. They range from subtle (momentary withdrawal, slight tension) to dramatic (hostile confrontation, session walkout).</p>
-<p>Ruptures are normal and inevitable. Every therapeutic relationship will experience moments of disconnection, misunderstanding, or strain. The question isn't whether ruptures will occur—they will—but whether they'll be detected and repaired.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Why Ruptures Matter</h2>
-<p>Unrepaired ruptures predict poor outcomes. Clients may drop out, may stay but disengage, or may continue in a therapy that isn't helping. The therapeutic relationship—the strongest predictor of outcome across orientations—is damaged.</p>
-<p>But repaired ruptures predict positive outcomes. When ruptures are detected and successfully repaired, several things happen:</p>
-<ul>
-<li>The alliance strengthens—clients learn the relationship can survive difficulty</li>
-<li>Clients experience a corrective relational experience</li>
-<li>Important material often emerges in the repair process</li>
-<li>The client develops capacity for repair in other relationships</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Types of Ruptures</h2>
-<p>Jeremy Safran and Christopher Muran, pioneers in alliance rupture research, identified two main types:</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Withdrawal Ruptures</h2>
-<p>The client pulls back, becomes distant, or complies superficially while internally disconnecting. Signs include:</p>
-<ul>
-<li>Becoming quiet or giving short answers</li>
-<li>Agreeing readily without genuine engagement</li>
-<li>Changing the subject away from emotional material</li>
-<li>Missing nonverbal cues of connection (eye contact, warmth)</li>
-<li>Going through the motions</li>
-<li>Seeming "flat" or distant</li>
-</ul>
-<p>Withdrawal ruptures are easy to miss because the client appears cooperative. They're not fighting you—they've just left the building emotionally.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Confrontation Ruptures</h2>
-<p>The client expresses dissatisfaction directly—criticism of the therapist, the treatment, or the process. Signs include:</p>
-<ul>
-<li>Expressing frustration or anger toward the therapist</li>
-<li>Challenging the therapist's approach or competence</li>
-<li>Questioning the value of therapy</li>
-<li>Making negative comments about the therapy</li>
-<li>Arguing or becoming defensive</li>
-</ul>
-<p>Confrontation ruptures are more obvious but can be more threatening to therapists. Our instinct may be to defend ourselves rather than to explore.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Detecting Ruptures</h2>
-<p>Detecting ruptures requires attention to multiple channels:</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Verbal Cues</h2>
-<ul>
-<li>Shorter answers</li>
-<li>Less self-disclosure</li>
-<li>More qualifications ("I guess," "sort of")</li>
-<li>Deflection or topic changes</li>
-<li>Direct expressions of dissatisfaction</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Nonverbal Cues</h2>
-<ul>
-<li>Reduced eye contact</li>
-<li>Closed body posture</li>
-<li>Flat affect</li>
-<li>Sighing</li>
-<li>Checking the time</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Relational Cues</h2>
-<ul>
-<li>Sense of disconnection</li>
-<li>Feeling like something is "off"</li>
-<li>Loss of collaborative feeling</li>
-<li>Therapist working harder than usual</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Your Gut</h2>
-<p>Trust your gut. If you sense that something shifted—that the client withdrew, that there's tension you can't name, that you lost them somehow—there probably was a rupture. Our relational sensing systems pick up on things before we can consciously articulate them.</p>`,
-            },
-{
-              type: "callout",
-              order: 13,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Detecting a Rupture`,
-              content: `<p>Dr. Johnson has been working with Jasmine for six months. In session 24, Jasmine mentions that her sister had a baby.</p>
-<p>Dr. Johnson: "Oh, that's wonderful! You must be excited to be an aunt."</p>
-<p>Jasmine: "Yeah. It's great." (looks away, voice flat)</p>
-<p>Dr. Johnson notices the shift. Jasmine's energy dropped. Her answer was short. Something happened.</p>
-<p>Dr. Johnson: "I noticed something shifted just then, when I said that about being excited. Did I miss something?"</p>
-<p>Jasmine (tearing up): "It's just... we've been trying to get pregnant for two years. It's hard seeing my sister have what we want."</p>
-<p>Dr. Johnson's assumption about Jasmine's feelings created a momentary rupture. Because she detected it quickly and named it, repair was possible and important material emerged.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>The Repair Process</h2>
-<p>Rupture repair involves several steps:</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>1. Noticing and Naming</h2>
-<p>The first step is noticing the rupture and naming it:</p>
-<p>"I'm sensing something shifted between us. Am I reading that right?"</p>
-<p>"Something seems different today than last week. Can you help me understand what you're experiencing?"</p>
-<p>"I notice that when I said [X], your energy seemed to change. What happened for you in that moment?"</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>2. Creating Space for Exploration</h2>
-<p>Once named, create space for the client to explore their experience:</p>
-<p>"Can you tell me more about what you're feeling right now?"</p>
-<p>"What's coming up for you as we talk about this?"</p>
-<p>"I'm interested in understanding what happened from your perspective."</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>3. Listening Non-Defensively</h2>
-<p>Whatever the client shares, listen to understand rather than to defend. This is difficult when the client is criticizing us or the therapy. Our instinct is to explain, justify, or correct. Resist.</p>
-<p>Just listen. Reflect. Seek to understand.</p>
-<p>"It sounds like when I said that, it felt like I wasn't really hearing you."</p>
-<p>"You felt dismissed by my response."</p>
-<p>"You've been feeling like the therapy isn't helping, and you weren't sure how to tell me."</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>4. Acknowledging Your Part</h2>
-<p>If you contributed to the rupture—and you usually did—acknowledge it:</p>
-<p>"I can see how what I said landed that way. I was trying to normalize your feelings, but it came across as minimizing them. I'm sorry."</p>
-<p>"You're right that I've been pushing you toward forgiveness. I think I got ahead of where you are."</p>
-<p>"I did assume I understood without really asking. That wasn't fair to you."</p>
-<p>Acknowledging your contribution is not weakness—it's modeling accountability and repair.</p>`,
-            },
-{
-              type: "text",
-              order: 19,
-              content: `<h2>5. Exploring Deeper Meaning</h2>
-<p>Often, ruptures connect to deeper themes in the client's life:</p>
-<p>"I wonder if this connects to a pattern—feeling unheard and not sure it's safe to speak up. Does that resonate?"</p>
-<p>"The way you withdrew just now, rather than telling me something was wrong—does that happen in other relationships too?"</p>`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>6. Working Toward Repair</h2>
-<p>Finally, work collaboratively toward repair:</p>
-<p>"What would help repair this?"</p>
-<p>"What do you need from me right now?"</p>
-<p>"How can we move forward in a way that feels okay?"</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>Language for Rupture Repair</h2>`,
-            },
-{
-              type: "text",
-              order: 22,
-              content: `<h2>Noticing Language</h2>
-<p>"I'm noticing something between us that I want to check in about."</p>
-<p>"Something feels different today. I'm not sure what it is."</p>
-<p>"I have a sense that something I said or did didn't sit right with you."</p>
-<p>"You seem quieter than usual. Can we talk about what's happening?"</p>`,
-            },
-{
-              type: "text",
-              order: 23,
-              content: `<h2>Inviting Language</h2>
-<p>"Can you help me understand what you're experiencing right now?"</p>
-<p>"I'd like to hear more about what that was like for you."</p>
-<p>"What's coming up as we talk about this?"</p>`,
-            },
-{
-              type: "text",
-              order: 24,
-              content: `<h2>Acknowledging Language</h2>
-<p>"I can see how that landed for you. I'm sorry."</p>
-<p>"You're right—I did assume instead of asking."</p>
-<p>"I can hear that my response missed the mark."</p>`,
-            },
-{
-              type: "text",
-              order: 25,
-              content: `<h2>Repair Language</h2>
-<p>"What would help right now?"</p>
-<p>"What do you need from me?"</p>
-<p>"How can we move forward from here?"</p>`,
-            },
-{
-              type: "text",
-              order: 26,
-              content: `<h2>Why Repair Is Therapeutic</h2>
-<p>The rupture-repair sequence may be one of the most therapeutic things that happens in therapy. When ruptures are successfully repaired:</p>
-<p><strong>Clients experience that relationships survive conflict.</strong> Many clients believe, based on their histories, that conflict destroys relationships. Successful repair provides counter-evidence.</p>
-<p><strong>Clients experience being truly heard.</strong> In the repair process, the client's experience is centered. They're listened to, believed, and responded to.</p>
-<p><strong>Alliance is strengthened.</strong> Paradoxically, repaired ruptures strengthen alliance more than ruptures that never occurred. The relationship has been tested and survived.</p>
-<p><strong>Patterns emerge.</strong> Ruptures often connect to core relational patterns. Exploring them illuminates themes that are central to the client's struggles.</p>
-<p><strong>Modeling occurs.</strong> Clients learn how to navigate and repair ruptures in their own relationships.</p>
-<p><strong>Treatment outcomes improve.</strong> Research consistently shows that successfully repaired ruptures predict positive outcomes.</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 27,
-              question: `According to Safran and Muran, the two main types of alliance ruptures are:`,
-              options: [
-                { text: `Major and minor`, isCorrect: true },
-                { text: `Withdrawal and confrontation`, isCorrect: false },
-                { text: `Client-caused and therapist-caused`, isCorrect: false },
-                { text: `Verbal and nonverbal`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 28,
-              question: `Withdrawal ruptures are characterized by:`,
-              options: [
-                { text: `Direct expression of dissatisfaction`, isCorrect: true },
-                { text: `Client becoming distant, compliant, or superficially engaged`, isCorrect: false },
-                { text: `Client leaving the session`, isCorrect: false },
-                { text: `Client arguing with the therapist`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 29,
-              question: `The first step in rupture repair is:`,
-              options: [
-                { text: `Defending your approach`, isCorrect: true },
-                { text: `Noticing and naming the rupture`, isCorrect: false },
-                { text: `Referring the client`, isCorrect: false },
-                { text: `Explaining what you meant`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 30,
-              question: `When a client criticizes the therapist during a rupture, the therapist should:`,
-              options: [
-                { text: `Defend themselves immediately`, isCorrect: true },
-                { text: `Explain what they really meant`, isCorrect: false },
-                { text: `Listen non-defensively to understand the client's experience`, isCorrect: false },
-                { text: `Terminate the session`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 31,
-              question: `Repaired ruptures in therapy:`,
-              options: [
-                { text: `Weaken the therapeutic alliance`, isCorrect: true },
-                { text: `Predict poor outcomes`, isCorrect: false },
-                { text: `Strengthen alliance and predict positive outcomes`, isCorrect: false },
-                { text: `Should be avoided entirely`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "text",
-              order: 32,
-              content: `<h2>Core Takeaways</h2>
-<p><strong>The elephant is always visible to the client too.</strong> Whatever you're avoiding, they see it. Naming it rarely creates news—it creates relief. Clients appreciate honesty.</p>
-<p><strong>Relationships can handle more than we think.</strong> Our fears about damaging the alliance are often overblown. Relationships, including therapeutic relationships, are more resilient than we give them credit for—especially when repair is possible.</p>
-<p><strong>Care can accompany truth.</strong> Difficult feedback delivered with care is a gift. It's possible to be honest and kind simultaneously. In fact, honesty delivered with care is often experienced as more caring than gentle dishonesty.</p>
-<p><strong>Your discomfort is not a reason to avoid.</strong> Our discomfort often signals that something important needs attention. The tightness in your chest before a difficult conversation isn't telling you to avoid—it's telling you that what you're about to do matters.</p>
-<p><strong>Practice increases skill.</strong> These conversations get easier with practice. Start with smaller elephants and build your capacity. Each successful conversation builds confidence for the next.</p>
-<p><strong>You're not alone.</strong> Consultation, supervision, and peer support help you prepare for and process difficult conversations. Use them.</p>`,
-            },
-{
-              type: "text",
-              order: 33,
-              content: `<h2>The Courage Question</h2>
-<p>Addressing the elephant in the room requires courage. Not reckless courage that barrels forward without care, but thoughtful courage that values truth and relationship equally.</p>
-<p>Every difficult conversation is a risk. You might be wrong. The client might react badly. The relationship might suffer. These risks are real.</p>
-<p>But avoidance is also risky. Issues go unaddressed. The relationship becomes less authentic. Treatment suffers. The client misses an opportunity to experience a relationship where difficult things can be named.</p>
-<p>Which risk is greater? In most cases, the risk of avoidance exceeds the risk of courageous honesty.</p>`,
-            },
-{
-              type: "text",
-              order: 34,
-              content: `<h2>A Final Reflection</h2>
-<p>Think of a client you're currently seeing. Is there an elephant in the room—something you've noticed but haven't addressed?</p>
-<p>What would it take to address it?</p>
-<p>What caring purpose would that conversation serve?</p>
-<p>What's the first step you could take?</p>
-<p>The courage to have difficult conversations isn't something you either have or don't have. It's a skill that develops with practice, a muscle that strengthens with use. Each time you name an elephant skillfully, you become better at naming the next one.</p>
-<p>Your clients deserve therapists willing to tell them the truth with care. You deserve to practice in a way that's authentic and sustainable.</p>
-<p>The elephants are waiting. They've been patient long enough.</p>
-<p>Thank you for your commitment to having the conversations that matter, even when they're hard.</p>`,
+      "order": 6,
+      "title": "Module 6: REPAIRING RUPTURES",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 6: REPAIRING RUPTURES",
+          "subtitle": "The Elephant in the Room: Navigating Difficult Conversations in Counseling Practice",
+          "sectionNumber": 6
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Define therapeutic alliance ruptures and explain their clinical significance</li>\n<li>Distinguish between {{callout:withdrawal-rupture}} and confrontation ruptures</li>\n<li>Detect ruptures using verbal, nonverbal, and intuitive cues</li>\n<li>Apply a systematic approach to rupture repair</li>\n<li>Articulate why rupture-repair sequences are therapeutically valuable</li>\n</ol>",
+          "callouts": {
+            "withdrawal-rupture": {
+              "label": "Withdrawal Rupture",
+              "type": "definition",
+              "body": "A rupture in which the client moves away — disengaging, deferring, going silent, or complying superficially — rather than toward the clinician."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>What Are Alliance Ruptures?</h2>\n<p>Alliance ruptures are moments of tension, breach, or disconnection in the therapeutic relationship. They range from subtle (momentary withdrawal, slight tension) to dramatic (hostile confrontation, session walkout).</p>\n<p>Ruptures are normal and inevitable. Every therapeutic relationship will experience moments of disconnection, misunderstanding, or strain. The question isn't whether ruptures will occur—they will—but whether they'll be detected and repaired.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Why Ruptures Matter</h2>\n<p>Unrepaired ruptures predict poor outcomes. Clients may drop out, may stay but disengage, or may continue in a therapy that isn't helping. The therapeutic relationship—the strongest predictor of outcome across orientations—is damaged.</p>\n<p>But repaired ruptures predict positive outcomes. When ruptures are detected and successfully repaired, several things happen:</p>\n<ul>\n<li>The alliance strengthens—clients learn the relationship can survive difficulty</li>\n<li>Clients experience a corrective relational experience</li>\n<li>Important material often emerges in the repair process</li>\n<li>The client develops capacity for repair in other relationships</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Types of Ruptures</h2>\n<p>Jeremy Safran and Christopher Muran, pioneers in alliance rupture research, identified two main types:</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Withdrawal Ruptures</h2>\n<p>The client pulls back, becomes distant, or complies superficially while internally disconnecting. Signs include:</p>\n<ul>\n<li>Becoming quiet or giving short answers</li>\n<li>Agreeing readily without genuine engagement</li>\n<li>Changing the subject away from emotional material</li>\n<li>Missing nonverbal cues of connection (eye contact, warmth)</li>\n<li>Going through the motions</li>\n<li>Seeming \"flat\" or distant</li>\n</ul>\n<p>Withdrawal ruptures are easy to miss because the client appears cooperative. They're not fighting you—they've just left the building emotionally.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Confrontation Ruptures</h2>\n<p>The client expresses dissatisfaction directly—criticism of the therapist, the treatment, or the process. Signs include:</p>\n<ul>\n<li>Expressing frustration or anger toward the therapist</li>\n<li>Challenging the therapist's approach or competence</li>\n<li>Questioning the value of therapy</li>\n<li>Making negative comments about the therapy</li>\n<li>Arguing or becoming defensive</li>\n</ul>\n<p>Confrontation ruptures are more obvious but can be more threatening to therapists. Our instinct may be to defend ourselves rather than to explore.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Detecting Ruptures</h2>\n<p>Detecting ruptures requires attention to multiple channels:</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Verbal Cues</h2>\n<ul>\n<li>Shorter answers</li>\n<li>Less self-disclosure</li>\n<li>More qualifications (\"I guess,\" \"sort of\")</li>\n<li>Deflection or topic changes</li>\n<li>Direct expressions of dissatisfaction</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Nonverbal Cues</h2>\n<ul>\n<li>Reduced eye contact</li>\n<li>Closed body posture</li>\n<li>Flat affect</li>\n<li>Sighing</li>\n<li>Checking the time</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Relational Cues</h2>\n<ul>\n<li>Sense of disconnection</li>\n<li>Feeling like something is \"off\"</li>\n<li>Loss of collaborative feeling</li>\n<li>Therapist working harder than usual</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Your Gut</h2>\n<p>Trust your gut. If you sense that something shifted—that the client withdrew, that there's tension you can't name, that you lost them somehow—there probably was a rupture. Our relational sensing systems pick up on things before we can consciously articulate them.</p>"
+        },
+        {
+          "type": "callout",
+          "order": 13,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Detecting a Rupture",
+          "content": "<p>Dr. Johnson has been working with Jasmine for six months. In session 24, Jasmine mentions that her sister had a baby.</p>\n<p>Dr. Johnson: \"Oh, that's wonderful! You must be excited to be an aunt.\"</p>\n<p>Jasmine: \"Yeah. It's great.\" (looks away, voice flat)</p>\n<p>Dr. Johnson notices the shift. Jasmine's energy dropped. Her answer was short. Something happened.</p>\n<p>Dr. Johnson: \"I noticed something shifted just then, when I said that about being excited. Did I miss something?\"</p>\n<p>Jasmine (tearing up): \"It's just... we've been trying to get pregnant for two years. It's hard seeing my sister have what we want.\"</p>\n<p>Dr. Johnson's assumption about Jasmine's feelings created a momentary rupture. Because she detected it quickly and named it, repair was possible and important material emerged.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>The Repair Process</h2>\n<p>Rupture repair involves several steps:</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>1. Noticing and Naming</h2>\n<p>The first step is noticing the rupture and naming it:</p>\n<p>\"I'm sensing something shifted between us. Am I reading that right?\"</p>\n<p>\"Something seems different today than last week. Can you help me understand what you're experiencing?\"</p>\n<p>\"I notice that when I said [X], your energy seemed to change. What happened for you in that moment?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>2. Creating Space for Exploration</h2>\n<p>Once named, create space for the client to explore their experience:</p>\n<p>\"Can you tell me more about what you're feeling right now?\"</p>\n<p>\"What's coming up for you as we talk about this?\"</p>\n<p>\"I'm interested in understanding what happened from your perspective.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>3. Listening Non-Defensively</h2>\n<p>Whatever the client shares, listen to understand rather than to defend. This is difficult when the client is criticizing us or the therapy. Our instinct is to explain, justify, or correct. Resist.</p>\n<p>Just listen. Reflect. Seek to understand.</p>\n<p>\"It sounds like when I said that, it felt like I wasn't really hearing you.\"</p>\n<p>\"You felt dismissed by my response.\"</p>\n<p>\"You've been feeling like the therapy isn't helping, and you weren't sure how to tell me.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>4. Acknowledging Your Part</h2>\n<p>If you contributed to the rupture—and you usually did—acknowledge it:</p>\n<p>\"I can see how what I said landed that way. I was trying to normalize your feelings, but it came across as minimizing them. I'm sorry.\"</p>\n<p>\"You're right that I've been pushing you toward forgiveness. I think I got ahead of where you are.\"</p>\n<p>\"I did assume I understood without really asking. That wasn't fair to you.\"</p>\n<p>Acknowledging your contribution is not weakness—it's modeling accountability and repair.</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>5. Exploring Deeper Meaning</h2>\n<p>Often, ruptures connect to deeper themes in the client's life:</p>\n<p>\"I wonder if this connects to a pattern—feeling unheard and not sure it's safe to speak up. Does that resonate?\"</p>\n<p>\"The way you withdrew just now, rather than telling me something was wrong—does that happen in other relationships too?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>6. Working Toward Repair</h2>\n<p>Finally, work collaboratively toward repair:</p>\n<p>\"What would help repair this?\"</p>\n<p>\"What do you need from me right now?\"</p>\n<p>\"How can we move forward in a way that feels okay?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Language for Rupture Repair</h2>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>Noticing Language</h2>\n<p>\"I'm noticing something between us that I want to check in about.\"</p>\n<p>\"Something feels different today. I'm not sure what it is.\"</p>\n<p>\"I have a sense that something I said or did didn't sit right with you.\"</p>\n<p>\"You seem quieter than usual. Can we talk about what's happening?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Inviting Language</h2>\n<p>\"Can you help me understand what you're experiencing right now?\"</p>\n<p>\"I'd like to hear more about what that was like for you.\"</p>\n<p>\"What's coming up as we talk about this?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Acknowledging Language</h2>\n<p>\"I can see how that landed for you. I'm sorry.\"</p>\n<p>\"You're right—I did assume instead of asking.\"</p>\n<p>\"I can hear that my response missed the mark.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Repair Language</h2>\n<p>\"What would help right now?\"</p>\n<p>\"What do you need from me?\"</p>\n<p>\"How can we move forward from here?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>Why Repair Is Therapeutic</h2>\n<p>The rupture-repair sequence may be one of the most therapeutic things that happens in therapy. When ruptures are successfully repaired:</p>\n<p><strong>Clients experience that relationships survive conflict.</strong> Many clients believe, based on their histories, that conflict destroys relationships. Successful repair provides counter-evidence.</p>\n<p><strong>Clients experience being truly heard.</strong> In the repair process, the client's experience is centered. They're listened to, believed, and responded to.</p>\n<p><strong>Alliance is strengthened.</strong> Paradoxically, repaired ruptures strengthen alliance more than ruptures that never occurred. The relationship has been tested and survived.</p>\n<p><strong>Patterns emerge.</strong> Ruptures often connect to core relational patterns. Exploring them illuminates themes that are central to the client's struggles.</p>\n<p><strong>Modeling occurs.</strong> Clients learn how to navigate and repair ruptures in their own relationships.</p>\n<p><strong>Treatment outcomes improve.</strong> Research consistently shows that successfully repaired ruptures predict positive outcomes.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Evidence Base for Rupture and Repair</h2>\n<p>The clinical emphasis on alliance ruptures and their repair is grounded in a substantial body of research, not merely intuition, and knowing the evidence strengthens the clinician’s confidence in leaning into rather than away from these moments.</p>\n<h3>What the Research Shows</h3>\n<p>The therapeutic alliance is one of the most robust predictors of outcome across treatments, and ruptures in that alliance — strains, tensions, breakdowns in collaboration — are common rather than aberrant. The work of Safran and Muran and others established that ruptures are not failures to be avoided but ordinary events to be recognized and worked through, and that the successful repair of ruptures is associated with good outcomes. Meta-analytic findings link rupture-repair processes to treatment benefit, and training clinicians to address ruptures appears to improve their effectiveness.</p>\n<h3>Implication for Practice</h3>\n<p>The clinical message is encouraging: a rupture is not a sign that the clinician has failed but an opportunity, and the capacity to notice and repair these moments is a learnable skill associated with better results. Far from threatening the alliance, the honest navigation of its strains is part of what makes the alliance strong — which is why developing comfort with rupture and repair is among the highest-yield investments a clinician can make.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "content": "<h2>Repair Across the Course of Therapy</h2>\n<p>Ruptures and their repair look different at different points in treatment, and attending to where the work is helps the clinician read and respond to strain.</p>\n<h3>Early, Middle, and Late</h3>\n<p>Early in treatment, ruptures frequently concern trust and safety — whether this clinician and this process can be relied upon — and repair lays the foundation for the work. In the middle phase, ruptures may surface around the deepening of difficult material, the pace of change, or disappointment as idealization fades, and their repair frequently moves the work forward. Near termination, strain can attach to the ending itself — to loss, to ambivalence about independence — and repair becomes part of a good goodbye.</p>\n<h3>Patterns Worth Naming</h3>\n<p>Recurring ruptures around the same theme frequently illuminate the client’s relational patterns outside therapy, making the repair not only a restoration of the alliance but a window into the very difficulties that brought the client to treatment. Recognizing a rupture’s place in the arc of therapy — and its possible link to the client’s broader patterns — lets the clinician respond to the strain in front of them and to what it represents.</p>",
+          "order": 28
+        },
+        {
+          "type": "text",
+          "content": "<h2>When Repair Is Difficult</h2>\n<p>Not every rupture repairs easily, and the clinician needs a stance for the moments when the usual process stalls.</p>\n<h3>Stubborn Ruptures</h3>\n<p>Some ruptures resist repair: the client withdraws and will not name what is wrong, or escalates in a way that makes non-defensive listening hard, or the rupture touches a theme so charged that each attempt at repair reactivates it. In these moments the clinician’s task is to stay present and non-defensive without forcing resolution, to tolerate the discomfort of an unrepaired strain, and to keep offering the relationship rather than retaliating or withdrawing in turn.</p>\n<h3>Persistence, Consultation, and Limits</h3>\n<p>Persistence frequently matters — a rupture that cannot be repaired in one session may yield over several — and consultation helps the clinician understand their own contribution and avoid being pulled into the client’s relational pattern. At times, despite genuine effort, a rupture does not repair and the client leaves; the clinician’s responsibility is to have offered honest, non-defensive engagement, recognizing that repair requires both parties and that some endings, while painful, are not failures of care.</p>",
+          "order": 29
+        },
+        {
+          "type": "text",
+          "content": "<h2>Self-Disclosure in Rupture Repair</h2>\n<p>Repairing a rupture frequently calls for a measure of clinician self-disclosure — acknowledging one’s own part, naming a feeling in the room — and using disclosure well is a distinct skill.</p>\n<h3>Disclosure That Serves the Client</h3>\n<p>Acknowledging one’s contribution to a rupture (“I think I missed something important last week, and I’d like to understand it”) models accountability and frequently unlocks the repair. Naming a present-moment dynamic (“I notice some distance between us today”) can make the unspoken discussable. The test is always whether the disclosure serves the client and the work, not whether it relieves the clinician’s guilt or need for reassurance.</p>\n<h3>Keeping the Focus on the Client</h3>\n<p>Disclosure goes wrong when it shifts the burden to the client — when the clinician’s confession invites the client to comfort them, or when explaining one’s intentions becomes a way of defending rather than understanding. Effective repair disclosure is brief, owns impact without over-explaining motive, and returns attention promptly to the client’s experience. Used judiciously, it demonstrates that the relationship can hold honesty in both directions while keeping the client’s needs at the center.</p>",
+          "order": 30
+        },
+        {
+          "type": "text",
+          "content": "<h2>Ruptures Around Money, Time, and the Frame</h2>\n<p>Some of the most avoided ruptures concern the practical frame — fees, missed-session charges, scheduling, the boundaries of the relationship — precisely because money and limits feel awkward to discuss.</p>\n<h3>The Charged Practicalities</h3>\n<p>Conversations about unpaid fees, late-cancellation charges, or requests to bend the frame carry emotional weight beyond their logistics: they touch worth, fairness, dependence, and the nature of the relationship. Clinicians frequently avoid them — absorbing unpaid balances, tolerating frame violations — to sidestep the discomfort, and the unaddressed issue then breeds resentment that quietly corrodes the work.</p>\n<h3>Holding the Frame as Care</h3>\n<p>Addressing these matters directly, early, and without apology treats the frame as part of the therapy rather than an awkward intrusion upon it. The clinician can name the practical issue plainly, explore its meaning where relevant, and hold the boundary as an act of care for the work and the relationship. A frame maintained honestly is more containing for the client than one quietly eroded to avoid a hard conversation.</p>",
+          "order": 31
+        },
+        {
+          "type": "text",
+          "content": "<h2>Difficult Conversations and the Clinician’s Sustainability</h2>\n<p>The capacity to have hard conversations week after week draws on the clinician’s own reserves, and sustaining that capacity is part of doing the work well over time.</p>\n<h3>The Cumulative Cost</h3>\n<p>Each difficult conversation asks the clinician to tolerate discomfort, absorb a client’s strong feeling, and remain present and non-defensive under pressure. Done repeatedly, especially with high-conflict or distressed clients, this is genuinely depleting, and a depleted clinician is precisely the one most tempted to avoid — to smooth over, to postpone, to let the elephant stand. Avoidance, in this sense, is frequently a symptom of an empty tank rather than a failure of nerve.</p>\n<h3>Replenishing the Capacity</h3>\n<p>Consultation that processes the emotional weight of the work, manageable caseloads, attention to one’s own wellbeing, and a community of colleagues all replenish the reserve that difficult conversations draw down. Sustaining the courage and steadiness these conversations require is not a matter of willpower alone but of caring for the clinician’s own capacity — which makes self-care a clinical competency rather than an indulgence.</p>",
+          "order": 32
+        },
+        {
+          "order": 33,
+          "type": "matching",
+          "matchingInstructions": "Match each rupture type (Safran & Muran) to its hallmark.",
+          "matchingPairs": [
+            {
+              "term": "Withdrawal rupture",
+              "definition": "The client moves away — disengaging, deferring, going silent, complying superficially"
+            },
+            {
+              "term": "Confrontation rupture",
+              "definition": "The client moves against — expressing anger, criticism, or dissatisfaction directly"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 34,
+          "question": "Withdrawal ruptures are characterized by:",
+          "options": [
+            {
+              "text": "Direct expression of dissatisfaction",
+              "isCorrect": true
+            },
+            {
+              "text": "Client becoming distant, compliant, or superficially engaged",
+              "isCorrect": false
+            },
+            {
+              "text": "Client leaving the session",
+              "isCorrect": false
+            },
+            {
+              "text": "Client arguing with the therapist",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 35,
+          "type": "sequencing",
+          "instructions": "Order the steps of the rupture-repair process.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Notice and name the rupture"
+            },
+            {
+              "order": 2,
+              "text": "Create space for exploration"
+            },
+            {
+              "order": 3,
+              "text": "Listen non-defensively"
+            },
+            {
+              "order": 4,
+              "text": "Acknowledge your part"
+            },
+            {
+              "order": 5,
+              "text": "Explore the deeper meaning"
+            },
+            {
+              "order": 6,
+              "text": "Work toward repair"
+            }
+          ],
+          "explanation": "Repair begins by noticing and naming the rupture, then creating space and listening without defending, acknowledging one’s contribution, exploring meaning, and moving toward repair."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 36,
+          "question": "When a client criticizes the therapist during a rupture, the therapist should:",
+          "options": [
+            {
+              "text": "Defend themselves immediately",
+              "isCorrect": true
+            },
+            {
+              "text": "Explain what they really meant",
+              "isCorrect": false
+            },
+            {
+              "text": "Listen non-defensively to understand the client's experience",
+              "isCorrect": false
+            },
+            {
+              "text": "Terminate the session",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 37,
+          "question": "Repaired ruptures in therapy:",
+          "options": [
+            {
+              "text": "Weaken the therapeutic alliance",
+              "isCorrect": true
+            },
+            {
+              "text": "Predict poor outcomes",
+              "isCorrect": false
+            },
+            {
+              "text": "Strengthen alliance and predict positive outcomes",
+              "isCorrect": false
+            },
+            {
+              "text": "Should be avoided entirely",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "text",
+          "order": 38,
+          "content": "<h2>Core Takeaways</h2>\n<p><strong>The elephant is always visible to the client too.</strong> Whatever you're avoiding, they see it. Naming it rarely creates news—it creates relief. Clients appreciate honesty.</p>\n<p><strong>Relationships can handle more than we think.</strong> Our fears about damaging the alliance are often overblown. Relationships, including therapeutic relationships, are more resilient than we give them credit for—especially when repair is possible.</p>\n<p><strong>Care can accompany truth.</strong> Difficult feedback delivered with care is a gift. It's possible to be honest and kind simultaneously. In fact, honesty delivered with care is often experienced as more caring than gentle dishonesty.</p>\n<p><strong>Your discomfort is not a reason to avoid.</strong> Our discomfort often signals that something important needs attention. The tightness in your chest before a difficult conversation isn't telling you to avoid—it's telling you that what you're about to do matters.</p>\n<p><strong>Practice increases skill.</strong> These conversations get easier with practice. Start with smaller elephants and build your capacity. Each successful conversation builds confidence for the next.</p>\n<p><strong>You're not alone.</strong> Consultation, supervision, and peer support help you prepare for and process difficult conversations. Use them.</p>"
+        },
+        {
+          "type": "text",
+          "order": 39,
+          "content": "<h2>The Courage Question</h2>\n<p>Addressing the elephant in the room requires courage. Not reckless courage that barrels forward without care, but thoughtful courage that values truth and relationship equally.</p>\n<p>Every difficult conversation is a risk. You might be wrong. The client might react badly. The relationship might suffer. These risks are real.</p>\n<p>But avoidance is also risky. Issues go unaddressed. The relationship becomes less authentic. Treatment suffers. The client misses an opportunity to experience a relationship where difficult things can be named.</p>\n<p>Which risk is greater? In most cases, the risk of avoidance exceeds the risk of courageous honesty.</p>"
+        },
+        {
+          "type": "text",
+          "order": 40,
+          "content": "<h2>A Final Reflection</h2>\n<p>Think of a client you're currently seeing. Is there an elephant in the room—something you've noticed but haven't addressed?</p>\n<p>What would it take to address it?</p>\n<p>What caring purpose would that conversation serve?</p>\n<p>What's the first step you could take?</p>\n<p>The courage to have difficult conversations isn't something you either have or don't have. It's a skill that develops with practice, a muscle that strengthens with use. Each time you name an elephant skillfully, you become better at naming the next one.</p>\n<p>Your clients deserve therapists willing to tell them the truth with care. You deserve to practice in a way that's authentic and sustainable.</p>\n<p>The elephants are waiting. They've been patient long enough.</p>\n<p>Thank you for your commitment to having the conversations that matter, even when they're hard.</p>"
+        }
       ]
     },
     {
-      order: 7,
-      title: `Course Summary and References`,
-      estimatedTime: 10,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Course Summary and References`,
-              subtitle: `Key Takeaways and APA 7th Edition References`,
-              sectionNumber: 7,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>Key Takeaways</h2><p>This course has provided a comprehensive examination of the elephant in the room: navigating difficult conversations in counseling practice. As you apply these concepts with clients, continue to seek consultation and pursue ongoing professional development.</p>`,
-            },
-{
-              type: "reflection",
-              order: 3,
-              prompt: `Course Reflection`,
-              content: `<p>Consider how the concepts presented in this course will inform your clinical work. What specific practices will you implement? What aspects of your current practice might you reconsider?</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<div class="cr-references"><h3>References</h3>
-<p class="cr-reference">Ackerman, S. J., & Hilsenroth, M. J. (2001). A review of therapist characteristics and techniques negatively impacting the therapeutic alliance. Psychotherapy, 38(2), 171-185.</p>
-<p class="cr-reference">American Counseling Association. (2014). 2014 ACA Code of Ethics. Alexandria, VA: Author.</p>
-<p class="cr-reference">Bordin, E. S. (1979). The generalizability of the psychoanalytic concept of the working alliance. Psychotherapy: Theory, Research & Practice, 16(3), 252-260.</p>
-<p class="cr-reference">Eubanks, C. F., Muran, J. C., & Safran, J. D. (2018). Alliance rupture repair: A meta-analysis. Psychotherapy, 55(4), 508-519.</p>
-<p class="cr-reference">Hays, P. A. (2016). Addressing cultural complexities in practice: Assessment, diagnosis, and therapy (3rd ed.). American Psychological Association.</p>
-<p class="cr-reference">Hook, J. N., Davis, D. E., Owen, J., Worthington, E. L., & Utsey, S. O. (2013). Cultural humility: Measuring openness to culturally diverse clients. Journal of Counseling Psychology, 60(3), 353-366.</p>
-<p class="cr-reference">Kanter, J. W., Rosen, D. C., Manbeck, K. E., Marquis, H. M. S., et al. (2020). Addressing microaggressions in racially charged patient-provider interactions. BMC Medical Education, 20, Article 88.</p>
-<p class="cr-reference">Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.</p>
-<p class="cr-reference">Norcross, J. C., & Lambert, M. J. (2018). Psychotherapy relationships that work III. Psychotherapy, 55(4), 303-315.</p>
-<p class="cr-reference">Owen, J., Tao, K. W., Imel, Z. E., Wampold, B. E., & Rodolfa, E. (2014). Addressing racial and ethnic microaggressions in therapy. Professional Psychology: Research and Practice, 45(4), 283-290.</p>
-<p class="cr-reference">Patterson, K., Grenny, J., McMillan, R., & Switzler, A. (2012). Crucial conversations: Tools for talking when stakes are high (2nd ed.). McGraw-Hill.</p>
-<p class="cr-reference">Safran, J. D., & Muran, J. C. (2000). Negotiating the therapeutic alliance: A relational treatment guide. Guilford Press.</p>
-<p class="cr-reference">Safran, J. D., Muran, J. C., & Eubanks-Carter, C. (2011). Repairing alliance ruptures. Psychotherapy, 48(1), 80-87.</p>
-<p class="cr-reference">Stone, D., Patton, B., & Heen, S. (2010). Difficult conversations: How to discuss what matters most. Penguin Books.</p>
-<p class="cr-reference">Sue, D. W. (2010). Microaggressions in everyday life: Race, gender, and sexual orientation. John Wiley & Sons.</p>
-<p class="cr-reference">Sue, D. W., & Sue, D. (2016). Counseling the culturally diverse: Theory and practice (7th ed.). John Wiley & Sons.</p>
-<p class="cr-reference">Tervalon, M., & Murray-García, J. (1998). Cultural humility versus cultural competence: A critical distinction in defining physician training outcomes in multicultural education. Journal of Health Care for the Poor and Underserved, 9(2), 117-125.</p>
-<p class="cr-reference">Wachtel, P. L. (2011). Therapeutic communication: Knowing what to say when (2nd ed.). Guilford Press.</p>
-<p class="cr-reference">Zilcha-Mano, S., & Errázuriz, P. (2015). One size does not fit all: Examining heterogeneity and identifying moderators. Journal of Counseling Psychology, 62(4), 579-591.</p>
-</div>`,
-            }
+      "order": 7,
+      "title": "Course Summary and References",
+      "estimatedTime": 10,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Course Summary and References",
+          "subtitle": "Key Takeaways and APA 7th Edition References",
+          "sectionNumber": 7
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Key Takeaways</h2><p>This course has provided a comprehensive examination of the elephant in the room: navigating difficult conversations in counseling practice. As you apply these concepts with clients, continue to seek consultation and pursue ongoing professional development.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 3,
+          "prompt": "Course Reflection",
+          "content": "<p>Consider how the concepts presented in this course will inform your clinical work. What specific practices will you implement? What aspects of your current practice might you reconsider?</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<div class=\"cr-references\"><h3>References</h3>\n<p class=\"cr-reference\">Ackerman, S. J., & Hilsenroth, M. J. (2001). A review of therapist characteristics and techniques negatively impacting the therapeutic alliance. Psychotherapy, 38(2), 171-185.</p>\n<p class=\"cr-reference\">American Counseling Association. (2014). 2014 ACA Code of Ethics. Alexandria, VA: Author.</p>\n<p class=\"cr-reference\">Bordin, E. S. (1979). The generalizability of the psychoanalytic concept of the working alliance. Psychotherapy: Theory, Research & Practice, 16(3), 252-260.</p>\n<p class=\"cr-reference\">Eubanks, C. F., Muran, J. C., & Safran, J. D. (2018). Alliance rupture repair: A meta-analysis. Psychotherapy, 55(4), 508-519.</p>\n<p class=\"cr-reference\">Hays, P. A. (2016). Addressing cultural complexities in practice: Assessment, diagnosis, and therapy (3rd ed.). American Psychological Association.</p>\n<p class=\"cr-reference\">Hook, J. N., Davis, D. E., Owen, J., Worthington, E. L., & Utsey, S. O. (2013). Cultural humility: Measuring openness to culturally diverse clients. Journal of Counseling Psychology, 60(3), 353-366.</p>\n<p class=\"cr-reference\">Kanter, J. W., Rosen, D. C., Manbeck, K. E., Marquis, H. M. S., et al. (2020). Addressing microaggressions in racially charged patient-provider interactions. BMC Medical Education, 20, Article 88.</p>\n<p class=\"cr-reference\">Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.</p>\n<p class=\"cr-reference\">Norcross, J. C., & Lambert, M. J. (2018). Psychotherapy relationships that work III. Psychotherapy, 55(4), 303-315.</p>\n<p class=\"cr-reference\">Owen, J., Tao, K. W., Imel, Z. E., Wampold, B. E., & Rodolfa, E. (2014). Addressing racial and ethnic microaggressions in therapy. Professional Psychology: Research and Practice, 45(4), 283-290.</p>\n<p class=\"cr-reference\">Patterson, K., Grenny, J., McMillan, R., & Switzler, A. (2012). Crucial conversations: Tools for talking when stakes are high (2nd ed.). McGraw-Hill.</p>\n<p class=\"cr-reference\">Safran, J. D., & Muran, J. C. (2000). Negotiating the therapeutic alliance: A relational treatment guide. Guilford Press.</p>\n<p class=\"cr-reference\">Safran, J. D., Muran, J. C., & Eubanks-Carter, C. (2011). Repairing alliance ruptures. Psychotherapy, 48(1), 80-87.</p>\n<p class=\"cr-reference\">Stone, D., Patton, B., & Heen, S. (2010). Difficult conversations: How to discuss what matters most. Penguin Books.</p>\n<p class=\"cr-reference\">Sue, D. W. (2010). Microaggressions in everyday life: Race, gender, and sexual orientation. John Wiley & Sons.</p>\n<p class=\"cr-reference\">Sue, D. W., & Sue, D. (2016). Counseling the culturally diverse: Theory and practice (7th ed.). John Wiley & Sons.</p>\n<p class=\"cr-reference\">Tervalon, M., & Murray-García, J. (1998). Cultural humility versus cultural competence: A critical distinction in defining physician training outcomes in multicultural education. Journal of Health Care for the Poor and Underserved, 9(2), 117-125.</p>\n<p class=\"cr-reference\">Wachtel, P. L. (2011). Therapeutic communication: Knowing what to say when (2nd ed.). Guilford Press.</p>\n<p class=\"cr-reference\">Zilcha-Mano, S., & Errázuriz, P. (2015). One size does not fit all: Examining heterogeneity and identifying moderators. Journal of Counseling Psychology, 62(4), 579-591.</p>\n</div>"
+        }
       ]
     }
   ]
 };
-
+course.wordCount = countCourseWords(course);
+const __floor = (course.ceHours || 0) * 6000;
+console.log(`wordCount: ${course.wordCount} | floor: ${__floor} | ${course.wordCount >= __floor ? 'PASS ✅' : 'SHORT ⚠️'}`);
 const existing = await col.findOne({ slug: course.slug });
 if (existing) { await col.updateOne({ _id: existing._id }, { $set: course }); console.log(`✅ UPDATED: ${course.title}`); }
 else { await col.insertOne(course); console.log(`✅ INSERTED: ${course.title}`); }

--- a/server/src/scripts/seedCR402_Walking_on_Eggshells_Working_with_High-Confl-18070words.js
+++ b/server/src/scripts/seedCR402_Walking_on_Eggshells_Working_with_High-Confl-18070words.js
@@ -6,2409 +6,2432 @@
 
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import { countCourseWords } from '../utils/courseWordCount.js';
 dotenv.config();
 if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 await mongoose.connect(process.env.MONGODB_URI);
 const col = mongoose.connection.db.collection('interactivecourses');
 
 const course = {
-  courseCode: 'CR-402',
-  slug: 'walking-on-eggshells-high-conflict-clients',
-  title: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-  subtitle: `A Comprehensive 3-Hour CE Course for Licensed Mental Health Professionals`,
-  description: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-  ceHours: 3,
-  ceuHours: 3,
-  accessType: 'subscription',
-  status: 'draft',
-  isPublished: false,
-  category: 'Clinical Skills',
-  nbccContentAreas: ['Counseling Theory/Practice'],
-  targetAudience: ['Licensed Professional Counselors','Licensed Clinical Social Workers','Licensed Marriage and Family Therapists','National Certified Counselors'],
-  objectives: [    `Identify at least six characteristics of high-conflict clients and describe the biopsychosocial factors contributing to these presentations.`,
-    `Recognize and respond to common patterns in high-conflict interactions including splitting, projective identification, testing behaviors, and escalation cycles.`,
-    `Implement Linehan's six levels of validation to de-escalate emotional intensity without reinforcing problematic behaviors.`,
-    `Establish clear, consistent boundaries using a compassionate yet firm approach, distinguishing between limit-setting and punishment.`,
-    `Apply dialectical behavior therapy principles including radical acceptance, wise mind, and dialectical thinking to high-conflict clinical situations.`,
-    `Identify and manage personal emotional reactions and countertransference triggered by high-conflict clients.`,
-    `Develop treatment frames and session structures that maximize therapeutic benefit while minimizing harm and preventing burnout.`,
-    `Utilize consultation, supervision, and self-care strategies essential for sustainable work with high-conflict populations.`],
-  provider: { name: 'GA Integrated Therapeutic Perspectives LLC', shortName: 'GAITP LLC', acepNumber: '7760', approvalBody: 'NBCC' },
-  presenter: { name: 'Kejuiana Johnson', credentials: 'MA, LPC, NCC, CPCS, BC-TMH', degree: 'MA', licenseNumber: 'LPC009587', licenseState: 'Georgia', licenseType: 'LPC' },
-  approvals: [{ body: 'NBCC', providerNumber: '7760', approvalStatus: 'approved', hourBreakdown: [{ label: 'core', hours: 3 }] }],
-  assessment: {
-    passingScore: 80, maxAttempts: 3, showExplanations: false,
-    questions: [
+  "courseCode": "CR-402",
+  "slug": "walking-on-eggshells-high-conflict-clients",
+  "title": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+  "subtitle": "A Comprehensive 3-Hour CE Course for Licensed Mental Health Professionals",
+  "description": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+  "ceHours": 3,
+  "ceuHours": 3,
+  "accessType": "subscription",
+  "status": "draft",
+  "isPublished": false,
+  "category": "Clinical Skills",
+  "nbccContentAreas": [
+    "Counseling Theory/Practice"
+  ],
+  "targetAudience": [
+    "Licensed Professional Counselors",
+    "Licensed Clinical Social Workers",
+    "Licensed Marriage and Family Therapists",
+    "National Certified Counselors"
+  ],
+  "objectives": [
+    "Identify at least six characteristics of high-conflict clients and describe the biopsychosocial factors contributing to these presentations.",
+    "Recognize and respond to common patterns in high-conflict interactions including splitting, projective identification, testing behaviors, and escalation cycles.",
+    "Implement Linehan's six levels of validation to de-escalate emotional intensity without reinforcing problematic behaviors.",
+    "Establish clear, consistent boundaries using a compassionate yet firm approach, distinguishing between limit-setting and punishment.",
+    "Apply dialectical behavior therapy principles including radical acceptance, wise mind, and dialectical thinking to high-conflict clinical situations.",
+    "Identify and manage personal emotional reactions and countertransference triggered by high-conflict clients.",
+    "Develop treatment frames and session structures that maximize therapeutic benefit while minimizing harm and preventing burnout.",
+    "Utilize consultation, supervision, and self-care strategies essential for sustainable work with high-conflict populations."
+  ],
+  "provider": {
+    "name": "GA Integrated Therapeutic Perspectives LLC",
+    "shortName": "GAITP LLC",
+    "acepNumber": "7760",
+    "approvalBody": "NBCC"
+  },
+  "presenter": {
+    "name": "Kejuiana Johnson",
+    "credentials": "MA, LPC, NCC, CPCS, BC-TMH",
+    "degree": "MA",
+    "licenseNumber": "LPC009587",
+    "licenseState": "Georgia",
+    "licenseType": "LPC"
+  },
+  "approvals": [
+    {
+      "body": "NBCC",
+      "providerNumber": "7760",
+      "approvalStatus": "approved",
+      "hourBreakdown": [
+        {
+          "label": "core",
+          "hours": 3
+        }
+      ]
+    }
+  ],
+  "assessment": {
+    "passingScore": 80,
+    "maxAttempts": 3,
+    "showExplanations": false,
+    "questions": [
       {
-        type: "multipleChoice",
-        question: `According to the course, "high-conflict" refers to:`,
-        options: [
-          { text: `A specific DSM-5 diagnosis`, isCorrect: true },
-          { text: `A behavioral description of challenging patterns regardless of diagnosis`, isCorrect: false },
-          { text: `Only clients with personality disorders`, isCorrect: false },
-          { text: `Clients who disagree with their therapist`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to the course, \"high-conflict\" refers to:",
+        "options": [
+          {
+            "text": "A specific DSM-5 diagnosis",
+            "isCorrect": true
+          },
+          {
+            "text": "A behavioral description of challenging patterns regardless of diagnosis",
+            "isCorrect": false
+          },
+          {
+            "text": "Only clients with personality disorders",
+            "isCorrect": false
+          },
+          {
+            "text": "Clients who disagree with their therapist",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `Which is NOT a characteristic of high-conflict clients?`,
-        options: [
-          { text: `All-or-nothing thinking`, isCorrect: true },
-          { text: `Intense emotional reactions`, isCorrect: false },
-          { text: `Consistent insight into their contribution to problems`, isCorrect: false },
-          { text: `Pattern of interpersonal conflict`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which is NOT a characteristic of high-conflict clients?",
+        "options": [
+          {
+            "text": "All-or-nothing thinking",
+            "isCorrect": true
+          },
+          {
+            "text": "Intense emotional reactions",
+            "isCorrect": false
+          },
+          {
+            "text": "Consistent insight into their contribution to problems",
+            "isCorrect": false
+          },
+          {
+            "text": "Pattern of interpersonal conflict",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The biosocial model understands borderline personality disorder as resulting from:`,
-        options: [
-          { text: `Poor character and lack of willpower`, isCorrect: true },
-          { text: `Biological emotional vulnerability combined with invalidating environments`, isCorrect: false },
-          { text: `Genetic factors only`, isCorrect: false },
-          { text: `Childhood trauma only`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The biosocial model understands borderline personality disorder as resulting from:",
+        "options": [
+          {
+            "text": "Poor character and lack of willpower",
+            "isCorrect": true
+          },
+          {
+            "text": "Biological emotional vulnerability combined with invalidating environments",
+            "isCorrect": false
+          },
+          {
+            "text": "Genetic factors only",
+            "isCorrect": false
+          },
+          {
+            "text": "Childhood trauma only",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `"Splitting" refers to:`,
-        options: [
-          { text: `Terminating therapy prematurely`, isCorrect: true },
-          { text: `The tendency to view people as all good or all bad`, isCorrect: false },
-          { text: `Multiple personality disorder`, isCorrect: false },
-          { text: `Separating from family of origin`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "\"Splitting\" refers to:",
+        "options": [
+          {
+            "text": "Terminating therapy prematurely",
+            "isCorrect": true
+          },
+          {
+            "text": "The tendency to view people as all good or all bad",
+            "isCorrect": false
+          },
+          {
+            "text": "Multiple personality disorder",
+            "isCorrect": false
+          },
+          {
+            "text": "Separating from family of origin",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `In projective identification, the therapist may begin to:`,
-        options: [
-          { text: `Diagnose the client accurately`, isCorrect: true },
-          { text: `Feel and act in ways consistent with the client's projections`, isCorrect: false },
-          { text: `Project their own issues onto the client`, isCorrect: false },
-          { text: `Identify with the client's successes`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "In projective identification, the therapist may begin to:",
+        "options": [
+          {
+            "text": "Diagnose the client accurately",
+            "isCorrect": true
+          },
+          {
+            "text": "Feel and act in ways consistent with the client's projections",
+            "isCorrect": false
+          },
+          {
+            "text": "Project their own issues onto the client",
+            "isCorrect": false
+          },
+          {
+            "text": "Identify with the client's successes",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `When high-conflict clients "test" the therapist, they are often:`,
-        options: [
-          { text: `Being deliberately manipulative`, isCorrect: true },
-          { text: `Unconsciously checking if the therapist will abandon them or handle their intensity`, isCorrect: false },
-          { text: `Trying to get the therapist fired`, isCorrect: false },
-          { text: `Demonstrating intellectual superiority`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When high-conflict clients \"test\" the therapist, they are often:",
+        "options": [
+          {
+            "text": "Being deliberately manipulative",
+            "isCorrect": true
+          },
+          {
+            "text": "Unconsciously checking if the therapist will abandon them or handle their intensity",
+            "isCorrect": false
+          },
+          {
+            "text": "Trying to get the therapist fired",
+            "isCorrect": false
+          },
+          {
+            "text": "Demonstrating intellectual superiority",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `According to Linehan's validation levels, "radical genuineness" involves:`,
-        options: [
-          { text: `Always agreeing with the client`, isCorrect: true },
-          { text: `Treating the client as a capable person, not a fragile patient`, isCorrect: false },
-          { text: `Being rude to the client`, isCorrect: false },
-          { text: `Sharing all of your personal opinions`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to Linehan's validation levels, \"radical genuineness\" involves:",
+        "options": [
+          {
+            "text": "Always agreeing with the client",
+            "isCorrect": true
+          },
+          {
+            "text": "Treating the client as a capable person, not a fragile patient",
+            "isCorrect": false
+          },
+          {
+            "text": "Being rude to the client",
+            "isCorrect": false
+          },
+          {
+            "text": "Sharing all of your personal opinions",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The key distinction between validation and agreement is:`,
-        options: [
-          { text: `There is no distinction; they mean the same thing`, isCorrect: true },
-          { text: `Validation acknowledges the emotion without necessarily agreeing about the situation`, isCorrect: false },
-          { text: `Validation is always inappropriate`, isCorrect: false },
-          { text: `Agreement is more important than validation`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The key distinction between validation and agreement is:",
+        "options": [
+          {
+            "text": "There is no distinction; they mean the same thing",
+            "isCorrect": true
+          },
+          {
+            "text": "Validation acknowledges the emotion without necessarily agreeing about the situation",
+            "isCorrect": false
+          },
+          {
+            "text": "Validation is always inappropriate",
+            "isCorrect": false
+          },
+          {
+            "text": "Agreement is more important than validation",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The "and" in validation statements (e.g., "I understand you're angry AND I need you to lower your voice") serves to:`,
-        options: [
-          { text: `Negate the validation`, isCorrect: true },
-          { text: `Connect validation to behavioral guidance without negating either`, isCorrect: false },
-          { text: `Confuse the client`, isCorrect: false },
-          { text: `End the conversation`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The \"and\" in validation statements (e.g., \"I understand you're angry AND I need you to lower your voice\") serves to:",
+        "options": [
+          {
+            "text": "Negate the validation",
+            "isCorrect": true
+          },
+          {
+            "text": "Connect validation to behavioral guidance without negating either",
+            "isCorrect": false
+          },
+          {
+            "text": "Confuse the client",
+            "isCorrect": false
+          },
+          {
+            "text": "End the conversation",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `What does the acronym JADE represent in boundary-setting?`,
-        options: [
-          { text: `Joyful, Appreciative, Determined, Eager`, isCorrect: true },
-          { text: `Justify, Argue, Defend, Explain (things to avoid overdoing)`, isCorrect: false },
-          { text: `Judgment, Anger, Disappointment, Evaluation`, isCorrect: false },
-          { text: `Join, Adapt, Develop, Establish`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "What does the acronym JADE represent in boundary-setting?",
+        "options": [
+          {
+            "text": "Joyful, Appreciative, Determined, Eager",
+            "isCorrect": true
+          },
+          {
+            "text": "Justify, Argue, Defend, Explain (things to avoid overdoing)",
+            "isCorrect": false
+          },
+          {
+            "text": "Judgment, Anger, Disappointment, Evaluation",
+            "isCorrect": false
+          },
+          {
+            "text": "Join, Adapt, Develop, Establish",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The difference between limit-setting and punishment is:`,
-        options: [
-          { text: `There is no difference`, isCorrect: true },
-          { text: `Limit-setting maintains structure while remaining collaborative; punishment is retaliatory`, isCorrect: false },
-          { text: `Punishment is more effective`, isCorrect: false },
-          { text: `Limit-setting always involves consequences`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The difference between limit-setting and punishment is:",
+        "options": [
+          {
+            "text": "There is no difference",
+            "isCorrect": true
+          },
+          {
+            "text": "Limit-setting maintains structure while remaining collaborative; punishment is retaliatory",
+            "isCorrect": false
+          },
+          {
+            "text": "Punishment is more effective",
+            "isCorrect": false
+          },
+          {
+            "text": "Limit-setting always involves consequences",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `Which reaction might indicate countertransference with high-conflict clients?`,
-        options: [
-          { text: `Maintaining appropriate boundaries`, isCorrect: true },
-          { text: `Dreading sessions and feeling relief when client cancels`, isCorrect: false },
-          { text: `Following treatment protocols`, isCorrect: false },
-          { text: `Consistent session attendance`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which reaction might indicate countertransference with high-conflict clients?",
+        "options": [
+          {
+            "text": "Maintaining appropriate boundaries",
+            "isCorrect": true
+          },
+          {
+            "text": "Dreading sessions and feeling relief when client cancels",
+            "isCorrect": false
+          },
+          {
+            "text": "Following treatment protocols",
+            "isCorrect": false
+          },
+          {
+            "text": "Consistent session attendance",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `DBT's hierarchy of treatment targets places which concern first?`,
-        options: [
-          { text: `Skills acquisition`, isCorrect: true },
-          { text: `Quality-of-life-interfering behaviors`, isCorrect: false },
-          { text: `Life-threatening behaviors`, isCorrect: false },
-          { text: `Financial issues`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "DBT's hierarchy of treatment targets places which concern first?",
+        "options": [
+          {
+            "text": "Skills acquisition",
+            "isCorrect": true
+          },
+          {
+            "text": "Quality-of-life-interfering behaviors",
+            "isCorrect": false
+          },
+          {
+            "text": "Life-threatening behaviors",
+            "isCorrect": false
+          },
+          {
+            "text": "Financial issues",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The course recommends caseload management that involves:`,
-        options: [
-          { text: `Filling entire caseload with high-conflict clients for efficiency`, isCorrect: true },
-          { text: `Balancing caseload so not every client is high-conflict`, isCorrect: false },
-          { text: `Never accepting high-conflict clients`, isCorrect: false },
-          { text: `Seeing high-conflict clients only on Fridays`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The course recommends caseload management that involves:",
+        "options": [
+          {
+            "text": "Filling entire caseload with high-conflict clients for efficiency",
+            "isCorrect": true
+          },
+          {
+            "text": "Balancing caseload so not every client is high-conflict",
+            "isCorrect": false
+          },
+          {
+            "text": "Never accepting high-conflict clients",
+            "isCorrect": false
+          },
+          {
+            "text": "Seeing high-conflict clients only on Fridays",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `Which statement about high-conflict clients is TRUE according to the course?`,
-        options: [
-          { text: `They are deliberately trying to make therapy difficult`, isCorrect: true },
-          { text: `High-conflict patterns typically developed as survival strategies in difficult circumstances`, isCorrect: false },
-          { text: `They cannot benefit from therapy`, isCorrect: false },
-          { text: `They should be immediately referred elsewhere`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Which statement about high-conflict clients is TRUE according to the course?",
+        "options": [
+          {
+            "text": "They are deliberately trying to make therapy difficult",
+            "isCorrect": true
+          },
+          {
+            "text": "High-conflict patterns typically developed as survival strategies in difficult circumstances",
+            "isCorrect": false
+          },
+          {
+            "text": "They cannot benefit from therapy",
+            "isCorrect": false
+          },
+          {
+            "text": "They should be immediately referred elsewhere",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `When a high-conflict client tests boundaries, effective therapists:`,
-        options: [
-          { text: `Abandon the boundary to maintain the relationship`, isCorrect: true },
-          { text: `Acknowledge the underlying need while maintaining the boundary`, isCorrect: false },
-          { text: `Immediately terminate treatment`, isCorrect: false },
-          { text: `Become punitive`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "When a high-conflict client tests boundaries, effective therapists:",
+        "options": [
+          {
+            "text": "Abandon the boundary to maintain the relationship",
+            "isCorrect": true
+          },
+          {
+            "text": "Acknowledge the underlying need while maintaining the boundary",
+            "isCorrect": false
+          },
+          {
+            "text": "Immediately terminate treatment",
+            "isCorrect": false
+          },
+          {
+            "text": "Become punitive",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `Self-care when working with high-conflict clients is described as:`,
-        options: [
-          { text: `Optional but nice to have`, isCorrect: true },
-          { text: `Essential for sustainability, not optional`, isCorrect: false },
-          { text: `Only needed after burnout occurs`, isCorrect: false },
-          { text: `Unnecessary for experienced clinicians`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Self-care when working with high-conflict clients is described as:",
+        "options": [
+          {
+            "text": "Optional but nice to have",
+            "isCorrect": true
+          },
+          {
+            "text": "Essential for sustainability, not optional",
+            "isCorrect": false
+          },
+          {
+            "text": "Only needed after burnout occurs",
+            "isCorrect": false
+          },
+          {
+            "text": "Unnecessary for experienced clinicians",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `Consultation and supervision when working with high-conflict clients should be:`,
-        options: [
-          { text: `Only sought during crises`, isCorrect: true },
-          { text: `Avoided to maintain client confidentiality`, isCorrect: false },
-          { text: `Ongoing, not just crisis-driven`, isCorrect: false },
-          { text: `Only for trainees`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "Consultation and supervision when working with high-conflict clients should be:",
+        "options": [
+          {
+            "text": "Only sought during crises",
+            "isCorrect": true
+          },
+          {
+            "text": "Avoided to maintain client confidentiality",
+            "isCorrect": false
+          },
+          {
+            "text": "Ongoing, not just crisis-driven",
+            "isCorrect": false
+          },
+          {
+            "text": "Only for trainees",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `The course describes the "eggshell" experience as:`,
-        options: [
-          { text: `A decorating style for therapy offices`, isCorrect: true },
-          { text: `The hypervigilance and fear of triggering clients that therapists experience`, isCorrect: false },
-          { text: `A diagnosis category`, isCorrect: false },
-          { text: `A type of projection`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "The course describes the \"eggshell\" experience as:",
+        "options": [
+          {
+            "text": "A decorating style for therapy offices",
+            "isCorrect": true
+          },
+          {
+            "text": "The hypervigilance and fear of triggering clients that therapists experience",
+            "isCorrect": false
+          },
+          {
+            "text": "A diagnosis category",
+            "isCorrect": false
+          },
+          {
+            "text": "A type of projection",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
       },
       {
-        type: "multipleChoice",
-        question: `According to the course, referring a high-conflict client:`,
-        options: [
-          { text: `Is always a sign of therapist failure`, isCorrect: true },
-          { text: `May be appropriate care when client needs specialized treatment or fit isn't working`, isCorrect: false },
-          { text: `Should never happen`, isCorrect: false },
-          { text: `Is the first option before attempting treatment`, isCorrect: false }
+        "type": "multipleChoice",
+        "question": "According to the course, referring a high-conflict client:",
+        "options": [
+          {
+            "text": "Is always a sign of therapist failure",
+            "isCorrect": true
+          },
+          {
+            "text": "May be appropriate care when client needs specialized treatment or fit isn't working",
+            "isCorrect": false
+          },
+          {
+            "text": "Should never happen",
+            "isCorrect": false
+          },
+          {
+            "text": "Is the first option before attempting treatment",
+            "isCorrect": false
+          }
         ],
-        correctAnswer: 0,
-        explanation: ``
+        "correctAnswer": 0,
+        "explanation": ""
+      },
+      {
+        "type": "trueFalse",
+        "question": "Validation means communicating that an emotional response is understandable, which is not the same as agreeing with the client’s interpretation.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "Validation affirms that the emotion makes sense given the context; it is distinct from agreement with the client’s conclusions."
+      },
+      {
+        "type": "trueFalse",
+        "question": "When holding a boundary, the clinician should justify, argue, defend, and explain at length to ensure the client understands.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": false
+          },
+          {
+            "text": "False",
+            "isCorrect": true
+          }
+        ],
+        "correctAnswer": 1,
+        "explanation": "That is JADE — the trap to avoid. Over-explaining invites debate; the clinician states the limit, acknowledges the feeling, and holds."
+      },
+      {
+        "type": "trueFalse",
+        "question": "The biosocial model attributes borderline patterns to the transaction between biological vulnerability and an invalidating environment.",
+        "options": [
+          {
+            "text": "True",
+            "isCorrect": true
+          },
+          {
+            "text": "False",
+            "isCorrect": false
+          }
+        ],
+        "correctAnswer": 0,
+        "explanation": "This transaction — not a single cause — is the core of Linehan’s biosocial model."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which are common countertransference reactions in high-conflict work? (Select all that apply)",
+        "options": [
+          {
+            "text": "Rescue fantasies",
+            "isCorrect": true
+          },
+          {
+            "text": "Retaliation impulses",
+            "isCorrect": true
+          },
+          {
+            "text": "Helplessness and despair",
+            "isCorrect": true
+          },
+          {
+            "text": "Guaranteed immunity to the client’s affect",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "Rescue fantasies, retaliation impulses, and helplessness are all common; no clinician is immune to being affected — the work is to notice and use the reactions."
+      },
+      {
+        "type": "multiSelect",
+        "question": "Which practices support sustainability in high-conflict work? (Select all that apply)",
+        "options": [
+          {
+            "text": "Regular consultation",
+            "isCorrect": true
+          },
+          {
+            "text": "A balanced, varied caseload",
+            "isCorrect": true
+          },
+          {
+            "text": "Attention to vicarious trauma and burnout signs",
+            "isCorrect": true
+          },
+          {
+            "text": "Carrying all high-conflict cases in isolation",
+            "isCorrect": false
+          }
+        ],
+        "explanation": "Consultation, caseload balance, and monitoring for vicarious trauma sustain the work; isolation with an all-high-conflict caseload erodes it."
       }
     ]
   },
-  references: [    { citation: `American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). Washington, DC: Author.` },
-    { citation: `Bateman, A., & Fonagy, P. (2016). Mentalization-based treatment for personality disorders: A practical guide. Oxford University Press.` },
-    { citation: `Chapman, A. L., & Gratz, K. L. (2015). The borderline personality disorder survival guide. New Harbinger Publications.` },
-    { citation: `Clarkin, J. F., Yeomans, F. E., & Kernberg, O. F. (2006). Psychotherapy of borderline personality: Focusing on object relations. American Psychiatric Publishing.` },
-    { citation: `Eddy, B. (2019). 5 types of people who can ruin your life: Identifying and dealing with narcissists, sociopaths, and other high-conflict personalities. TarcherPerigee.` },
-    { citation: `Gunderson, J. G., & Links, P. S. (2014). Handbook of good psychiatric management for borderline personality disorder. American Psychiatric Publishing.` },
-    { citation: `Kreisman, J. J., & Straus, H. (2010). I hate you—don't leave me: Understanding the borderline personality (Rev. ed.). TarcherPerigee.` },
-    { citation: `Linehan, M. M. (1993). Cognitive-behavioral treatment of borderline personality disorder. Guilford Press.` },
-    { citation: `Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.` },
-    { citation: `Mason, P. T., & Kreger, R. (2020). Stop walking on eggshells: Taking your life back when someone you care about has borderline personality disorder (3rd ed.). New Harbinger Publications.` },
-    { citation: `McWilliams, N. (2011). Psychoanalytic diagnosis: Understanding personality structure in the clinical process (2nd ed.). Guilford Press.` },
-    { citation: `Paris, J. (2020). Treatment of borderline personality disorder: A guide to evidence-based practice (2nd ed.). Guilford Press.` },
-    { citation: `Roth, K., & Friedman, F. B. (2003). Surviving a borderline parent: How to heal your childhood wounds and build trust, boundaries, and self-esteem. New Harbinger Publications.` },
-    { citation: `Stoffers-Winterling, J., Völlm, B. A., Rücker, G., Timmer, A., Huband, N., & Lieb, K. (2012). Psychological therapies for people with borderline personality disorder. Cochrane Database of Systematic Reviews, 2012(8), CD005652.` },
-    { citation: `Zanarini, M. C. (2009). Psychotherapy of borderline personality disorder. Acta Psychiatrica Scandinavica, 120(5), 373-377.` }],
-  sections: [
+  "references": [
     {
-      order: 1,
-      title: `Module 1: UNDERSTANDING HIGH-CONFLICT PRESENTATIONS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 1: UNDERSTANDING HIGH-CONFLICT PRESENTATIONS`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 1,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Define "high-conflict" as a behavioral description rather than a diagnosis</li>
-<li>Identify six key characteristics common to high-conflict presentations</li>
-<li>Describe contributing factors including personality pathology, trauma, and attachment</li>
-<li>Apply the biosocial model to understand borderline presentations</li>
-<li>Differentiate between borderline and narcissistic patterns in clinical work</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Defining High-Conflict Clients</h2>
-<p>"High-conflict" is a behavioral description, not a diagnostic category. You won't find it in the DSM-5. It's a term clinicians use to describe clients whose interpersonal patterns create significant challenges in the therapeutic relationship and beyond.</p>
-<p>High-conflict clients share certain characteristics regardless of their specific diagnosis. They may carry diagnoses of borderline personality disorder, narcissistic personality disorder, other Cluster B presentations, complex PTSD, or no personality disorder diagnosis at all. What unites them is a pattern of interpersonal behavior that creates conflict, intensity, and difficulty—in therapy and in life.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Core Characteristics</h2>
-<p>High-conflict clients typically demonstrate several of the following characteristics:</p>
-<p><strong>All-or-nothing thinking.</strong> People and situations are seen as all good or all bad, with little room for nuance, ambivalence, or complexity. The therapist is either wonderful or terrible. The partner is either perfect or evil. There's no middle ground, no "good enough," no tolerance for the reality that most people and situations contain both positive and negative elements.</p>
-<p>This cognitive pattern—sometimes called "splitting" when applied to people—creates instability in relationships. When someone is idealized, any evidence of imperfection feels like betrayal. When someone is devalued, no positive evidence penetrates the negative view. People cycle from one category to the other based on relatively minor triggers.</p>
-<p><strong>Intense, rapid emotional reactions.</strong> Emotions in high-conflict clients are often strong, swift, and slow to return to baseline. Something that might mildly annoy another person produces rage. A minor disappointment produces despair. A small perceived rejection produces abandonment panic.</p>
-<p>These emotional reactions often seem disproportionate to the triggering event—from an outside observer's perspective. From inside the client's experience, the reaction makes sense given their interpretation of the situation. Understanding this gap between external observation and internal experience is crucial for effective treatment.</p>
-<p><strong>Blame externalization.</strong> When things go wrong, the cause is located outside the self. It's the other person's fault. The system is broken. Circumstances are to blame. While external factors certainly contribute to life's problems, high-conflict individuals show a consistent pattern of failing to examine their own contribution to difficulties.</p>
-<p>This externalization protects fragile self-esteem but prevents learning and change. If problems are always someone else's fault, there's nothing to work on. The client becomes a passive victim of circumstances rather than an agent who can make different choices.</p>
-<p><strong>Preoccupation with others' behavior.</strong> High-conflict clients often focus intensely on what others are doing wrong. They track perceived slights meticulously. They keep score of fairness violations. They can recite detailed histories of how others have wronged them.</p>
-<p>This other-focus serves a defensive function—it keeps attention away from the self. But it also maintains conflict by ensuring that grievances are never resolved or released. Every interaction is filtered through a lens of vigilance for mistreatment.</p>
-<p><strong>Difficulty taking feedback.</strong> Even gentle, carefully delivered feedback is experienced as attack. The high-conflict client becomes defensive, counter-attacks, shuts down, or leaves. This makes therapy—which inherently involves some feedback—extremely challenging. The therapist must navigate between honest observation and triggering defensive collapse.</p>
-<p><strong>Pattern of interpersonal conflict.</strong> High-conflict is not situational—it's pervasive. These clients have histories of repeated conflicts across relationships and settings. Multiple ex-partners are "crazy" or "abusive." Multiple employers were unfair. Multiple friendships ended badly. Multiple previous therapists failed them. The common denominator—the client themselves—remains unexamined.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>🎭 Clinical Vignette: Recognizing High-Conflict Patterns</h2>
-<p>Angela, a 32-year-old marketing professional, presents for therapy after her third divorce. In the intake, several high-conflict indicators emerge:</p>
-<p><strong>On her ex-husbands:</strong> "The first one was a narcissist. Totally emotionally abusive. The second one seemed great at first, but turned out to be a complete liar. And this last one—I thought he was different, but he's the worst of all. He's turned everyone against me. My lawyer says he's never seen anyone so vindictive."</p>
-<p><strong>On previous therapy:</strong> "I've seen like six therapists. Most of them didn't get it. One was actually pretty good, but then she abandoned me—just quit seeing me out of nowhere. She probably couldn't handle my case. The last one was terrible—she blamed me for everything."</p>
-<p><strong>On her current situation:</strong> "I'm not saying I'm perfect, but I know I'm not the problem here. Everyone keeps saying I need to look at myself, but I've done that. The problem is I keep choosing the wrong people."</p>
-<p><strong>In the session:</strong> Angela alternates between tearful vulnerability and sharp criticism. When the therapist asks a clarifying question, Angela snaps: "Why are you focusing on that? That's not what's important." Minutes later, she's praising the therapist: "You're actually listening to me. That's more than anyone else has done."</p>
-<p><strong>Decision Point:</strong> What high-conflict characteristics do you observe?</p>
-<p><strong>Answer Key:</strong></p>
-<ul>
-<li>All-or-nothing thinking: Ex-husbands are all terrible, previous therapists either "got it" or were terrible</li>
-<li>Blame externalization: "I'm not the problem," others are to blame</li>
-<li>Pattern of conflict: Three divorces, six therapists, conflicts across relationships</li>
-<li>Difficulty with feedback: Snaps when asked clarifying question</li>
-<li>Rapid emotional shifts: Alternates between vulnerability, criticism, and praise</li>
-<li>Preoccupation with others' behavior: Detailed accounts of others' wrongdoing</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>📋 Reflection Exercise: Your High-Conflict Clients</h2>
-<p>Think of a current or recent high-conflict client. Identify which characteristics they demonstrate:</p><table class="cr-table">
-<tr><th>Characteristic</th><th>Present?</th><th>Example</th></tr>
-<tr><td>All-or-nothing thinking</td><td>☐ Yes ☐ No</td><td></td></tr>
-<tr><td>Intense emotional reactions</td><td>☐ Yes ☐ No</td><td></td></tr>
-<tr><td>Blame externalization</td><td>☐ Yes ☐ No</td><td></td></tr>
-<tr><td>Preoccupation with others</td><td>☐ Yes ☐ No</td><td></td></tr>
-<tr><td>Difficulty with feedback</td><td>☐ Yes ☐ No</td><td></td></tr>
-<tr><td>Pattern of conflict</td><td>☐ Yes ☐ No</td><td></td></tr>
-</table>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Contributing Factors</h2>
-<p>High-conflict presentations don't emerge from nowhere. They typically develop from the intersection of several factors:</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Personality Pathology</h2>
-<p>Personality disorders, particularly Cluster B disorders (borderline, narcissistic, antisocial, histrionic), often underlie high-conflict presentations. The DSM-5 defines personality disorders as enduring patterns of inner experience and behavior that deviate markedly from cultural expectations, are pervasive and inflexible, have onset in adolescence or early adulthood, are stable over time, and lead to distress or impairment.</p>
-<p><strong>Borderline personality disorder</strong> is perhaps the most commonly encountered high-conflict presentation in outpatient therapy. Core features include affective instability, interpersonal instability, identity disturbance, and impulsivity. The fear of abandonment that characterizes BPD drives much of the high-conflict behavior—clients desperately seek connection while simultaneously pushing people away.</p>
-<p><strong>Narcissistic personality disorder</strong> presents differently but can be equally challenging. Core features include grandiosity, need for admiration, and lack of empathy. The fragile self-esteem beneath the grandiose exterior makes narcissistic clients extremely sensitive to any perceived criticism or slight.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Complex Trauma</h2>
-<p>High-conflict patterns often emerge from complex developmental trauma—prolonged, repeated trauma occurring within caregiving relationships. When children are hurt by the people who are supposed to protect them, they develop distorted models of relationships: love is dangerous, trust leads to betrayal, closeness means pain.</p>
-<p>These traumatic templates get activated in therapy. The therapist offers care—and the client's system says "danger." The therapist sets a limit—and the client experiences abandonment. The therapeutic relationship becomes a stage on which trauma dynamics play out.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Attachment Disruption</h2>
-<p>Attachment theory helps us understand why early relationships matter so much. Children develop internal working models of relationships based on their experiences with primary caregivers. Secure attachment leads to models where others are trustworthy and the self is worthy of care. Insecure attachment leads to various distorted models.</p>
-<p><strong>Disorganized attachment</strong>—the pattern most associated with high-conflict presentations—develops when the caregiver is simultaneously the source of fear and the source of comfort. The child faces an impossible dilemma: they need to approach the caregiver for safety, but the caregiver is the threat. This creates a fragmented, contradictory internal model that persists into adulthood.</p>
-<p>Adults with disorganized attachment struggle in close relationships. They want connection but expect harm. They approach and then retreat. They idealize and then devalue. The very closeness of the therapeutic relationship can activate these patterns intensely.</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Neurobiological Factors</h2>
-<p>Emerging research suggests that some individuals have nervous systems that are temperamentally more reactive. They experience emotions more intensely, become dysregulated more easily, and take longer to return to baseline. This isn't their fault—it's biological variation.</p>
-<p>When emotional vulnerability is combined with invalidating environments, the result is often the patterns we label "high-conflict." The biosocial model of BPD, developed by Marsha Linehan, posits exactly this transaction: biological vulnerability plus environmental invalidation produces emotional dysregulation and the interpersonal patterns associated with borderline personality disorder.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Learned Patterns</h2>
-<p>High-conflict behavior may also be learned. If a child grows up in a high-conflict family, they learn that relationships involve drama, intensity, and chaos. They learn that the way to get needs met is through escalation. They may have no template for calm, stable relating.</p>
-<p>Similarly, if high-conflict behavior has been reinforced—if escalation leads to getting one's way, if dramatic expressions of distress bring care—the behavior persists because it works. Understanding the reinforcement history helps us understand the behavior without excusing it.</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>The Biosocial Model: Understanding Borderline Presentations</h2>
-<p>Marsha Linehan's biosocial model provides an invaluable framework for understanding how borderline patterns develop. The model posits a transaction between two factors:</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Biological Vulnerability</h2>
-<p>Some individuals are born with emotional systems that are more reactive than average. They experience emotions more intensely. They're triggered more easily. They take longer to return to baseline once dysregulated. This isn't a character flaw—it's neurobiological variation, as real as variations in height or eye color.</p>
-<p>This emotional vulnerability is evident from early childhood. These are the babies who cry more intensely, the toddlers who have bigger tantrums, the children who are described as "sensitive" or "dramatic." Their emotional systems run hot.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Invalidating Environments</h2>
-<p>An invalidating environment is one that chronically communicates to the child that their emotional responses are wrong, bad, inappropriate, or excessive. This can happen in many ways:</p>
-<p><strong>Dismissal:</strong> "You're fine. There's nothing to cry about." "Stop making a big deal out of nothing."</p>
-<p><strong>Punishment:</strong> "Go to your room until you can calm down." "If you're going to act like that, you can't come with us."</p>
-<p><strong>Inconsistent response:</strong> Sometimes the parent responds to distress with comfort, sometimes with anger, sometimes with neglect. The child can't predict what response they'll get.</p>
-<p><strong>Role reversal:</strong> The child is expected to manage the parent's emotions rather than vice versa. The child learns their own needs are less important than the parent's stability.</p>
-<p><strong>Abuse and neglect:</strong> Severe forms of invalidation involve direct trauma—physical abuse, sexual abuse, severe neglect.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>The Transaction</h2>
-<p>When emotional vulnerability meets chronic invalidation, a developmental cascade begins. The emotionally vulnerable child expresses distress. The invalidating environment responds with dismissal, punishment, or inconsistency. The child's distress escalates. Eventually, the environment responds—often after the child has escalated to dramatic levels.</p>
-<p>The child learns several toxic lessons:</p>
-<ul>
-<li>My emotions are wrong or bad</li>
-<li>I can't trust my own experience</li>
-<li>Moderate expressions of distress don't work</li>
-<li>Extreme expressions sometimes get response</li>
-<li>Emotions are dangerous and must be controlled or hidden</li>
-</ul>
-<p>These lessons produce the adult patterns we see in borderline presentations: emotional dysregulation, self-invalidation, oscillation between suppression and extreme expression, interpersonal instability, and chronic sense of emptiness and identity confusion.</p>
-<p>Understanding this model creates compassion. The high-conflict client didn't choose these patterns. They developed in response to impossible circumstances. The skills they lacked weren't taught. The validation they needed wasn't provided. Their "dysfunction" was, in a sense, the best adaptation available given their biology and environment.</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>Borderline vs. Narcissistic Patterns</h2>
-<p>While both borderline and narcissistic presentations can be high-conflict, they create different therapeutic challenges:</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>Borderline Patterns</h2>
-<p><strong>Core experience:</strong> Fear of abandonment, chronic emptiness, unstable identity</p>
-<p><strong>Presentation in therapy:</strong> Clings intensely to the therapist, may idealize then devalue, expresses desperation and distress openly, fears therapist will leave</p>
-<p><strong>Therapeutic challenge:</strong> Managing intensity without reinforcing crisis, setting limits without triggering abandonment panic, tolerating idealization/devaluation cycles</p>
-<p><strong>What helps:</strong> Validation, consistency, clear boundaries, skills teaching</p>`,
-            },
-{
-              type: "text",
-              order: 19,
-              content: `<h2>Narcissistic Patterns</h2>
-<p><strong>Core experience:</strong> Fragile self-esteem beneath grandiose exterior, shame-sensitivity, need for admiration</p>
-<p><strong>Presentation in therapy:</strong> May present as superior to others including therapist, dismisses input that doesn't affirm, sensitive to any perceived criticism, may not see themselves as having problems</p>
-<p><strong>Therapeutic challenge:</strong> Engaging without collusion in grandiosity, providing feedback without triggering shame collapse, managing their devaluation of therapy</p>
-<p><strong>What helps:</strong> Respect for their need to feel capable, careful delivery of feedback, patience with slow progress</p>
-<p>Many high-conflict clients show features of both patterns. The categories are useful guides, not rigid boxes.</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 20,
-              question: `"High-conflict" is best described as:`,
-              options: [
-                { text: `A DSM-5 diagnosis`, isCorrect: true },
-                { text: `A behavioral description regardless of specific diagnosis`, isCorrect: false },
-                { text: `Another term for borderline personality disorder`, isCorrect: false },
-                { text: `A temporary state during crisis`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 21,
-              question: `Which is NOT typically a characteristic of high-conflict clients?`,
-              options: [
-                { text: `All-or-nothing thinking`, isCorrect: true },
-                { text: `Blame externalization`, isCorrect: false },
-                { text: `Consistent self-reflection about their contribution to problems`, isCorrect: false },
-                { text: `Pattern of interpersonal conflict`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 22,
-              question: `The biosocial model explains borderline patterns as resulting from:`,
-              options: [
-                { text: `Poor parenting choices alone`, isCorrect: true },
-                { text: `Genetic factors alone`, isCorrect: false },
-                { text: `Biological emotional vulnerability combined with invalidating environments`, isCorrect: false },
-                { text: `Traumatic brain injury`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 23,
-              question: `Disorganized attachment develops when:`,
-              options: [
-                { text: `The caregiver is consistently warm and responsive`, isCorrect: true },
-                { text: `The caregiver is simultaneously the source of fear and comfort`, isCorrect: false },
-                { text: `The child has no caregiver`, isCorrect: false },
-                { text: `The child has multiple caregivers`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 24,
-              question: `Compared to borderline presentations, narcissistic presentations typically involve:`,
-              options: [
-                { text: `More fear of abandonment`, isCorrect: true },
-                { text: `More sensitivity to perceived criticism and shame`, isCorrect: false },
-                { text: `More open expression of distress`, isCorrect: false },
-                { text: `More clinging to the therapist`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+      "citation": "American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). Washington, DC: Author."
+    },
+    {
+      "citation": "Bateman, A., & Fonagy, P. (2016). Mentalization-based treatment for personality disorders: A practical guide. Oxford University Press."
+    },
+    {
+      "citation": "Chapman, A. L., & Gratz, K. L. (2015). The borderline personality disorder survival guide. New Harbinger Publications."
+    },
+    {
+      "citation": "Clarkin, J. F., Yeomans, F. E., & Kernberg, O. F. (2006). Psychotherapy of borderline personality: Focusing on object relations. American Psychiatric Publishing."
+    },
+    {
+      "citation": "Eddy, B. (2019). 5 types of people who can ruin your life: Identifying and dealing with narcissists, sociopaths, and other high-conflict personalities. TarcherPerigee."
+    },
+    {
+      "citation": "Gunderson, J. G., & Links, P. S. (2014). Handbook of good psychiatric management for borderline personality disorder. American Psychiatric Publishing."
+    },
+    {
+      "citation": "Kreisman, J. J., & Straus, H. (2010). I hate you—don't leave me: Understanding the borderline personality (Rev. ed.). TarcherPerigee."
+    },
+    {
+      "citation": "Linehan, M. M. (1993). Cognitive-behavioral treatment of borderline personality disorder. Guilford Press."
+    },
+    {
+      "citation": "Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press."
+    },
+    {
+      "citation": "Mason, P. T., & Kreger, R. (2020). Stop walking on eggshells: Taking your life back when someone you care about has borderline personality disorder (3rd ed.). New Harbinger Publications."
+    },
+    {
+      "citation": "McWilliams, N. (2011). Psychoanalytic diagnosis: Understanding personality structure in the clinical process (2nd ed.). Guilford Press."
+    },
+    {
+      "citation": "Paris, J. (2020). Treatment of borderline personality disorder: A guide to evidence-based practice (2nd ed.). Guilford Press."
+    },
+    {
+      "citation": "Roth, K., & Friedman, F. B. (2003). Surviving a borderline parent: How to heal your childhood wounds and build trust, boundaries, and self-esteem. New Harbinger Publications."
+    },
+    {
+      "citation": "Stoffers-Winterling, J., Völlm, B. A., Rücker, G., Timmer, A., Huband, N., & Lieb, K. (2012). Psychological therapies for people with borderline personality disorder. Cochrane Database of Systematic Reviews, 2012(8), CD005652."
+    },
+    {
+      "citation": "Zanarini, M. C. (2009). Psychotherapy of borderline personality disorder. Acta Psychiatrica Scandinavica, 120(5), 373-377."
+    }
+  ],
+  "sections": [
+    {
+      "order": 1,
+      "title": "Module 1: UNDERSTANDING HIGH-CONFLICT PRESENTATIONS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 1: UNDERSTANDING HIGH-CONFLICT PRESENTATIONS",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 1
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Define \"high-conflict\" as a behavioral description rather than a diagnosis</li>\n<li>Identify six key characteristics common to high-conflict presentations</li>\n<li>Describe contributing factors including personality pathology, trauma, and attachment</li>\n<li>Apply the {{callout:biosocial-model}} to understand borderline presentations</li>\n<li>Differentiate between borderline and narcissistic patterns in clinical work</li>\n</ol>",
+          "callouts": {
+            "biosocial-model": {
+              "label": "Biosocial Model",
+              "type": "reference",
+              "body": "Linehan’s account of borderline patterns as arising from the transaction between biological emotional vulnerability and a chronically invalidating environment."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Defining High-Conflict Clients</h2>\n<p>\"High-conflict\" is a behavioral description, not a diagnostic category. You won't find it in the DSM-5. It's a term clinicians use to describe clients whose interpersonal patterns create significant challenges in the therapeutic relationship and beyond.</p>\n<p>High-conflict clients share certain characteristics regardless of their specific diagnosis. They may carry diagnoses of borderline personality disorder, narcissistic personality disorder, other Cluster B presentations, complex PTSD, or no personality disorder diagnosis at all. What unites them is a pattern of interpersonal behavior that creates conflict, intensity, and difficulty—in therapy and in life.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Core Characteristics</h2>\n<p>High-conflict clients typically demonstrate several of the following characteristics:</p>\n<p><strong>All-or-nothing thinking.</strong> People and situations are seen as all good or all bad, with little room for nuance, ambivalence, or complexity. The therapist is either wonderful or terrible. The partner is either perfect or evil. There's no middle ground, no \"good enough,\" no tolerance for the reality that most people and situations contain both positive and negative elements.</p>\n<p>This cognitive pattern—sometimes called \"splitting\" when applied to people—creates instability in relationships. When someone is idealized, any evidence of imperfection feels like betrayal. When someone is devalued, no positive evidence penetrates the negative view. People cycle from one category to the other based on relatively minor triggers.</p>\n<p><strong>Intense, rapid emotional reactions.</strong> Emotions in high-conflict clients are often strong, swift, and slow to return to baseline. Something that might mildly annoy another person produces rage. A minor disappointment produces despair. A small perceived rejection produces abandonment panic.</p>\n<p>These emotional reactions often seem disproportionate to the triggering event—from an outside observer's perspective. From inside the client's experience, the reaction makes sense given their interpretation of the situation. Understanding this gap between external observation and internal experience is crucial for effective treatment.</p>\n<p><strong>Blame externalization.</strong> When things go wrong, the cause is located outside the self. It's the other person's fault. The system is broken. Circumstances are to blame. While external factors certainly contribute to life's problems, high-conflict individuals show a consistent pattern of failing to examine their own contribution to difficulties.</p>\n<p>This externalization protects fragile self-esteem but prevents learning and change. If problems are always someone else's fault, there's nothing to work on. The client becomes a passive victim of circumstances rather than an agent who can make different choices.</p>\n<p><strong>Preoccupation with others' behavior.</strong> High-conflict clients often focus intensely on what others are doing wrong. They track perceived slights meticulously. They keep score of fairness violations. They can recite detailed histories of how others have wronged them.</p>\n<p>This other-focus serves a defensive function—it keeps attention away from the self. But it also maintains conflict by ensuring that grievances are never resolved or released. Every interaction is filtered through a lens of vigilance for mistreatment.</p>\n<p><strong>Difficulty taking feedback.</strong> Even gentle, carefully delivered feedback is experienced as attack. The high-conflict client becomes defensive, counter-attacks, shuts down, or leaves. This makes therapy—which inherently involves some feedback—extremely challenging. The therapist must navigate between honest observation and triggering defensive collapse.</p>\n<p><strong>Pattern of interpersonal conflict.</strong> High-conflict is not situational—it's pervasive. These clients have histories of repeated conflicts across relationships and settings. Multiple ex-partners are \"crazy\" or \"abusive.\" Multiple employers were unfair. Multiple friendships ended badly. Multiple previous therapists failed them. The common denominator—the client themselves—remains unexamined.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>🎭 Clinical Vignette: Recognizing High-Conflict Patterns</h2>\n<p>Angela, a 32-year-old marketing professional, presents for therapy after her third divorce. In the intake, several high-conflict indicators emerge:</p>\n<p><strong>On her ex-husbands:</strong> \"The first one was a narcissist. Totally emotionally abusive. The second one seemed great at first, but turned out to be a complete liar. And this last one—I thought he was different, but he's the worst of all. He's turned everyone against me. My lawyer says he's never seen anyone so vindictive.\"</p>\n<p><strong>On previous therapy:</strong> \"I've seen like six therapists. Most of them didn't get it. One was actually pretty good, but then she abandoned me—just quit seeing me out of nowhere. She probably couldn't handle my case. The last one was terrible—she blamed me for everything.\"</p>\n<p><strong>On her current situation:</strong> \"I'm not saying I'm perfect, but I know I'm not the problem here. Everyone keeps saying I need to look at myself, but I've done that. The problem is I keep choosing the wrong people.\"</p>\n<p><strong>In the session:</strong> Angela alternates between tearful vulnerability and sharp criticism. When the therapist asks a clarifying question, Angela snaps: \"Why are you focusing on that? That's not what's important.\" Minutes later, she's praising the therapist: \"You're actually listening to me. That's more than anyone else has done.\"</p>\n<p><strong>Decision Point:</strong> What high-conflict characteristics do you observe?</p>\n<p><strong>Answer Key:</strong></p>\n<ul>\n<li>All-or-nothing thinking: Ex-husbands are all terrible, previous therapists either \"got it\" or were terrible</li>\n<li>Blame externalization: \"I'm not the problem,\" others are to blame</li>\n<li>Pattern of conflict: Three divorces, six therapists, conflicts across relationships</li>\n<li>Difficulty with feedback: Snaps when asked clarifying question</li>\n<li>Rapid emotional shifts: Alternates between vulnerability, criticism, and praise</li>\n<li>Preoccupation with others' behavior: Detailed accounts of others' wrongdoing</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>📋 Reflection Exercise: Your High-Conflict Clients</h2>\n<p>Think of a current or recent high-conflict client. Identify which characteristics they demonstrate:</p><table class=\"cr-table\">\n<tr><th>Characteristic</th><th>Present?</th><th>Example</th></tr>\n<tr><td>All-or-nothing thinking</td><td>☐ Yes ☐ No</td><td></td></tr>\n<tr><td>Intense emotional reactions</td><td>☐ Yes ☐ No</td><td></td></tr>\n<tr><td>Blame externalization</td><td>☐ Yes ☐ No</td><td></td></tr>\n<tr><td>Preoccupation with others</td><td>☐ Yes ☐ No</td><td></td></tr>\n<tr><td>Difficulty with feedback</td><td>☐ Yes ☐ No</td><td></td></tr>\n<tr><td>Pattern of conflict</td><td>☐ Yes ☐ No</td><td></td></tr>\n</table>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Contributing Factors</h2>\n<p>High-conflict presentations don't emerge from nowhere. They typically develop from the intersection of several factors:</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Personality Pathology</h2>\n<p>Personality disorders, particularly Cluster B disorders (borderline, narcissistic, antisocial, histrionic), often underlie high-conflict presentations. The DSM-5 defines personality disorders as enduring patterns of inner experience and behavior that deviate markedly from cultural expectations, are pervasive and inflexible, have onset in adolescence or early adulthood, are stable over time, and lead to distress or impairment.</p>\n<p><strong>Borderline personality disorder</strong> is perhaps the most commonly encountered high-conflict presentation in outpatient therapy. Core features include affective instability, interpersonal instability, identity disturbance, and impulsivity. The fear of abandonment that characterizes BPD drives much of the high-conflict behavior—clients desperately seek connection while simultaneously pushing people away.</p>\n<p><strong>Narcissistic personality disorder</strong> presents differently but can be equally challenging. Core features include grandiosity, need for admiration, and lack of empathy. The fragile self-esteem beneath the grandiose exterior makes narcissistic clients extremely sensitive to any perceived criticism or slight.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Complex Trauma</h2>\n<p>High-conflict patterns often emerge from complex developmental trauma—prolonged, repeated trauma occurring within caregiving relationships. When children are hurt by the people who are supposed to protect them, they develop distorted models of relationships: love is dangerous, trust leads to betrayal, closeness means pain.</p>\n<p>These traumatic templates get activated in therapy. The therapist offers care—and the client's system says \"danger.\" The therapist sets a limit—and the client experiences abandonment. The therapeutic relationship becomes a stage on which trauma dynamics play out.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Attachment Disruption</h2>\n<p>Attachment theory helps us understand why early relationships matter so much. Children develop internal working models of relationships based on their experiences with primary caregivers. Secure attachment leads to models where others are trustworthy and the self is worthy of care. Insecure attachment leads to various distorted models.</p>\n<p><strong>Disorganized attachment</strong>—the pattern most associated with high-conflict presentations—develops when the caregiver is simultaneously the source of fear and the source of comfort. The child faces an impossible dilemma: they need to approach the caregiver for safety, but the caregiver is the threat. This creates a fragmented, contradictory internal model that persists into adulthood.</p>\n<p>Adults with disorganized attachment struggle in close relationships. They want connection but expect harm. They approach and then retreat. They idealize and then devalue. The very closeness of the therapeutic relationship can activate these patterns intensely.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Neurobiological Factors</h2>\n<p>Emerging research suggests that some individuals have nervous systems that are temperamentally more reactive. They experience emotions more intensely, become dysregulated more easily, and take longer to return to baseline. This isn't their fault—it's biological variation.</p>\n<p>When emotional vulnerability is combined with {{callout:invalidating-environment}}s, the result is often the patterns we label \"high-conflict.\" The biosocial model of BPD, developed by Marsha Linehan, posits exactly this transaction: biological vulnerability plus environmental invalidation produces emotional dysregulation and the interpersonal patterns associated with borderline personality disorder.</p>",
+          "callouts": {
+            "invalidating-environment": {
+              "label": "Invalidating Environment",
+              "type": "definition",
+              "body": "A developmental context that dismisses, punishes, or erratically responds to a person’s emotional experience, teaching them to distrust their own emotions."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Learned Patterns</h2>\n<p>High-conflict behavior may also be learned. If a child grows up in a high-conflict family, they learn that relationships involve drama, intensity, and chaos. They learn that the way to get needs met is through escalation. They may have no template for calm, stable relating.</p>\n<p>Similarly, if high-conflict behavior has been reinforced—if escalation leads to getting one's way, if dramatic expressions of distress bring care—the behavior persists because it works. Understanding the reinforcement history helps us understand the behavior without excusing it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>The Biosocial Model: Understanding Borderline Presentations</h2>\n<p>Marsha Linehan's biosocial model provides an invaluable framework for understanding how borderline patterns develop. The model posits a transaction between two factors:</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Biological Vulnerability</h2>\n<p>Some individuals are born with emotional systems that are more reactive than average. They experience emotions more intensely. They're triggered more easily. They take longer to return to baseline once dysregulated. This isn't a character flaw—it's neurobiological variation, as real as variations in height or eye color.</p>\n<p>This emotional vulnerability is evident from early childhood. These are the babies who cry more intensely, the toddlers who have bigger tantrums, the children who are described as \"sensitive\" or \"dramatic.\" Their emotional systems run hot.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Invalidating Environments</h2>\n<p>An invalidating environment is one that chronically communicates to the child that their emotional responses are wrong, bad, inappropriate, or excessive. This can happen in many ways:</p>\n<p><strong>Dismissal:</strong> \"You're fine. There's nothing to cry about.\" \"Stop making a big deal out of nothing.\"</p>\n<p><strong>Punishment:</strong> \"Go to your room until you can calm down.\" \"If you're going to act like that, you can't come with us.\"</p>\n<p><strong>Inconsistent response:</strong> Sometimes the parent responds to distress with comfort, sometimes with anger, sometimes with neglect. The child can't predict what response they'll get.</p>\n<p><strong>Role reversal:</strong> The child is expected to manage the parent's emotions rather than vice versa. The child learns their own needs are less important than the parent's stability.</p>\n<p><strong>Abuse and neglect:</strong> Severe forms of invalidation involve direct trauma—physical abuse, sexual abuse, severe neglect.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>The Transaction</h2>\n<p>When emotional vulnerability meets chronic invalidation, a developmental cascade begins. The emotionally vulnerable child expresses distress. The invalidating environment responds with dismissal, punishment, or inconsistency. The child's distress escalates. Eventually, the environment responds—often after the child has escalated to dramatic levels.</p>\n<p>The child learns several toxic lessons:</p>\n<ul>\n<li>My emotions are wrong or bad</li>\n<li>I can't trust my own experience</li>\n<li>Moderate expressions of distress don't work</li>\n<li>Extreme expressions sometimes get response</li>\n<li>Emotions are dangerous and must be controlled or hidden</li>\n</ul>\n<p>These lessons produce the adult patterns we see in borderline presentations: emotional dysregulation, self-invalidation, oscillation between suppression and extreme expression, interpersonal instability, and chronic sense of emptiness and identity confusion.</p>\n<p>Understanding this model creates compassion. The high-conflict client didn't choose these patterns. They developed in response to impossible circumstances. The skills they lacked weren't taught. The validation they needed wasn't provided. Their \"dysfunction\" was, in a sense, the best adaptation available given their biology and environment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Borderline vs. Narcissistic Patterns</h2>\n<p>While both borderline and narcissistic presentations can be high-conflict, they create different therapeutic challenges:</p>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Borderline Patterns</h2>\n<p><strong>Core experience:</strong> Fear of abandonment, chronic emptiness, unstable identity</p>\n<p><strong>Presentation in therapy:</strong> Clings intensely to the therapist, may idealize then devalue, expresses desperation and distress openly, fears therapist will leave</p>\n<p><strong>Therapeutic challenge:</strong> Managing intensity without reinforcing crisis, setting limits without triggering abandonment panic, tolerating idealization/devaluation cycles</p>\n<p><strong>What helps:</strong> Validation, consistency, clear boundaries, skills teaching</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Narcissistic Patterns</h2>\n<p><strong>Core experience:</strong> Fragile self-esteem beneath grandiose exterior, shame-sensitivity, need for admiration</p>\n<p><strong>Presentation in therapy:</strong> May present as superior to others including therapist, dismisses input that doesn't affirm, sensitive to any perceived criticism, may not see themselves as having problems</p>\n<p><strong>Therapeutic challenge:</strong> Engaging without collusion in grandiosity, providing feedback without triggering shame collapse, managing their devaluation of therapy</p>\n<p><strong>What helps:</strong> Respect for their need to feel capable, careful delivery of feedback, patience with slow progress</p>\n<p>Many high-conflict clients show features of both patterns. The categories are useful guides, not rigid boxes.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Situational High Conflict: When There Is No Personality Disorder</h2>\n<p>High-conflict presentations are not always rooted in personality pathology. Clients without any personality disorder can present as high-conflict under particular conditions, and assuming pathology where the driver is situational leads the clinician astray.</p>\n<h3>Conflict Driven by Circumstance</h3>\n<p>Acute crisis, overwhelming stress, contested divorce or custody disputes, trauma reactivation, substance use, medical or neurological conditions, and grief can all produce the volatility, reactivity, and difficulty that read as “high-conflict.” In these cases the conflict is a response to circumstance rather than an enduring pattern, and it frequently resolves as the situation stabilizes or the underlying state is treated.</p>\n<h3>Assessing the Source</h3>\n<p>The clinician therefore distinguishes a stable, pervasive, longstanding pattern from a situational, state-driven one, attending to the client’s baseline, the timeline, and the context. This distinction shapes both formulation and prognosis: situational high conflict calls for stabilization and support rather than the long-arc, structure-heavy approach a personality-based pattern requires. Pathologizing a situationally overwhelmed client — or, conversely, missing a genuine enduring pattern — both undermine the work.</p>",
+          "order": 20
+        },
+        {
+          "type": "multipleChoice",
+          "order": 21,
+          "question": "\"High-conflict\" is best described as:",
+          "options": [
+            {
+              "text": "A DSM-5 diagnosis",
+              "isCorrect": true
+            },
+            {
+              "text": "A behavioral description regardless of specific diagnosis",
+              "isCorrect": false
+            },
+            {
+              "text": "Another term for borderline personality disorder",
+              "isCorrect": false
+            },
+            {
+              "text": "A temporary state during crisis",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 22,
+          "question": "Which is NOT typically a characteristic of high-conflict clients?",
+          "options": [
+            {
+              "text": "All-or-nothing thinking",
+              "isCorrect": true
+            },
+            {
+              "text": "Blame externalization",
+              "isCorrect": false
+            },
+            {
+              "text": "Consistent self-reflection about their contribution to problems",
+              "isCorrect": false
+            },
+            {
+              "text": "Pattern of interpersonal conflict",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 23,
+          "type": "multiSelect",
+          "question": "According to the biosocial model, borderline patterns arise from the transaction between which factors? (Select all that apply)",
+          "options": [
+            {
+              "text": "Biological emotional vulnerability",
+              "isCorrect": true
+            },
+            {
+              "text": "A chronically invalidating environment",
+              "isCorrect": true
+            },
+            {
+              "text": "The ongoing transaction between the two over time",
+              "isCorrect": true
+            },
+            {
+              "text": "A single traumatic event in adulthood",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "The biosocial model locates borderline patterns in the transaction between biological emotional vulnerability and a chronically invalidating environment — not in any single event."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 24,
+          "question": "Disorganized attachment develops when:",
+          "options": [
+            {
+              "text": "The caregiver is consistently warm and responsive",
+              "isCorrect": true
+            },
+            {
+              "text": "The caregiver is simultaneously the source of fear and comfort",
+              "isCorrect": false
+            },
+            {
+              "text": "The child has no caregiver",
+              "isCorrect": false
+            },
+            {
+              "text": "The child has multiple caregivers",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 25,
+          "question": "Compared to borderline presentations, narcissistic presentations typically involve:",
+          "options": [
+            {
+              "text": "More fear of abandonment",
+              "isCorrect": true
+            },
+            {
+              "text": "More sensitivity to perceived criticism and shame",
+              "isCorrect": false
+            },
+            {
+              "text": "More open expression of distress",
+              "isCorrect": false
+            },
+            {
+              "text": "More clinging to the therapist",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 2,
-      title: `Module 2: PATTERNS IN HIGH-CONFLICT INTERACTIONS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 2: PATTERNS IN HIGH-CONFLICT INTERACTIONS`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 2,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Define splitting and explain its function in high-conflict dynamics</li>
-<li>Describe projective identification and recognize when it's occurring</li>
-<li>Identify testing behaviors and respond therapeutically</li>
-<li>Recognize escalation cycles and intervene effectively</li>
-<li>Understand high-conflict behavior as communication</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Splitting</h2>
-<p>Splitting is the tendency to view people and situations in all-or-nothing terms—all good or all bad—with little capacity for integration or nuance. In psychodynamic terms, it represents a failure of object constancy: the inability to hold a stable, integrated image of another person that includes both positive and negative qualities.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>How Splitting Manifests in Therapy</h2>
-<p><strong>Idealization/devaluation cycles:</strong> The client may initially idealize you. You're the best therapist they've ever had. You finally understand them. You're different from all the others. This feels good—who doesn't like being appreciated?—but it's a setup. Idealization is inherently unstable because it requires perfection. Eventually, you'll do something that reveals your human imperfection, and idealization will flip to devaluation.</p>
-<p>The trigger can be minor. You're a few minutes late. You misremember a detail. You set a necessary limit. You take a vacation. Suddenly, you've joined the ranks of everyone else who has failed them. You don't really care. You're just doing a job. Maybe you were never actually helpful.</p>
-<p><strong>Provider splitting:</strong> The client may split between you and other providers. You're the good therapist; the psychiatrist is terrible. Or the psychiatrist understands them; you don't. This can feel flattering when you're on the "good" side, but it creates treatment interference and will eventually reverse.</p>
-<p><strong>Relationship splitting:</strong> The client describes relationships in black-and-white terms. Ex-partners are uniformly terrible. The current partner is either perfect or horrible, depending on the week. Friends are either "real" or "fake." The client seems unable to see that most people are complicated mixtures of positive and negative qualities.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Responding to Splitting</h2>
-<p><strong>Don't take the idealization at face value.</strong> When a client puts you on a pedestal, gently introduce reality. "I appreciate that you feel I understand you, and I want you to know that I'm human and will disappoint you sometimes. When that happens, I hope we can talk about it rather than you concluding I'm terrible."</p>
-<p><strong>Don't take the devaluation personally.</strong> When you've been knocked off the pedestal, remember that this is a pattern, not an accurate assessment of your worth as a therapist. Stay steady. Don't become defensive. Model stability in the face of their instability.</p>
-<p><strong>Name the pattern.</strong> When you observe splitting, name it gently. "I notice that last week you felt I really understood you, and this week you're feeling like I don't get it at all. I wonder if there's a pattern where people are either wonderful or terrible, without much middle ground."</p>
-<p><strong>Introduce gray.</strong> Help clients develop tolerance for ambivalence. "So your mother did something that really hurt you. And she's also the person who drove an hour to help you move last month. Both things are true. People can be disappointing AND caring at the same time."</p>`,
-            },
-{
-              type: "callout",
-              order: 6,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Splitting in Action`,
-              content: `<p>Marcus has been seeing Dr. Williams for three months. Initially, he praised her effusively: "You're the first therapist who actually gets what I've been through. The others were useless, but you're different."</p>
-<p>In session 14, Dr. Williams needs to reschedule a session for a professional conference. Marcus's response is dramatic:</p>
-<p>"So you're abandoning me too. Just like everyone else. I knew this was too good to be true. You seemed different, but you're just like all the others—you pretend to care, but when it comes down to it, your career is more important than your clients."</p>
-<p>Dr. Williams responds: "I can hear how upset you are, and I want to understand. It sounds like the reschedule feels like abandonment to you—like evidence that I don't really care. Is that right?"</p>
-<p>Marcus: "Well, isn't it? You're choosing a conference over me."</p>
-<p>Dr. Williams: "I can see why it might feel that way. And I want to offer another perspective: I care about you and our work together, AND I'm going to a conference next week. Both things are true. The conference doesn't mean I don't care. What would help you with this?"</p>
-<p>This response validates Marcus's feeling while introducing nuance ("both things are true") and redirecting toward problem-solving.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Projective Identification</h2>
-<p>Projective identification is one of the most challenging dynamics in work with high-conflict clients. Understanding it protects you from being controlled by it.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>The Mechanism</h2>
-<p>Projective identification occurs in stages:</p>
-<ol>
-<li><strong>Projection:</strong> The client has feelings they can't tolerate—rage, helplessness, worthlessness—and unconsciously projects them onto the therapist. They perceive the therapist as having the feeling.</li>
-</ol>
-<ol>
-<li><strong>Interpersonal pressure:</strong> Through their behavior, the client creates interpersonal pressure on the therapist to actually experience the projected feeling. This isn't conscious manipulation—it's an unconscious process.</li>
-</ol>
-<ol>
-<li><strong>Identification:</strong> The therapist begins to actually feel what was projected. The therapist feels the rage, the helplessness, the worthlessness.</li>
-</ol>
-<ol>
-<li><strong>Enactment:</strong> If unaware of the process, the therapist may act on the projected feeling—becoming punitive (acting out the projected rage), giving up (acting out the projected helplessness), or becoming critical (acting out the projected criticism).</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Recognizing Projective Identification</h2>
-<p>You might be experiencing projective identification when:</p>
-<ul>
-<li>You feel unlike yourself with a particular client</li>
-<li>You feel intense emotions that seem disproportionate to what's happening</li>
-<li>You're having thoughts or impulses you would normally never have</li>
-<li>You feel controlled or manipulated, though you can't quite identify how</li>
-<li>You find yourself wanting to act in ways inconsistent with your usual style</li>
-</ul>
-<p>Common projected feelings include:</p>
-<p><strong>Rage:</strong> The client is unconsciously furious but can't tolerate it. You find yourself feeling irritated, frustrated, even angry with this client—more than their behavior would seem to warrant.</p>
-<p><strong>Helplessness:</strong> The client feels helpless but projects it outward. You find yourself feeling incompetent, hopeless about the treatment, unsure what to do.</p>
-<p><strong>Worthlessness:</strong> The client carries shame and worthlessness but externalizes it. You find yourself feeling inadequate, wondering if you're actually a good therapist.</p>
-<p><strong>Abandonment:</strong> The client expects abandonment and unconsciously creates situations that might lead to it. You find yourself wanting to refer out, reduce sessions, or end treatment.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Using Projective Identification Therapeutically</h2>
-<p>The feelings you experience through projective identification are data. They tell you something about the client's internal world.</p>
-<p><strong>Notice:</strong> Pay attention to unusual feelings that arise with specific clients. "Interesting—I'm feeling really helpless right now. That's not my usual experience."</p>
-<p><strong>Contain:</strong> Hold the feeling without acting on it. You don't have to discharge the rage, succumb to the helplessness, or flee the worthlessness. You can contain it.</p>
-<p><strong>Reflect:</strong> Consider what this tells you about the client. "If I'm feeling helpless, this might be how the client feels much of the time. They may have put their helplessness into me because it's too painful to bear."</p>
-<p><strong>Return (carefully):</strong> You can sometimes return the projected content in a more bearable form. "I notice I've been feeling quite stuck and helpless in our work lately. I wonder if that's a feeling that's familiar to you—if you often feel like nothing will help and nothing will change."</p>`,
-            },
-{
-              type: "callout",
-              order: 11,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Projective Identification`,
-              content: `<p>Dr. Chen has been working with Rachel for six months. Lately, she's been dreading their sessions. She feels irritable the moment Rachel sits down, and finds herself making sharp comments she wouldn't make with other clients. After last session, she caught herself thinking, "I can't stand her."</p>
-<p>In supervision, Dr. Chen's supervisor asks: "What do you think Rachel feels?"</p>
-<p>Dr. Chen reflects: "She talks about feeling invisible and unimportant. She says her mother always made her feel like a burden."</p>
-<p>Supervisor: "And now you're feeling burdened by her. You can't stand her—much like Rachel believes her mother couldn't stand her."</p>
-<p>Dr. Chen realizes: "She's put her experience of being unbearable into me. And I almost enacted it by wanting to get rid of her."</p>
-<p>With this awareness, Dr. Chen can respond differently. Instead of acting on the projected feeling, she can name it: "Rachel, I want to share something I've been noticing in myself. I've been feeling more irritable in our sessions lately, and I've been wondering if that might connect to something you experience—this feeling of being too much for people, of being a burden. Does that resonate?"</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Testing Behaviors</h2>
-<p>High-conflict clients often engage in testing behaviors—actions that (usually unconsciously) test the therapist's limits, caring, or stability.</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>What Testing Looks Like</h2>
-<p><strong>Boundary tests:</strong> The client pushes against boundaries to see if you'll maintain them. They ask for longer sessions, call between sessions, ask personal questions, or request special exceptions to policies.</p>
-<p><strong>Caring tests:</strong> The client creates situations that test whether you really care. They have a crisis before you go on vacation. They threaten to quit therapy. They escalate distress to see if you'll respond.</p>
-<p><strong>Stability tests:</strong> The client acts in provocative ways to see if you'll remain steady. They attack you verbally to see if you'll retaliate. They idealize you to see if you'll become grandiose. They threaten to see if you'll become frightened and comply.</p>
-<p><strong>Abandonment tests:</strong> The client creates conditions that might justify you leaving them. They miss sessions, don't pay bills, behave badly—all testing whether you'll confirm their expectation of abandonment.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Understanding Tests</h2>
-<p>Testing usually isn't conscious manipulation. It's an unconscious process driven by early relational experiences. The client learned that caregivers were unreliable, boundaries were arbitrary, or love was conditional. They're testing whether you're different or the same as their previous experiences.</p>
-<p>In a sense, they need you to pass the test. They need evidence that boundaries can be consistent, that caring can persist through difficulty, that relationships can survive conflict. Every time you maintain your stance without retaliating or abandoning, you provide data that contradicts their trauma templates.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Responding to Tests</h2>
-<p><strong>Don't take it personally.</strong> The testing isn't about you—it's about their history and expectations.</p>
-<p><strong>Maintain the frame.</strong> When boundaries are tested, hold them clearly and kindly. "I understand you'd like to extend the session, and we do need to stop at our regular time. Let's pick this up next week."</p>
-<p><strong>Be consistent.</strong> Inconsistency confirms that caregivers are unpredictable. Consistency—even when the client is pushing back—provides corrective experience.</p>
-<p><strong>Name it (sometimes).</strong> When testing patterns become clear, naming them can be powerful: "I notice that each time I'm about to go on vacation, there's a crisis. I wonder if part of you is testing whether I'll still be here when I get back."</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 16,
-              question: `Splitting involves:`,
-              options: [
-                { text: `Clients dividing their attention between multiple therapists`, isCorrect: true },
-                { text: `Viewing people as all good or all bad with little nuance`, isCorrect: false },
-                { text: `A defense against termination`, isCorrect: false },
-                { text: `Deliberately manipulating therapists`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 17,
-              question: `In projective identification, the therapist:`,
-              options: [
-                { text: `Projects their feelings onto the client`, isCorrect: true },
-                { text: `Never experiences the client's projected feelings`, isCorrect: false },
-                { text: `May actually begin to feel what the client has projected`, isCorrect: false },
-                { text: `Should immediately interpret the projection`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 18,
-              question: `Testing behaviors are best understood as:`,
-              options: [
-                { text: `Conscious manipulation`, isCorrect: true },
-                { text: `Unconscious processes testing whether the therapist is different from previous caregivers`, isCorrect: false },
-                { text: `Signs that the client should be terminated`, isCorrect: false },
-                { text: `Evidence of antisocial personality`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 19,
-              question: `When a client tests boundaries, the therapist should:`,
-              options: [
-                { text: `Become rigid and punitive`, isCorrect: true },
-                { text: `Abandon the boundary to preserve the relationship`, isCorrect: false },
-                { text: `Maintain the boundary clearly and kindly`, isCorrect: false },
-                { text: `Terminate the client for boundary violations`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 20,
-              question: `The feelings therapists experience through projective identification:`,
-              options: [
-                { text: `Are irrelevant to treatment`, isCorrect: true },
-                { text: `Are data about the client's internal world`, isCorrect: false },
-                { text: `Should be ignored`, isCorrect: false },
-                { text: `Mean the therapist needs personal therapy`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+      "order": 2,
+      "title": "Module 2: PATTERNS IN HIGH-CONFLICT INTERACTIONS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 2: PATTERNS IN HIGH-CONFLICT INTERACTIONS",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 2
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Define splitting and explain its function in high-conflict dynamics</li>\n<li>Describe {{callout:projective-identification}} and recognize when it's occurring</li>\n<li>Identify testing behaviors and respond therapeutically</li>\n<li>Recognize escalation cycles and intervene effectively</li>\n<li>Understand high-conflict behavior as communication</li>\n</ol>",
+          "callouts": {
+            "projective-identification": {
+              "label": "Projective Identification",
+              "type": "clinical",
+              "body": "An unconscious process in which the client evokes in the clinician the very feelings the client cannot tolerate; the clinician’s reactions become data about the client’s inner world."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Splitting</h2>\n<p>{{callout:splitting}} is the tendency to view people and situations in all-or-nothing terms—all good or all bad—with little capacity for integration or nuance. In psychodynamic terms, it represents a failure of object constancy: the inability to hold a stable, integrated image of another person that includes both positive and negative qualities.</p>",
+          "callouts": {
+            "splitting": {
+              "label": "Splitting",
+              "type": "definition",
+              "body": "A defense in which experience is divided into all-good and all-bad with no integration; in therapy, the clinician (or others) may be idealized then abruptly devalued."
+            }
+          }
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>How Splitting Manifests in Therapy</h2>\n<p><strong>Idealization/devaluation cycles:</strong> The client may initially idealize you. You're the best therapist they've ever had. You finally understand them. You're different from all the others. This feels good—who doesn't like being appreciated?—but it's a setup. Idealization is inherently unstable because it requires perfection. Eventually, you'll do something that reveals your human imperfection, and idealization will flip to devaluation.</p>\n<p>The trigger can be minor. You're a few minutes late. You misremember a detail. You set a necessary limit. You take a vacation. Suddenly, you've joined the ranks of everyone else who has failed them. You don't really care. You're just doing a job. Maybe you were never actually helpful.</p>\n<p><strong>Provider splitting:</strong> The client may split between you and other providers. You're the good therapist; the psychiatrist is terrible. Or the psychiatrist understands them; you don't. This can feel flattering when you're on the \"good\" side, but it creates treatment interference and will eventually reverse.</p>\n<p><strong>Relationship splitting:</strong> The client describes relationships in black-and-white terms. Ex-partners are uniformly terrible. The current partner is either perfect or horrible, depending on the week. Friends are either \"real\" or \"fake.\" The client seems unable to see that most people are complicated mixtures of positive and negative qualities.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Responding to Splitting</h2>\n<p><strong>Don't take the idealization at face value.</strong> When a client puts you on a pedestal, gently introduce reality. \"I appreciate that you feel I understand you, and I want you to know that I'm human and will disappoint you sometimes. When that happens, I hope we can talk about it rather than you concluding I'm terrible.\"</p>\n<p><strong>Don't take the devaluation personally.</strong> When you've been knocked off the pedestal, remember that this is a pattern, not an accurate assessment of your worth as a therapist. Stay steady. Don't become defensive. Model stability in the face of their instability.</p>\n<p><strong>Name the pattern.</strong> When you observe splitting, name it gently. \"I notice that last week you felt I really understood you, and this week you're feeling like I don't get it at all. I wonder if there's a pattern where people are either wonderful or terrible, without much middle ground.\"</p>\n<p><strong>Introduce gray.</strong> Help clients develop tolerance for ambivalence. \"So your mother did something that really hurt you. And she's also the person who drove an hour to help you move last month. Both things are true. People can be disappointing AND caring at the same time.\"</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Idealization and Devaluation Cycles</h2>\n<p>Closely related to splitting are the cycles of idealization and devaluation that high-conflict clients may move through, sometimes rapidly, and understanding the cycle helps the clinician stay steady across its swings.</p>\n<h3>The Swing</h3>\n<p>A client may idealize the clinician — “you’re the only one who has ever understood me” — and then, often after a disappointment or perceived slight, devalue just as completely — “you’re just like everyone else.” The intensity is genuine in both phases, and the clinician can be pulled to enjoy the idealization and then feel wounded or defensive in the devaluation, riding the client’s swings rather than holding a center.</p>\n<h3>Holding a Steady Center</h3>\n<p>The therapeutic stance is to remain the same person across both phases — neither inflated by idealization nor crushed by devaluation — and, over time, to help the client tolerate a more integrated, realistic view in which the clinician is neither all-good nor all-bad. Naming the pattern gently when the alliance can bear it, and steadily disconfirming the expectation that disappointment must mean rupture, helps the client move toward the integration that splitting forecloses.</p>",
+          "order": 6
+        },
+        {
+          "type": "text",
+          "content": "<h2>Working With Rage and Contempt in the Room</h2>\n<p>Among the hardest moments in high-conflict work are episodes of intense rage or contempt directed at the clinician, and having a stance for these moments prevents them from derailing treatment.</p>\n<h3>Staying Regulated Under Fire</h3>\n<p>When a client erupts in anger or treats the clinician with contempt, the clinician’s own threat response activates — the pull to retaliate, defend, or withdraw is strong. The first task is to stay regulated: to breathe, ground, and resist matching the client’s escalation, since a dysregulated clinician cannot help a dysregulated client. Safety comes first, and genuine threats are addressed directly, but most in-session rage is emotional flooding rather than danger.</p>\n<h3>Understanding and Responding</h3>\n<p>Rage and contempt frequently mask vulnerability — shame, fear, hurt, or a terror of abandonment — and the clinician who can see the pain beneath the attack responds to that rather than to the surface hostility. Validating the underlying emotion without endorsing abusive behavior, holding the limit that the clinician will not be mistreated while staying connected, and returning to the rupture once the storm passes all keep these moments within the work rather than ending it.</p>",
+          "order": 7
+        },
+        {
+          "type": "callout",
+          "order": 8,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Splitting in Action",
+          "content": "<p>Marcus has been seeing Dr. Williams for three months. Initially, he praised her effusively: \"You're the first therapist who actually gets what I've been through. The others were useless, but you're different.\"</p>\n<p>In session 14, Dr. Williams needs to reschedule a session for a professional conference. Marcus's response is dramatic:</p>\n<p>\"So you're abandoning me too. Just like everyone else. I knew this was too good to be true. You seemed different, but you're just like all the others—you pretend to care, but when it comes down to it, your career is more important than your clients.\"</p>\n<p>Dr. Williams responds: \"I can hear how upset you are, and I want to understand. It sounds like the reschedule feels like abandonment to you—like evidence that I don't really care. Is that right?\"</p>\n<p>Marcus: \"Well, isn't it? You're choosing a conference over me.\"</p>\n<p>Dr. Williams: \"I can see why it might feel that way. And I want to offer another perspective: I care about you and our work together, AND I'm going to a conference next week. Both things are true. The conference doesn't mean I don't care. What would help you with this?\"</p>\n<p>This response validates Marcus's feeling while introducing nuance (\"both things are true\") and redirecting toward problem-solving.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Projective Identification</h2>\n<p>Projective identification is one of the most challenging dynamics in work with high-conflict clients. Understanding it protects you from being controlled by it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>The Mechanism</h2>\n<p>Projective identification occurs in stages:</p>\n<ol>\n<li><strong>Projection:</strong> The client has feelings they can't tolerate—rage, helplessness, worthlessness—and unconsciously projects them onto the therapist. They perceive the therapist as having the feeling.</li>\n</ol>\n<ol>\n<li><strong>Interpersonal pressure:</strong> Through their behavior, the client creates interpersonal pressure on the therapist to actually experience the projected feeling. This isn't conscious manipulation—it's an unconscious process.</li>\n</ol>\n<ol>\n<li><strong>Identification:</strong> The therapist begins to actually feel what was projected. The therapist feels the rage, the helplessness, the worthlessness.</li>\n</ol>\n<ol>\n<li><strong>Enactment:</strong> If unaware of the process, the therapist may act on the projected feeling—becoming punitive (acting out the projected rage), giving up (acting out the projected helplessness), or becoming critical (acting out the projected criticism).</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Recognizing Projective Identification</h2>\n<p>You might be experiencing projective identification when:</p>\n<ul>\n<li>You feel unlike yourself with a particular client</li>\n<li>You feel intense emotions that seem disproportionate to what's happening</li>\n<li>You're having thoughts or impulses you would normally never have</li>\n<li>You feel controlled or manipulated, though you can't quite identify how</li>\n<li>You find yourself wanting to act in ways inconsistent with your usual style</li>\n</ul>\n<p>Common projected feelings include:</p>\n<p><strong>Rage:</strong> The client is unconsciously furious but can't tolerate it. You find yourself feeling irritated, frustrated, even angry with this client—more than their behavior would seem to warrant.</p>\n<p><strong>Helplessness:</strong> The client feels helpless but projects it outward. You find yourself feeling incompetent, hopeless about the treatment, unsure what to do.</p>\n<p><strong>Worthlessness:</strong> The client carries shame and worthlessness but externalizes it. You find yourself feeling inadequate, wondering if you're actually a good therapist.</p>\n<p><strong>Abandonment:</strong> The client expects abandonment and unconsciously creates situations that might lead to it. You find yourself wanting to refer out, reduce sessions, or end treatment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Using Projective Identification Therapeutically</h2>\n<p>The feelings you experience through projective identification are data. They tell you something about the client's internal world.</p>\n<p><strong>Notice:</strong> Pay attention to unusual feelings that arise with specific clients. \"Interesting—I'm feeling really helpless right now. That's not my usual experience.\"</p>\n<p><strong>Contain:</strong> Hold the feeling without acting on it. You don't have to discharge the rage, succumb to the helplessness, or flee the worthlessness. You can contain it.</p>\n<p><strong>Reflect:</strong> Consider what this tells you about the client. \"If I'm feeling helpless, this might be how the client feels much of the time. They may have put their helplessness into me because it's too painful to bear.\"</p>\n<p><strong>Return (carefully):</strong> You can sometimes return the projected content in a more bearable form. \"I notice I've been feeling quite stuck and helpless in our work lately. I wonder if that's a feeling that's familiar to you—if you often feel like nothing will help and nothing will change.\"</p>"
+        },
+        {
+          "type": "callout",
+          "order": 13,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Projective Identification",
+          "content": "<p>Dr. Chen has been working with Rachel for six months. Lately, she's been dreading their sessions. She feels irritable the moment Rachel sits down, and finds herself making sharp comments she wouldn't make with other clients. After last session, she caught herself thinking, \"I can't stand her.\"</p>\n<p>In supervision, Dr. Chen's supervisor asks: \"What do you think Rachel feels?\"</p>\n<p>Dr. Chen reflects: \"She talks about feeling invisible and unimportant. She says her mother always made her feel like a burden.\"</p>\n<p>Supervisor: \"And now you're feeling burdened by her. You can't stand her—much like Rachel believes her mother couldn't stand her.\"</p>\n<p>Dr. Chen realizes: \"She's put her experience of being unbearable into me. And I almost enacted it by wanting to get rid of her.\"</p>\n<p>With this awareness, Dr. Chen can respond differently. Instead of acting on the projected feeling, she can name it: \"Rachel, I want to share something I've been noticing in myself. I've been feeling more irritable in our sessions lately, and I've been wondering if that might connect to something you experience—this feeling of being too much for people, of being a burden. Does that resonate?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Testing Behaviors</h2>\n<p>High-conflict clients often engage in testing behaviors—actions that (usually unconsciously) test the therapist's limits, caring, or stability.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>What Testing Looks Like</h2>\n<p><strong>Boundary tests:</strong> The client pushes against boundaries to see if you'll maintain them. They ask for longer sessions, call between sessions, ask personal questions, or request special exceptions to policies.</p>\n<p><strong>Caring tests:</strong> The client creates situations that test whether you really care. They have a crisis before you go on vacation. They threaten to quit therapy. They escalate distress to see if you'll respond.</p>\n<p><strong>Stability tests:</strong> The client acts in provocative ways to see if you'll remain steady. They attack you verbally to see if you'll retaliate. They idealize you to see if you'll become grandiose. They threaten to see if you'll become frightened and comply.</p>\n<p><strong>Abandonment tests:</strong> The client creates conditions that might justify you leaving them. They miss sessions, don't pay bills, behave badly—all testing whether you'll confirm their expectation of abandonment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Understanding Tests</h2>\n<p>Testing usually isn't conscious manipulation. It's an unconscious process driven by early relational experiences. The client learned that caregivers were unreliable, boundaries were arbitrary, or love was conditional. They're testing whether you're different or the same as their previous experiences.</p>\n<p>In a sense, they need you to pass the test. They need evidence that boundaries can be consistent, that caring can persist through difficulty, that relationships can survive conflict. Every time you maintain your stance without retaliating or abandoning, you provide data that contradicts their trauma templates.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Responding to Tests</h2>\n<p><strong>Don't take it personally.</strong> The testing isn't about you—it's about their history and expectations.</p>\n<p><strong>Maintain the frame.</strong> When boundaries are tested, hold them clearly and kindly. \"I understand you'd like to extend the session, and we do need to stop at our regular time. Let's pick this up next week.\"</p>\n<p><strong>Be consistent.</strong> Inconsistency confirms that caregivers are unpredictable. Consistency—even when the client is pushing back—provides corrective experience.</p>\n<p><strong>Name it (sometimes).</strong> When testing patterns become clear, naming them can be powerful: \"I notice that each time I'm about to go on vacation, there's a crisis. I wonder if part of you is testing whether I'll still be here when I get back.\"</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Containment: Holding What the Client Cannot Yet Hold</h2>\n<p>A central function of the clinician in high-conflict work is {{callout:containment}} — receiving the client’s overwhelming affect, holding it without being destabilized, and returning it in a more manageable form.</p>\n<h3>What Containment Means</h3>\n<p>When a client floods with rage, terror, or despair that they cannot yet regulate, the clinician’s steady, regulated presence does something the client cannot do alone: it holds the feeling without amplifying it, panicking, or pushing it away. The clinician metabolizes what is projected — staying thoughtful where the client is overwhelmed — and gradually the client borrows that capacity, internalizing the experience of being held.</p>\n<h3>Containment in Practice</h3>\n<p>Containment is not passivity; it is active regulation under pressure. It looks like remaining calm and present during escalation, naming and validating the emotion without being swept into it, and demonstrating that the feeling can be survived and understood. Over time, this repeated experience of being contained helps the client build their own capacity to tolerate and regulate affect, which is among the deepest aims of the work.</p>",
+          "order": 18,
+          "callouts": {
+            "containment": {
+              "label": "Containment",
+              "type": "clinical",
+              "body": "The clinician’s capacity to receive and hold a client’s overwhelming affect without being destabilized, returning it in a more manageable form."
+            }
+          }
+        },
+        {
+          "order": 19,
+          "type": "fillInBlank",
+          "title": "Quick check — splitting",
+          "blanks": [
+            {
+              "prompt": "Splitting divides experience into all-good and all-________ with no integration:",
+              "answer": "bad"
+            },
+            {
+              "prompt": "In therapy the clinician may first be idealized and then abruptly:",
+              "answer": "devalued",
+              "acceptAlternates": [
+                "devalue"
+              ]
+            }
+          ]
+        },
+        {
+          "order": 20,
+          "type": "multiSelect",
+          "question": "In projective identification, the therapist’s emotional reactions are best used how? (Select all that apply)",
+          "options": [
+            {
+              "text": "As data about the client’s inner world",
+              "isCorrect": true
+            },
+            {
+              "text": "Noticed and reflected on rather than acted out",
+              "isCorrect": true
+            },
+            {
+              "text": "Processed in consultation when intense",
+              "isCorrect": true
+            },
+            {
+              "text": "Taken as proof of the therapist’s own inadequacy",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "The feelings evoked through projective identification are information about the client’s experience, to be noticed and used — not enacted, and not read as the clinician’s failing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 21,
+          "question": "Testing behaviors are best understood as:",
+          "options": [
+            {
+              "text": "Conscious manipulation",
+              "isCorrect": true
+            },
+            {
+              "text": "Unconscious processes testing whether the therapist is different from previous caregivers",
+              "isCorrect": false
+            },
+            {
+              "text": "Signs that the client should be terminated",
+              "isCorrect": false
+            },
+            {
+              "text": "Evidence of antisocial personality",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 22,
+          "question": "When a client tests boundaries, the therapist should:",
+          "options": [
+            {
+              "text": "Become rigid and punitive",
+              "isCorrect": true
+            },
+            {
+              "text": "Abandon the boundary to preserve the relationship",
+              "isCorrect": false
+            },
+            {
+              "text": "Maintain the boundary clearly and kindly",
+              "isCorrect": false
+            },
+            {
+              "text": "Terminate the client for boundary violations",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 23,
+          "question": "The feelings therapists experience through projective identification:",
+          "options": [
+            {
+              "text": "Are irrelevant to treatment",
+              "isCorrect": true
+            },
+            {
+              "text": "Are data about the client's internal world",
+              "isCorrect": false
+            },
+            {
+              "text": "Should be ignored",
+              "isCorrect": false
+            },
+            {
+              "text": "Mean the therapist needs personal therapy",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 3,
-      title: `Module 3: VALIDATION THAT WORKS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 3: VALIDATION THAT WORKS`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 3,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Explain why validation is essential for high-conflict clients</li>
-<li>Distinguish between validation and agreement</li>
-<li>Describe and apply Linehan's six levels of validation</li>
-<li>Validate emotional experience while addressing problematic behavior</li>
-<li>Avoid common validation mistakes</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>The Validation Paradox</h2>
-<p>High-conflict clients desperately need validation. Their histories often include profound invalidation—their emotions were dismissed, punished, or ignored. Their current experience may include ongoing invalidation from partners, family, employers, and even other healthcare providers who see them as "difficult" or "dramatic."</p>
-<p>And yet validation feels risky. Won't validating their emotions reinforce their problematic behavior? Won't agreeing that they've been mistreated encourage their victim stance? Won't expressing understanding enable their continued dysfunction?</p>
-<p>This is the validation paradox: the people who most need validation are often the people whose behavior makes us least want to provide it.</p>
-<p>The solution lies in understanding what validation actually is—and isn't.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Validation vs. Agreement</h2>
-<p><strong>Validation is not agreement.</strong> This distinction is crucial and often misunderstood.</p>
-<p>Validation says: "Your emotional response makes sense given how you're experiencing this situation."</p>
-<p>Validation does not say: "You're right about the situation" or "Your response is appropriate" or "The other person is wrong."</p>
-<p>Consider this example:</p>
-<p>Client: "My sister completely ignored me at the family dinner. She barely said two words to me. She's always been jealous of me, and she deliberately made me feel invisible."</p>
-<p><strong>Agreeing</strong> would be: "That's terrible. Your sister sounds awful."</p>
-<p><strong>Validating</strong> would be: "It sounds like you felt really invisible and hurt at that dinner—like you weren't acknowledged at all. That's a painful feeling."</p>
-<p>Notice the difference. The validating response:</p>
-<ul>
-<li>Acknowledges the emotional experience (feeling invisible, hurt)</li>
-<li>Doesn't challenge or confirm the interpretation (sister deliberately ignored)</li>
-<li>Doesn't evaluate the sister's behavior</li>
-<li>Stays with the client's internal experience</li>
-</ul>
-<p>You can validate the emotion without validating the interpretation or the behavioral response.</p>
-<p>"I understand why you're angry" doesn't mean "You're right to be angry" or "The anger is justified" or "What you did with the anger was appropriate."</p>
-<p>"It makes sense you'd feel hurt" doesn't mean "Your interpretation is correct" or "The other person did something wrong."</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Linehan's Six Levels of Validation</h2>
-<p>Marsha Linehan identified six levels of validation, moving from basic attentiveness to radical genuineness. Each level involves the therapist responding to the client's experience in a way that communicates: "You make sense."</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Level 1: Being Present</h2>
-<p>The most basic form of validation is simply being present and attentive. This means:</p>
-<ul>
-<li>Maintaining eye contact (culturally appropriate)</li>
-<li>Not multitasking or appearing distracted</li>
-<li>Turning toward the client physically</li>
-<li>Being fully there</li>
-</ul>
-<p>This sounds simple, but for clients who have been chronically ignored or dismissed, simply being attended to can be validating. Your presence says: "You are worth paying attention to."</p>
-<p><strong>Example:</strong> Client is describing a difficult experience. Therapist maintains steady eye contact, leans forward slightly, puts away notes, and gives full attention without looking at the clock.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Level 2: Accurate Reflection</h2>
-<p>Level 2 involves reflecting back what the client communicates—without adding interpretation or editorializing. You're letting the client know you've heard and understood their communication.</p>
-<p><strong>Example:</strong> Client: "I can't believe she said that to me in front of everyone. It was so humiliating."</p>
-<p>Therapist: "She said something embarrassing in front of the group, and you felt humiliated."</p>
-<p>This may seem like mere parroting, but for clients who are rarely heard accurately, having their communication reflected back is validating. It says: "I heard you. I got it."</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Level 3: Articulating the Unverbalized</h2>
-<p>Level 3 goes beyond what the client explicitly said to what they seem to be experiencing but haven't directly expressed. You're reading between the lines and putting words to unspoken experience.</p>
-<p><strong>Example:</strong> Client: "She said it was fine that I couldn't make her party. But her voice was cold, and she hung up really fast."</p>
-<p>Therapist: "It sounds like even though she said it was fine, you're picking up that she's actually upset with you. And maybe that leaves you feeling anxious about where you stand with her?"</p>
-<p>The therapist articulated what the client implied but didn't say directly: the worry about the friend's actual feelings, the anxiety about the relationship. This deeper attunement validates the client's full experience, not just the surface content.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Level 4: Validating in Terms of Past</h2>
-<p>Level 4 involves validating the client's response as understandable given their history. Even if the response might seem disproportionate to the current situation, it makes sense given what the client has experienced.</p>
-<p><strong>Example:</strong> Client: "I know it's stupid, but when my boss called me into his office, I was convinced I was getting fired. I was panicking all day."</p>
-<p>Therapist: "Given that you grew up with a father who was unpredictable and punishing, it makes sense that being called into an authority figure's office would trigger fear. Your nervous system learned early on that authority figures are dangerous. Even if it wasn't 'rational' in this situation, your response makes sense given your history."</p>
-<p>This level validates by connecting current reactions to formative experiences. It says: "You're not crazy or stupid. There's a reason you respond this way."</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Level 5: Validating in Terms of Present Context</h2>
-<p>Level 5 validates the client's response as understandable given the current situation. This is validation that the response makes sense right now, not just because of history.</p>
-<p><strong>Example:</strong> Client: "Everyone keeps telling me I'm overreacting about the layoffs. But half my department just got let go!"</p>
-<p>Therapist: "Given that your company just laid off half your department, anxiety about your own job security isn't overreacting—it's a normal response to a genuinely uncertain situation. Anyone in your position might feel the same way."</p>
-<p>This level says: "Your response isn't just understandable because of your history—it makes sense in this situation. Anyone might respond this way."</p>
-<p>Level 5 validation is powerful because it doesn't pathologize. It normalizes. It says: you're not having this reaction because you're broken or because of your trauma—you're having it because it makes sense.</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Level 6: Radical Genuineness</h2>
-<p>Level 6 is the deepest form of validation. It involves treating the client as a capable, equal person rather than as a fragile patient. It means being authentic and genuine in the relationship rather than hiding behind the therapist role.</p>
-<p><strong>Example:</strong> Client: "I don't know why I'm even trying to explain this to you. You probably think I'm just crazy."</p>
-<p>Therapist: "Actually, I think you're making a lot of sense. What you're describing is a really difficult situation, and I can see why you're struggling with it. I don't think you're crazy at all—I think you're dealing with something genuinely hard."</p>
-<p>This level involves the therapist showing up as a real person who genuinely sees and respects the client. It says: "I'm not humoring you or managing you. I actually see you as competent, and I'm engaging with you as an equal."</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Validating Emotions While Addressing Behavior</h2>
-<p>The key skill for high-conflict work is the ability to validate the emotion while still addressing problematic behavior. The word "and" is your friend.</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>The Formula</h2>
-<p>"I understand [emotion]. AND [behavioral guidance]."</p>
-<p><strong>Examples:</strong></p>
-<p>"I can see you're really angry right now—that anger makes sense given how dismissed you felt. AND I need you to lower your voice so we can continue talking."</p>
-<p>"I understand the urge to text him multiple times when you're panicking—that fear of abandonment is excruciating. AND we've talked about how that behavior pushes him away."</p>
-<p>"It makes sense that you want to call in sick when you're feeling this depressed—getting out of bed feels impossible. AND staying in bed is making the depression worse."</p>
-<p>The "and" is crucial. It connects validation to behavioral guidance without negating either. It's not "but" (which erases what came before) but "and" (which holds both things as true simultaneously).</p>`,
-            },
-{
-              type: "callout",
-              order: 14,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Validation with Behavioral Guidance`,
-              content: `<p>Lauren is a high-conflict client who has been escalating in sessions. Last week she began yelling at Dr. Martinez about a perceived slight.</p>
-<p>Lauren: [voice rising] "You don't actually care about me! You just sit there and collect your fee! If you cared, you would have called me back last night!"</p>
-<p>Dr. Martinez: "Lauren, I can hear how hurt and angry you are right now. You reached out when you were struggling, and you didn't get a response. That left you feeling uncared for, and given everything you've experienced, that feeling makes complete sense." [Pause]</p>
-<p>"AND I need us to lower the intensity here so we can actually talk about what happened. Can you take a breath with me?"</p>
-<p>Lauren: [still agitated but slightly calmer] "You don't understand what it's like to feel so alone."</p>
-<p>Dr. Martinez: "You're right that I don't know exactly what your experience is like. What I do know is that feeling alone is painful—really painful. And I want us to be able to talk about it. Can we do that now?"</p>
-<p>Notice how Dr. Martinez:</p>
-<ul>
-<li>Validated the emotion (hurt, anger, feeling uncared for)</li>
-<li>Connected to history ("given everything you've experienced")</li>
-<li>Set a limit on the escalation ("lower the intensity")</li>
-<li>Redirected toward productive conversation</li>
-<li>Acknowledged her own limitations ("I don't know exactly")</li>
-</ul>`,
-            },
-{
-              type: "multipleChoice",
-              order: 15,
-              question: `Validation differs from agreement in that:`,
-              options: [
-                { text: `They are the same thing`, isCorrect: true },
-                { text: `Validation acknowledges emotional experience without necessarily endorsing interpretations or behaviors`, isCorrect: false },
-                { text: `Validation is always inappropriate with high-conflict clients`, isCorrect: false },
-                { text: `Agreement is more therapeutic`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 16,
-              question: `Linehan's Level 4 validation involves:`,
-              options: [
-                { text: `Simply being present`, isCorrect: true },
-                { text: `Reflecting back what the client said`, isCorrect: false },
-                { text: `Validating the response as understandable given the client's history`, isCorrect: false },
-                { text: `Treating the client as fragile`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 17,
-              question: `The word "and" in validation statements:`,
-              options: [
-                { text: `Negates the validation`, isCorrect: true },
-                { text: `Connects validation to behavioral guidance without negating either`, isCorrect: false },
-                { text: `Should be replaced with "but"`, isCorrect: false },
-                { text: `Is grammatically incorrect`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 18,
-              question: `Radical genuineness (Level 6) involves:`,
-              options: [
-                { text: `Hiding behind the therapist role`, isCorrect: true },
-                { text: `Treating the client as fragile`, isCorrect: false },
-                { text: `Treating the client as a capable, equal person`, isCorrect: false },
-                { text: `Agreeing with everything the client says`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 19,
-              question: `When a client is escalating emotionally, the therapist should:`,
-              options: [
-                { text: `Match the client's intensity`, isCorrect: true },
-                { text: `Validate the emotion and set limits on the behavior`, isCorrect: false },
-                { text: `End the session immediately`, isCorrect: false },
-                { text: `Ignore the escalation`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>Common Validation Mistakes</h2>
-<p>Even well-intentioned clinicians make validation errors that undermine effectiveness:</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>Mistake 1: Validating the Interpretation Instead of the Emotion</h2>
-<p><strong>Problem:</strong> "You're right, your boss is completely unfair."</p>
-<p>This validates the client's interpretation of the situation rather than their emotional experience. It takes sides on a factual question you can't verify, and it doesn't actually help the client process their experience.</p>
-<p><strong>Better:</strong> "I can hear how frustrated and dismissed you're feeling. That sense of being treated unfairly is really painful."</p>`,
-            },
-{
-              type: "text",
-              order: 22,
-              content: `<h2>Mistake 2: Rushing Past Validation to Problem-Solving</h2>
-<p><strong>Problem:</strong> "I understand you're upset. Have you tried talking to HR?"</p>
-<p>The validation is cursory—a box to check before getting to "real" work. But for high-conflict clients, validation IS the real work. Premature problem-solving communicates that you don't really want to hear about their experience.</p>
-<p><strong>Better:</strong> "Tell me more about what happened. I want to understand how this felt for you." [Then, after thorough validation] "When you're ready, we can think about what might help."</p>`,
-            },
-{
-              type: "text",
-              order: 23,
-              content: `<h2>Mistake 3: Using "But" Instead of "And"</h2>
-<p><strong>Problem:</strong> "I understand you're angry, BUT you can't yell at me."</p>
-<p>"But" erases what came before. It signals that the validation was perfunctory—just a setup for the real message.</p>
-<p><strong>Better:</strong> "I understand you're angry—that anger makes sense given what happened—AND I need you to lower your voice so we can keep talking."</p>`,
-            },
-{
-              type: "text",
-              order: 24,
-              content: `<h2>Mistake 4: Validation That Feels Patronizing</h2>
-<p><strong>Problem:</strong> "Of course you feel that way, sweetie. That's totally normal."</p>
-<p>Overly warm or diminutive language can feel condescending, especially to clients who are hypervigilant about being dismissed or treated as incompetent.</p>
-<p><strong>Better:</strong> Genuine, adult-to-adult validation: "What you're describing makes sense. Most people would feel something similar in that situation."</p>`,
-            },
-{
-              type: "text",
-              order: 25,
-              content: `<h2>Mistake 5: Hollow Validation</h2>
-<p><strong>Problem:</strong> "I hear you." [said flatly, without genuine engagement]</p>
-<p>Validation requires genuine attunement. Clients can tell when you're going through the motions. Words alone aren't validation—the emotional genuineness behind them matters.</p>
-<p><strong>Better:</strong> Slow down. Actually attune to the client's experience. Let your face, voice, and body communicate that you're genuinely trying to understand.</p>`,
-            },
-{
-              type: "text",
-              order: 26,
-              content: `<h2>🎭 Clinical Vignette: Validation in Challenging Moments</h2>
-<p><strong>Scenario:</strong> Your client Derek is furious. He storms into session saying his ex-wife is "a complete psycho" who turned his kids against him. He's pacing, voice raised, fists clenched.</p>
-<p><strong>Decision Point:</strong> How do you respond?</p>
-<p><strong>Option A:</strong> "Derek, I can't talk to you when you're this escalated. You need to calm down."</p>
-<p><strong>Option B:</strong> "She sounds terrible. I don't know how you put up with her."</p>
-<p><strong>Option C:</strong> "I can see you're absolutely furious right now—this is really activating for you. Something happened with your ex that has you feeling completely powerless and enraged."</p>
-<p><strong>Option D:</strong> "Let's take some deep breaths and then we can talk."</p>
-<p><strong>Analysis:</strong></p>
-<p><strong>Option A</strong> is invalidating. It tells Derek his emotion is unacceptable and makes his emotional state his fault. With a high-conflict client, this may escalate rather than de-escalate.</p>
-<p><strong>Option B</strong> validates the interpretation (ex is terrible) rather than the emotion, and allies with Derek against someone you've never met. This feeds into splitting rather than addressing it.</p>
-<p><strong>Option C</strong> is the best choice. It names and validates the emotion (fury, feeling powerless and enraged) without endorsing the interpretation. It communicates that you see what's happening for him.</p>
-<p><strong>Option D</strong> isn't terrible, but it moves to regulation techniques before validation. Derek may experience "let's take breaths" as dismissive of his experience. Validation should come first.</p>
-<p><strong>After Option C, you might continue:</strong></p>
-<p>"Tell me what happened. I want to understand what set this off."</p>
-<p>[After listening] "So she told the kids you wouldn't be at their concert because you don't care, when actually she changed the time without telling you. No wonder you're this furious—she's putting words in your mouth and painting you as the bad guy."</p>
-<p>[Later] "Your anger makes complete sense. AND I want to make sure we use our time well. Can we sit down and figure out what to do about this?"</p>`,
-            },
-{
-              type: "text",
-              order: 27,
-              content: `<h2>Validating Across Contexts: Specific Applications</h2>`,
-            },
-{
-              type: "text",
-              order: 28,
-              content: `<h2>Validating During Suicidal Ideation</h2>
-<p>When a client expresses suicidal thoughts, validation is essential—but therapists often skip it out of anxiety:</p>
-<p><strong>Invalidating response:</strong> "You have so much to live for! Have you thought about how your kids would feel?"</p>
-<p><strong>Validating response:</strong> "It sounds like the pain has gotten so intense that you're thinking about not being here anymore. When suffering is this bad, wanting it to stop makes sense—even if we find another way to stop it besides dying."</p>
-<p>Validation here doesn't endorse suicide—it acknowledges the pain that's driving the ideation. From this validated place, you can explore further and safety plan.</p>`,
-            },
-{
-              type: "text",
-              order: 29,
-              content: `<h2>Validating When You Disagree</h2>
-<p>Sometimes clients describe situations where your assessment differs from theirs. You can still validate the emotion while holding a different perspective on the facts:</p>
-<p><strong>Client:</strong> "My therapist before you abandoned me. She just quit seeing me out of nowhere."</p>
-<p><strong>Your knowledge:</strong> The previous therapist retired after giving three months' notice.</p>
-<p><strong>Invalidating:</strong> "Actually, she gave you plenty of notice. She didn't abandon you."</p>
-<p><strong>Validating:</strong> "Ending that relationship felt like abandonment—sudden and painful, like she left you without warning. That feeling of being abandoned is real, whatever the circumstances were."</p>
-<p>You've validated the emotional truth without agreeing with the factual interpretation. Later, you might gently explore the discrepancy—but only after the emotion is validated.</p>`,
-            },
-{
-              type: "text",
-              order: 30,
-              content: `<h2>Validating When Setting Limits</h2>
-<p>Validation and limits aren't opposites—they work together:</p>
-<p><strong>Situation:</strong> Client is 20 minutes late for the third session in a row.</p>
-<p><strong>Without validation:</strong> "We need to talk about your lateness. This is a pattern, and it's affecting your treatment."</p>
-<p><strong>With validation:</strong> "I want to check in about something. I've noticed you've been arriving late the past few weeks, and I'm wondering if something is making it hard to get here. I'm not trying to criticize—I genuinely want to understand what's happening." [Listen] "It sounds like there's some real ambivalence about being here. That's actually really normal and worth talking about. AND I want to make sure we have enough time to work together. Can we figure out what would help?"</p>`,
-            },
-{
-              type: "text",
-              order: 31,
-              content: `<h2>🛠️ Skill Builder: Validation Practice</h2>
-<p>For each client statement, write a validating response:</p>
-<p><strong>1. "Nobody understands me. Even you don't get it."</strong></p>
-<p>Your validating response: _________________________________</p>
-<p><strong>Sample answer:</strong> "It sounds incredibly lonely to feel like no one understands you—including me. That feeling of being unseen and misunderstood is painful. Tell me more about what I'm missing."</p>
-<p><strong>2. "I can't believe you're going on vacation. You're abandoning me just like everyone else."</strong></p>
-<p>Your validating response: _________________________________</p>
-<p><strong>Sample answer:</strong> "I can hear how scary it is that I'll be away. When you've experienced people leaving, any absence can feel like abandonment. Your fear is real, even though I'm coming back."</p>
-<p><strong>3. "My mother is toxic. She's never once supported me in my entire life."</strong></p>
-<p>Your validating response: _________________________________</p>
-<p><strong>Sample answer:</strong> "There's so much pain in what you're describing—a lifetime of feeling unsupported by the person who was supposed to support you most. That kind of wound runs deep."</p>`,
+      "order": 3,
+      "title": "Module 3: VALIDATION THAT WORKS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 3: VALIDATION THAT WORKS",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 3
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Explain why validation is essential for high-conflict clients</li>\n<li>Distinguish between validation and agreement</li>\n<li>Describe and apply Linehan's six levels of validation</li>\n<li>Validate emotional experience while addressing problematic behavior</li>\n<li>Avoid common validation mistakes</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>The Validation Paradox</h2>\n<p>High-conflict clients desperately need validation. Their histories often include profound invalidation—their emotions were dismissed, punished, or ignored. Their current experience may include ongoing invalidation from partners, family, employers, and even other healthcare providers who see them as \"difficult\" or \"dramatic.\"</p>\n<p>And yet validation feels risky. Won't validating their emotions reinforce their problematic behavior? Won't agreeing that they've been mistreated encourage their victim stance? Won't expressing understanding enable their continued dysfunction?</p>\n<p>This is the validation paradox: the people who most need validation are often the people whose behavior makes us least want to provide it.</p>\n<p>The solution lies in understanding what validation actually is—and isn't.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Validation vs. Agreement</h2>\n<p><strong>Validation is not agreement.</strong> This distinction is crucial and often misunderstood.</p>\n<p>Validation says: \"Your emotional response makes sense given how you're experiencing this situation.\"</p>\n<p>Validation does not say: \"You're right about the situation\" or \"Your response is appropriate\" or \"The other person is wrong.\"</p>\n<p>Consider this example:</p>\n<p>Client: \"My sister completely ignored me at the family dinner. She barely said two words to me. She's always been jealous of me, and she deliberately made me feel invisible.\"</p>\n<p><strong>Agreeing</strong> would be: \"That's terrible. Your sister sounds awful.\"</p>\n<p><strong>Validating</strong> would be: \"It sounds like you felt really invisible and hurt at that dinner—like you weren't acknowledged at all. That's a painful feeling.\"</p>\n<p>Notice the difference. The validating response:</p>\n<ul>\n<li>Acknowledges the emotional experience (feeling invisible, hurt)</li>\n<li>Doesn't challenge or confirm the interpretation (sister deliberately ignored)</li>\n<li>Doesn't evaluate the sister's behavior</li>\n<li>Stays with the client's internal experience</li>\n</ul>\n<p>You can validate the emotion without validating the interpretation or the behavioral response.</p>\n<p>\"I understand why you're angry\" doesn't mean \"You're right to be angry\" or \"The anger is justified\" or \"What you did with the anger was appropriate.\"</p>\n<p>\"It makes sense you'd feel hurt\" doesn't mean \"Your interpretation is correct\" or \"The other person did something wrong.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Linehan's Six Levels of Validation</h2>\n<p>Marsha Linehan identified six levels of validation, moving from basic attentiveness to {{callout:radical-genuineness}}. Each level involves the therapist responding to the client's experience in a way that communicates: \"You make sense.\"</p>",
+          "callouts": {
+            "radical-genuineness": {
+              "label": "Radical Genuineness",
+              "type": "clinical",
+              "body": "Linehan’s highest level of validation: responding to the client as an equal and a real person rather than from behind a professional role."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Level 1: Being Present</h2>\n<p>The most basic form of validation is simply being present and attentive. This means:</p>\n<ul>\n<li>Maintaining eye contact (culturally appropriate)</li>\n<li>Not multitasking or appearing distracted</li>\n<li>Turning toward the client physically</li>\n<li>Being fully there</li>\n</ul>\n<p>This sounds simple, but for clients who have been chronically ignored or dismissed, simply being attended to can be validating. Your presence says: \"You are worth paying attention to.\"</p>\n<p><strong>Example:</strong> Client is describing a difficult experience. Therapist maintains steady eye contact, leans forward slightly, puts away notes, and gives full attention without looking at the clock.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Level 2: Accurate Reflection</h2>\n<p>Level 2 involves reflecting back what the client communicates—without adding interpretation or editorializing. You're letting the client know you've heard and understood their communication.</p>\n<p><strong>Example:</strong> Client: \"I can't believe she said that to me in front of everyone. It was so humiliating.\"</p>\n<p>Therapist: \"She said something embarrassing in front of the group, and you felt humiliated.\"</p>\n<p>This may seem like mere parroting, but for clients who are rarely heard accurately, having their communication reflected back is validating. It says: \"I heard you. I got it.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Level 3: Articulating the Unverbalized</h2>\n<p>Level 3 goes beyond what the client explicitly said to what they seem to be experiencing but haven't directly expressed. You're reading between the lines and putting words to unspoken experience.</p>\n<p><strong>Example:</strong> Client: \"She said it was fine that I couldn't make her party. But her voice was cold, and she hung up really fast.\"</p>\n<p>Therapist: \"It sounds like even though she said it was fine, you're picking up that she's actually upset with you. And maybe that leaves you feeling anxious about where you stand with her?\"</p>\n<p>The therapist articulated what the client implied but didn't say directly: the worry about the friend's actual feelings, the anxiety about the relationship. This deeper attunement validates the client's full experience, not just the surface content.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Level 4: Validating in Terms of Past</h2>\n<p>Level 4 involves validating the client's response as understandable given their history. Even if the response might seem disproportionate to the current situation, it makes sense given what the client has experienced.</p>\n<p><strong>Example:</strong> Client: \"I know it's stupid, but when my boss called me into his office, I was convinced I was getting fired. I was panicking all day.\"</p>\n<p>Therapist: \"Given that you grew up with a father who was unpredictable and punishing, it makes sense that being called into an authority figure's office would trigger fear. Your nervous system learned early on that authority figures are dangerous. Even if it wasn't 'rational' in this situation, your response makes sense given your history.\"</p>\n<p>This level validates by connecting current reactions to formative experiences. It says: \"You're not crazy or stupid. There's a reason you respond this way.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Level 5: Validating in Terms of Present Context</h2>\n<p>Level 5 validates the client's response as understandable given the current situation. This is validation that the response makes sense right now, not just because of history.</p>\n<p><strong>Example:</strong> Client: \"Everyone keeps telling me I'm overreacting about the layoffs. But half my department just got let go!\"</p>\n<p>Therapist: \"Given that your company just laid off half your department, anxiety about your own job security isn't overreacting—it's a normal response to a genuinely uncertain situation. Anyone in your position might feel the same way.\"</p>\n<p>This level says: \"Your response isn't just understandable because of your history—it makes sense in this situation. Anyone might respond this way.\"</p>\n<p>Level 5 validation is powerful because it doesn't pathologize. It normalizes. It says: you're not having this reaction because you're broken or because of your trauma—you're having it because it makes sense.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Level 6: Radical Genuineness</h2>\n<p>Level 6 is the deepest form of validation. It involves treating the client as a capable, equal person rather than as a fragile patient. It means being authentic and genuine in the relationship rather than hiding behind the therapist role.</p>\n<p><strong>Example:</strong> Client: \"I don't know why I'm even trying to explain this to you. You probably think I'm just crazy.\"</p>\n<p>Therapist: \"Actually, I think you're making a lot of sense. What you're describing is a really difficult situation, and I can see why you're struggling with it. I don't think you're crazy at all—I think you're dealing with something genuinely hard.\"</p>\n<p>This level involves the therapist showing up as a real person who genuinely sees and respects the client. It says: \"I'm not humoring you or managing you. I actually see you as competent, and I'm engaging with you as an equal.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Validating Emotions While Addressing Behavior</h2>\n<p>The key skill for high-conflict work is the ability to validate the emotion while still addressing problematic behavior. The word \"and\" is your friend.</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>The Formula</h2>\n<p>\"I understand [emotion]. AND [behavioral guidance].\"</p>\n<p><strong>Examples:</strong></p>\n<p>\"I can see you're really angry right now—that anger makes sense given how dismissed you felt. AND I need you to lower your voice so we can continue talking.\"</p>\n<p>\"I understand the urge to text him multiple times when you're panicking—that fear of abandonment is excruciating. AND we've talked about how that behavior pushes him away.\"</p>\n<p>\"It makes sense that you want to call in sick when you're feeling this depressed—getting out of bed feels impossible. AND staying in bed is making the depression worse.\"</p>\n<p>The \"and\" is crucial. It connects validation to behavioral guidance without negating either. It's not \"but\" (which erases what came before) but \"and\" (which holds both things as true simultaneously).</p>"
+        },
+        {
+          "type": "callout",
+          "order": 14,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Validation with Behavioral Guidance",
+          "content": "<p>Lauren is a high-conflict client who has been escalating in sessions. Last week she began yelling at Dr. Martinez about a perceived slight.</p>\n<p>Lauren: [voice rising] \"You don't actually care about me! You just sit there and collect your fee! If you cared, you would have called me back last night!\"</p>\n<p>Dr. Martinez: \"Lauren, I can hear how hurt and angry you are right now. You reached out when you were struggling, and you didn't get a response. That left you feeling uncared for, and given everything you've experienced, that feeling makes complete sense.\" [Pause]</p>\n<p>\"AND I need us to lower the intensity here so we can actually talk about what happened. Can you take a breath with me?\"</p>\n<p>Lauren: [still agitated but slightly calmer] \"You don't understand what it's like to feel so alone.\"</p>\n<p>Dr. Martinez: \"You're right that I don't know exactly what your experience is like. What I do know is that feeling alone is painful—really painful. And I want us to be able to talk about it. Can we do that now?\"</p>\n<p>Notice how Dr. Martinez:</p>\n<ul>\n<li>Validated the emotion (hurt, anger, feeling uncared for)</li>\n<li>Connected to history (\"given everything you've experienced\")</li>\n<li>Set a limit on the escalation (\"lower the intensity\")</li>\n<li>Redirected toward productive conversation</li>\n<li>Acknowledged her own limitations (\"I don't know exactly\")</li>\n</ul>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 15,
+          "question": "Validation differs from agreement in that:",
+          "options": [
+            {
+              "text": "They are the same thing",
+              "isCorrect": true
+            },
+            {
+              "text": "Validation acknowledges emotional experience without necessarily endorsing interpretations or behaviors",
+              "isCorrect": false
+            },
+            {
+              "text": "Validation is always inappropriate with high-conflict clients",
+              "isCorrect": false
+            },
+            {
+              "text": "Agreement is more therapeutic",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 16,
+          "type": "matching",
+          "matchingInstructions": "Match each of Linehan’s six levels of validation to its description.",
+          "matchingPairs": [
+            {
+              "term": "Level 1",
+              "definition": "Being present and attentive"
+            },
+            {
+              "term": "Level 2",
+              "definition": "Accurate reflection of what the client expresses"
+            },
+            {
+              "term": "Level 3",
+              "definition": "Articulating the unverbalized"
+            },
+            {
+              "term": "Level 4",
+              "definition": "Validating in terms of the client’s history/biology"
+            },
+            {
+              "term": "Level 5",
+              "definition": "Validating in terms of present context (a reasonable response now)"
+            },
+            {
+              "term": "Level 6",
+              "definition": "Radical genuineness — responding as an equal, real person"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 17,
+          "question": "The word \"and\" in validation statements:",
+          "options": [
+            {
+              "text": "Negates the validation",
+              "isCorrect": true
+            },
+            {
+              "text": "Connects validation to behavioral guidance without negating either",
+              "isCorrect": false
+            },
+            {
+              "text": "Should be replaced with \"but\"",
+              "isCorrect": false
+            },
+            {
+              "text": "Is grammatically incorrect",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 18,
+          "question": "Radical genuineness (Level 6) involves:",
+          "options": [
+            {
+              "text": "Hiding behind the therapist role",
+              "isCorrect": true
+            },
+            {
+              "text": "Treating the client as fragile",
+              "isCorrect": false
+            },
+            {
+              "text": "Treating the client as a capable, equal person",
+              "isCorrect": false
+            },
+            {
+              "text": "Agreeing with everything the client says",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 19,
+          "question": "When a client is escalating emotionally, the therapist should:",
+          "options": [
+            {
+              "text": "Match the client's intensity",
+              "isCorrect": true
+            },
+            {
+              "text": "Validate the emotion and set limits on the behavior",
+              "isCorrect": false
+            },
+            {
+              "text": "End the session immediately",
+              "isCorrect": false
+            },
+            {
+              "text": "Ignore the escalation",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Common Validation Mistakes</h2>\n<p>Even well-intentioned clinicians make validation errors that undermine effectiveness:</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Mistake 1: Validating the Interpretation Instead of the Emotion</h2>\n<p><strong>Problem:</strong> \"You're right, your boss is completely unfair.\"</p>\n<p>This validates the client's interpretation of the situation rather than their emotional experience. It takes sides on a factual question you can't verify, and it doesn't actually help the client process their experience.</p>\n<p><strong>Better:</strong> \"I can hear how frustrated and dismissed you're feeling. That sense of being treated unfairly is really painful.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>Mistake 2: Rushing Past Validation to Problem-Solving</h2>\n<p><strong>Problem:</strong> \"I understand you're upset. Have you tried talking to HR?\"</p>\n<p>The validation is cursory—a box to check before getting to \"real\" work. But for high-conflict clients, validation IS the real work. Premature problem-solving communicates that you don't really want to hear about their experience.</p>\n<p><strong>Better:</strong> \"Tell me more about what happened. I want to understand how this felt for you.\" [Then, after thorough validation] \"When you're ready, we can think about what might help.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Mistake 3: Using \"But\" Instead of \"And\"</h2>\n<p><strong>Problem:</strong> \"I understand you're angry, BUT you can't yell at me.\"</p>\n<p>\"But\" erases what came before. It signals that the validation was perfunctory—just a setup for the real message.</p>\n<p><strong>Better:</strong> \"I understand you're angry—that anger makes sense given what happened—AND I need you to lower your voice so we can keep talking.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Mistake 4: Validation That Feels Patronizing</h2>\n<p><strong>Problem:</strong> \"Of course you feel that way, sweetie. That's totally normal.\"</p>\n<p>Overly warm or diminutive language can feel condescending, especially to clients who are hypervigilant about being dismissed or treated as incompetent.</p>\n<p><strong>Better:</strong> Genuine, adult-to-adult validation: \"What you're describing makes sense. Most people would feel something similar in that situation.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Mistake 5: Hollow Validation</h2>\n<p><strong>Problem:</strong> \"I hear you.\" [said flatly, without genuine engagement]</p>\n<p>Validation requires genuine attunement. Clients can tell when you're going through the motions. Words alone aren't validation—the emotional genuineness behind them matters.</p>\n<p><strong>Better:</strong> Slow down. Actually attune to the client's experience. Let your face, voice, and body communicate that you're genuinely trying to understand.</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>🎭 Clinical Vignette: Validation in Challenging Moments</h2>\n<p><strong>Scenario:</strong> Your client Derek is furious. He storms into session saying his ex-wife is \"a complete psycho\" who turned his kids against him. He's pacing, voice raised, fists clenched.</p>\n<p><strong>Decision Point:</strong> How do you respond?</p>\n<p><strong>Option A:</strong> \"Derek, I can't talk to you when you're this escalated. You need to calm down.\"</p>\n<p><strong>Option B:</strong> \"She sounds terrible. I don't know how you put up with her.\"</p>\n<p><strong>Option C:</strong> \"I can see you're absolutely furious right now—this is really activating for you. Something happened with your ex that has you feeling completely powerless and enraged.\"</p>\n<p><strong>Option D:</strong> \"Let's take some deep breaths and then we can talk.\"</p>\n<p><strong>Analysis:</strong></p>\n<p><strong>Option A</strong> is invalidating. It tells Derek his emotion is unacceptable and makes his emotional state his fault. With a high-conflict client, this may escalate rather than de-escalate.</p>\n<p><strong>Option B</strong> validates the interpretation (ex is terrible) rather than the emotion, and allies with Derek against someone you've never met. This feeds into splitting rather than addressing it.</p>\n<p><strong>Option C</strong> is the best choice. It names and validates the emotion (fury, feeling powerless and enraged) without endorsing the interpretation. It communicates that you see what's happening for him.</p>\n<p><strong>Option D</strong> isn't terrible, but it moves to regulation techniques before validation. Derek may experience \"let's take breaths\" as dismissive of his experience. Validation should come first.</p>\n<p><strong>After Option C, you might continue:</strong></p>\n<p>\"Tell me what happened. I want to understand what set this off.\"</p>\n<p>[After listening] \"So she told the kids you wouldn't be at their concert because you don't care, when actually she changed the time without telling you. No wonder you're this furious—she's putting words in your mouth and painting you as the bad guy.\"</p>\n<p>[Later] \"Your anger makes complete sense. AND I want to make sure we use our time well. Can we sit down and figure out what to do about this?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 27,
+          "content": "<h2>Validating Across Contexts: Specific Applications</h2>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Validating During Suicidal Ideation</h2>\n<p>When a client expresses suicidal thoughts, validation is essential—but therapists often skip it out of anxiety:</p>\n<p><strong>Invalidating response:</strong> \"You have so much to live for! Have you thought about how your kids would feel?\"</p>\n<p><strong>Validating response:</strong> \"It sounds like the pain has gotten so intense that you're thinking about not being here anymore. When suffering is this bad, wanting it to stop makes sense—even if we find another way to stop it besides dying.\"</p>\n<p>Validation here doesn't endorse suicide—it acknowledges the pain that's driving the ideation. From this validated place, you can explore further and safety plan.</p>"
+        },
+        {
+          "type": "text",
+          "order": 29,
+          "content": "<h2>Validating When You Disagree</h2>\n<p>Sometimes clients describe situations where your assessment differs from theirs. You can still validate the emotion while holding a different perspective on the facts:</p>\n<p><strong>Client:</strong> \"My therapist before you abandoned me. She just quit seeing me out of nowhere.\"</p>\n<p><strong>Your knowledge:</strong> The previous therapist retired after giving three months' notice.</p>\n<p><strong>Invalidating:</strong> \"Actually, she gave you plenty of notice. She didn't abandon you.\"</p>\n<p><strong>Validating:</strong> \"Ending that relationship felt like abandonment—sudden and painful, like she left you without warning. That feeling of being abandoned is real, whatever the circumstances were.\"</p>\n<p>You've validated the emotional truth without agreeing with the factual interpretation. Later, you might gently explore the discrepancy—but only after the emotion is validated.</p>"
+        },
+        {
+          "type": "text",
+          "order": 30,
+          "content": "<h2>Validating When Setting Limits</h2>\n<p>Validation and limits aren't opposites—they work together:</p>\n<p><strong>Situation:</strong> Client is 20 minutes late for the third session in a row.</p>\n<p><strong>Without validation:</strong> \"We need to talk about your lateness. This is a pattern, and it's affecting your treatment.\"</p>\n<p><strong>With validation:</strong> \"I want to check in about something. I've noticed you've been arriving late the past few weeks, and I'm wondering if something is making it hard to get here. I'm not trying to criticize—I genuinely want to understand what's happening.\" [Listen] \"It sounds like there's some real ambivalence about being here. That's actually really normal and worth talking about. AND I want to make sure we have enough time to work together. Can we figure out what would help?\"</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Teaching Clients to Validate Themselves</h2>\n<p>A longer-term aim of validation work is to help clients develop the capacity to validate themselves, since chronic self-invalidation is central to many high-conflict and dysregulated presentations.</p>\n<h3>From External to Internal</h3>\n<p>Clients who grew up in invalidating environments frequently learned to distrust and dismiss their own emotional experience, which drives both the desperate search for external validation and the escalation when it is not received. As the clinician models accurate validation over time, the client begins to internalize it — learning to recognize their emotions as real and understandable rather than as evidence that something is wrong with them.</p>\n<h3>Building the Skill</h3>\n<p>The clinician can make this explicit: naming the client’s self-invalidation when it appears, helping the client practice describing and accepting their own emotional responses, and reinforcing moments of self-validation. Teaching that an emotion can be valid (understandable given the context) even when the interpretation attached to it is not, gives clients a tool for steadying themselves between sessions and reduces the reliance on others to regulate their sense of reality.</p>",
+          "order": 31
+        },
+        {
+          "type": "text",
+          "content": "<h2>Validation and Cultural Difference</h2>\n<p>Emotional expression, the meaning of distress, and what feels validating are all shaped by culture, and validation that works attends to the client’s cultural world rather than applying a single template.</p>\n<h3>Reading Emotion in Context</h3>\n<p>Norms for expressing and containing emotion vary widely, as do beliefs about suffering, family, autonomy, and help-seeking. An emotional display that reads as dysregulation through one cultural lens may be ordinary expression through another, and a validating response in one context may feel intrusive or off-key in another. The clinician stays curious about what a given emotion and its expression mean to this particular client.</p>\n<h3>Culturally Attuned Validation</h3>\n<p>Accurate validation — communicating that the client’s emotional response is understandable given their context — requires understanding that context, including its cultural dimensions. The clinician validates in terms the client recognizes, attends to how their own cultural assumptions shape what they notice and affirm, and treats the client as the expert on their own experience. Validation grounded in genuine cultural humility lands as real rather than formulaic.</p>",
+          "order": 32
+        },
+        {
+          "type": "text",
+          "order": 33,
+          "content": "<h2>🛠️ Skill Builder: Validation Practice</h2>\n<p>For each client statement, write a validating response:</p>\n<p><strong>1. \"Nobody understands me. Even you don't get it.\"</strong></p>\n<p>Your validating response: _________________________________</p>\n<p><strong>Sample answer:</strong> \"It sounds incredibly lonely to feel like no one understands you—including me. That feeling of being unseen and misunderstood is painful. Tell me more about what I'm missing.\"</p>\n<p><strong>2. \"I can't believe you're going on vacation. You're abandoning me just like everyone else.\"</strong></p>\n<p>Your validating response: _________________________________</p>\n<p><strong>Sample answer:</strong> \"I can hear how scary it is that I'll be away. When you've experienced people leaving, any absence can feel like abandonment. Your fear is real, even though I'm coming back.\"</p>\n<p><strong>3. \"My mother is toxic. She's never once supported me in my entire life.\"</strong></p>\n<p>Your validating response: _________________________________</p>\n<p><strong>Sample answer:</strong> \"There's so much pain in what you're describing—a lifetime of feeling unsupported by the person who was supposed to support you most. That kind of wound runs deep.\"</p>"
+        }
       ]
     },
     {
-      order: 4,
-      title: `Module 4: BOUNDARIES WITH COMPASSION`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 4: BOUNDARIES WITH COMPASSION`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 4,
+      "order": 4,
+      "title": "Module 4: BOUNDARIES WITH COMPASSION",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 4: BOUNDARIES WITH COMPASSION",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 4
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Explain why boundaries are essential in high-conflict work</li>\n<li>Distinguish between limit-setting and punishment</li>\n<li>Use specific language for setting boundaries compassionately</li>\n<li>Respond effectively when boundaries are tested</li>\n<li>Navigate the balance between flexibility and firmness</li>\n<li>Develop and maintain a consistent therapeutic frame</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Why Boundaries Are Essential</h2>\n<p>With high-conflict clients, boundaries are not optional extras—they're fundamental requirements for effective treatment and therapist sustainability.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>The Paradox of Boundaries</h2>\n<p>Here's a paradox that confuses many therapists: High-conflict clients often desperately seek connection and acceptance while simultaneously engaging in behaviors that push people away and destroy relationships. They may beg for more contact while behaving in ways that make contact unbearable. They may idealize you while testing whether you'll abandon them like everyone else.</p>\n<p>This paradox means that the very clients who most need boundaries are often the ones who react most strongly against them. Understanding this helps us hold boundaries with compassion rather than punishment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Why Boundaries Help High-Conflict Clients</h2>\n<p><strong>Containment:</strong> Clients with emotional dysregulation often feel like they're falling apart. Clear, consistent boundaries provide external structure when internal structure is lacking. The predictability of the therapeutic frame becomes a container for overwhelming feelings.</p>\n<p><strong>Safety:</strong> Paradoxically, clients may feel safer when limits exist. A therapist who maintains boundaries demonstrates that they won't be overwhelmed or destroyed by the client's intensity. The message is: \"I can handle you. I'm not going anywhere.\"</p>\n<p><strong>Modeling:</strong> Many high-conflict clients have never experienced healthy boundaries. They grew up in environments where boundaries were either rigid and punitive or nonexistent. Watching you maintain limits with warmth shows them a different way.</p>\n<p><strong>Protecting the therapy:</strong> Without boundaries, therapy becomes unsustainable. Sessions that go hours over, constant between-session contact, crises that never resolve—these destroy the therapist and ultimately harm the client.</p>\n<p><strong>Reality testing:</strong> Clear limits help clients understand what's appropriate in relationships. They provide feedback about social norms that clients may not have internalized.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Why Therapists Struggle with Boundaries</h2>\n<p>If boundaries help clients, why do therapists struggle to maintain them?</p>\n<p><strong>Fear of abandonment:</strong> We worry that limits will feel like rejection and the client will leave. Sometimes they do leave—but more often, maintained limits lead to stronger therapeutic relationships.</p>\n<p><strong>Rescue fantasies:</strong> We want to be the one who finally helps by giving more than others would. But infinite giving isn't help—it's enabling.</p>\n<p><strong>Guilt:</strong> We feel guilty saying no to someone in pain. But saying yes to everything often harms more than helps.</p>\n<p><strong>Unclear personal limits:</strong> Some therapists don't know their own limits until they've exceeded them. Understanding your needs is prerequisite to communicating them.</p>\n<p><strong>Conflict avoidance:</strong> Setting limits can trigger negative reactions. Avoiding limits avoids conflict—but creates bigger problems later.</p>\n<p><strong>Training gaps:</strong> Many programs don't teach practical boundary skills. Therapists know boundaries matter but not how to implement them.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>💡 Myth vs. Fact: Boundaries</h2><table class=\"cr-table\">\n<tr><th>Myth</th><th>Fact</th></tr>\n<tr><td>Boundaries are cold and uncaring</td><td>Boundaries delivered with warmth provide containment and safety</td></tr>\n<tr><td>Good therapists make exceptions for difficult clients</td><td>Good therapists maintain limits especially with clients who need them most</td></tr>\n<tr><td>Clients will leave if you set limits</td><td>Clients often deepen engagement when they experience consistent limits</td></tr>\n<tr><td>Flexibility means having no limits</td><td>Flexibility means thoughtful limits, not absent ones</td></tr>\n<tr><td>If I care, I should always be available</td><td>Caring requires sustainability, which requires limits</td></tr>\n</table>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>The Difference Between Limits and Punishment</h2>\n<p>Limits are not punishment. Understanding this distinction is crucial.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Punishment</h2>\n<p>Punishment is designed to cause suffering as a consequence for behavior. It communicates: \"You were bad, so now I will hurt you.\"</p>\n<p><strong>Characteristics of punishment:</strong></p>\n<ul>\n<li>Delivered with anger or coldness</li>\n<li>Intended to make the person feel bad</li>\n<li>Often arbitrary or disproportionate</li>\n<li>Communicates rejection of the person</li>\n<li>Creates shame</li>\n</ul>\n<p><strong>Examples of punishment disguised as boundaries:</strong></p>\n<ul>\n<li>\"Since you called me too much last week, I'm not going to return any calls this week.\"</li>\n<li>\"I'm ending our session early because you were late.\" (said with hostility)</li>\n<li>Withdrawing warmth to show displeasure</li>\n<li>Using cold silence in response to boundary violations</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Limit-Setting</h2>\n<p>Limits are necessary parameters that protect the therapy and the therapist while remaining in relationship with the client. They communicate: \"I care about you AND I need this to continue working together.\"</p>\n<p><strong>Characteristics of healthy limits:</strong></p>\n<ul>\n<li>Delivered with warmth and clear rationale</li>\n<li>Intended to protect, not punish</li>\n<li>Proportionate and consistent</li>\n<li>Maintains connection to the person</li>\n<li>Avoids inducing shame</li>\n</ul>\n<p><strong>Examples of healthy limit-setting:</strong></p>\n<ul>\n<li>\"I care about being able to help you, and to do that, I need to keep our sessions to our scheduled time. Let's plan how to use our time next week.\"</li>\n<li>\"I noticed you called several times yesterday. I want to understand what was happening, AND I want to talk about how we can handle between-session distress in a way that works for both of us.\"</li>\n<li>\"I need to stop our session on time today. I know that's hard when there's so much to talk about. Let's make a plan for where to start next week.\"</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>🎭 Clinical Vignette: Limit vs. Punishment</h2>\n<p><strong>Situation:</strong> Your client Tyler texted you 15 times yesterday, including at 2 AM. The content wasn't crisis-level—mostly rumination about a fight with his partner.</p>\n<p><strong>Punishment response:</strong> \"Tyler, I'm very disappointed. I've told you that texting is for emergencies only. This was completely inappropriate. I'm going to have to reconsider whether I can continue seeing you if you can't respect my boundaries.\"</p>\n<p><strong>Problems:</strong> Delivered with disappointment and threat. Induces shame. Threatens abandonment. Doesn't explore what was happening for Tyler. Doesn't problem-solve.</p>\n<p><strong>Limit-setting response:</strong> \"Tyler, I noticed you sent quite a few texts yesterday, including in the middle of the night. I want to understand what was happening for you—it sounds like things felt really intense. AND I need us to figure out a different plan for those moments, because I'm not able to respond to texts outside of sessions except in emergencies, and I want to make sure you have support that actually works. Can we talk about what was going on and what might help next time?\"</p>\n<p><strong>Why this works:</strong> Validates the distress. Names the limit clearly. Maintains connection. Invites collaboration on solutions. Doesn't induce shame.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>Specific Boundary Language</h2>\n<p>Language matters enormously in boundary-setting. Here are frameworks for common situations:</p>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>The AND Framework</h2>\n<p>Use \"and\" instead of \"but\" to connect validation and limits:</p>\n<p><strong>Instead of:</strong> \"I understand you're upset, BUT you can't yell at me.\"</p>\n<p><strong>Try:</strong> \"I understand you're upset—that makes sense given what happened—AND I need you to lower your voice so we can keep talking.\"</p>\n<p>\"But\" negates what came before. \"And\" holds both realities together.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>The Because Framework</h2>\n<p>Provide brief rationale for limits:</p>\n<p>\"I'm going to stop us there <strong>because</strong> I want to make sure we have time for the other important things you mentioned.\"</p>\n<p>\"I can't return calls after 6 PM <strong>because</strong> I need to be present with my family, AND I want to be fully available to you during our sessions.\"</p>\n<p>Rationale isn't justification or permission-seeking—it's respect. Clients deserve to understand why limits exist.</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>The I-Statement Framework</h2>\n<p>Frame limits in terms of your needs, not their deficiencies:</p>\n<p><strong>Instead of:</strong> \"You're being too demanding.\"</p>\n<p><strong>Try:</strong> \"I need some structure around our between-session contact so I can be fully present in our work.\"</p>\n<p>I-statements reduce defensiveness by focusing on your needs rather than their behavior.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>The Care + Limit Framework</h2>\n<p>Lead with care, follow with limit:</p>\n<p>\"I care about you and our work together. That's why I need to be honest about something...\"</p>\n<p>\"Because I want to keep working with you, I need us to address how sessions are going.\"</p>\n<p>This frames limits as emerging from care, not rejection.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>For Client Safety</h2>\n<p>High-conflict clients often experienced chaotic, boundary-less environments growing up. Boundaries were arbitrary, inconsistent, or nonexistent. The child couldn't predict what was allowed or what consequences would follow.</p>\n<p>Paradoxically, this history of boundary-lessness creates intense discomfort with boundaries—but also a deep need for them. Clear, consistent boundaries provide:</p>\n<p><strong>Containment:</strong> Boundaries create a container for the chaos. They define the space within which therapeutic work happens. Without boundaries, therapy becomes as unpredictable as the client's childhood environment.</p>\n<p><strong>Safety:</strong> Clients need to know the therapist won't be overwhelmed, won't retaliate, won't abandon ship. Boundaries that hold—even when tested—communicate that the therapist can handle the client's intensity.</p>\n<p><strong>Reality:</strong> Boundaries provide reality testing. The client may wish for unlimited access, special exceptions, boundary-less merger. Reality says no. Learning to tolerate this reality is therapeutic.</p>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>For Treatment Effectiveness</h2>\n<p>Without boundaries, treatment degrades:</p>\n<ul>\n<li>Sessions that have no clear start or end become formless</li>\n<li>Between-session contact that's unlimited becomes therapy-on-demand</li>\n<li>Special exceptions that multiply become the rule</li>\n<li>The frame that contains the work dissolves</li>\n</ul>\n<p>Effective treatment requires a frame. The frame includes session time, frequency, fee, policies about contact, and expectations about behavior. When the frame holds, therapeutic work is possible. When the frame collapses, chaos reigns.</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>For Therapist Sustainability</h2>\n<p>Perhaps most critically, boundaries protect the therapist. Without them:</p>\n<ul>\n<li>The therapist becomes exhausted from unlimited availability</li>\n<li>Resentment builds from accommodations that feel forced</li>\n<li>Burnout becomes inevitable</li>\n<li>The therapist may eventually abandon the client—confirming the client's worst fears</li>\n</ul>\n<p>Maintaining boundaries isn't selfish—it's what makes ongoing treatment possible. A burned-out therapist can't help anyone.</p>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Setting Boundaries: Language and Approach</h2>\n<p>How you set boundaries matters as much as the boundaries themselves. The goal is to be clear AND kind, firm AND compassionate.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>The Formula</h2>\n<p><strong>State the limit + Express care + Offer alternative</strong></p>\n<p>\"I can't [limit], AND I care about [concern], so let's [alternative].\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>Language Examples</h2>\n<p><strong>For session length:</strong> \"I care about you, and I can see you're in a difficult place right now. We do need to stop at our regular time, though. Let's make sure we save a few minutes to talk about how you'll manage until next week.\"</p>\n<p><strong>For between-session contact:</strong> \"I understand you're struggling and want to connect. I'm not available for calls between sessions except in true emergencies. What we can do is work on building your capacity to manage difficult moments—that's actually more helpful long-term than me being available 24/7.\"</p>\n<p><strong>For fee policies:</strong> \"I know the fee is a stretch for you, and I want us to continue working together. I can't reduce my fee further, but I can help you think about options—sliding scale clinics, budgeting, or whether weekly sessions are sustainable right now.\"</p>\n<p><strong>For session behavior:</strong> \"I can see how much pain you're in right now—that pain is real. And I need you to stop yelling so we can actually talk about it. Can you take a breath with me?\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Key Principles</h2>\n<p><strong>Be clear:</strong> State boundaries explicitly, not implied. High-conflict clients may not pick up on hints, and ambiguity creates room for conflict.</p>\n<p><strong>Be kind:</strong> Deliver boundaries with warmth, not punishment. Your tone matters.</p>\n<p><strong>Be consistent:</strong> Enforce boundaries reliably. Inconsistency is more damaging than strict boundaries, because it recreates the unpredictability of the client's past.</p>\n<p><strong>Be prepared for pushback:</strong> High-conflict clients will test boundaries. This is expected. Your response to testing matters more than whether testing occurs.</p>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Limit-Setting vs. Punishment</h2>\n<p>There's a crucial distinction between therapeutic limit-setting and punitive punishment:</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Punishment</h2>\n<p>Punishment is retaliatory. It aims to cause discomfort in response to unwanted behavior. It often comes from the therapist's frustration rather than the client's needs.</p>\n<p>Examples of punitive responses:</p>\n<ul>\n<li>\"Since you missed two sessions, I'm going to charge you for both and not see you for a month.\"</li>\n<li>\"If you keep calling between sessions, I'll terminate treatment.\"</li>\n<li>\"I'm not going to discuss that topic since you yelled at me last time.\"</li>\n</ul>\n<p>Punishment damages the relationship, confirms the client's expectation of harsh treatment, and doesn't teach skills.</p>"
+        },
+        {
+          "type": "text",
+          "order": 26,
+          "content": "<h2>Limit-Setting</h2>\n<p>Limit-setting maintains necessary structure while remaining collaborative. It's about protecting the treatment frame, not punishing the client.</p>\n<p>Examples of therapeutic limit-setting:</p>\n<ul>\n<li>\"Missing sessions makes it hard for therapy to be effective. Let's talk about what gets in the way of you being here consistently and whether our current schedule works for you.\"</li>\n<li>\"I've noticed you've been calling more frequently between sessions. I want to understand what's happening—and also to be clear that between-session calls need to be for emergencies. Let's use our session time to figure out what you need.\"</li>\n<li>\"Last session got pretty intense. I want to come back to that topic, and I also want us to have a plan for how to keep the conversation productive. What would help?\"</li>\n</ul>\n<p>Limit-setting:</p>\n<ul>\n<li>States expectations clearly</li>\n<li>Explores the underlying issue</li>\n<li>Maintains the relationship</li>\n<li>Teaches rather than punishes</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 27,
+          "content": "<h2>When Boundaries Are Tested</h2>\n<p>Boundaries will be tested. This is not if but when. How you respond to testing determines whether boundaries become therapeutic or merely controlling.</p>"
+        },
+        {
+          "type": "text",
+          "order": 28,
+          "content": "<h2>Expect Testing</h2>\n<p>The client who was raised with inconsistent boundaries learned that boundaries can be broken if you push hard enough. They will push. This isn't manipulation (usually)—it's a learned survival strategy.</p>\n<p>Testing also serves a deeper purpose: the client needs to know if you're different. Will you crumble? Will you retaliate? Will you disappear? Every time you hold the boundary without retaliation or abandonment, you provide evidence that contradicts their template.</p>"
+        },
+        {
+          "type": "text",
+          "order": 29,
+          "content": "<h2>Respond with the Three A's</h2>\n<p>When boundaries are tested, use the Three A's:</p>\n<p><strong>Acknowledge the underlying need:</strong> \"I hear that you're really struggling and want more support.\"</p>\n<p><strong>Affirm the boundary:</strong> \"And our agreement is that we meet once weekly.\"</p>\n<p><strong>Redirect to skills:</strong> \"Let's talk about what you can do when you're struggling between sessions.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 30,
+          "content": "<h2>Avoid JADE</h2>\n<p>Don't over-Justify, Argue, Defend, or Explain. Excessive explanation invites debate. State the boundary, acknowledge the feeling, and hold.</p>\n<p><strong>Instead of:</strong> \"I can't take your call at 9pm because I have a family, and I need personal time, and it's not fair to my other clients, and actually my policy is clearly stated in the consent form...\"</p>\n<p><strong>Try:</strong> \"I hear you're struggling. I'm not available for calls in the evenings. What we can do is talk about this at our next session. Can you use your coping skills until then?\"</p>"
+        },
+        {
+          "type": "callout",
+          "order": 31,
+          "calloutType": "clinical",
+          "title": "Clinical Vignette: Boundary Testing",
+          "content": "<p>Shannon has been in therapy with Dr. Patel for four months. She's begun texting between sessions—first occasionally, then daily, now multiple times a day. Most texts are updates about her day or complaints about her boyfriend.</p>\n<p><strong>Session 18:</strong></p>\n<p>Dr. Patel: \"Shannon, I want to talk about the texts. I've noticed they've increased a lot over the past few weeks—you're texting me several times a day now.\"</p>\n<p>Shannon: [defensive] \"I thought you wanted me to reach out when I'm struggling. Isn't that what therapy is for?\"</p>\n<p>Dr. Patel: \"I appreciate that you feel connected enough to want to share with me. That's actually a good sign. AND texting multiple times daily isn't something I can respond to, and I don't think it's actually helping you in the way you need.\"</p>\n<p>Shannon: \"So you don't care about what happens to me between sessions?\"</p>\n<p>Dr. Patel: \"I do care. That's why I want us to figure out a better approach. When you text me, what are you hoping will happen?\"</p>\n<p>Shannon: \"I don't know. I guess I just want to feel like you're there.\"</p>\n<p>Dr. Patel: \"That makes sense. You want to feel connected and not alone. The hard truth is, I can't be there by text multiple times a day—but I also don't think that would actually solve the loneliness. Let's talk about what would really help with that feeling.\"</p>\n<p>Notice how Dr. Patel:</p>\n<ul>\n<li>Named the pattern directly</li>\n<li>Validated the underlying need (connection)</li>\n<li>Held the boundary clearly</li>\n<li>Explored what the behavior was about</li>\n<li>Redirected toward what would actually help</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>Crisis vs. Boundary Violation</h2>\n<p>A genuine clinical emergency is different from a boundary violation. The challenge is distinguishing them.</p>"
+        },
+        {
+          "type": "text",
+          "order": 33,
+          "content": "<h2>Genuine Emergencies</h2>\n<p>Real emergencies warrant flexible response:</p>\n<ul>\n<li>Active suicidal crisis with plan and intent</li>\n<li>Immediate safety threat</li>\n<li>Acute psychiatric decompensation</li>\n<li>Situations requiring immediate intervention</li>\n</ul>\n<p>When genuine emergencies arise, respond appropriately—even if it means bending usual policies.</p>"
+        },
+        {
+          "type": "text",
+          "order": 34,
+          "content": "<h2>Pseudo-Emergencies</h2>\n<p>High-conflict clients may experience (or present) many situations as emergencies that aren't:</p>\n<ul>\n<li>Intense emotional distress that feels unbearable but isn't dangerous</li>\n<li>Interpersonal conflicts that feel urgent</li>\n<li>Anxiety about situations that aren't immediately threatening</li>\n<li>Distress that escalates when needs aren't met</li>\n</ul>\n<p>These experiences are real and painful, but they're not emergencies requiring immediate therapist response. Treating them as emergencies:</p>\n<ul>\n<li>Reinforces that the client can't manage distress</li>\n<li>Creates unsustainable expectations</li>\n<li>Prevents development of self-soothing skills</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 35,
+          "content": "<h2>Making the Distinction</h2>\n<p>When in doubt:</p>\n<ul>\n<li>Assess for actual safety risk</li>\n<li>Ask directly: \"Are you having thoughts of hurting yourself?\"</li>\n<li>Respond to genuine safety concerns</li>\n<li>For non-emergencies, provide validation AND redirect to skills</li>\n<li>Process the incident at the next session</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Boundaries in the Digital Age</h2>\n<p>Texts, emails, messaging apps, and after-hours contact have made boundaries around availability one of the most common and challenging frame issues in high-conflict work.</p>\n<h3>The Pull of Constant Access</h3>\n<p>High-conflict and dysregulated clients may reach out frequently between sessions — lengthy texts, urgent emails, repeated calls — and the clinician feels the pull to respond immediately, both out of genuine concern and out of anxiety about what non-response might trigger. Without a clear policy, availability erodes session by session, contact escalates, and the clinician moves toward depletion while the client’s reliance on between-session reassurance grows.</p>\n<h3>A Clear, Compassionate Policy</h3>\n<p>The clinician sets the digital frame explicitly and early: what channels are used, for what purposes, with what response time, and what to do in a genuine emergency. The frame is held with compassion and consistency — “I’ll see your message and respond at our next session; if it’s an emergency, here is what to do” — so that the client is contained rather than abandoned. Consistency is itself therapeutic, teaching that the relationship has reliable shape rather than depending on the client’s level of distress.</p>",
+          "order": 36
+        },
+        {
+          "type": "multipleChoice",
+          "order": 37,
+          "question": "Boundaries in high-conflict work are important because:",
+          "options": [
+            {
+              "text": "They punish problematic behavior",
+              "isCorrect": true
             },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Explain why boundaries are essential in high-conflict work</li>
-<li>Distinguish between limit-setting and punishment</li>
-<li>Use specific language for setting boundaries compassionately</li>
-<li>Respond effectively when boundaries are tested</li>
-<li>Navigate the balance between flexibility and firmness</li>
-<li>Develop and maintain a consistent therapeutic frame</li>
-</ol>`,
+            {
+              "text": "They provide containment, safety, and reality testing",
+              "isCorrect": false
             },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Why Boundaries Are Essential</h2>
-<p>With high-conflict clients, boundaries are not optional extras—they're fundamental requirements for effective treatment and therapist sustainability.</p>`,
+            {
+              "text": "They keep the therapist distant from the client",
+              "isCorrect": false
             },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>The Paradox of Boundaries</h2>
-<p>Here's a paradox that confuses many therapists: High-conflict clients often desperately seek connection and acceptance while simultaneously engaging in behaviors that push people away and destroy relationships. They may beg for more contact while behaving in ways that make contact unbearable. They may idealize you while testing whether you'll abandon them like everyone else.</p>
-<p>This paradox means that the very clients who most need boundaries are often the ones who react most strongly against them. Understanding this helps us hold boundaries with compassion rather than punishment.</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Why Boundaries Help High-Conflict Clients</h2>
-<p><strong>Containment:</strong> Clients with emotional dysregulation often feel like they're falling apart. Clear, consistent boundaries provide external structure when internal structure is lacking. The predictability of the therapeutic frame becomes a container for overwhelming feelings.</p>
-<p><strong>Safety:</strong> Paradoxically, clients may feel safer when limits exist. A therapist who maintains boundaries demonstrates that they won't be overwhelmed or destroyed by the client's intensity. The message is: "I can handle you. I'm not going anywhere."</p>
-<p><strong>Modeling:</strong> Many high-conflict clients have never experienced healthy boundaries. They grew up in environments where boundaries were either rigid and punitive or nonexistent. Watching you maintain limits with warmth shows them a different way.</p>
-<p><strong>Protecting the therapy:</strong> Without boundaries, therapy becomes unsustainable. Sessions that go hours over, constant between-session contact, crises that never resolve—these destroy the therapist and ultimately harm the client.</p>
-<p><strong>Reality testing:</strong> Clear limits help clients understand what's appropriate in relationships. They provide feedback about social norms that clients may not have internalized.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Why Therapists Struggle with Boundaries</h2>
-<p>If boundaries help clients, why do therapists struggle to maintain them?</p>
-<p><strong>Fear of abandonment:</strong> We worry that limits will feel like rejection and the client will leave. Sometimes they do leave—but more often, maintained limits lead to stronger therapeutic relationships.</p>
-<p><strong>Rescue fantasies:</strong> We want to be the one who finally helps by giving more than others would. But infinite giving isn't help—it's enabling.</p>
-<p><strong>Guilt:</strong> We feel guilty saying no to someone in pain. But saying yes to everything often harms more than helps.</p>
-<p><strong>Unclear personal limits:</strong> Some therapists don't know their own limits until they've exceeded them. Understanding your needs is prerequisite to communicating them.</p>
-<p><strong>Conflict avoidance:</strong> Setting limits can trigger negative reactions. Avoiding limits avoids conflict—but creates bigger problems later.</p>
-<p><strong>Training gaps:</strong> Many programs don't teach practical boundary skills. Therapists know boundaries matter but not how to implement them.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>💡 Myth vs. Fact: Boundaries</h2><table class="cr-table">
-<tr><th>Myth</th><th>Fact</th></tr>
-<tr><td>Boundaries are cold and uncaring</td><td>Boundaries delivered with warmth provide containment and safety</td></tr>
-<tr><td>Good therapists make exceptions for difficult clients</td><td>Good therapists maintain limits especially with clients who need them most</td></tr>
-<tr><td>Clients will leave if you set limits</td><td>Clients often deepen engagement when they experience consistent limits</td></tr>
-<tr><td>Flexibility means having no limits</td><td>Flexibility means thoughtful limits, not absent ones</td></tr>
-<tr><td>If I care, I should always be available</td><td>Caring requires sustainability, which requires limits</td></tr>
-</table>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>The Difference Between Limits and Punishment</h2>
-<p>Limits are not punishment. Understanding this distinction is crucial.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Punishment</h2>
-<p>Punishment is designed to cause suffering as a consequence for behavior. It communicates: "You were bad, so now I will hurt you."</p>
-<p><strong>Characteristics of punishment:</strong></p>
-<ul>
-<li>Delivered with anger or coldness</li>
-<li>Intended to make the person feel bad</li>
-<li>Often arbitrary or disproportionate</li>
-<li>Communicates rejection of the person</li>
-<li>Creates shame</li>
-</ul>
-<p><strong>Examples of punishment disguised as boundaries:</strong></p>
-<ul>
-<li>"Since you called me too much last week, I'm not going to return any calls this week."</li>
-<li>"I'm ending our session early because you were late." (said with hostility)</li>
-<li>Withdrawing warmth to show displeasure</li>
-<li>Using cold silence in response to boundary violations</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Limit-Setting</h2>
-<p>Limits are necessary parameters that protect the therapy and the therapist while remaining in relationship with the client. They communicate: "I care about you AND I need this to continue working together."</p>
-<p><strong>Characteristics of healthy limits:</strong></p>
-<ul>
-<li>Delivered with warmth and clear rationale</li>
-<li>Intended to protect, not punish</li>
-<li>Proportionate and consistent</li>
-<li>Maintains connection to the person</li>
-<li>Avoids inducing shame</li>
-</ul>
-<p><strong>Examples of healthy limit-setting:</strong></p>
-<ul>
-<li>"I care about being able to help you, and to do that, I need to keep our sessions to our scheduled time. Let's plan how to use our time next week."</li>
-<li>"I noticed you called several times yesterday. I want to understand what was happening, AND I want to talk about how we can handle between-session distress in a way that works for both of us."</li>
-<li>"I need to stop our session on time today. I know that's hard when there's so much to talk about. Let's make a plan for where to start next week."</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>🎭 Clinical Vignette: Limit vs. Punishment</h2>
-<p><strong>Situation:</strong> Your client Tyler texted you 15 times yesterday, including at 2 AM. The content wasn't crisis-level—mostly rumination about a fight with his partner.</p>
-<p><strong>Punishment response:</strong> "Tyler, I'm very disappointed. I've told you that texting is for emergencies only. This was completely inappropriate. I'm going to have to reconsider whether I can continue seeing you if you can't respect my boundaries."</p>
-<p><strong>Problems:</strong> Delivered with disappointment and threat. Induces shame. Threatens abandonment. Doesn't explore what was happening for Tyler. Doesn't problem-solve.</p>
-<p><strong>Limit-setting response:</strong> "Tyler, I noticed you sent quite a few texts yesterday, including in the middle of the night. I want to understand what was happening for you—it sounds like things felt really intense. AND I need us to figure out a different plan for those moments, because I'm not able to respond to texts outside of sessions except in emergencies, and I want to make sure you have support that actually works. Can we talk about what was going on and what might help next time?"</p>
-<p><strong>Why this works:</strong> Validates the distress. Names the limit clearly. Maintains connection. Invites collaboration on solutions. Doesn't induce shame.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>Specific Boundary Language</h2>
-<p>Language matters enormously in boundary-setting. Here are frameworks for common situations:</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>The AND Framework</h2>
-<p>Use "and" instead of "but" to connect validation and limits:</p>
-<p><strong>Instead of:</strong> "I understand you're upset, BUT you can't yell at me."</p>
-<p><strong>Try:</strong> "I understand you're upset—that makes sense given what happened—AND I need you to lower your voice so we can keep talking."</p>
-<p>"But" negates what came before. "And" holds both realities together.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>The Because Framework</h2>
-<p>Provide brief rationale for limits:</p>
-<p>"I'm going to stop us there <strong>because</strong> I want to make sure we have time for the other important things you mentioned."</p>
-<p>"I can't return calls after 6 PM <strong>because</strong> I need to be present with my family, AND I want to be fully available to you during our sessions."</p>
-<p>Rationale isn't justification or permission-seeking—it's respect. Clients deserve to understand why limits exist.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>The I-Statement Framework</h2>
-<p>Frame limits in terms of your needs, not their deficiencies:</p>
-<p><strong>Instead of:</strong> "You're being too demanding."</p>
-<p><strong>Try:</strong> "I need some structure around our between-session contact so I can be fully present in our work."</p>
-<p>I-statements reduce defensiveness by focusing on your needs rather than their behavior.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>The Care + Limit Framework</h2>
-<p>Lead with care, follow with limit:</p>
-<p>"I care about you and our work together. That's why I need to be honest about something..."</p>
-<p>"Because I want to keep working with you, I need us to address how sessions are going."</p>
-<p>This frames limits as emerging from care, not rejection.</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>For Client Safety</h2>
-<p>High-conflict clients often experienced chaotic, boundary-less environments growing up. Boundaries were arbitrary, inconsistent, or nonexistent. The child couldn't predict what was allowed or what consequences would follow.</p>
-<p>Paradoxically, this history of boundary-lessness creates intense discomfort with boundaries—but also a deep need for them. Clear, consistent boundaries provide:</p>
-<p><strong>Containment:</strong> Boundaries create a container for the chaos. They define the space within which therapeutic work happens. Without boundaries, therapy becomes as unpredictable as the client's childhood environment.</p>
-<p><strong>Safety:</strong> Clients need to know the therapist won't be overwhelmed, won't retaliate, won't abandon ship. Boundaries that hold—even when tested—communicate that the therapist can handle the client's intensity.</p>
-<p><strong>Reality:</strong> Boundaries provide reality testing. The client may wish for unlimited access, special exceptions, boundary-less merger. Reality says no. Learning to tolerate this reality is therapeutic.</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>For Treatment Effectiveness</h2>
-<p>Without boundaries, treatment degrades:</p>
-<ul>
-<li>Sessions that have no clear start or end become formless</li>
-<li>Between-session contact that's unlimited becomes therapy-on-demand</li>
-<li>Special exceptions that multiply become the rule</li>
-<li>The frame that contains the work dissolves</li>
-</ul>
-<p>Effective treatment requires a frame. The frame includes session time, frequency, fee, policies about contact, and expectations about behavior. When the frame holds, therapeutic work is possible. When the frame collapses, chaos reigns.</p>`,
-            },
-{
-              type: "text",
-              order: 19,
-              content: `<h2>For Therapist Sustainability</h2>
-<p>Perhaps most critically, boundaries protect the therapist. Without them:</p>
-<ul>
-<li>The therapist becomes exhausted from unlimited availability</li>
-<li>Resentment builds from accommodations that feel forced</li>
-<li>Burnout becomes inevitable</li>
-<li>The therapist may eventually abandon the client—confirming the client's worst fears</li>
-</ul>
-<p>Maintaining boundaries isn't selfish—it's what makes ongoing treatment possible. A burned-out therapist can't help anyone.</p>`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>Setting Boundaries: Language and Approach</h2>
-<p>How you set boundaries matters as much as the boundaries themselves. The goal is to be clear AND kind, firm AND compassionate.</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>The Formula</h2>
-<p><strong>State the limit + Express care + Offer alternative</strong></p>
-<p>"I can't [limit], AND I care about [concern], so let's [alternative]."</p>`,
-            },
-{
-              type: "text",
-              order: 22,
-              content: `<h2>Language Examples</h2>
-<p><strong>For session length:</strong> "I care about you, and I can see you're in a difficult place right now. We do need to stop at our regular time, though. Let's make sure we save a few minutes to talk about how you'll manage until next week."</p>
-<p><strong>For between-session contact:</strong> "I understand you're struggling and want to connect. I'm not available for calls between sessions except in true emergencies. What we can do is work on building your capacity to manage difficult moments—that's actually more helpful long-term than me being available 24/7."</p>
-<p><strong>For fee policies:</strong> "I know the fee is a stretch for you, and I want us to continue working together. I can't reduce my fee further, but I can help you think about options—sliding scale clinics, budgeting, or whether weekly sessions are sustainable right now."</p>
-<p><strong>For session behavior:</strong> "I can see how much pain you're in right now—that pain is real. And I need you to stop yelling so we can actually talk about it. Can you take a breath with me?"</p>`,
-            },
-{
-              type: "text",
-              order: 23,
-              content: `<h2>Key Principles</h2>
-<p><strong>Be clear:</strong> State boundaries explicitly, not implied. High-conflict clients may not pick up on hints, and ambiguity creates room for conflict.</p>
-<p><strong>Be kind:</strong> Deliver boundaries with warmth, not punishment. Your tone matters.</p>
-<p><strong>Be consistent:</strong> Enforce boundaries reliably. Inconsistency is more damaging than strict boundaries, because it recreates the unpredictability of the client's past.</p>
-<p><strong>Be prepared for pushback:</strong> High-conflict clients will test boundaries. This is expected. Your response to testing matters more than whether testing occurs.</p>`,
-            },
-{
-              type: "text",
-              order: 24,
-              content: `<h2>Limit-Setting vs. Punishment</h2>
-<p>There's a crucial distinction between therapeutic limit-setting and punitive punishment:</p>`,
-            },
-{
-              type: "text",
-              order: 25,
-              content: `<h2>Punishment</h2>
-<p>Punishment is retaliatory. It aims to cause discomfort in response to unwanted behavior. It often comes from the therapist's frustration rather than the client's needs.</p>
-<p>Examples of punitive responses:</p>
-<ul>
-<li>"Since you missed two sessions, I'm going to charge you for both and not see you for a month."</li>
-<li>"If you keep calling between sessions, I'll terminate treatment."</li>
-<li>"I'm not going to discuss that topic since you yelled at me last time."</li>
-</ul>
-<p>Punishment damages the relationship, confirms the client's expectation of harsh treatment, and doesn't teach skills.</p>`,
-            },
-{
-              type: "text",
-              order: 26,
-              content: `<h2>Limit-Setting</h2>
-<p>Limit-setting maintains necessary structure while remaining collaborative. It's about protecting the treatment frame, not punishing the client.</p>
-<p>Examples of therapeutic limit-setting:</p>
-<ul>
-<li>"Missing sessions makes it hard for therapy to be effective. Let's talk about what gets in the way of you being here consistently and whether our current schedule works for you."</li>
-<li>"I've noticed you've been calling more frequently between sessions. I want to understand what's happening—and also to be clear that between-session calls need to be for emergencies. Let's use our session time to figure out what you need."</li>
-<li>"Last session got pretty intense. I want to come back to that topic, and I also want us to have a plan for how to keep the conversation productive. What would help?"</li>
-</ul>
-<p>Limit-setting:</p>
-<ul>
-<li>States expectations clearly</li>
-<li>Explores the underlying issue</li>
-<li>Maintains the relationship</li>
-<li>Teaches rather than punishes</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 27,
-              content: `<h2>When Boundaries Are Tested</h2>
-<p>Boundaries will be tested. This is not if but when. How you respond to testing determines whether boundaries become therapeutic or merely controlling.</p>`,
-            },
-{
-              type: "text",
-              order: 28,
-              content: `<h2>Expect Testing</h2>
-<p>The client who was raised with inconsistent boundaries learned that boundaries can be broken if you push hard enough. They will push. This isn't manipulation (usually)—it's a learned survival strategy.</p>
-<p>Testing also serves a deeper purpose: the client needs to know if you're different. Will you crumble? Will you retaliate? Will you disappear? Every time you hold the boundary without retaliation or abandonment, you provide evidence that contradicts their template.</p>`,
-            },
-{
-              type: "text",
-              order: 29,
-              content: `<h2>Respond with the Three A's</h2>
-<p>When boundaries are tested, use the Three A's:</p>
-<p><strong>Acknowledge the underlying need:</strong> "I hear that you're really struggling and want more support."</p>
-<p><strong>Affirm the boundary:</strong> "And our agreement is that we meet once weekly."</p>
-<p><strong>Redirect to skills:</strong> "Let's talk about what you can do when you're struggling between sessions."</p>`,
-            },
-{
-              type: "text",
-              order: 30,
-              content: `<h2>Avoid JADE</h2>
-<p>Don't over-Justify, Argue, Defend, or Explain. Excessive explanation invites debate. State the boundary, acknowledge the feeling, and hold.</p>
-<p><strong>Instead of:</strong> "I can't take your call at 9pm because I have a family, and I need personal time, and it's not fair to my other clients, and actually my policy is clearly stated in the consent form..."</p>
-<p><strong>Try:</strong> "I hear you're struggling. I'm not available for calls in the evenings. What we can do is talk about this at our next session. Can you use your coping skills until then?"</p>`,
-            },
-{
-              type: "callout",
-              order: 31,
-              calloutType: "clinical",
-              title: `Clinical Vignette: Boundary Testing`,
-              content: `<p>Shannon has been in therapy with Dr. Patel for four months. She's begun texting between sessions—first occasionally, then daily, now multiple times a day. Most texts are updates about her day or complaints about her boyfriend.</p>
-<p><strong>Session 18:</strong></p>
-<p>Dr. Patel: "Shannon, I want to talk about the texts. I've noticed they've increased a lot over the past few weeks—you're texting me several times a day now."</p>
-<p>Shannon: [defensive] "I thought you wanted me to reach out when I'm struggling. Isn't that what therapy is for?"</p>
-<p>Dr. Patel: "I appreciate that you feel connected enough to want to share with me. That's actually a good sign. AND texting multiple times daily isn't something I can respond to, and I don't think it's actually helping you in the way you need."</p>
-<p>Shannon: "So you don't care about what happens to me between sessions?"</p>
-<p>Dr. Patel: "I do care. That's why I want us to figure out a better approach. When you text me, what are you hoping will happen?"</p>
-<p>Shannon: "I don't know. I guess I just want to feel like you're there."</p>
-<p>Dr. Patel: "That makes sense. You want to feel connected and not alone. The hard truth is, I can't be there by text multiple times a day—but I also don't think that would actually solve the loneliness. Let's talk about what would really help with that feeling."</p>
-<p>Notice how Dr. Patel:</p>
-<ul>
-<li>Named the pattern directly</li>
-<li>Validated the underlying need (connection)</li>
-<li>Held the boundary clearly</li>
-<li>Explored what the behavior was about</li>
-<li>Redirected toward what would actually help</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 32,
-              content: `<h2>Crisis vs. Boundary Violation</h2>
-<p>A genuine clinical emergency is different from a boundary violation. The challenge is distinguishing them.</p>`,
-            },
-{
-              type: "text",
-              order: 33,
-              content: `<h2>Genuine Emergencies</h2>
-<p>Real emergencies warrant flexible response:</p>
-<ul>
-<li>Active suicidal crisis with plan and intent</li>
-<li>Immediate safety threat</li>
-<li>Acute psychiatric decompensation</li>
-<li>Situations requiring immediate intervention</li>
-</ul>
-<p>When genuine emergencies arise, respond appropriately—even if it means bending usual policies.</p>`,
-            },
-{
-              type: "text",
-              order: 34,
-              content: `<h2>Pseudo-Emergencies</h2>
-<p>High-conflict clients may experience (or present) many situations as emergencies that aren't:</p>
-<ul>
-<li>Intense emotional distress that feels unbearable but isn't dangerous</li>
-<li>Interpersonal conflicts that feel urgent</li>
-<li>Anxiety about situations that aren't immediately threatening</li>
-<li>Distress that escalates when needs aren't met</li>
-</ul>
-<p>These experiences are real and painful, but they're not emergencies requiring immediate therapist response. Treating them as emergencies:</p>
-<ul>
-<li>Reinforces that the client can't manage distress</li>
-<li>Creates unsustainable expectations</li>
-<li>Prevents development of self-soothing skills</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 35,
-              content: `<h2>Making the Distinction</h2>
-<p>When in doubt:</p>
-<ul>
-<li>Assess for actual safety risk</li>
-<li>Ask directly: "Are you having thoughts of hurting yourself?"</li>
-<li>Respond to genuine safety concerns</li>
-<li>For non-emergencies, provide validation AND redirect to skills</li>
-<li>Process the incident at the next session</li>
-</ul>`,
-            },
-{
-              type: "multipleChoice",
-              order: 36,
-              question: `Boundaries in high-conflict work are important because:`,
-              options: [
-                { text: `They punish problematic behavior`, isCorrect: true },
-                { text: `They provide containment, safety, and reality testing`, isCorrect: false },
-                { text: `They keep the therapist distant from the client`, isCorrect: false },
-                { text: `They are required by licensing boards`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 37,
-              question: `The difference between limit-setting and punishment is:`,
-              options: [
-                { text: `There is no meaningful difference`, isCorrect: true },
-                { text: `Limit-setting maintains structure while remaining collaborative; punishment is retaliatory`, isCorrect: false },
-                { text: `Punishment is more effective`, isCorrect: false },
-                { text: `Limit-setting is only for mild issues`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 38,
-              question: `When a boundary is tested, the recommended response involves:`,
-              options: [
-                { text: `Extensive justification and explanation`, isCorrect: true },
-                { text: `Immediate termination`, isCorrect: false },
-                { text: `Acknowledging the underlying need, affirming the boundary, and redirecting to skills`, isCorrect: false },
-                { text: `Abandoning the boundary to preserve the relationship`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 39,
-              question: `JADE stands for:`,
-              options: [
-                { text: `Justification, Acceptance, Defense, Empathy`, isCorrect: true },
-                { text: `Justify, Argue, Defend, Explain (things to avoid overdoing)`, isCorrect: false },
-                { text: `Join, Accept, Discuss, Engage`, isCorrect: false },
-                { text: `Judgment, Assessment, Diagnosis, Evaluation`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 40,
-              question: `Pseudo-emergencies should be handled by:`,
-              options: [
-                { text: `Responding as if they were genuine emergencies`, isCorrect: true },
-                { text: `Ignoring them completely`, isCorrect: false },
-                { text: `Validating the distress while redirecting to skills`, isCorrect: false },
-                { text: `Terminating the client for manipulation`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+            {
+              "text": "They are required by licensing boards",
+              "isCorrect": false
             }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 38,
+          "type": "multiSelect",
+          "question": "What distinguishes limit-setting from punishment in high-conflict work? (Select all that apply)",
+          "options": [
+            {
+              "text": "Limits protect the work and the relationship; punishment expresses frustration",
+              "isCorrect": true
+            },
+            {
+              "text": "Limits are paired with validation and care",
+              "isCorrect": true
+            },
+            {
+              "text": "Limits are consistent and predictable rather than retaliatory",
+              "isCorrect": true
+            },
+            {
+              "text": "Punishment is the recommended response to repeated testing",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "Limits protect the work, are paired with care and validation, and are consistent; punishment, driven by frustration and retaliation, is not the therapeutic stance."
+        },
+        {
+          "order": 39,
+          "type": "sequencing",
+          "instructions": "Order the “Three A’s” for responding when a boundary is tested.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Acknowledge the underlying need (“I hear you’re really struggling and want more support”)"
+            },
+            {
+              "order": 2,
+              "text": "Affirm the boundary (“And our agreement is that we meet once weekly”)"
+            },
+            {
+              "order": 3,
+              "text": "Redirect to skills (“Let’s talk about what you can do between sessions”)"
+            }
+          ],
+          "explanation": "The Three A’s acknowledge the need, affirm the boundary, and redirect to skills — holding the limit while staying connected."
+        },
+        {
+          "order": 40,
+          "type": "fillInBlank",
+          "title": "JADE — the trap to avoid",
+          "blanks": [
+            {
+              "prompt": "J —",
+              "answer": "Justify"
+            },
+            {
+              "prompt": "A —",
+              "answer": "Argue"
+            },
+            {
+              "prompt": "D —",
+              "answer": "Defend"
+            },
+            {
+              "prompt": "E —",
+              "answer": "Explain"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 41,
+          "question": "Pseudo-emergencies should be handled by:",
+          "options": [
+            {
+              "text": "Responding as if they were genuine emergencies",
+              "isCorrect": true
+            },
+            {
+              "text": "Ignoring them completely",
+              "isCorrect": false
+            },
+            {
+              "text": "Validating the distress while redirecting to skills",
+              "isCorrect": false
+            },
+            {
+              "text": "Terminating the client for manipulation",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 5,
-      title: `Module 5: MANAGING YOUR REACTIONS`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 5: MANAGING YOUR REACTIONS`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 5,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Identify common countertransference reactions with high-conflict clients</li>
-<li>Recognize signs of over-identification and under-identification</li>
-<li>Use in-session strategies for managing emotional activation</li>
-<li>Develop between-session practices for processing and recovery</li>
-<li>Distinguish between personal reactions and projective identification</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Why This Work Is Hard</h2>
-<p>Working with high-conflict clients is genuinely difficult. This isn't about needing to be a better therapist or trying harder. The difficulty is inherent to the work.</p>
-<p>High-conflict clients evoke strong reactions because:</p>
-<p><strong>Their emotions are contagious.</strong> Affect regulation is interpersonal. When you spend an hour with someone in intense emotional states, their emotions affect your nervous system. You absorb some of what they're carrying. This is actually part of empathy—but it means you're affected by their distress.</p>
-<p><strong>Projective identification puts feelings into you.</strong> As we discussed earlier, clients unconsciously project unwanted feelings—and you begin to feel them. The rage, helplessness, worthlessness, or despair you experience may not be entirely "yours."</p>
-<p><strong>Boundaries are constantly tested.</strong> The ongoing pressure to abandon limits is exhausting, especially when testing triggers your own concerns about being too rigid, too cold, or uncaring.</p>
-<p><strong>Progress is slow and nonlinear.</strong> With other clients, you see movement. With high-conflict clients, progress is measured in tiny increments over long periods—with frequent setbacks. This can feel demoralizing.</p>
-<p><strong>Nothing you do seems right.</strong> You're walking on eggshells because any intervention might trigger crisis. This constant vigilance is draining.</p>
-<p><strong>You become a target for displaced anger.</strong> High-conflict clients may direct at you the rage they feel toward parents, partners, or others. You're the safe target—available, consistent, unlikely to leave. But being a target takes a toll.</p>
-<p>Acknowledging that this work is hard isn't weakness—it's reality. Effective practice requires working with this reality, not pretending it doesn't exist.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>📋 Reflection Exercise: The Impact on You</h2>
-<p>Honestly assess how high-conflict clients affect you:</p>
-<p><strong>Physical reactions I notice:</strong> _________________________________</p>
-<p><strong>Emotional reactions I notice:</strong> _________________________________</p>
-<p><strong>Thoughts I have about high-conflict clients:</strong> _________________________________</p>
-<p><strong>Behaviors I engage in (over-preparing, dreading, avoiding):</strong> _________________________________</p>
-<p><strong>How this affects my life outside work:</strong> _________________________________</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Common Countertransference Reactions</h2>
-<p>High-conflict clients evoke predictable countertransference patterns. Recognizing them in yourself is the first step to managing them.</p>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Rescue Fantasies</h2>
-<p>You want to save this client. You'll be the one who finally helps when everyone else has failed. You find yourself extending sessions, making special exceptions, thinking about them constantly. You're over-invested.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Thinking about the client excessively between sessions</li>
-<li>Making exceptions you wouldn't make for other clients</li>
-<li>Feeling special because you're "getting through" to them</li>
-<li>Feeling competitive with their previous therapists</li>
-</ul>
-<p><strong>The danger:</strong> Rescue fantasies lead to boundary violations, burnout, and eventual disappointment (yours and theirs) when you inevitably can't save them. They also reinforce the client's position as helpless victim needing rescue rather than capable agent of their own change.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Retaliation Impulses</h2>
-<p>You feel like punishing this client. You want to discharge the frustration they've put in you. You find yourself being sharper than usual, withholding warmth, or secretly hoping they'll drop out.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Internal thoughts like "I can't stand this person"</li>
-<li>Being harsher than your usual style</li>
-<li>Forgetting session times or appointments</li>
-<li>Finding reasons to shorten sessions</li>
-<li>Feeling satisfaction when they struggle</li>
-</ul>
-<p><strong>The danger:</strong> Acting on retaliation impulses confirms the client's expectation that relationships are hostile and people will hurt them. It damages the alliance and may retraumatize. Even subtle retaliation is often sensed by high-conflict clients who are hypervigilant for rejection.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Helplessness and Despair</h2>
-<p>You feel stuck, incompetent, hopeless about the treatment. Nothing works. You've tried everything. You don't know what to do.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Feeling deskilled with this client specifically</li>
-<li>Questioning whether you're actually a good therapist</li>
-<li>Feeling hopeless about the client's future</li>
-<li>Repeated thoughts of "nothing will help"</li>
-<li>Session notes becoming briefer or more perfunctory</li>
-</ul>
-<p><strong>The danger:</strong> This hopelessness may be projected (the client's despair put into you) or may reflect genuine therapeutic impasse. Either way, unchecked hopelessness leads to giving up—through referral, termination, or disengagement while continuing to see the client.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>Avoidance</h2>
-<p>You dread sessions. You feel relief when they cancel. You find yourself hoping they'll drop out. You might even unconsciously act in ways that push them away.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Relief when sessions are cancelled</li>
-<li>Finding yourself checking if they're on today's schedule with dread</li>
-<li>Less thorough preparation for their sessions</li>
-<li>Shorter sessions without clinical rationale</li>
-<li>"Forgetting" to return their calls</li>
-</ul>
-<p><strong>The danger:</strong> Avoidance leads to disengagement, which the client senses. Eventually, it may lead to abandonment—either the client dropping out (feeling rejected) or the therapist finding reasons to terminate.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Over-identification</h2>
-<p>You identify so strongly with the client's victimization that you lose objectivity. You see them as pure victims of terrible others. You collude with their externalization of blame.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Sharing the client's anger at the people in their life</li>
-<li>Unable to see the client's contribution to their problems</li>
-<li>Feeling angry at the client's partner, family, or employer</li>
-<li>Joining in criticism of others without balance</li>
-</ul>
-<p><strong>The danger:</strong> Over-identification prevents challenging the client's contribution to their problems. It enables rather than treats. The client doesn't grow because you're confirming their victim narrative rather than helping them develop agency.</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Under-identification</h2>
-<p>You can't relate to this client at all. They seem foreign, unreasonable, other. You judge them harshly and feel superior.</p>
-<p><strong>Warning signs:</strong></p>
-<ul>
-<li>Internal thoughts like "I would never act that way"</li>
-<li>Difficulty finding anything likable about the client</li>
-<li>Feeling superior or contemptuous</li>
-<li>Dismissing their pain because of how they express it</li>
-</ul>
-<p><strong>The danger:</strong> Under-identification creates distance that impedes empathy and connection. The client feels judged, confirming their fear that they're unacceptable. The therapeutic relationship—which may be their best chance for corrective experience—fails to form.</p>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>🎭 Clinical Vignette: Recognizing Countertransference</h2>
-<p>Dr. Thompson has been seeing Brianna for 8 months. Lately, she's noticed:</p>
-<ul>
-<li>She checks her schedule Monday mornings hoping Brianna cancelled</li>
-<li>In sessions, she finds herself saying less, offering fewer reflections</li>
-<li>She's been 5 minutes late to start Brianna's sessions twice this month</li>
-<li>After sessions, she feels drained and irritable with her next client</li>
-<li>She's been thinking about referring Brianna to "someone who specializes in personality disorders"</li>
-</ul>
-<p><strong>Decision Point:</strong> What countertransference pattern is Dr. Thompson experiencing?</p>
-<p><strong>Answer:</strong> Dr. Thompson is showing signs of <strong>avoidance</strong>—dread, relief at cancellation, subtle disengagement, lateness, and thoughts of referral. The referral rationalization ("someone who specializes") may be a way to justify ending a relationship she's struggling to maintain.</p>
-<p><strong>What should she do?</strong></p>
-<ol>
-<li>Recognize the pattern without self-judgment</li>
-<li>Seek consultation to get outside perspective</li>
-<li>Explore what's driving the avoidance (is it projected emotion? Her own stuff? Something about the fit?)</li>
-<li>Make an intentional decision about continuing, rather than acting out avoidance unconsciously</li>
-<li>If continuing, address what would need to change to make the work sustainable</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>In-Session Strategies</h2>
-<p>When you're activated during a session, you need strategies to manage your reactions in real-time.</p>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Notice</h2>
-<p>The first step is always noticing. Build internal awareness of your emotional state:</p>
-<ul>
-<li>What am I feeling right now?</li>
-<li>Where do I feel it in my body?</li>
-<li>Is this feeling familiar or unusual?</li>
-<li>How intense is it on a 0-10 scale?</li>
-</ul>
-<p>Noticing creates space between stimulus and response. Without noticing, you act automatically. With noticing, you have choice.</p>
-<p><strong>Practice:</strong> During every session, briefly check in with yourself at least once. What am I feeling right now?</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Breathe</h2>
-<p>When activated, our breathing becomes shallow and rapid. This maintains arousal. Conscious breathing—slow, deep, emphasizing the exhale—activates the parasympathetic nervous system and reduces activation.</p>
-<p>You can do this invisibly during session. While the client is talking, consciously slow and deepen your breath. This regulates your own nervous system and also (through co-regulation) can help regulate the client's.</p>
-<p><strong>Practice:</strong> When you notice activation, take three slow breaths with extended exhales before responding.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Ground</h2>
-<p>Grounding brings you back to the present moment and your physical body:</p>
-<ul>
-<li>Feel your feet on the floor</li>
-<li>Feel your seat in the chair</li>
-<li>Notice the weight of your hands</li>
-<li>Take in the visual details of the room</li>
-</ul>
-<p>Grounding is especially helpful when you're feeling overwhelmed, dissociative, or "swept away" by the client's intensity.</p>
-<p><strong>Practice:</strong> Develop a subtle grounding routine you can use in session—pressing feet into floor, feeling hands on armrests.</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>Contain</h2>
-<p>You don't have to act on what you're feeling. Strong feelings can be held, observed, and contained. This is different from suppression (which creates pressure) or dissociation (which creates disconnection). Containment is conscious holding.</p>
-<p>Imagine placing the intense feeling in a container—a box, a jar—to be examined later. It's acknowledged but not acted upon.</p>
-<p><strong>Practice:</strong> When intense feeling arises, silently name it and imagine placing it in a container: "Anger. I see you. I'm putting you in the box to look at after session."</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>Use the Feeling as Data</h2>
-<p>As discussed in the projective identification section, your feelings are information about the client's internal world. Instead of "Why am I so angry?" try "What does my anger tell me about what this client experiences?"</p>
-<p>Shifting from "my problematic feeling" to "useful clinical data" changes your relationship to the emotion.</p>
-<p><strong>Practice:</strong> After session, reflect: What feelings did I have? What might they tell me about the client's inner experience?</p>`,
-            },
-{
-              type: "text",
-              order: 19,
-              content: `<h2>Take a Pause</h2>
-<p>If you need a moment, take one. It's acceptable to say:</p>
-<ul>
-<li>"Let me think about what you just said."</li>
-<li>"That's important. Give me a moment."</li>
-<li>"I want to make sure I respond thoughtfully."</li>
-</ul>
-<p>A pause of even 10-15 seconds gives your nervous system time to settle.</p>
-<p><strong>Practice:</strong> When uncertain how to respond, take a visible pause rather than filling silence with an unconsidered response.</p>`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>Between-Session Strategies</h2>
-<p>Managing reactions isn't just about what happens in session—it's about processing and recovery between sessions.</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>Decompress After Difficult Sessions</h2>
-<p>Don't immediately jump to your next client. Give yourself even a few minutes to transition:</p>
-<ul>
-<li>Take a short walk</li>
-<li>Stretch</li>
-<li>Step outside briefly</li>
-<li>Do a brief grounding exercise</li>
-</ul>
-<p>This prevents carrying one session's residue into the next.</p>`,
-            },
-{
-              type: "text",
-              order: 22,
-              content: `<h2>Process with Appropriate Others</h2>
-<p>Talking about difficult sessions helps—but choose your audience wisely:</p>
-<ul>
-<li>Consultants and supervisors (ideal—clinical perspective)</li>
-<li>Peer consultation groups (mutual support and learning)</li>
-<li>Personal therapist (for personal reactions and patterns)</li>
-</ul>
-<p>Avoid:</p>
-<ul>
-<li>Venting to colleagues who aren't consultants (can become gossip)</li>
-<li>Processing with family/friends (can burden relationships)</li>
-<li>Keeping everything inside (leads to burnout)</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 23,
-              content: `<h2>Consultation Is Not Optional</h2>
-<p>With high-conflict clients, regular consultation should be built into your practice, not reserved for crises. This provides:</p>
-<ul>
-<li>Objective perspective on dynamics</li>
-<li>Validation that the work is hard</li>
-<li>Alternative viewpoints and interventions</li>
-<li>Support for your wellbeing</li>
-<li>Protection from blind spots</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 24,
-              content: `<h2>Self-Care Is Not Self-Indulgence</h2>
-<p>The physical and emotional demands of high-conflict work require attention to self-care:</p>
-<ul>
-<li>Adequate sleep</li>
-<li>Physical movement</li>
-<li>Nutrition</li>
-<li>Activities that replenish</li>
-<li>Relationships that sustain</li>
-</ul>
-<p>This isn't luxury—it's maintenance. A depleted therapist can't provide effective treatment.</p>`,
-            },
-{
-              type: "text",
-              order: 25,
-              content: `<h2>Caseload Balance</h2>
-<p>Not every client on your caseload can be high-conflict. Balance your caseload with clients who are lower-intensity, who show progress readily, who replenish rather than deplete.</p>
-<p>If your caseload is heavily weighted toward high-conflict clients, adjust. Either reduce the proportion or ensure adequate support and self-care to sustain the work.</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 26,
-              question: `Countertransference reactions with high-conflict clients:`,
-              options: [
-                { text: `Indicate the therapist needs more training`, isCorrect: true },
-                { text: `Are normal responses to genuinely difficult work`, isCorrect: false },
-                { text: `Should never be discussed`, isCorrect: false },
-                { text: `Mean the therapist should not work with this population`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 27,
-              question: `"Rescue fantasies" involve:`,
-              options: [
-                { text: `The client wanting to save the therapist`, isCorrect: true },
-                { text: `The therapist becoming over-invested in saving the client`, isCorrect: false },
-                { text: `Appropriate therapeutic engagement`, isCorrect: false },
-                { text: `Crisis intervention`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 28,
-              question: `When emotionally activated during a session, the first step is:`,
-              options: [
-                { text: `End the session immediately`, isCorrect: true },
-                { text: `Tell the client what you're feeling`, isCorrect: false },
-                { text: `Notice what you're feeling`, isCorrect: false },
-                { text: `Interpret the client's behavior`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 29,
-              question: `Between-session processing should include:`,
-              options: [
-                { text: `Venting to anyone who will listen`, isCorrect: true },
-                { text: `Consultation with appropriate colleagues or supervisors`, isCorrect: false },
-                { text: `Avoiding all thought of difficult clients`, isCorrect: false },
-                { text: `Extensive journaling about client flaws`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 30,
-              question: `Caseload management with high-conflict clients should include:`,
-              options: [
-                { text: `Taking on as many high-conflict clients as possible`, isCorrect: true },
-                { text: `Balancing high-intensity clients with clients who are lower-intensity`, isCorrect: false },
-                { text: `Avoiding all high-conflict clients`, isCorrect: false },
-                { text: `Working exclusively with high-conflict clients to develop expertise`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
+      "order": 5,
+      "title": "Module 5: MANAGING YOUR REACTIONS",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 5: MANAGING YOUR REACTIONS",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 5
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Identify common {{callout:countertransference}} reactions with high-conflict clients</li>\n<li>Recognize signs of over-identification and under-identification</li>\n<li>Use in-session strategies for managing emotional activation</li>\n<li>Develop between-session practices for processing and recovery</li>\n<li>Distinguish between personal reactions and projective identification</li>\n</ol>",
+          "callouts": {
+            "countertransference": {
+              "label": "Countertransference",
+              "type": "clinical",
+              "body": "The clinician’s emotional reactions to the client; in high-conflict work, a critical source of information when noticed and used rather than enacted."
             }
+          }
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Why This Work Is Hard</h2>\n<p>Working with high-conflict clients is genuinely difficult. This isn't about needing to be a better therapist or trying harder. The difficulty is inherent to the work.</p>\n<p>High-conflict clients evoke strong reactions because:</p>\n<p><strong>Their emotions are contagious.</strong> Affect regulation is interpersonal. When you spend an hour with someone in intense emotional states, their emotions affect your nervous system. You absorb some of what they're carrying. This is actually part of empathy—but it means you're affected by their distress.</p>\n<p><strong>Projective identification puts feelings into you.</strong> As we discussed earlier, clients unconsciously project unwanted feelings—and you begin to feel them. The rage, helplessness, worthlessness, or despair you experience may not be entirely \"yours.\"</p>\n<p><strong>Boundaries are constantly tested.</strong> The ongoing pressure to abandon limits is exhausting, especially when testing triggers your own concerns about being too rigid, too cold, or uncaring.</p>\n<p><strong>Progress is slow and nonlinear.</strong> With other clients, you see movement. With high-conflict clients, progress is measured in tiny increments over long periods—with frequent setbacks. This can feel demoralizing.</p>\n<p><strong>Nothing you do seems right.</strong> You're walking on eggshells because any intervention might trigger crisis. This constant vigilance is draining.</p>\n<p><strong>You become a target for displaced anger.</strong> High-conflict clients may direct at you the rage they feel toward parents, partners, or others. You're the safe target—available, consistent, unlikely to leave. But being a target takes a toll.</p>\n<p>Acknowledging that this work is hard isn't weakness—it's reality. Effective practice requires working with this reality, not pretending it doesn't exist.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>📋 Reflection Exercise: The Impact on You</h2>\n<p>Honestly assess how high-conflict clients affect you:</p>\n<p><strong>Physical reactions I notice:</strong> _________________________________</p>\n<p><strong>Emotional reactions I notice:</strong> _________________________________</p>\n<p><strong>Thoughts I have about high-conflict clients:</strong> _________________________________</p>\n<p><strong>Behaviors I engage in (over-preparing, dreading, avoiding):</strong> _________________________________</p>\n<p><strong>How this affects my life outside work:</strong> _________________________________</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Common Countertransference Reactions</h2>\n<p>High-conflict clients evoke predictable countertransference patterns. Recognizing them in yourself is the first step to managing them.</p>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Rescue Fantasies</h2>\n<p>You want to save this client. You'll be the one who finally helps when everyone else has failed. You find yourself extending sessions, making special exceptions, thinking about them constantly. You're over-invested.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Thinking about the client excessively between sessions</li>\n<li>Making exceptions you wouldn't make for other clients</li>\n<li>Feeling special because you're \"getting through\" to them</li>\n<li>Feeling competitive with their previous therapists</li>\n</ul>\n<p><strong>The danger:</strong> Rescue fantasies lead to boundary violations, burnout, and eventual disappointment (yours and theirs) when you inevitably can't save them. They also reinforce the client's position as helpless victim needing rescue rather than capable agent of their own change.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Retaliation Impulses</h2>\n<p>You feel like punishing this client. You want to discharge the frustration they've put in you. You find yourself being sharper than usual, withholding warmth, or secretly hoping they'll drop out.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Internal thoughts like \"I can't stand this person\"</li>\n<li>Being harsher than your usual style</li>\n<li>Forgetting session times or appointments</li>\n<li>Finding reasons to shorten sessions</li>\n<li>Feeling satisfaction when they struggle</li>\n</ul>\n<p><strong>The danger:</strong> Acting on retaliation impulses confirms the client's expectation that relationships are hostile and people will hurt them. It damages the alliance and may retraumatize. Even subtle retaliation is often sensed by high-conflict clients who are hypervigilant for rejection.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Helplessness and Despair</h2>\n<p>You feel stuck, incompetent, hopeless about the treatment. Nothing works. You've tried everything. You don't know what to do.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Feeling deskilled with this client specifically</li>\n<li>Questioning whether you're actually a good therapist</li>\n<li>Feeling hopeless about the client's future</li>\n<li>Repeated thoughts of \"nothing will help\"</li>\n<li>Session notes becoming briefer or more perfunctory</li>\n</ul>\n<p><strong>The danger:</strong> This hopelessness may be projected (the client's despair put into you) or may reflect genuine therapeutic impasse. Either way, unchecked hopelessness leads to giving up—through referral, termination, or disengagement while continuing to see the client.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>Avoidance</h2>\n<p>You dread sessions. You feel relief when they cancel. You find yourself hoping they'll drop out. You might even unconsciously act in ways that push them away.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Relief when sessions are cancelled</li>\n<li>Finding yourself checking if they're on today's schedule with dread</li>\n<li>Less thorough preparation for their sessions</li>\n<li>Shorter sessions without clinical rationale</li>\n<li>\"Forgetting\" to return their calls</li>\n</ul>\n<p><strong>The danger:</strong> Avoidance leads to disengagement, which the client senses. Eventually, it may lead to abandonment—either the client dropping out (feeling rejected) or the therapist finding reasons to terminate.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Over-identification</h2>\n<p>You identify so strongly with the client's victimization that you lose objectivity. You see them as pure victims of terrible others. You collude with their externalization of blame.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Sharing the client's anger at the people in their life</li>\n<li>Unable to see the client's contribution to their problems</li>\n<li>Feeling angry at the client's partner, family, or employer</li>\n<li>Joining in criticism of others without balance</li>\n</ul>\n<p><strong>The danger:</strong> Over-identification prevents challenging the client's contribution to their problems. It enables rather than treats. The client doesn't grow because you're confirming their victim narrative rather than helping them develop agency.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Under-identification</h2>\n<p>You can't relate to this client at all. They seem foreign, unreasonable, other. You judge them harshly and feel superior.</p>\n<p><strong>Warning signs:</strong></p>\n<ul>\n<li>Internal thoughts like \"I would never act that way\"</li>\n<li>Difficulty finding anything likable about the client</li>\n<li>Feeling superior or contemptuous</li>\n<li>Dismissing their pain because of how they express it</li>\n</ul>\n<p><strong>The danger:</strong> Under-identification creates distance that impedes empathy and connection. The client feels judged, confirming their fear that they're unacceptable. The therapeutic relationship—which may be their best chance for corrective experience—fails to form.</p>"
+        },
+        {
+          "type": "text",
+          "order": 12,
+          "content": "<h2>🎭 Clinical Vignette: Recognizing Countertransference</h2>\n<p>Dr. Thompson has been seeing Brianna for 8 months. Lately, she's noticed:</p>\n<ul>\n<li>She checks her schedule Monday mornings hoping Brianna cancelled</li>\n<li>In sessions, she finds herself saying less, offering fewer reflections</li>\n<li>She's been 5 minutes late to start Brianna's sessions twice this month</li>\n<li>After sessions, she feels drained and irritable with her next client</li>\n<li>She's been thinking about referring Brianna to \"someone who specializes in personality disorders\"</li>\n</ul>\n<p><strong>Decision Point:</strong> What countertransference pattern is Dr. Thompson experiencing?</p>\n<p><strong>Answer:</strong> Dr. Thompson is showing signs of <strong>avoidance</strong>—dread, relief at cancellation, subtle disengagement, lateness, and thoughts of referral. The referral rationalization (\"someone who specializes\") may be a way to justify ending a relationship she's struggling to maintain.</p>\n<p><strong>What should she do?</strong></p>\n<ol>\n<li>Recognize the pattern without self-judgment</li>\n<li>Seek consultation to get outside perspective</li>\n<li>Explore what's driving the avoidance (is it projected emotion? Her own stuff? Something about the fit?)</li>\n<li>Make an intentional decision about continuing, rather than acting out avoidance unconsciously</li>\n<li>If continuing, address what would need to change to make the work sustainable</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 13,
+          "content": "<h2>In-Session Strategies</h2>\n<p>When you're activated during a session, you need strategies to manage your reactions in real-time.</p>"
+        },
+        {
+          "type": "text",
+          "order": 14,
+          "content": "<h2>Notice</h2>\n<p>The first step is always noticing. Build internal awareness of your emotional state:</p>\n<ul>\n<li>What am I feeling right now?</li>\n<li>Where do I feel it in my body?</li>\n<li>Is this feeling familiar or unusual?</li>\n<li>How intense is it on a 0-10 scale?</li>\n</ul>\n<p>Noticing creates space between stimulus and response. Without noticing, you act automatically. With noticing, you have choice.</p>\n<p><strong>Practice:</strong> During every session, briefly check in with yourself at least once. What am I feeling right now?</p>"
+        },
+        {
+          "type": "text",
+          "order": 15,
+          "content": "<h2>Breathe</h2>\n<p>When activated, our breathing becomes shallow and rapid. This maintains arousal. Conscious breathing—slow, deep, emphasizing the exhale—activates the parasympathetic nervous system and reduces activation.</p>\n<p>You can do this invisibly during session. While the client is talking, consciously slow and deepen your breath. This regulates your own nervous system and also (through co-regulation) can help regulate the client's.</p>\n<p><strong>Practice:</strong> When you notice activation, take three slow breaths with extended exhales before responding.</p>"
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>Ground</h2>\n<p>Grounding brings you back to the present moment and your physical body:</p>\n<ul>\n<li>Feel your feet on the floor</li>\n<li>Feel your seat in the chair</li>\n<li>Notice the weight of your hands</li>\n<li>Take in the visual details of the room</li>\n</ul>\n<p>Grounding is especially helpful when you're feeling overwhelmed, dissociative, or \"swept away\" by the client's intensity.</p>\n<p><strong>Practice:</strong> Develop a subtle grounding routine you can use in session—pressing feet into floor, feeling hands on armrests.</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Contain</h2>\n<p>You don't have to act on what you're feeling. Strong feelings can be held, observed, and contained. This is different from suppression (which creates pressure) or dissociation (which creates disconnection). Containment is conscious holding.</p>\n<p>Imagine placing the intense feeling in a container—a box, a jar—to be examined later. It's acknowledged but not acted upon.</p>\n<p><strong>Practice:</strong> When intense feeling arises, silently name it and imagine placing it in a container: \"Anger. I see you. I'm putting you in the box to look at after session.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Use the Feeling as Data</h2>\n<p>As discussed in the projective identification section, your feelings are information about the client's internal world. Instead of \"Why am I so angry?\" try \"What does my anger tell me about what this client experiences?\"</p>\n<p>Shifting from \"my problematic feeling\" to \"useful clinical data\" changes your relationship to the emotion.</p>\n<p><strong>Practice:</strong> After session, reflect: What feelings did I have? What might they tell me about the client's inner experience?</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Take a Pause</h2>\n<p>If you need a moment, take one. It's acceptable to say:</p>\n<ul>\n<li>\"Let me think about what you just said.\"</li>\n<li>\"That's important. Give me a moment.\"</li>\n<li>\"I want to make sure I respond thoughtfully.\"</li>\n</ul>\n<p>A pause of even 10-15 seconds gives your nervous system time to settle.</p>\n<p><strong>Practice:</strong> When uncertain how to respond, take a visible pause rather than filling silence with an unconsidered response.</p>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Between-Session Strategies</h2>\n<p>Managing reactions isn't just about what happens in session—it's about processing and recovery between sessions.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Decompress After Difficult Sessions</h2>\n<p>Don't immediately jump to your next client. Give yourself even a few minutes to transition:</p>\n<ul>\n<li>Take a short walk</li>\n<li>Stretch</li>\n<li>Step outside briefly</li>\n<li>Do a brief grounding exercise</li>\n</ul>\n<p>This prevents carrying one session's residue into the next.</p>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>Process with Appropriate Others</h2>\n<p>Talking about difficult sessions helps—but choose your audience wisely:</p>\n<ul>\n<li>Consultants and supervisors (ideal—clinical perspective)</li>\n<li>Peer consultation groups (mutual support and learning)</li>\n<li>Personal therapist (for personal reactions and patterns)</li>\n</ul>\n<p>Avoid:</p>\n<ul>\n<li>Venting to colleagues who aren't consultants (can become gossip)</li>\n<li>Processing with family/friends (can burden relationships)</li>\n<li>Keeping everything inside (leads to burnout)</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Consultation Is Not Optional</h2>\n<p>With high-conflict clients, regular consultation should be built into your practice, not reserved for crises. This provides:</p>\n<ul>\n<li>Objective perspective on dynamics</li>\n<li>Validation that the work is hard</li>\n<li>Alternative viewpoints and interventions</li>\n<li>Support for your wellbeing</li>\n<li>Protection from blind spots</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Self-Care Is Not Self-Indulgence</h2>\n<p>The physical and emotional demands of high-conflict work require attention to self-care:</p>\n<ul>\n<li>Adequate sleep</li>\n<li>Physical movement</li>\n<li>Nutrition</li>\n<li>Activities that replenish</li>\n<li>Relationships that sustain</li>\n</ul>\n<p>This isn't luxury—it's maintenance. A depleted therapist can't provide effective treatment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Caseload Balance</h2>\n<p>Not every client on your caseload can be high-conflict. Balance your caseload with clients who are lower-intensity, who show progress readily, who replenish rather than deplete.</p>\n<p>If your caseload is heavily weighted toward high-conflict clients, adjust. Either reduce the proportion or ensure adequate support and self-care to sustain the work.</p>"
+        },
+        {
+          "type": "text",
+          "content": "<h2>Building a Consultation Practice</h2>\n<p>Consultation is repeatedly named as essential in high-conflict work, and building a genuine consultation practice — not just occasional crisis advice — is among the clinician’s most protective investments.</p>\n<h3>Why Consultation Is Essential</h3>\n<p>High-conflict work activates the clinician’s own reactions, pulls for enactments, and erodes perspective in ways that are difficult to see from inside the dyad. A consultant or peer group provides the outside view that catches countertransference, splitting, and drift, supports difficult decisions about limits and risk, and shares the emotional weight that would otherwise accumulate in isolation.</p>\n<h3>Making It Real</h3>\n<p>An effective consultation practice is regular rather than only reactive, honest rather than self-protective, and oriented toward the clinician’s reactions as much as the client’s presentation. Whether a formal consultation group, a trusted peer, or paid supervision, the relationship is one in which the clinician can bring their dread, their mistakes, and their uncertainty without shame. Treating consultation as a standing commitment rather than an emergency measure sustains both the clinician and the quality of care.</p>",
+          "order": 26
+        },
+        {
+          "type": "text",
+          "content": "<h2>When You Dread the Session</h2>\n<p>A telling and important signal in high-conflict work is the clinician’s own dread before a session, and treating that dread as information rather than ignoring it protects both clinician and client.</p>\n<h3>Dread as Data</h3>\n<p>Noticing that one is anxious before a particular client’s session, hoping for a cancellation, or feeling depleted afterward is meaningful clinical information. It may reflect the client’s projective communication, an unaddressed rupture, the clinician’s own activated history, the limits of the clinician’s capacity, or a genuine mismatch. Ignored, the dread leaks into the work as avoidance, irritability, or withdrawal that the client perceives.</p>\n<h3>Responding to the Signal</h3>\n<p>The clinician brings the dread to consultation, examines what it is communicating, and responds accordingly — repairing a rupture, adjusting the frame, attending to their own activation, rebalancing the caseload, or, where appropriate, referring. Treating dread as a problem to be solved rather than a feeling to be endured keeps the clinician honest about their own capacity and prevents the slow erosion of care that unexamined dread produces.</p>",
+          "order": 27
+        },
+        {
+          "type": "text",
+          "content": "<h2>Vicarious Trauma in High-Conflict Work</h2>\n<p>Beyond ordinary countertransference, sustained work with high-conflict and traumatized clients can produce vicarious traumatization — a cumulative change in the clinician’s own inner world — and recognizing it is part of sustainable practice.</p>\n<h3>The Cumulative Toll</h3>\n<p>Repeated exposure to clients’ trauma, crisis, hostility, and dysregulation can gradually shift the clinician’s beliefs about safety, trust, and other people, and can produce trauma-like symptoms, emotional depletion, and a creeping cynicism or numbness. This is an occupational reality of the work done well, not a personal failing, and it tends to accrue quietly until it is significant.</p>\n<h3>Protecting Against It</h3>\n<p>Guarding against vicarious trauma requires deliberate practices: a varied caseload that is not all high-conflict, consultation that processes the emotional impact, attention to one’s own wellbeing and life outside the work, and honest monitoring for early warning signs. A clinician who tends to their own inner world preserves the steady, regulated presence that high-conflict clients most need — making self-protection a clinical responsibility rather than a luxury.</p>",
+          "order": 28
+        },
+        {
+          "type": "multipleChoice",
+          "order": 29,
+          "question": "Countertransference reactions with high-conflict clients:",
+          "options": [
+            {
+              "text": "Indicate the therapist needs more training",
+              "isCorrect": true
+            },
+            {
+              "text": "Are normal responses to genuinely difficult work",
+              "isCorrect": false
+            },
+            {
+              "text": "Should never be discussed",
+              "isCorrect": false
+            },
+            {
+              "text": "Mean the therapist should not work with this population",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 30,
+          "type": "matching",
+          "matchingInstructions": "Match each countertransference reaction to its description.",
+          "matchingPairs": [
+            {
+              "term": "Rescue fantasies",
+              "definition": "The urge to save the client, often leading to over-functioning and eroded boundaries"
+            },
+            {
+              "term": "Retaliation impulses",
+              "definition": "The pull to punish or withdraw in response to the client’s hostility"
+            },
+            {
+              "term": "Helplessness/despair",
+              "definition": "Feeling hopeless or ineffective, mirroring the client’s state"
+            },
+            {
+              "term": "Over-identification",
+              "definition": "Losing professional perspective by merging with the client’s experience"
+            }
+          ]
+        },
+        {
+          "type": "multipleChoice",
+          "order": 31,
+          "question": "When emotionally activated during a session, the first step is:",
+          "options": [
+            {
+              "text": "End the session immediately",
+              "isCorrect": true
+            },
+            {
+              "text": "Tell the client what you're feeling",
+              "isCorrect": false
+            },
+            {
+              "text": "Notice what you're feeling",
+              "isCorrect": false
+            },
+            {
+              "text": "Interpret the client's behavior",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 32,
+          "type": "multiSelect",
+          "question": "Healthy between-session processing after difficult sessions includes which of the following? (Select all that apply)",
+          "options": [
+            {
+              "text": "Decompressing and attending to one’s own state",
+              "isCorrect": true
+            },
+            {
+              "text": "Consultation or processing with appropriate others",
+              "isCorrect": true
+            },
+            {
+              "text": "Self-care treated as a professional necessity",
+              "isCorrect": true
+            },
+            {
+              "text": "Ruminating alone about the session without support",
+              "isCorrect": false
+            }
+          ],
+          "explanation": "Between-session processing means decompressing, using consultation, and treating self-care as essential — not isolated rumination."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 33,
+          "question": "Caseload management with high-conflict clients should include:",
+          "options": [
+            {
+              "text": "Taking on as many high-conflict clients as possible",
+              "isCorrect": true
+            },
+            {
+              "text": "Balancing high-intensity clients with clients who are lower-intensity",
+              "isCorrect": false
+            },
+            {
+              "text": "Avoiding all high-conflict clients",
+              "isCorrect": false
+            },
+            {
+              "text": "Working exclusively with high-conflict clients to develop expertise",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        }
       ]
     },
     {
-      order: 6,
-      title: `Module 6: TREATMENT STRUCTURE AND SUSTAINABILITY`,
-      estimatedTime: 30,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Module 6: TREATMENT STRUCTURE AND SUSTAINABILITY`,
-              subtitle: `Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients`,
-              sectionNumber: 6,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>🎯 Module Learning Objectives</h2>
-<p>By the end of this module, participants will be able to:</p>
-<ol>
-<li>Design treatment frames appropriate for high-conflict clients</li>
-<li>Structure sessions to contain intensity and maximize productivity</li>
-<li>Identify when referral or termination is appropriate</li>
-<li>Implement DBT principles even without full DBT implementation</li>
-<li>Develop sustainability practices for long-term work with this population</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 3,
-              content: `<h2>Treatment Frame</h2>
-<p>Effective treatment with high-conflict clients requires a clear, explicit treatment frame—the structure within which therapy happens.</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<h2>Elements of the Frame</h2>
-<p><strong>Explicit agreements:</strong> Don't assume clients understand expectations. Make them explicit:</p>
-<ul>
-<li>Session frequency and length</li>
-<li>Policy on cancellations and lateness</li>
-<li>Fee and payment expectations</li>
-<li>Between-session contact (what's allowed, what's not)</li>
-<li>Crisis protocols (what constitutes a crisis, what to do)</li>
-<li>Confidentiality and its limits</li>
-</ul>
-<p><strong>Consistent schedule:</strong> Regular, predictable session times provide structure. Avoid frequent rescheduling, which creates chaos.</p>
-<p><strong>Defined goals:</strong> What are we working on? Clear treatment targets help maintain focus when chaos threatens to derail.</p>
-<p><strong>Role clarity:</strong> What is your role? What isn't your role? You are the therapist—not friend, parent, crisis hotline, or savior.</p>
-<p><strong>Stated limits:</strong> What happens if agreements are violated? Not as threat, but as clear information. "If sessions are missed repeatedly without notice, we'll need to discuss whether this format is working for you."</p>`,
-            },
-{
-              type: "text",
-              order: 5,
-              content: `<h2>Frame Agreement</h2>
-<p>Consider having a written treatment agreement for high-conflict clients that spells out the frame explicitly. This provides:</p>
-<ul>
-<li>Clear reference point for both parties</li>
-<li>Protection against "I didn't know" claims</li>
-<li>Basis for addressing violations</li>
-<li>Structure that anxious clients may find containing</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 6,
-              content: `<h2>Session Structure</h2>
-<p>Within the overall treatment frame, individual sessions benefit from structure too.</p>`,
-            },
-{
-              type: "text",
-              order: 7,
-              content: `<h2>Structured Sessions</h2>
-<p>A predictable session structure helps manage chaos:</p>
-<p><strong>Opening (5 minutes):</strong> Check-in. What's most pressing? What needs to be on today's agenda?</p>
-<p><strong>Agenda setting (2 minutes):</strong> Agree on the focus for today. You can't address everything—prioritize.</p>
-<p><strong>Main work (35-40 minutes):</strong> Focused intervention on agenda items. Return to the agenda when tangents emerge.</p>
-<p><strong>Summary (5 minutes):</strong> What did we cover? What's the main takeaway?</p>
-<p><strong>Closing (5 minutes):</strong> Between-session task (one small, manageable thing). How will you manage until next session?</p>
-<p>This structure isn't rigid—it's containing. It prevents sessions from becoming overwhelming dumps of crisis after crisis with no progress.</p>`,
-            },
-{
-              type: "text",
-              order: 8,
-              content: `<h2>Managing In-Session Crisis</h2>
-<p>When crisis emerges in session:</p>
-<p><strong>Assess safety:</strong> Is this a genuine safety issue or intense distress?</p>
-<p><strong>Validate the distress:</strong> "I can see you're in a lot of pain right now."</p>
-<p><strong>Contain:</strong> "Let's slow down and figure out what would help."</p>
-<p><strong>Problem-solve:</strong> "What's one thing that would make this more manageable?"</p>
-<p><strong>Return to frame:</strong> "I want to make sure we use our time well. Can we [return to agenda item]?"</p>
-<p>The goal isn't to suppress crisis but to contain it within the therapeutic frame rather than letting it consume all the space.</p>`,
-            },
-{
-              type: "text",
-              order: 9,
-              content: `<h2>DBT as a Model</h2>
-<p>Dialectical Behavior Therapy (DBT) offers a comprehensive treatment structure for high-conflict clients, particularly those with borderline presentations. Even without full DBT implementation, its principles inform effective treatment.</p>`,
-            },
-{
-              type: "text",
-              order: 10,
-              content: `<h2>Core DBT Principles</h2>
-<p><strong>Dialectical stance:</strong> Holding opposites simultaneously. The client is doing the best they can AND needs to do better. We accept the client as they are AND push for change. These aren't contradictions—they're dialectics.</p>
-<p><strong>Biosocial understanding:</strong> The client's patterns make sense given their biology and history. This creates compassion without excusing.</p>
-<p><strong>Hierarchy of targets:</strong> DBT prioritizes treatment targets:</p>
-<ol>
-<li>Life-threatening behaviors (suicidality, self-harm)</li>
-<li>Therapy-interfering behaviors (missing sessions, not engaging)</li>
-<li>Quality-of-life-interfering behaviors (symptoms, problems)</li>
-<li>Skill building</li>
-</ol>
-<p>This hierarchy provides clear priorities when everything seems urgent.</p>
-<p><strong>Skills focus:</strong> DBT emphasizes teaching skills—distress tolerance, emotion regulation, interpersonal effectiveness, mindfulness. These skills give clients alternatives to problematic behaviors.</p>
-<p><strong>Consultation team:</strong> DBT requires therapists to be part of a consultation team—not optional but essential. This recognizes that the work requires support.</p>`,
-            },
-{
-              type: "text",
-              order: 11,
-              content: `<h2>Applying DBT Principles Without Full DBT</h2>
-<p>Even without DBT certification or full program implementation, you can:</p>
-<ul>
-<li>Adopt a dialectical stance</li>
-<li>Use biosocial understanding to create compassion</li>
-<li>Prioritize targets using the DBT hierarchy</li>
-<li>Teach basic skills (grounding, distress tolerance, interpersonal effectiveness)</li>
-<li>Seek consultation as essential, not optional</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 12,
-              content: `<h2>When to Refer</h2>
-<p>Sometimes, the right treatment isn't with you. Referral is appropriate when:</p>`,
-            },
-{
-              type: "text",
-              order: 13,
-              content: `<h2>Scope Limitations</h2>
-<p>The client needs specialized treatment you don't provide:</p>
-<ul>
-<li>Comprehensive DBT (if you don't provide it)</li>
-<li>Trauma-focused therapy (EMDR, PE) if outside your scope</li>
-<li>Medication management</li>
-<li>Substance abuse treatment</li>
-<li>Higher level of care (IOP, PHP, residential)</li>
-</ul>`,
-            },
-{
-              type: "text",
-              order: 14,
-              content: `<h2>Skill Limitations</h2>
-<p>You lack training or experience for this presentation. This isn't failure—it's honest recognition of limits. The client deserves treatment by someone equipped to provide it.</p>`,
-            },
-{
-              type: "text",
-              order: 15,
-              content: `<h2>Countertransference Barriers</h2>
-<p>Your personal reactions interfere with effective treatment. Despite consultation and self-work, you can't maintain therapeutic stance. The client deserves treatment not hampered by your struggles.</p>`,
-            },
-{
-              type: "text",
-              order: 16,
-              content: `<h2>Client Welfare</h2>
-<p>The client would simply be better served elsewhere—different style, different specialty, better fit. Referring isn't giving up; it's ensuring appropriate care.</p>`,
-            },
-{
-              type: "text",
-              order: 17,
-              content: `<h2>Persistent Treatment-Interfering Behavior</h2>
-<p>Despite repeated addressing, the client continues behaviors that make treatment impossible (chronic no-shows, repeated safety crises that disrupt all other work, ongoing boundary violations). At some point, the format isn't working.</p>`,
-            },
-{
-              type: "text",
-              order: 18,
-              content: `<h2>How to Refer</h2>
-<p>When referral is indicated:</p>
-<p><strong>Be honest:</strong> "I want to be direct with you. I'm not confident I'm the right therapist for what you need."</p>
-<p><strong>Don't blame:</strong> This isn't about the client being too difficult. It's about fit and appropriateness.</p>
-<p><strong>Provide options:</strong> Give specific referrals, not just "you should find someone else."</p>
-<p><strong>Manage the transition:</strong> Don't abandon. Provide transition sessions if possible. Remain available briefly during handoff.</p>`,
-            },
-{
-              type: "text",
-              order: 19,
-              content: `<h2>Sustainability Practices</h2>
-<p>Long-term work with high-conflict clients requires sustainability practices built into your professional life.</p>`,
-            },
-{
-              type: "text",
-              order: 20,
-              content: `<h2>Essential Practices</h2>
-<p><strong>Ongoing consultation:</strong> Not just for crises. Regular, scheduled consultation with colleagues who understand this work.</p>
-<p><strong>Personal therapy:</strong> Highly recommended for anyone doing intensive high-conflict work. Your own therapy helps you understand your patterns and process the impact of the work.</p>
-<p><strong>Caseload management:</strong> Balance. Not every client can be high-intensity.</p>
-<p><strong>Time boundaries:</strong> Protect your off-hours. Compassion fatigue accelerates when work bleeds into all of life.</p>
-<p><strong>Physical wellbeing:</strong> Sleep, exercise, nutrition. The body keeps the score of this work too.</p>
-<p><strong>Meaning-making:</strong> Connect to why this work matters. High-conflict clients often have the most heartbreaking histories and greatest need. Finding meaning sustains engagement.</p>`,
-            },
-{
-              type: "text",
-              order: 21,
-              content: `<h2>Burnout Warning Signs</h2>
-<p>Watch for:</p>
-<ul>
-<li>Chronic exhaustion</li>
-<li>Dreading work generally (not just specific clients)</li>
-<li>Cynicism about clients or the profession</li>
-<li>Depersonalization (treating clients as problems, not people)</li>
-<li>Reduced sense of accomplishment</li>
-<li>Physical symptoms (headaches, GI issues, sleep problems)</li>
-<li>Increased substance use</li>
-<li>Withdrawal from support systems</li>
-</ul>
-<p>Early intervention prevents full burnout. If you notice these signs, take action—increase consultation, reduce caseload, take time off, seek support.</p>`,
-            },
-{
-              type: "multipleChoice",
-              order: 22,
-              question: `Treatment frame elements include all EXCEPT:`,
-              options: [
-                { text: `Explicit agreements about expectations`, isCorrect: true },
-                { text: `Clear treatment goals`, isCorrect: false },
-                { text: `Unlimited between-session access`, isCorrect: false },
-                { text: `Session frequency and length`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 23,
-              question: `Session structure helps high-conflict work by:`,
-              options: [
-                { text: `Preventing any discussion of difficult topics`, isCorrect: true },
-                { text: `Containing chaos and maximizing productive use of time`, isCorrect: false },
-                { text: `Making the client feel controlled`, isCorrect: false },
-                { text: `Avoiding all emotional content`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 24,
-              question: `DBT's hierarchy of treatment targets places highest priority on:`,
-              options: [
-                { text: `Building skills`, isCorrect: true },
-                { text: `Quality-of-life issues`, isCorrect: false },
-                { text: `Life-threatening behaviors`, isCorrect: false },
-                { text: `Insurance requirements`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 25,
-              question: `Referral is appropriate when:`,
-              options: [
-                { text: `The client is difficult`, isCorrect: true },
-                { text: `The client needs treatment outside your scope or the fit isn't working`, isCorrect: false },
-                { text: `The client disagrees with you`, isCorrect: false },
-                { text: `Any countertransference arises`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "multipleChoice",
-              order: 26,
-              question: `Burnout warning signs include:`,
-              options: [
-                { text: `Occasionally feeling tired after difficult sessions`, isCorrect: true },
-                { text: `Chronic exhaustion, cynicism, and depersonalization`, isCorrect: false },
-                { text: `Taking consultation seriously`, isCorrect: false },
-                { text: `Setting appropriate boundaries`, isCorrect: false },
-              ],
-              correctAnswer: 0,
-              explanation: `⚠️ Verify correct answer before publishing.`,
-            },
-{
-              type: "text",
-              order: 27,
-              content: `<h2>These Clients Are Suffering</h2>
-<p>Underneath the difficult behavior is genuine pain. The patterns that make high-conflict clients challenging—the splitting, the intensity, the boundary-testing—didn't emerge from nowhere. They developed as survival strategies in impossible circumstances.</p>
-<p>The child who learned that caregivers are dangerous grows into an adult who expects relationships to hurt—and who unconsciously creates the very pain they expect. The child who learned that emotions are unacceptable grows into an adult who swings between suppression and explosion. The child who received inconsistent responses to distress grows into an adult who escalates to get needs met.</p>
-<p>None of this excuses problematic behavior. Clients remain responsible for their actions and their choices. But understanding the origins of these patterns can create compassion—both for them and for yourself as you try to help.</p>`,
-            },
-{
-              type: "text",
-              order: 28,
-              content: `<h2>The Suffering Behind the Behavior</h2>
-<p>When you encounter difficult behavior, consider what might lie beneath:</p>
-<p><strong>When a client rages at you:</strong> They may be terrified. Rage often masks fear—fear of abandonment, fear of vulnerability, fear of being hurt again.</p>
-<p><strong>When a client clings desperately:</strong> They may have learned that connection is fleeting and must be held onto or it will disappear.</p>
-<p><strong>When a client tests your limits:</strong> They may need to know if you're safe before they can trust you—and testing is how they've learned to find out.</p>
-<p><strong>When a client devalues you:</strong> They may be protecting themselves from disappointment. If they decide you're terrible first, you can't hurt them by leaving.</p>
-<p><strong>When a client escalates to crisis:</strong> They may have learned that only crisis gets response. Moderate distress was ignored; only extreme distress brought care.</p>
-<p>Understanding doesn't mean accepting harmful behavior. It means having compassion while still holding boundaries and expectations.</p>`,
-            },
-{
-              type: "text",
-              order: 29,
-              content: `<h2>You Can Be Compassionate AND Have Limits</h2>
-<p>Compassion doesn't mean tolerating everything. Boundaries delivered with care are actually more compassionate than resentful accommodation. They provide the containment these clients need.</p>
-<p>You can say: "I care about you, AND I need to stop our session on time." You can say: "I understand your pain, AND I can't be available by phone every evening." You can say: "I see how hard this is, AND I need you to stop yelling so we can talk."</p>
-<p>The dialectic is: complete acceptance of the person AND firm expectation of change. These aren't contradictions—they're what effective treatment requires.</p>`,
-            },
-{
-              type: "text",
-              order: 30,
-              content: `<h2>The Both/And of Effective Treatment</h2>
-<p>Both/and thinking is central to working with high-conflict clients:</p>
-<ul>
-<li>Both understanding AND holding accountable</li>
-<li>Both validating AND challenging</li>
-<li>Both accepting AND expecting change</li>
-<li>Both caring AND maintaining limits</li>
-<li>Both staying present AND protecting yourself</li>
-</ul>
-<p>When you find yourself feeling like you must choose one or the other, pause. Usually, both are possible. That's the dialectical stance.</p>`,
-            },
-{
-              type: "text",
-              order: 31,
-              content: `<h2>Your Reactions Are Data</h2>
-<p>What you feel in the room tells you something about the client's experience. The helplessness, rage, worthlessness you experience through projective identification gives you access to the client's inner world.</p>
-<p>Use this information wisely. Notice what you feel. Wonder what it tells you about the client. Consider how to return the projected content in a more bearable form.</p>
-<p>But also: not everything you feel is projection. Sometimes your frustration is appropriate response to frustrating behavior. Sometimes your dread is appropriate response to a genuinely difficult situation. Distinguish between projection and reasonable reaction—both exist.</p>`,
-            },
-{
-              type: "text",
-              order: 32,
-              content: `<h2>Using Your Reactions Therapeutically</h2>
-<p>When you notice a strong reaction, ask yourself:</p>
-<ol>
-<li><strong>Is this me or them?</strong> Could this feeling be projected? Or is it a reasonable response to the situation?</li>
-</ol>
-<ol>
-<li><strong>What might this feeling tell me about the client's experience?</strong> If this is projective identification, what does it reveal about what the client carries?</li>
-</ol>
-<ol>
-<li><strong>How can I use this information?</strong> Can I name the feeling? Return it in a more bearable form? Use it to increase my empathy?</li>
-</ol>
-<ol>
-<li><strong>Do I need to address something?</strong> If my reaction indicates a problem (client's behavior, treatment frame issues, my own countertransference), what needs to happen?</li>
-</ol>`,
-            },
-{
-              type: "text",
-              order: 33,
-              content: `<h2>Structure Helps Everyone</h2>
-<p>Clear treatment frames benefit clients who need containment AND therapists who need sustainability. Session structure helps manage chaos AND prevents work from becoming formless.</p>
-<p>Structure isn't cold or controlling—it's caring. It says: "This work is important enough to protect. This space is safe enough to hold difficult things. This relationship is strong enough to contain intensity."</p>
-<p>Clients may push against structure, but they often come to rely on it. The predictability of your sessions may be the only consistent thing in their lives.</p>`,
-            },
-{
-              type: "text",
-              order: 34,
-              content: `<h2>You Can't Do This Alone</h2>
-<p>Consultation, supervision, peer support—these aren't optional extras. They're essential infrastructure for this work. The consultation team in DBT isn't luxury; it's recognition that high-conflict work requires support.</p>
-<p>Build consultation into your practice. Find colleagues who understand this work. Seek supervision even as an experienced clinician. Use personal therapy to address your own patterns.</p>
-<p>Isolation is the enemy of sustainability. Connection is the antidote.</p>`,
-            },
-{
-              type: "text",
-              order: 35,
-              content: `<h2>Building Your Support System</h2>
-<p><strong>Formal consultation:</strong> Regular meetings with a consultant who can help with difficult cases.</p>
-<p><strong>Peer support:</strong> Colleagues who understand the work and can provide mutual support.</p>
-<p><strong>Supervision:</strong> Even after licensure, clinical supervision improves practice.</p>
-<p><strong>Personal therapy:</strong> For processing countertransference and maintaining your own wellbeing.</p>
-<p><strong>Professional community:</strong> Involvement in professional organizations, training events, and communities of practice.</p>
-<p><strong>Non-work connections:</strong> Relationships and activities that have nothing to do with clinical work—essential for maintaining perspective.</p>`,
-            },
-{
-              type: "text",
-              order: 36,
-              content: `<h2>Take Care of Yourself</h2>
-<p>Your wellbeing matters—not just for you, but for your clients. A burned-out therapist can't provide effective treatment. A depleted therapist can't offer the steadiness high-conflict clients need.</p>
-<p>Self-care isn't self-indulgence. It's professional maintenance. Sleep, exercise, nutrition, recreation, relationships—these aren't distractions from the work; they're what makes the work possible.</p>`,
-            },
-{
-              type: "text",
-              order: 37,
-              content: `<h2>Sustainable Practice Checklist</h2>
-<p>☐ <strong>Caseload is balanced</strong> (not all high-conflict all the time) ☐ <strong>Breaks between sessions</strong> (not back-to-back all day) ☐ <strong>Regular consultation</strong> (scheduled, not just crisis-driven) ☐ <strong>Personal therapy</strong> (if doing intensive high-conflict work) ☐ <strong>Physical self-care</strong> (sleep, exercise, nutrition) ☐ <strong>Relationships outside work</strong> (friends, family, community) ☐ <strong>Activities that replenish</strong> (hobbies, interests, play) ☐ <strong>Boundaries on work time</strong> (not taking work home mentally) ☐ <strong>Professional development</strong> (continuing to learn and grow) ☐ <strong>Self-compassion</strong> (treating yourself kindly when the work is hard)</p>`,
-            },
-{
-              type: "text",
-              order: 38,
-              content: `<h2>Final Thoughts</h2>
-<p>High-conflict clients are challenging. They trigger us. They exhaust us. They make us question ourselves. And yet, they are often the clients who most need skilled, consistent, compassionate intervention.</p>
-<p>By developing your capacity to work skillfully with these presentations, you expand access to care for people who desperately need it—people who have been rejected, failed, and abandoned by helpers throughout their lives.</p>
-<p>It's hard work. It's important work. And with the right skills, the right support, and the right self-care, it's sustainable work.</p>
-<p>Thank you for your commitment to this difficult, important work.</p>`,
-            },
-{
-              type: "text",
-              order: 39,
-              content: `<h2>📋 Post-Course Pulse Check</h2>
-<p>Rate your comfort level now (1 = very uncomfortable, 5 = very comfortable):</p><table class="cr-table">
-<tr><th>Situation</th><th>Before</th><th>After</th></tr>
-<tr><td>Working with high-conflict clients generally</td><td></td><td></td></tr>
-<tr><td>Validating without reinforcing</td><td></td><td></td></tr>
-<tr><td>Setting boundaries with compassion</td><td></td><td></td></tr>
-<tr><td>Managing your own reactions</td><td></td><td></td></tr>
-<tr><td>Maintaining sustainable practice</td><td></td><td></td></tr>
-</table>`,
-            },
-{
-              type: "text",
-              order: 40,
-              content: `<h2>🛠️ Action Plan: Applying This Course</h2>
-<p>Based on this course, identify three specific changes you will make:</p>
-<p><strong>1. With high-conflict clients, I will:</strong> _________________________________</p>
-<p><strong>2. In managing my own reactions, I will:</strong> _________________________________</p>
-<p><strong>3. For sustainable practice, I will:</strong> _________________________________</p>`,
+      "order": 6,
+      "title": "Module 6: TREATMENT STRUCTURE AND SUSTAINABILITY",
+      "estimatedTime": 30,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Module 6: TREATMENT STRUCTURE AND SUSTAINABILITY",
+          "subtitle": "Walking on Eggshells: Working with High-Conflict and Emotionally Dysregulated Clients",
+          "sectionNumber": 6
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>🎯 Module Learning Objectives</h2>\n<p>By the end of this module, participants will be able to:</p>\n<ol>\n<li>Design treatment frames appropriate for high-conflict clients</li>\n<li>Structure sessions to contain intensity and maximize productivity</li>\n<li>Identify when referral or termination is appropriate</li>\n<li>Implement DBT principles even without full DBT implementation</li>\n<li>Develop sustainability practices for long-term work with this population</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 3,
+          "content": "<h2>Treatment Frame</h2>\n<p>Effective treatment with high-conflict clients requires a clear, explicit treatment frame—the structure within which therapy happens.</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<h2>Elements of the Frame</h2>\n<p><strong>Explicit agreements:</strong> Don't assume clients understand expectations. Make them explicit:</p>\n<ul>\n<li>Session frequency and length</li>\n<li>Policy on cancellations and lateness</li>\n<li>Fee and payment expectations</li>\n<li>Between-session contact (what's allowed, what's not)</li>\n<li>Crisis protocols (what constitutes a crisis, what to do)</li>\n<li>Confidentiality and its limits</li>\n</ul>\n<p><strong>Consistent schedule:</strong> Regular, predictable session times provide structure. Avoid frequent rescheduling, which creates chaos.</p>\n<p><strong>Defined goals:</strong> What are we working on? Clear treatment targets help maintain focus when chaos threatens to derail.</p>\n<p><strong>Role clarity:</strong> What is your role? What isn't your role? You are the therapist—not friend, parent, crisis hotline, or savior.</p>\n<p><strong>Stated limits:</strong> What happens if agreements are violated? Not as threat, but as clear information. \"If sessions are missed repeatedly without notice, we'll need to discuss whether this format is working for you.\"</p>"
+        },
+        {
+          "type": "text",
+          "order": 5,
+          "content": "<h2>Frame Agreement</h2>\n<p>Consider having a written treatment agreement for high-conflict clients that spells out the frame explicitly. This provides:</p>\n<ul>\n<li>Clear reference point for both parties</li>\n<li>Protection against \"I didn't know\" claims</li>\n<li>Basis for addressing violations</li>\n<li>Structure that anxious clients may find containing</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 6,
+          "content": "<h2>Session Structure</h2>\n<p>Within the overall treatment frame, individual sessions benefit from structure too.</p>"
+        },
+        {
+          "type": "text",
+          "order": 7,
+          "content": "<h2>Structured Sessions</h2>\n<p>A predictable session structure helps manage chaos:</p>\n<p><strong>Opening (5 minutes):</strong> Check-in. What's most pressing? What needs to be on today's agenda?</p>\n<p><strong>Agenda setting (2 minutes):</strong> Agree on the focus for today. You can't address everything—prioritize.</p>\n<p><strong>Main work (35-40 minutes):</strong> Focused intervention on agenda items. Return to the agenda when tangents emerge.</p>\n<p><strong>Summary (5 minutes):</strong> What did we cover? What's the main takeaway?</p>\n<p><strong>Closing (5 minutes):</strong> Between-session task (one small, manageable thing). How will you manage until next session?</p>\n<p>This structure isn't rigid—it's containing. It prevents sessions from becoming overwhelming dumps of crisis after crisis with no progress.</p>"
+        },
+        {
+          "type": "text",
+          "order": 8,
+          "content": "<h2>Managing In-Session Crisis</h2>\n<p>When crisis emerges in session:</p>\n<p><strong>Assess safety:</strong> Is this a genuine safety issue or intense distress?</p>\n<p><strong>Validate the distress:</strong> \"I can see you're in a lot of pain right now.\"</p>\n<p><strong>Contain:</strong> \"Let's slow down and figure out what would help.\"</p>\n<p><strong>Problem-solve:</strong> \"What's one thing that would make this more manageable?\"</p>\n<p><strong>Return to frame:</strong> \"I want to make sure we use our time well. Can we [return to agenda item]?\"</p>\n<p>The goal isn't to suppress crisis but to contain it within the therapeutic frame rather than letting it consume all the space.</p>"
+        },
+        {
+          "type": "text",
+          "order": 9,
+          "content": "<h2>DBT as a Model</h2>\n<p>Dialectical Behavior Therapy (DBT) offers a comprehensive treatment structure for high-conflict clients, particularly those with borderline presentations. Even without full DBT implementation, its principles inform effective treatment.</p>"
+        },
+        {
+          "type": "text",
+          "order": 10,
+          "content": "<h2>Core DBT Principles</h2>\n<p><strong>Dialectical stance:</strong> Holding opposites simultaneously. The client is doing the best they can AND needs to do better. We accept the client as they are AND push for change. These aren't contradictions—they're dialectics.</p>\n<p><strong>Biosocial understanding:</strong> The client's patterns make sense given their biology and history. This creates compassion without excusing.</p>\n<p><strong>Hierarchy of targets:</strong> DBT prioritizes treatment targets:</p>\n<ol>\n<li>Life-threatening behaviors (suicidality, self-harm)</li>\n<li>Therapy-interfering behaviors (missing sessions, not engaging)</li>\n<li>Quality-of-life-interfering behaviors (symptoms, problems)</li>\n<li>Skill building</li>\n</ol>\n<p>This hierarchy provides clear priorities when everything seems urgent.</p>\n<p><strong>Skills focus:</strong> DBT emphasizes teaching skills—distress tolerance, emotion regulation, interpersonal effectiveness, mindfulness. These skills give clients alternatives to problematic behaviors.</p>\n<p><strong>Consultation team:</strong> DBT requires therapists to be part of a consultation team—not optional but essential. This recognizes that the work requires support.</p>"
+        },
+        {
+          "type": "text",
+          "order": 11,
+          "content": "<h2>Applying DBT Principles Without Full DBT</h2>\n<p>Even without DBT certification or full program implementation, you can:</p>\n<ul>\n<li>Adopt a {{callout:dialectical}} stance</li>\n<li>Use biosocial understanding to create compassion</li>\n<li>Prioritize targets using the DBT hierarchy</li>\n<li>Teach basic skills (grounding, distress tolerance, interpersonal effectiveness)</li>\n<li>Seek consultation as essential, not optional</li>\n</ul>",
+          "callouts": {
+            "dialectical": {
+              "label": "Dialectical Stance",
+              "type": "reference",
+              "body": "Holding two apparently opposing truths at once — e.g., full acceptance of the client AND a push for change; the core stance underlying DBT."
             }
+          }
+        },
+        {
+          "type": "text",
+          "content": "<h2>Coordinating Care and Managing Splitting Across a Team</h2>\n<p>High-conflict clients frequently involve multiple providers — a prescriber, a group, a case manager, a prior therapist — and the splitting that occurs within sessions can extend across the treatment team if it is not managed.</p>\n<h3>When Splitting Goes Systemic</h3>\n<p>A client may idealize one provider while devaluing another, carry conflicting accounts between them, or position providers against each other, sometimes recreating across the team the very dynamics that mark their relationships. Providers who do not communicate can find themselves unwittingly enacting the split — one becoming the “good” helper and another the “bad” one — which fragments care and undermines everyone’s work.</p>\n<h3>Holding the Team Together</h3>\n<p>The antidote is communication and a shared, consistent frame: providers coordinate (with appropriate consent), compare notes when accounts diverge, present a unified and consistent stance, and avoid being drawn into criticism of one another. A coordinated team that holds together models the integration the client struggles to achieve and prevents the splitting from sabotaging care. Regular communication among providers is not a courtesy in these cases but a clinical necessity.</p>",
+          "order": 12
+        },
+        {
+          "type": "text",
+          "content": "<h2>Documentation in High-Conflict Cases</h2>\n<p>High-conflict cases warrant especially careful documentation, both because risk and complexity are higher and because the record supports sound, defensible clinical decisions.</p>\n<h3>What Careful Documentation Captures</h3>\n<p>The clinician records risk assessments, safety planning, boundary-setting and the reasoning behind it, crisis contacts, consultation obtained, and treatment decisions — in objective, behavioral, non-pejorative language. Notes describe what occurred and the clinical rationale rather than characterizing the client, capturing for example the limit set, the reason, and the client’s response rather than labeling the client as “manipulative.”</p>\n<h3>Why It Matters Here</h3>\n<p>Thorough documentation supports continuity, demonstrates the reasoning behind difficult decisions about limits, risk, and referral, and provides a record should questions later arise — all more likely in high-conflict work. It also disciplines the clinician’s own thinking and guards against the drift toward reactive, blame-tinged framing that these cases can pull for. The record should reflect careful, compassionate clinical judgment.</p>",
+          "order": 13
+        },
+        {
+          "type": "text",
+          "content": "<h2>The Long View: Change Is Slow and Real</h2>\n<p>Sustaining work with high-conflict clients requires a realistic, hopeful long view, since change in these presentations is genuine but gradual, and clinician expectations shape both stamina and outcome.</p>\n<h3>The Pace of Change</h3>\n<p>Deep relational and emotional patterns formed over years do not shift in weeks; progress in high-conflict work is frequently nonlinear, marked by setbacks, testing, and apparent regressions that can discourage a clinician expecting steady improvement. Recognizing that this pace is normal — not evidence of failure — protects the clinician from premature pessimism and the client from being given up on.</p>\n<h3>Hope Grounded in Evidence</h3>\n<p>The hopeful truth is that these clients can and do improve, particularly with consistent, validating, well-structured treatment; the evidence for approaches like DBT with borderline presentations is genuinely encouraging. Holding a long view — patient, realistic, and hopeful — allows the clinician to weather the difficult stretches, to recognize incremental gains, and to offer the steady persistence that, more than any single technique, makes change possible.</p>",
+          "order": 14
+        },
+        {
+          "type": "text",
+          "content": "<h2>Recognizing Incremental Progress</h2>\n<p>Because change in high-conflict work is gradual and nonlinear, the clinician needs an eye for incremental progress — the small markers that signal real movement and sustain hope through difficult stretches.</p>\n<h3>What Small Progress Looks Like</h3>\n<p>Progress may appear not as the disappearance of crises but as a shorter recovery after them, a rupture repaired more quickly, a moment of self-validation where there was none, a limit accepted without escalation, or a flash of reflection in the midst of distress. These markers are easy to miss when the clinician is braced for the next storm, yet they are the genuine substance of change in these presentations.</p>\n<h3>Tracking and Naming Gains</h3>\n<p>Noticing and, where appropriate, naming these gains — to oneself and sometimes to the client — reinforces them and counters the discouragement that high-conflict work can breed. Measurement-based tracking, periodic review of where the client began, and consultation that holds the long arc all help the clinician see the slope of progress beneath the week-to-week volatility. Recognizing small wins is not naive optimism but accurate, sustaining attention to change as it actually occurs.</p>",
+          "order": 15
+        },
+        {
+          "type": "text",
+          "order": 16,
+          "content": "<h2>When to Refer</h2>\n<p>Sometimes, the right treatment isn't with you. Referral is appropriate when:</p>"
+        },
+        {
+          "type": "text",
+          "order": 17,
+          "content": "<h2>Scope Limitations</h2>\n<p>The client needs specialized treatment you don't provide:</p>\n<ul>\n<li>Comprehensive DBT (if you don't provide it)</li>\n<li>Trauma-focused therapy (EMDR, PE) if outside your scope</li>\n<li>Medication management</li>\n<li>Substance abuse treatment</li>\n<li>Higher level of care (IOP, PHP, residential)</li>\n</ul>"
+        },
+        {
+          "type": "text",
+          "order": 18,
+          "content": "<h2>Skill Limitations</h2>\n<p>You lack training or experience for this presentation. This isn't failure—it's honest recognition of limits. The client deserves treatment by someone equipped to provide it.</p>"
+        },
+        {
+          "type": "text",
+          "order": 19,
+          "content": "<h2>Countertransference Barriers</h2>\n<p>Your personal reactions interfere with effective treatment. Despite consultation and self-work, you can't maintain therapeutic stance. The client deserves treatment not hampered by your struggles.</p>"
+        },
+        {
+          "type": "text",
+          "order": 20,
+          "content": "<h2>Client Welfare</h2>\n<p>The client would simply be better served elsewhere—different style, different specialty, better fit. Referring isn't giving up; it's ensuring appropriate care.</p>"
+        },
+        {
+          "type": "text",
+          "order": 21,
+          "content": "<h2>Persistent Treatment-Interfering Behavior</h2>\n<p>Despite repeated addressing, the client continues behaviors that make treatment impossible (chronic no-shows, repeated safety crises that disrupt all other work, ongoing boundary violations). At some point, the format isn't working.</p>"
+        },
+        {
+          "type": "text",
+          "order": 22,
+          "content": "<h2>How to Refer</h2>\n<p>When referral is indicated:</p>\n<p><strong>Be honest:</strong> \"I want to be direct with you. I'm not confident I'm the right therapist for what you need.\"</p>\n<p><strong>Don't blame:</strong> This isn't about the client being too difficult. It's about fit and appropriateness.</p>\n<p><strong>Provide options:</strong> Give specific referrals, not just \"you should find someone else.\"</p>\n<p><strong>Manage the transition:</strong> Don't abandon. Provide transition sessions if possible. Remain available briefly during handoff.</p>"
+        },
+        {
+          "type": "text",
+          "order": 23,
+          "content": "<h2>Sustainability Practices</h2>\n<p>Long-term work with high-conflict clients requires sustainability practices built into your professional life.</p>"
+        },
+        {
+          "type": "text",
+          "order": 24,
+          "content": "<h2>Essential Practices</h2>\n<p><strong>Ongoing consultation:</strong> Not just for crises. Regular, scheduled consultation with colleagues who understand this work.</p>\n<p><strong>Personal therapy:</strong> Highly recommended for anyone doing intensive high-conflict work. Your own therapy helps you understand your patterns and process the impact of the work.</p>\n<p><strong>Caseload management:</strong> Balance. Not every client can be high-intensity.</p>\n<p><strong>Time boundaries:</strong> Protect your off-hours. Compassion fatigue accelerates when work bleeds into all of life.</p>\n<p><strong>Physical wellbeing:</strong> Sleep, exercise, nutrition. The body keeps the score of this work too.</p>\n<p><strong>Meaning-making:</strong> Connect to why this work matters. High-conflict clients often have the most heartbreaking histories and greatest need. Finding meaning sustains engagement.</p>"
+        },
+        {
+          "type": "text",
+          "order": 25,
+          "content": "<h2>Burnout Warning Signs</h2>\n<p>Watch for:</p>\n<ul>\n<li>Chronic exhaustion</li>\n<li>Dreading work generally (not just specific clients)</li>\n<li>Cynicism about clients or the profession</li>\n<li>Depersonalization (treating clients as problems, not people)</li>\n<li>Reduced sense of accomplishment</li>\n<li>Physical symptoms (headaches, GI issues, sleep problems)</li>\n<li>Increased substance use</li>\n<li>Withdrawal from support systems</li>\n</ul>\n<p>Early intervention prevents full burnout. If you notice these signs, take action—increase consultation, reduce caseload, take time off, seek support.</p>"
+        },
+        {
+          "type": "multipleChoice",
+          "order": 26,
+          "question": "Treatment frame elements include all EXCEPT:",
+          "options": [
+            {
+              "text": "Explicit agreements about expectations",
+              "isCorrect": true
+            },
+            {
+              "text": "Clear treatment goals",
+              "isCorrect": false
+            },
+            {
+              "text": "Unlimited between-session access",
+              "isCorrect": false
+            },
+            {
+              "text": "Session frequency and length",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 27,
+          "question": "Session structure helps high-conflict work by:",
+          "options": [
+            {
+              "text": "Preventing any discussion of difficult topics",
+              "isCorrect": true
+            },
+            {
+              "text": "Containing chaos and maximizing productive use of time",
+              "isCorrect": false
+            },
+            {
+              "text": "Making the client feel controlled",
+              "isCorrect": false
+            },
+            {
+              "text": "Avoiding all emotional content",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "order": 28,
+          "type": "sequencing",
+          "instructions": "Order DBT’s hierarchy of treatment targets from highest to lowest priority.",
+          "steps": [
+            {
+              "order": 1,
+              "text": "Life-threatening behaviors"
+            },
+            {
+              "order": 2,
+              "text": "Therapy-interfering behaviors"
+            },
+            {
+              "order": 3,
+              "text": "Quality-of-life-interfering behaviors"
+            },
+            {
+              "order": 4,
+              "text": "Skills acquisition"
+            }
+          ],
+          "explanation": "DBT addresses life-threatening behaviors first, then therapy-interfering behaviors, then quality-of-life issues, then skills — safety always takes priority."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 29,
+          "question": "Referral is appropriate when:",
+          "options": [
+            {
+              "text": "The client is difficult",
+              "isCorrect": true
+            },
+            {
+              "text": "The client needs treatment outside your scope or the fit isn't working",
+              "isCorrect": false
+            },
+            {
+              "text": "The client disagrees with you",
+              "isCorrect": false
+            },
+            {
+              "text": "Any countertransference arises",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "multipleChoice",
+          "order": 30,
+          "question": "Burnout warning signs include:",
+          "options": [
+            {
+              "text": "Occasionally feeling tired after difficult sessions",
+              "isCorrect": true
+            },
+            {
+              "text": "Chronic exhaustion, cynicism, and depersonalization",
+              "isCorrect": false
+            },
+            {
+              "text": "Taking consultation seriously",
+              "isCorrect": false
+            },
+            {
+              "text": "Setting appropriate boundaries",
+              "isCorrect": false
+            }
+          ],
+          "correctAnswer": 0,
+          "explanation": "⚠️ Verify correct answer before publishing."
+        },
+        {
+          "type": "text",
+          "order": 31,
+          "content": "<h2>These Clients Are Suffering</h2>\n<p>Underneath the difficult behavior is genuine pain. The patterns that make high-conflict clients challenging—the splitting, the intensity, the boundary-testing—didn't emerge from nowhere. They developed as survival strategies in impossible circumstances.</p>\n<p>The child who learned that caregivers are dangerous grows into an adult who expects relationships to hurt—and who unconsciously creates the very pain they expect. The child who learned that emotions are unacceptable grows into an adult who swings between suppression and explosion. The child who received inconsistent responses to distress grows into an adult who escalates to get needs met.</p>\n<p>None of this excuses problematic behavior. Clients remain responsible for their actions and their choices. But understanding the origins of these patterns can create compassion—both for them and for yourself as you try to help.</p>"
+        },
+        {
+          "type": "text",
+          "order": 32,
+          "content": "<h2>The Suffering Behind the Behavior</h2>\n<p>When you encounter difficult behavior, consider what might lie beneath:</p>\n<p><strong>When a client rages at you:</strong> They may be terrified. Rage often masks fear—fear of abandonment, fear of vulnerability, fear of being hurt again.</p>\n<p><strong>When a client clings desperately:</strong> They may have learned that connection is fleeting and must be held onto or it will disappear.</p>\n<p><strong>When a client tests your limits:</strong> They may need to know if you're safe before they can trust you—and testing is how they've learned to find out.</p>\n<p><strong>When a client devalues you:</strong> They may be protecting themselves from disappointment. If they decide you're terrible first, you can't hurt them by leaving.</p>\n<p><strong>When a client escalates to crisis:</strong> They may have learned that only crisis gets response. Moderate distress was ignored; only extreme distress brought care.</p>\n<p>Understanding doesn't mean accepting harmful behavior. It means having compassion while still holding boundaries and expectations.</p>"
+        },
+        {
+          "type": "text",
+          "order": 33,
+          "content": "<h2>You Can Be Compassionate AND Have Limits</h2>\n<p>Compassion doesn't mean tolerating everything. Boundaries delivered with care are actually more compassionate than resentful accommodation. They provide the containment these clients need.</p>\n<p>You can say: \"I care about you, AND I need to stop our session on time.\" You can say: \"I understand your pain, AND I can't be available by phone every evening.\" You can say: \"I see how hard this is, AND I need you to stop yelling so we can talk.\"</p>\n<p>The dialectic is: complete acceptance of the person AND firm expectation of change. These aren't contradictions—they're what effective treatment requires.</p>"
+        },
+        {
+          "type": "text",
+          "order": 34,
+          "content": "<h2>The Both/And of Effective Treatment</h2>\n<p>Both/and thinking is central to working with high-conflict clients:</p>\n<ul>\n<li>Both understanding AND holding accountable</li>\n<li>Both validating AND challenging</li>\n<li>Both accepting AND expecting change</li>\n<li>Both caring AND maintaining limits</li>\n<li>Both staying present AND protecting yourself</li>\n</ul>\n<p>When you find yourself feeling like you must choose one or the other, pause. Usually, both are possible. That's the dialectical stance.</p>"
+        },
+        {
+          "type": "text",
+          "order": 35,
+          "content": "<h2>Your Reactions Are Data</h2>\n<p>What you feel in the room tells you something about the client's experience. The helplessness, rage, worthlessness you experience through projective identification gives you access to the client's inner world.</p>\n<p>Use this information wisely. Notice what you feel. Wonder what it tells you about the client. Consider how to return the projected content in a more bearable form.</p>\n<p>But also: not everything you feel is projection. Sometimes your frustration is appropriate response to frustrating behavior. Sometimes your dread is appropriate response to a genuinely difficult situation. Distinguish between projection and reasonable reaction—both exist.</p>"
+        },
+        {
+          "type": "text",
+          "order": 36,
+          "content": "<h2>Using Your Reactions Therapeutically</h2>\n<p>When you notice a strong reaction, ask yourself:</p>\n<ol>\n<li><strong>Is this me or them?</strong> Could this feeling be projected? Or is it a reasonable response to the situation?</li>\n</ol>\n<ol>\n<li><strong>What might this feeling tell me about the client's experience?</strong> If this is projective identification, what does it reveal about what the client carries?</li>\n</ol>\n<ol>\n<li><strong>How can I use this information?</strong> Can I name the feeling? Return it in a more bearable form? Use it to increase my empathy?</li>\n</ol>\n<ol>\n<li><strong>Do I need to address something?</strong> If my reaction indicates a problem (client's behavior, treatment frame issues, my own countertransference), what needs to happen?</li>\n</ol>"
+        },
+        {
+          "type": "text",
+          "order": 37,
+          "content": "<h2>Structure Helps Everyone</h2>\n<p>Clear treatment frames benefit clients who need containment AND therapists who need sustainability. Session structure helps manage chaos AND prevents work from becoming formless.</p>\n<p>Structure isn't cold or controlling—it's caring. It says: \"This work is important enough to protect. This space is safe enough to hold difficult things. This relationship is strong enough to contain intensity.\"</p>\n<p>Clients may push against structure, but they often come to rely on it. The predictability of your sessions may be the only consistent thing in their lives.</p>"
+        },
+        {
+          "type": "text",
+          "order": 38,
+          "content": "<h2>You Can't Do This Alone</h2>\n<p>Consultation, supervision, peer support—these aren't optional extras. They're essential infrastructure for this work. The consultation team in DBT isn't luxury; it's recognition that high-conflict work requires support.</p>\n<p>Build consultation into your practice. Find colleagues who understand this work. Seek supervision even as an experienced clinician. Use personal therapy to address your own patterns.</p>\n<p>Isolation is the enemy of sustainability. Connection is the antidote.</p>"
+        },
+        {
+          "type": "text",
+          "order": 39,
+          "content": "<h2>Building Your Support System</h2>\n<p><strong>Formal consultation:</strong> Regular meetings with a consultant who can help with difficult cases.</p>\n<p><strong>Peer support:</strong> Colleagues who understand the work and can provide mutual support.</p>\n<p><strong>Supervision:</strong> Even after licensure, clinical supervision improves practice.</p>\n<p><strong>Personal therapy:</strong> For processing countertransference and maintaining your own wellbeing.</p>\n<p><strong>Professional community:</strong> Involvement in professional organizations, training events, and communities of practice.</p>\n<p><strong>Non-work connections:</strong> Relationships and activities that have nothing to do with clinical work—essential for maintaining perspective.</p>"
+        },
+        {
+          "type": "text",
+          "order": 40,
+          "content": "<h2>Take Care of Yourself</h2>\n<p>Your wellbeing matters—not just for you, but for your clients. A burned-out therapist can't provide effective treatment. A depleted therapist can't offer the steadiness high-conflict clients need.</p>\n<p>Self-care isn't self-indulgence. It's professional maintenance. Sleep, exercise, nutrition, recreation, relationships—these aren't distractions from the work; they're what makes the work possible.</p>"
+        },
+        {
+          "type": "text",
+          "order": 41,
+          "content": "<h2>Sustainable Practice Checklist</h2>\n<p>☐ <strong>Caseload is balanced</strong> (not all high-conflict all the time) ☐ <strong>Breaks between sessions</strong> (not back-to-back all day) ☐ <strong>Regular consultation</strong> (scheduled, not just crisis-driven) ☐ <strong>Personal therapy</strong> (if doing intensive high-conflict work) ☐ <strong>Physical self-care</strong> (sleep, exercise, nutrition) ☐ <strong>Relationships outside work</strong> (friends, family, community) ☐ <strong>Activities that replenish</strong> (hobbies, interests, play) ☐ <strong>Boundaries on work time</strong> (not taking work home mentally) ☐ <strong>Professional development</strong> (continuing to learn and grow) ☐ <strong>Self-compassion</strong> (treating yourself kindly when the work is hard)</p>"
+        },
+        {
+          "type": "text",
+          "order": 42,
+          "content": "<h2>Final Thoughts</h2>\n<p>High-conflict clients are challenging. They trigger us. They exhaust us. They make us question ourselves. And yet, they are often the clients who most need skilled, consistent, compassionate intervention.</p>\n<p>By developing your capacity to work skillfully with these presentations, you expand access to care for people who desperately need it—people who have been rejected, failed, and abandoned by helpers throughout their lives.</p>\n<p>It's hard work. It's important work. And with the right skills, the right support, and the right self-care, it's sustainable work.</p>\n<p>Thank you for your commitment to this difficult, important work.</p>"
+        },
+        {
+          "type": "text",
+          "order": 43,
+          "content": "<h2>📋 Post-Course Pulse Check</h2>\n<p>Rate your comfort level now (1 = very uncomfortable, 5 = very comfortable):</p><table class=\"cr-table\">\n<tr><th>Situation</th><th>Before</th><th>After</th></tr>\n<tr><td>Working with high-conflict clients generally</td><td></td><td></td></tr>\n<tr><td>Validating without reinforcing</td><td></td><td></td></tr>\n<tr><td>Setting boundaries with compassion</td><td></td><td></td></tr>\n<tr><td>Managing your own reactions</td><td></td><td></td></tr>\n<tr><td>Maintaining sustainable practice</td><td></td><td></td></tr>\n</table>"
+        },
+        {
+          "type": "text",
+          "order": 44,
+          "content": "<h2>🛠️ Action Plan: Applying This Course</h2>\n<p>Based on this course, identify three specific changes you will make:</p>\n<p><strong>1. With high-conflict clients, I will:</strong> _________________________________</p>\n<p><strong>2. In managing my own reactions, I will:</strong> _________________________________</p>\n<p><strong>3. For sustainable practice, I will:</strong> _________________________________</p>"
+        }
       ]
     },
     {
-      order: 7,
-      title: `Course Summary and References`,
-      estimatedTime: 10,
-      contentBlocks: [
-{
-              type: "sectionDivider",
-              order: 1,
-              title: `Course Summary and References`,
-              subtitle: `Key Takeaways and APA 7th Edition References`,
-              sectionNumber: 7,
-            },
-{
-              type: "text",
-              order: 2,
-              content: `<h2>Key Takeaways</h2><p>This course has provided a comprehensive examination of walking on eggshells: working with high-conflict and emotionally dysregulated clients. As you apply these concepts with clients, continue to seek consultation and pursue ongoing professional development.</p>`,
-            },
-{
-              type: "reflection",
-              order: 3,
-              prompt: `Course Reflection`,
-              content: `<p>Consider how the concepts presented in this course will inform your clinical work. What specific practices will you implement? What aspects of your current practice might you reconsider?</p>`,
-            },
-{
-              type: "text",
-              order: 4,
-              content: `<div class="cr-references"><h3>References</h3>
-<p class="cr-reference">American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). Washington, DC: Author.</p>
-<p class="cr-reference">Bateman, A., & Fonagy, P. (2016). Mentalization-based treatment for personality disorders: A practical guide. Oxford University Press.</p>
-<p class="cr-reference">Chapman, A. L., & Gratz, K. L. (2015). The borderline personality disorder survival guide. New Harbinger Publications.</p>
-<p class="cr-reference">Clarkin, J. F., Yeomans, F. E., & Kernberg, O. F. (2006). Psychotherapy of borderline personality: Focusing on object relations. American Psychiatric Publishing.</p>
-<p class="cr-reference">Eddy, B. (2019). 5 types of people who can ruin your life: Identifying and dealing with narcissists, sociopaths, and other high-conflict personalities. TarcherPerigee.</p>
-<p class="cr-reference">Gunderson, J. G., & Links, P. S. (2014). Handbook of good psychiatric management for borderline personality disorder. American Psychiatric Publishing.</p>
-<p class="cr-reference">Kreisman, J. J., & Straus, H. (2010). I hate you—don't leave me: Understanding the borderline personality (Rev. ed.). TarcherPerigee.</p>
-<p class="cr-reference">Linehan, M. M. (1993). Cognitive-behavioral treatment of borderline personality disorder. Guilford Press.</p>
-<p class="cr-reference">Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.</p>
-<p class="cr-reference">Mason, P. T., & Kreger, R. (2020). Stop walking on eggshells: Taking your life back when someone you care about has borderline personality disorder (3rd ed.). New Harbinger Publications.</p>
-<p class="cr-reference">McWilliams, N. (2011). Psychoanalytic diagnosis: Understanding personality structure in the clinical process (2nd ed.). Guilford Press.</p>
-<p class="cr-reference">Paris, J. (2020). Treatment of borderline personality disorder: A guide to evidence-based practice (2nd ed.). Guilford Press.</p>
-<p class="cr-reference">Roth, K., & Friedman, F. B. (2003). Surviving a borderline parent: How to heal your childhood wounds and build trust, boundaries, and self-esteem. New Harbinger Publications.</p>
-<p class="cr-reference">Stoffers-Winterling, J., Völlm, B. A., Rücker, G., Timmer, A., Huband, N., & Lieb, K. (2012). Psychological therapies for people with borderline personality disorder. Cochrane Database of Systematic Reviews, 2012(8), CD005652.</p>
-<p class="cr-reference">Zanarini, M. C. (2009). Psychotherapy of borderline personality disorder. Acta Psychiatrica Scandinavica, 120(5), 373-377.</p>
-</div>`,
-            }
+      "order": 7,
+      "title": "Course Summary and References",
+      "estimatedTime": 10,
+      "contentBlocks": [
+        {
+          "type": "sectionDivider",
+          "order": 1,
+          "title": "Course Summary and References",
+          "subtitle": "Key Takeaways and APA 7th Edition References",
+          "sectionNumber": 7
+        },
+        {
+          "type": "text",
+          "order": 2,
+          "content": "<h2>Key Takeaways</h2><p>This course has provided a comprehensive examination of walking on eggshells: working with high-conflict and emotionally dysregulated clients. As you apply these concepts with clients, continue to seek consultation and pursue ongoing professional development.</p>"
+        },
+        {
+          "type": "reflection",
+          "order": 3,
+          "prompt": "Course Reflection",
+          "content": "<p>Consider how the concepts presented in this course will inform your clinical work. What specific practices will you implement? What aspects of your current practice might you reconsider?</p>"
+        },
+        {
+          "type": "text",
+          "order": 4,
+          "content": "<div class=\"cr-references\"><h3>References</h3>\n<p class=\"cr-reference\">American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). Washington, DC: Author.</p>\n<p class=\"cr-reference\">Bateman, A., & Fonagy, P. (2016). Mentalization-based treatment for personality disorders: A practical guide. Oxford University Press.</p>\n<p class=\"cr-reference\">Chapman, A. L., & Gratz, K. L. (2015). The borderline personality disorder survival guide. New Harbinger Publications.</p>\n<p class=\"cr-reference\">Clarkin, J. F., Yeomans, F. E., & Kernberg, O. F. (2006). Psychotherapy of borderline personality: Focusing on object relations. American Psychiatric Publishing.</p>\n<p class=\"cr-reference\">Eddy, B. (2019). 5 types of people who can ruin your life: Identifying and dealing with narcissists, sociopaths, and other high-conflict personalities. TarcherPerigee.</p>\n<p class=\"cr-reference\">Gunderson, J. G., & Links, P. S. (2014). Handbook of good psychiatric management for borderline personality disorder. American Psychiatric Publishing.</p>\n<p class=\"cr-reference\">Kreisman, J. J., & Straus, H. (2010). I hate you—don't leave me: Understanding the borderline personality (Rev. ed.). TarcherPerigee.</p>\n<p class=\"cr-reference\">Linehan, M. M. (1993). Cognitive-behavioral treatment of borderline personality disorder. Guilford Press.</p>\n<p class=\"cr-reference\">Linehan, M. M. (2015). DBT skills training manual (2nd ed.). Guilford Press.</p>\n<p class=\"cr-reference\">Mason, P. T., & Kreger, R. (2020). Stop walking on eggshells: Taking your life back when someone you care about has borderline personality disorder (3rd ed.). New Harbinger Publications.</p>\n<p class=\"cr-reference\">McWilliams, N. (2011). Psychoanalytic diagnosis: Understanding personality structure in the clinical process (2nd ed.). Guilford Press.</p>\n<p class=\"cr-reference\">Paris, J. (2020). Treatment of borderline personality disorder: A guide to evidence-based practice (2nd ed.). Guilford Press.</p>\n<p class=\"cr-reference\">Roth, K., & Friedman, F. B. (2003). Surviving a borderline parent: How to heal your childhood wounds and build trust, boundaries, and self-esteem. New Harbinger Publications.</p>\n<p class=\"cr-reference\">Stoffers-Winterling, J., Völlm, B. A., Rücker, G., Timmer, A., Huband, N., & Lieb, K. (2012). Psychological therapies for people with borderline personality disorder. Cochrane Database of Systematic Reviews, 2012(8), CD005652.</p>\n<p class=\"cr-reference\">Zanarini, M. C. (2009). Psychotherapy of borderline personality disorder. Acta Psychiatrica Scandinavica, 120(5), 373-377.</p>\n</div>"
+        }
       ]
     }
   ]
 };
-
+course.wordCount = countCourseWords(course);
+const __floor = (course.ceHours || 0) * 6000;
+console.log(`wordCount: ${course.wordCount} | floor: ${__floor} | ${course.wordCount >= __floor ? 'PASS ✅' : 'SHORT ⚠️'}`);
 const existing = await col.findOne({ slug: course.slug });
 if (existing) { await col.updateOne({ _id: existing._id }, { $set: course }); console.log(`✅ UPDATED: ${course.title}`); }
 else { await col.insertOne(course); console.log(`✅ INSERTED: ${course.title}`); }


### PR DESCRIPTION
Rebuilds 2 existing Tier-2 CE seed scripts in place: expanded content to clear the 6,000-words/CE floor, block-level callout pills, varied knowledge-check formats, plus a wordCount fix (`course.wordCount = countCourseWords(...)`). Courses stay `status: draft` — NOT published.

### This change = exactly 2 modified files
My single commit (`b2bfe8a`) modifies only:
- `server/src/scripts/seedCR401_The_Elephant_in_the_Room_Navigating_Difficul-18038words.js`
- `server/src/scripts/seedCR402_Walking_on_Eggshells_Working_with_High-Confl-18070words.js`

`git diff --stat <dev-base>..HEAD` → 2 files changed, 4651 insertions(+), 4387 deletions(-). No viewer, route, model, or other files touched.

### Pre-flight gates (all pass)
- `node --check` OK on both
- `grep -c "modules:"` = 0 on both (no modules trap)
- `grep -c "course.wordCount = countCourseWords"` = 1 on both (the wordCount fix present)

### ⚠️ Note on the diff-vs-`main`
Branch was cut from the active dev branch `claude/funny-clarke-0xzzxe` (not yet on GitHub / not merged to main), so GitHub diffs it against `main` and the file list also shows pre-existing dev commits. Those are **not** part of this change. **Do not merge into `main` as-is.**

Seeding has NOT been run — awaiting confirmation that Render has deployed the branch.

https://claude.ai/code/session_01TN1G78V1cc3vxm5xC9US9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN1G78V1cc3vxm5xC9US9b)_