### PR TITLE
CR-303..307: add APA-7 references to canonical seeds (draft) [partial — 401/402-clean + topUp deferred]

### DIFF
--- a/server/src/scripts/seedCR303-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR303-EXPANDED-canonical.js
@@ -1483,8 +1483,79 @@ const COURSE_DATA = {
         }
       ]
     }
+  ],
+  "references": [
+    {
+      "citation": "American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). https://doi.org/10.1176/appi.books.9780890425787"
+    },
+    {
+      "citation": "Annon, J. S. (1976). The PLISSIT model: A proposed conceptual scheme for the behavioral treatment of sexual problems. Journal of Sex Education and Therapy, 2(1), 1–15. https://doi.org/10.1080/01614576.1976.11074483"
+    },
+    {
+      "citation": "Bancroft, J. (2009). Human sexuality and its problems (3rd ed.). Churchill Livingstone/Elsevier."
+    },
+    {
+      "citation": "Basson, R. (2001). Using a different model for female sexual response to address women’s problematic low sexual desire. Journal of Sex & Marital Therapy, 27(5), 395–403. https://doi.org/10.1080/713846827"
+    },
+    {
+      "citation": "DeLamater, J., & Koepsel, E. (2015). Relationships and sexual expression in later life: A biopsychosocial perspective. Sexual and Relationship Therapy, 30(1), 37–59. https://doi.org/10.1080/14681994.2014.939506"
+    },
+    {
+      "citation": "Fortenberry, J. D. (2013). Puberty and adolescent sexuality. Hormones and Behavior, 64(2), 280–287. https://doi.org/10.1016/j.yhbeh.2013.03.007"
+    },
+    {
+      "citation": "Lindau, S. T., Schumm, L. P., Laumann, E. O., Levinson, W., O’Muircheartaigh, C. A., & Waite, L. J. (2007). A study of sexuality and health among older adults in the United States. New England Journal of Medicine, 357(8), 762–774. https://doi.org/10.1056/NEJMoa067423"
+    },
+    {
+      "citation": "Nusbaum, M. R. H., & Hamilton, C. D. (2002). The proactive sexual health history. American Family Physician, 66(9), 1705–1712."
+    },
+    {
+      "citation": "Tolman, D. L., & McClelland, S. I. (2011). Normative sexuality development in adolescence: A decade in review, 2000–2009. Journal of Research on Adolescence, 21(1), 242–255. https://doi.org/10.1111/j.1532-7795.2010.00726.x"
+    },
+    {
+      "citation": "World Association for Sexual Health. (2014). Declaration of sexual rights. https://worldsexualhealth.net/"
+    },
+    {
+      "citation": "World Health Organization. (2006). Defining sexual health: Report of a technical consultation on sexual health, 28–31 January 2002, Geneva. World Health Organization."
+    }
   ]
 };
+
+COURSE_DATA.references = [
+  {
+    "author": "American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). https://doi.org/10.1176/appi.books.9780890425787"
+  },
+  {
+    "author": "Annon, J. S. (1976). The PLISSIT model: A proposed conceptual scheme for the behavioral treatment of sexual problems. Journal of Sex Education and Therapy, 2(1), 1–15. https://doi.org/10.1080/01614576.1976.11074483"
+  },
+  {
+    "author": "Bancroft, J. (2009). Human sexuality and its problems (3rd ed.). Churchill Livingstone/Elsevier"
+  },
+  {
+    "author": "Basson, R. (2001). Using a different model for female sexual response to address women’s problematic low sexual desire. Journal of Sex & Marital Therapy, 27(5), 395–403. https://doi.org/10.1080/713846827"
+  },
+  {
+    "author": "DeLamater, J., & Koepsel, E. (2015). Relationships and sexual expression in later life: A biopsychosocial perspective. Sexual and Relationship Therapy, 30(1), 37–59. https://doi.org/10.1080/14681994.2014.939506"
+  },
+  {
+    "author": "Fortenberry, J. D. (2013). Puberty and adolescent sexuality. Hormones and Behavior, 64(2), 280–287. https://doi.org/10.1016/j.yhbeh.2013.03.007"
+  },
+  {
+    "author": "Lindau, S. T., Schumm, L. P., Laumann, E. O., Levinson, W., O’Muircheartaigh, C. A., & Waite, L. J. (2007). A study of sexuality and health among older adults in the United States. New England Journal of Medicine, 357(8), 762–774. https://doi.org/10.1056/NEJMoa067423"
+  },
+  {
+    "author": "Nusbaum, M. R. H., & Hamilton, C. D. (2002). The proactive sexual health history. American Family Physician, 66(9), 1705–1712"
+  },
+  {
+    "author": "Tolman, D. L., & McClelland, S. I. (2011). Normative sexuality development in adolescence: A decade in review, 2000–2009. Journal of Research on Adolescence, 21(1), 242–255. https://doi.org/10.1111/j.1532-7795.2010.00726.x"
+  },
+  {
+    "author": "World Association for Sexual Health. (2014). Declaration of sexual rights. https://worldsexualhealth.net/"
+  },
+  {
+    "author": "World Health Organization. (2006). Defining sexual health: Report of a technical consultation on sexual health, 28–31 January 2002, Geneva. World Health Organization"
+  }
+];
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -1500,10 +1571,11 @@ async function main() {
   doc.modules = undefined; // clear stale modules[] so only sections[] remain
   doc.markModified('sections');
   doc.markModified('assessment');
+  doc.markModified('references');
 
   await doc.save(); // triggers pre-save wordCount hook + schema validation
   const fresh = await Course.findById(doc._id).lean();
-  console.log('Saved. Sections:', fresh.sections?.length, '| wordCount:', fresh.wordCount, '| accessType:', fresh.accessType, '| status:', fresh.status);
+  console.log('Saved. Sections:', fresh.sections?.length, '| wordCount:', fresh.wordCount, '| accessType:', fresh.accessType, '| status:', fresh.status, '| refs:', fresh.references?.length);
 
   await mongoose.disconnect();
   console.log('Done.');

--- a/server/src/scripts/seedCR304-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR304-EXPANDED-canonical.js
@@ -789,94 +789,67 @@ const COURSE_DATA = {
   },
   "references": [
     {
-      "title": "Demarginalizing the intersection of race and sex. University of Chicago Legal Forum, 140, 139–167.",
-      "author": "Crenshaw, K",
-      "year": 1989,
-      "source": "ce and sex. University of Chicago Legal Forum, 140, 139–167."
+      "citation": "American Psychological Association (2012). Guidelines for psychological practice with lesbian, gay, and bisexual clients. American Psychologist, 67(1), 10–42."
     },
     {
-      "title": "Prejudice, social stress, and mental health in lesbian, gay, and bisexual populations. Psychological Bulletin, 129(5),",
-      "author": "Meyer, I",
-      "year": 2003,
-      "source": "sexual populations. Psychological Bulletin, 129(5), 674–697."
+      "citation": "American Psychological Association. (2015). Guidelines for psychological practice with transgender and gender nonconforming people. American Psychologist, 70(9), 832–864. https://doi.org/10.1037/a0039906"
     },
     {
-      "title": "Family rejection as a predictor of negative health outcomes. Pediatrics, 123(1), 346–352.",
-      "author": "Ryan, C",
-      "year": 2009,
-      "source": "or of negative health outcomes. Pediatrics, 123(1), 346–352."
+      "citation": "American Psychological Association. (2021). APA guidelines for psychological practice with sexual minority persons. https://www.apa.org/about/policy/psychological-practice-sexual-minority-persons.pdf"
     },
     {
-      "title": "Chosen name use is linked to reduced depressive symptoms, suicidal ideation, and suicidal behavior among transgender yo",
-      "author": "Russell, S",
-      "year": 2018,
-      "source": "sgender youth. Journal of Adolescent Health, 63(4), 503–505."
+      "citation": "APA Task Force on Appropriate Therapeutic Responses to Sexual Orientation (2009). Report. American Psychological Association."
     },
     {
-      "title": "National survey on LGBTQ youth mental health. https://www.thetrevorproject.org",
-      "author": "The Trevor Project",
-      "year": 2022,
-      "source": "LGBTQ youth mental health. https://www.thetrevorproject.org"
+      "citation": "Balsam, K. (2011). Cultural victimization among LGBT people of color. Journal of GLBT Family Studies, 7(4), 398–421."
     },
     {
-      "title": "World Professional Association for Transgender Health standards of care, version 8. International Journal of Transgende",
-      "author": "Coleman, E",
-      "year": 2022,
-      "source": "nternational Journal of Transgender Health, 23(S1), S1–S259."
+      "citation": "Bockting, W. O., Miner, M. H., Swinburne Romine, R. E., Hamilton, A., & Coleman, E. (2013). Stigma, mental health, and resilience in an online sample of the US transgender population. American Journal of Public Health, 103(5), 943–951. https://doi.org/10.2105/AJPH.2013.301241"
     },
     {
-      "title": "Uncovering clinical principles and techniques to address minority stress, mental health, and related health risks among",
-      "author": "Pachankis, J",
-      "year": 2014,
-      "source": "g gay and bisexual men. Clinical Psychology, 21(4), 313–330."
+      "citation": "Coleman, E., Radix, A. E., Bouman, W. P., Brown, G. R., de Vries, A. L. C., Deutsch, M. B., … Arcelus, J. (2022). Standards of care for the health of transgender and gender diverse people, version 8. International Journal of Transgender Health, 23(sup1), S1–S259. https://doi.org/10.1080/26895269.2022.2100644"
     },
     {
-      "title": "Guidelines for psychological practice with lesbian, gay, and bisexual clients. American Psychologist, 67(1), 10–42.",
-      "author": "American Psychological Association",
-      "year": 2012,
-      "source": ", and bisexual clients. American Psychologist, 67(1), 10–42."
+      "citation": "Crenshaw, K. (1989). Demarginalizing the intersection of race and sex. University of Chicago Legal Forum, 140, 139–167."
     },
     {
-      "title": "Guidelines for psychological practice with transgender and gender nonconforming people. American Psychologist, 70(9), 8",
-      "author": "APA",
-      "year": 2015,
-      "source": "nonconforming people. American Psychologist, 70(9), 832–864."
+      "citation": "Crenshaw, K. (1991). Mapping the margins: Intersectionality, identity politics, and violence against women of color. Stanford Law Review, 43(6), 1241–1299. https://doi.org/10.2307/1229039"
     },
     {
-      "title": "Cultural victimization among LGBT people of color. Journal of GLBT Family Studies, 7(4), 398–421.",
-      "author": "Balsam, K",
-      "year": 2011,
-      "source": "ple of color. Journal of GLBT Family Studies, 7(4), 398–421."
+      "citation": "Hatzenbuehler, M. L. (2009). How does sexual minority stigma “get under the skin”? A psychological mediation framework. Psychological Bulletin, 135(5), 707–730. https://doi.org/10.1037/a0016441"
     },
     {
-      "title": "Global health burden and needs of transgender populations. Lancet, 388(10042), 412–436.",
-      "author": "Reisner, S",
-      "year": 2016,
-      "source": "eds of transgender populations. Lancet, 388(10042), 412–436."
+      "citation": "Hendricks, M. L., & Testa, R. J. (2012). A conceptual framework for clinical work with transgender and gender nonconforming clients: An adaptation of the minority stress model. Professional Psychology: Research and Practice, 43(5), 460–467. https://doi.org/10.1037/a0029597"
     },
     {
-      "title": "A conceptual framework for clinical work with transgender and gender nonconforming clients. Professional Psychology, 43",
-      "author": "Hendricks, M",
-      "year": 2012,
-      "source": "conforming clients. Professional Psychology, 43(5), 460–467."
+      "citation": "Meyer, I. H. (2003). Prejudice, social stress, and mental health in lesbian, gay, and bisexual populations: Conceptual issues and research evidence. Psychological Bulletin, 129(5), 674–697. https://doi.org/10.1037/0033-2909.129.5.674"
     },
     {
-      "title": "Report. American Psychological Association.",
-      "author": "APA Task Force on Appropriate Therapeutic Responses to Sexual Orientation",
-      "year": 2009,
-      "source": "ntation. (2009). Report. American Psychological Association."
+      "citation": "Pachankis, J. (2014). Uncovering clinical principles and techniques to address minority stress, mental health, and related health risks among"
     },
     {
-      "title": "Ending conversion therapy: Supporting and affirming LGBTQ youth. SAMHSA.",
-      "author": "Substance Abuse and Mental Health Services Administration",
-      "year": 2015,
-      "source": "rsion therapy: Supporting and affirming LGBTQ youth. SAMHSA."
+      "citation": "Reed, G. M., Drescher, J., Krueger, R. B., Atalla, E., Cochran, S. D., First, M. B., … Saxena, S. (2016). Disorders related to sexuality and gender identity in the ICD-11. World Psychiatry, 15(3), 205–221. https://doi.org/10.1002/wps.20354"
     },
     {
-      "title": "LGBT people in the US not protected by state non-discrimination statutes. UCLA School of Law.",
-      "author": "Williams Institute",
-      "year": 2020,
-      "source": "ed by state non-discrimination statutes. UCLA School of Law."
+      "citation": "Reisner, S. (2016). Global health burden and needs of transgender populations. Lancet, 388(10042), 412–436."
+    },
+    {
+      "citation": "Russell, S. (2018). Chosen name use is linked to reduced depressive symptoms, suicidal ideation, and suicidal behavior among transgender yo"
+    },
+    {
+      "citation": "Russell, S. T., & Fish, J. N. (2016). Mental health in lesbian, gay, bisexual, and transgender (LGBT) youth. Annual Review of Clinical Psychology, 12, 465–487. https://doi.org/10.1146/annurev-clinpsy-021815-093153"
+    },
+    {
+      "citation": "Ryan, C. (2009). Family rejection as a predictor of negative health outcomes. Pediatrics, 123(1), 346–352."
+    },
+    {
+      "citation": "Substance Abuse and Mental Health Services Administration (2015). Ending conversion therapy: Supporting and affirming LGBTQ youth. SAMHSA."
+    },
+    {
+      "citation": "The Trevor Project (2022). National survey on LGBTQ youth mental health. https://www.thetrevorproject.org"
+    },
+    {
+      "citation": "Williams Institute (2020). LGBT people in the US not protected by state non-discrimination statutes. UCLA School of Law."
     }
   ],
   "sections": [
@@ -1641,6 +1614,39 @@ const COURSE_DATA = {
   ]
 };
 
+COURSE_DATA.references = [
+  {
+    "author": "American Psychological Association. (2015). Guidelines for psychological practice with transgender and gender nonconforming people. American Psychologist, 70(9), 832–864. https://doi.org/10.1037/a0039906"
+  },
+  {
+    "author": "American Psychological Association. (2021). APA guidelines for psychological practice with sexual minority persons. https://www.apa.org/about/policy/psychological-practice-sexual-minority-persons.pdf"
+  },
+  {
+    "author": "Bockting, W. O., Miner, M. H., Swinburne Romine, R. E., Hamilton, A., & Coleman, E. (2013). Stigma, mental health, and resilience in an online sample of the US transgender population. American Journal of Public Health, 103(5), 943–951. https://doi.org/10.2105/AJPH.2013.301241"
+  },
+  {
+    "author": "Coleman, E., Radix, A. E., Bouman, W. P., Brown, G. R., de Vries, A. L. C., Deutsch, M. B., … Arcelus, J. (2022). Standards of care for the health of transgender and gender diverse people, version 8. International Journal of Transgender Health, 23(sup1), S1–S259. https://doi.org/10.1080/26895269.2022.2100644"
+  },
+  {
+    "author": "Crenshaw, K. (1991). Mapping the margins: Intersectionality, identity politics, and violence against women of color. Stanford Law Review, 43(6), 1241–1299. https://doi.org/10.2307/1229039"
+  },
+  {
+    "author": "Hatzenbuehler, M. L. (2009). How does sexual minority stigma “get under the skin”? A psychological mediation framework. Psychological Bulletin, 135(5), 707–730. https://doi.org/10.1037/a0016441"
+  },
+  {
+    "author": "Hendricks, M. L., & Testa, R. J. (2012). A conceptual framework for clinical work with transgender and gender nonconforming clients: An adaptation of the minority stress model. Professional Psychology: Research and Practice, 43(5), 460–467. https://doi.org/10.1037/a0029597"
+  },
+  {
+    "author": "Meyer, I. H. (2003). Prejudice, social stress, and mental health in lesbian, gay, and bisexual populations: Conceptual issues and research evidence. Psychological Bulletin, 129(5), 674–697. https://doi.org/10.1037/0033-2909.129.5.674"
+  },
+  {
+    "author": "Reed, G. M., Drescher, J., Krueger, R. B., Atalla, E., Cochran, S. D., First, M. B., … Saxena, S. (2016). Disorders related to sexuality and gender identity in the ICD-11. World Psychiatry, 15(3), 205–221. https://doi.org/10.1002/wps.20354"
+  },
+  {
+    "author": "Russell, S. T., & Fish, J. N. (2016). Mental health in lesbian, gay, bisexual, and transgender (LGBT) youth. Annual Review of Clinical Psychology, 12, 465–487. https://doi.org/10.1146/annurev-clinpsy-021815-093153"
+  }
+];
+
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 async function main(){
@@ -1649,6 +1655,7 @@ async function main(){
   if(!doc){ console.error('CR-304 not found:', COURSE_DATA.slug); process.exit(1); }
   for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
   doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  doc.markModified('references');
   await doc.save();
   const fresh=await Course.findById(doc._id).lean();
   console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);

--- a/server/src/scripts/seedCR305-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR305-EXPANDED-canonical.js
@@ -714,106 +714,67 @@ const COURSE_DATA = {
   },
   "references": [
     {
-      "title": "The National Intimate Partner and Sexual Violence Survey. CDC.",
-      "author": "Basile, K",
-      "year": 2022,
-      "source": "e National Intimate Partner and Sexual Violence Survey. CDC."
+      "citation": "American Psychological Association. (2017). Clinical practice guideline for the treatment of posttraumatic stress disorder (PTSD) in adults. https://www.apa.org/ptsd-guideline"
     },
     {
-      "title": "Treating trauma and traumatic grief in children and adolescents (2nd ed.). Guilford Press.",
-      "author": "Cohen, J",
-      "year": 2017,
-      "source": "grief in children and adolescents (2nd ed.). Guilford Press."
+      "citation": "Basile, K. (2022). The National Intimate Partner and Sexual Violence Survey. CDC."
     },
     {
-      "title": "Prolonged exposure therapy for PTSD: Therapist guide (2nd ed.). Oxford University Press.",
-      "author": "Foa, E",
-      "year": 2019,
-      "source": "or PTSD: Therapist guide (2nd ed.). Oxford University Press."
+      "citation": "Campbell, R., Dworkin, E., & Cabral, G. (2009). An ecological model of the impact of sexual assault on women’s mental health. Trauma, Violence, & Abuse, 10(3), 225–246. https://doi.org/10.1177/1524838009334456"
     },
     {
-      "title": "In an unspoken voice. North Atlantic Books.",
-      "author": "Levine, P",
-      "year": 2010,
-      "source": "e, P. A. (2010). In an unspoken voice. North Atlantic Books."
+      "citation": "Cohen, J. A., Mannarino, A. P., & Deblinger, E. (2017). Treating trauma and traumatic grief in children and adolescents (2nd ed.). Guilford Press."
     },
     {
-      "title": "Tonic immobility during sexual assault. Acta Obstetricia et Gynecologica Scandinavica, 96(8), 932–938.",
-      "author": "Möller, A",
-      "year": 2017,
-      "source": "ta Obstetricia et Gynecologica Scandinavica, 96(8), 932–938."
+      "citation": "Courtois, C. A., & Ford, J. D. (2013). Treatment of complex trauma: A sequenced, relationship-based approach. Guilford Press."
     },
     {
-      "title": "Statistics about sexual violence.",
-      "author": "National Sexual Violence Resource Center",
-      "year": 2015,
-      "source": "e Resource Center. (2015). Statistics about sexual violence."
+      "citation": "Foa, E. B., Hembree, E. A., Rothbaum, B. O., & Rauch, S. A. M. (2019). Prolonged exposure therapy for PTSD: Emotional processing of traumatic experiences (2nd ed.). Oxford University Press."
     },
     {
-      "title": "Trauma and the body. Norton.",
-      "author": "Ogden, P",
-      "year": 2006,
-      "source": "Minton, K., & Pain, C. (2006). Trauma and the body. Norton."
+      "citation": "Foynes, M. (2014). Child abuse: Betrayal and disclosure. Child Abuse & Neglect, 33(4), 209–217."
     },
     {
-      "title": "The polyvagal theory. Norton.",
-      "author": "Porges, S",
-      "year": 2011,
-      "source": "Porges, S. W. (2011). The polyvagal theory. Norton."
+      "citation": "Herman, J. L. (2015). Trauma and recovery: The aftermath of violence—from domestic abuse to political terror (Rev. ed.). Basic Books. (Original work published 1992)"
     },
     {
-      "title": "Cognitive processing therapy for PTSD. Guilford Press.",
-      "author": "Resick, P",
-      "year": 2017,
-      "source": "017). Cognitive processing therapy for PTSD. Guilford Press."
+      "citation": "Levine, P. (2010). In an unspoken voice. North Atlantic Books."
     },
     {
-      "title": "Trauma-informed care in behavioral health services (TIP 57).",
-      "author": "SAMHSA",
-      "year": 2014,
-      "source": "Trauma-informed care in behavioral health services (TIP 57)."
+      "citation": "Möller, A. (2017). Tonic immobility during sexual assault. Acta Obstetricia et Gynecologica Scandinavica, 96(8), 932–938."
     },
     {
-      "title": "Eye movement desensitization and reprocessing therapy (3rd ed.). Guilford Press.",
-      "author": "Shapiro, F",
-      "year": 2018,
-      "source": "tization and reprocessing therapy (3rd ed.). Guilford Press."
+      "citation": "National Sexual Violence Resource Center (2015). Statistics about sexual violence."
     },
     {
-      "title": "The developing mind. Guilford Press.",
-      "author": "Siegel, D",
-      "year": 1999,
-      "source": "Siegel, D. J. (1999). The developing mind. Guilford Press."
+      "citation": "Ogden, P., Minton, K., & Pain, C. (2006). Trauma and the body: A sensorimotor approach to psychotherapy. W. W. Norton."
     },
     {
-      "title": "The Posttraumatic Growth Inventory. Journal of Traumatic Stress, 9(3), 455–471.",
-      "author": "Tedeschi, R",
-      "year": 1996,
-      "source": "rowth Inventory. Journal of Traumatic Stress, 9(3), 455–471."
+      "citation": "Porges, S. (2011). The polyvagal theory. Norton."
     },
     {
-      "title": "The body keeps the score. Viking.",
-      "author": "van der Kolk, B",
-      "year": 2014,
-      "source": "an der Kolk, B. A. (2014). The body keeps the score. Viking."
+      "citation": "Resick, P. A., Monson, C. M., & Chard, K. M. (2017). Cognitive processing therapy for PTSD: A comprehensive manual. Guilford Press."
     },
     {
-      "title": "The PTSD Checklist for DSM-5 (PCL-5). National Center for PTSD.",
-      "author": "Weathers, F",
-      "year": 2013,
-      "source": "PTSD Checklist for DSM-5 (PCL-5). National Center for PTSD."
+      "citation": "Ryan, C. (2009). Family rejection as predictor of negative health outcomes. Pediatrics, 123(1), 346–352."
     },
     {
-      "title": "Child abuse: Betrayal and disclosure. Child Abuse & Neglect, 33(4), 209–217.",
-      "author": "Foynes, M",
-      "year": 2014,
-      "source": "rayal and disclosure. Child Abuse & Neglect, 33(4), 209–217."
+      "citation": "SAMHSA (2014). Trauma-informed care in behavioral health services (TIP 57)."
     },
     {
-      "title": "Family rejection as predictor of negative health outcomes. Pediatrics, 123(1), 346–352.",
-      "author": "Ryan, C",
-      "year": 2009,
-      "source": "or of negative health outcomes. Pediatrics, 123(1), 346–352."
+      "citation": "Shapiro, F. (2018). Eye movement desensitization and reprocessing (EMDR) therapy: Basic principles, protocols, and procedures (3rd ed.). Guilford Press."
+    },
+    {
+      "citation": "Siegel, D. J. (1999). The developing mind: How relationships and the brain interact to shape who we are. Guilford Press."
+    },
+    {
+      "citation": "Tedeschi, R. (1996). The Posttraumatic Growth Inventory. Journal of Traumatic Stress, 9(3), 455–471."
+    },
+    {
+      "citation": "van der Kolk, B. A. (2014). The body keeps the score: Brain, mind, and body in the healing of trauma. Viking."
+    },
+    {
+      "citation": "Weathers, F. (2013). The PTSD Checklist for DSM-5 (PCL-5). National Center for PTSD."
     }
   ],
   "sections": [
@@ -1571,6 +1532,42 @@ const COURSE_DATA = {
   ]
 };
 
+COURSE_DATA.references = [
+  {
+    "author": "American Psychological Association. (2017). Clinical practice guideline for the treatment of posttraumatic stress disorder (PTSD) in adults. https://www.apa.org/ptsd-guideline"
+  },
+  {
+    "author": "Campbell, R., Dworkin, E., & Cabral, G. (2009). An ecological model of the impact of sexual assault on women’s mental health. Trauma, Violence, & Abuse, 10(3), 225–246. https://doi.org/10.1177/1524838009334456"
+  },
+  {
+    "author": "Cohen, J. A., Mannarino, A. P., & Deblinger, E. (2017). Treating trauma and traumatic grief in children and adolescents (2nd ed.). Guilford Press"
+  },
+  {
+    "author": "Courtois, C. A., & Ford, J. D. (2013). Treatment of complex trauma: A sequenced, relationship-based approach. Guilford Press"
+  },
+  {
+    "author": "Foa, E. B., Hembree, E. A., Rothbaum, B. O., & Rauch, S. A. M. (2019). Prolonged exposure therapy for PTSD: Emotional processing of traumatic experiences (2nd ed.). Oxford University Press"
+  },
+  {
+    "author": "Herman, J. L. (2015). Trauma and recovery: The aftermath of violence—from domestic abuse to political terror (Rev. ed.). Basic Books. (Original work published 1992)"
+  },
+  {
+    "author": "Ogden, P., Minton, K., & Pain, C. (2006). Trauma and the body: A sensorimotor approach to psychotherapy. W. W. Norton"
+  },
+  {
+    "author": "Resick, P. A., Monson, C. M., & Chard, K. M. (2017). Cognitive processing therapy for PTSD: A comprehensive manual. Guilford Press"
+  },
+  {
+    "author": "Shapiro, F. (2018). Eye movement desensitization and reprocessing (EMDR) therapy: Basic principles, protocols, and procedures (3rd ed.). Guilford Press"
+  },
+  {
+    "author": "Siegel, D. J. (1999). The developing mind: How relationships and the brain interact to shape who we are. Guilford Press"
+  },
+  {
+    "author": "van der Kolk, B. A. (2014). The body keeps the score: Brain, mind, and body in the healing of trauma. Viking"
+  }
+];
+
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 async function main(){
@@ -1579,6 +1576,7 @@ async function main(){
   if(!doc){ console.error('CR-305 not found:', COURSE_DATA.slug); process.exit(1); }
   for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
   doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  doc.markModified('references');
   await doc.save();
   const fresh=await Course.findById(doc._id).lean();
   console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);

--- a/server/src/scripts/seedCR306-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR306-EXPANDED-canonical.js
@@ -814,100 +814,85 @@ const COURSE_DATA = {
   },
   "references": [
     {
-      "title": "AASECT scope of practice. https://www.aasect.org",
-      "author": "American Association of Sexuality Educators, Counselors and Therapists",
-      "year": 2023,
-      "source": "ts. (2023). AASECT scope of practice. https://www.aasect.org"
+      "citation": "American Association of Sexuality Educators, Counselors and Therapists (2023). AASECT scope of practice. https://www.aasect.org"
     },
     {
-      "title": "Human sexuality and its problems (3rd ed.). Churchill Livingstone.",
-      "author": "Bancroft, J",
-      "year": 2009,
-      "source": "sexuality and its problems (3rd ed.). Churchill Livingstone."
+      "citation": "American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). https://doi.org/10.1176/appi.books.9780890425787"
     },
     {
-      "title": "Using a different model for female sexual response to address women's problematic low sexual desire. Journal of Sex & M",
-      "author": "Basson, R",
-      "year": 2001,
-      "source": "al desire. Journal of Sex & Marital Therapy, 27(5), 395–403."
+      "citation": "Annon, J. S. (1976). The PLISSIT model: A proposed conceptual scheme for the behavioral treatment of sexual problems. Journal of Sex Education and Therapy, 2(1), 1–15. https://doi.org/10.1080/01614576.1976.11074483"
     },
     {
-      "title": "Group mindfulness-based therapy significantly improves sexual desire in women. Behaviour Research and Therapy, 57, 43–5",
-      "author": "Brotto, L",
-      "year": 2014,
-      "source": "desire in women. Behaviour Research and Therapy, 57, 43–54."
+      "citation": "Bancroft, J. (2009). Human sexuality and its problems (3rd ed.). Churchill Livingstone."
     },
     {
-      "title": "Becoming orgasmic: A sexual and personal growth program for women. Prentice Hall.",
-      "author": "Heiman, J",
-      "year": 1988,
-      "source": "sexual and personal growth program for women. Prentice Hall."
+      "citation": "Bancroft, J., & Janssen, E. (2000). The dual control model of male sexual response: A theoretical approach to centrally mediated erectile dysfunction. Neuroscience & Biobehavioral Reviews, 24(5), 571–579. https://doi.org/10.1016/S0149-7634(00)00024-5"
     },
     {
-      "title": "Disorders of sexual desire. Brunner/Mazel.",
-      "author": "Kaplan, H",
-      "year": 1979,
-      "source": "an, H. S. (1979). Disorders of sexual desire. Brunner/Mazel."
+      "citation": "Barlow, D. H. (1986). Causes of sexual dysfunction: The role of anxiety and cognitive interference. Journal of Consulting and Clinical Psychology, 54(2), 140–148. https://doi.org/10.1037/0022-006X.54.2.140"
     },
     {
-      "title": "Principles and practice of sex therapy (4th ed.). Guilford Press.",
-      "author": "Leiblum, S",
-      "year": 2007,
-      "source": "iples and practice of sex therapy (4th ed.). Guilford Press."
+      "citation": "Basson, R. (2000). The female sexual response: A different model. Journal of Sex & Marital Therapy, 26(1), 51–65. https://doi.org/10.1080/009262300278641"
     },
     {
-      "title": "Human sexual response. Little, Brown.",
-      "author": "Masters, W",
-      "year": 1966,
-      "source": "Johnson, V. E. (1966). Human sexual response. Little, Brown."
+      "citation": "Basson, R. (2001). Using a different model for female sexual response to address women's problematic low sexual desire. Journal of Sex & M"
     },
     {
-      "title": "Sexual awareness: Your guide to healthy couple sexuality. Routledge.",
-      "author": "McCarthy, B",
-      "year": 2012,
-      "source": "wareness: Your guide to healthy couple sexuality. Routledge."
+      "citation": "Binik, Y. M., & Hall, K. S. K. (Eds.). (2020). Principles and practice of sex therapy (6th ed.). Guilford Press."
     },
     {
-      "title": "The Female Sexual Function Index (FSFI): A multidimensional self-report instrument for the assessment of female sexual",
-      "author": "Rosen, R",
-      "year": 2000,
-      "source": "function. Journal of Sex & Marital Therapy, 26(2), 191–208."
+      "citation": "Brotto, L. (2014). Group mindfulness-based therapy significantly improves sexual desire in women. Behaviour Research and Therapy, 57, 43–5"
     },
     {
-      "title": "The International Index of Erectile Function (IIEF). Urology, 49(6), 822–830.",
-      "author": "Rosen, R",
-      "year": 1997,
-      "source": "Index of Erectile Function (IIEF). Urology, 49(6), 822–830."
+      "citation": "Brotto, L. (2016). Psychological and interpersonal dimensions of sexual function and dysfunction. Journal of Sexual Medicine, 13(4), 538–5"
     },
     {
-      "title": "A new view of women's sexual problems: Why new? Why now? Journal of Sex Research, 38(2), 89–96.",
-      "author": "Tiefer, L",
-      "year": 2001,
-      "source": "ms: Why new? Why now? Journal of Sex Research, 38(2), 89–96."
+      "citation": "Heiman, J. (1988). Becoming orgasmic: A sexual and personal growth program for women. Prentice Hall."
     },
     {
-      "title": "Intersystems approaches to sex therapy. In K. Hertlein, G. Weeks, & N. Gambescia (Eds.), Systemic sex therapy (2nd ed.,",
-      "author": "Weeks, G",
-      "year": 2015,
-      "source": "(Eds.), Systemic sex therapy (2nd ed., pp. 3–24). Routledge."
+      "citation": "Kaplan, H. (1979). Disorders of sexual desire. Brunner/Mazel."
     },
     {
-      "title": "Defining sexual health: Report of a technical consultation on sexual health. WHO.",
-      "author": "World Health Organization",
-      "year": 2006,
-      "source": "h: Report of a technical consultation on sexual health. WHO."
+      "citation": "Kaplan, H. S. (1974). The new sex therapy: Active treatment of sexual dysfunctions. Brunner/Mazel."
     },
     {
-      "title": "The new male sexuality (Rev. ed.). Bantam.",
-      "author": "Zilbergeld, B",
-      "year": 1999,
-      "source": "rgeld, B. (1999). The new male sexuality (Rev. ed.). Bantam."
+      "citation": "Leiblum, S. (2007). Principles and practice of sex therapy (4th ed.). Guilford Press."
     },
     {
-      "title": "Psychological and interpersonal dimensions of sexual function and dysfunction. Journal of Sexual Medicine, 13(4), 538–5",
-      "author": "Brotto, L",
-      "year": 2016,
-      "source": "and dysfunction. Journal of Sexual Medicine, 13(4), 538–571."
+      "citation": "Masters, W. (1966). Human sexual response. Little, Brown."
+    },
+    {
+      "citation": "Masters, W. H., & Johnson, V. E. (1970). Human sexual inadequacy. Little, Brown."
+    },
+    {
+      "citation": "McCarthy, B. (2012). Sexual awareness: Your guide to healthy couple sexuality. Routledge."
+    },
+    {
+      "citation": "Metz, M. E., & McCarthy, B. W. (2007). The “good-enough sex” model for couple sexual satisfaction. Sexual and Relationship Therapy, 22(3), 351–362. https://doi.org/10.1080/14681990601013492"
+    },
+    {
+      "citation": "Rosen, R. (1997). The International Index of Erectile Function (IIEF). Urology, 49(6), 822–830."
+    },
+    {
+      "citation": "Rosen, R. (2000). The Female Sexual Function Index (FSFI): A multidimensional self-report instrument for the assessment of female sexual"
+    },
+    {
+      "citation": "Tiefer, L. (2001). A new view of women's sexual problems: Why new? Why now? Journal of Sex Research, 38(2), 89–96."
+    },
+    {
+      "citation": "Weeks, G. (2015). Intersystems approaches to sex therapy. In K. Hertlein, G. Weeks, & N. Gambescia (Eds.), Systemic sex therapy (2nd ed.,"
+    },
+    {
+      "citation": "Weiner, L., & Avery-Clark, C. (2017). Sensate focus in sex therapy: The illustrated manual. Routledge."
+    },
+    {
+      "citation": "Wincze, J. P., & Weisberg, R. B. (2015). Sexual dysfunction: A guide for assessment and treatment (3rd ed.). Guilford Press."
+    },
+    {
+      "citation": "World Health Organization (2006). Defining sexual health: Report of a technical consultation on sexual health. WHO."
+    },
+    {
+      "citation": "Zilbergeld, B. (1999). The new male sexuality (Rev. ed.). Bantam."
     }
   ],
   "sections": [
@@ -1785,6 +1770,42 @@ const COURSE_DATA = {
   ]
 };
 
+COURSE_DATA.references = [
+  {
+    "author": "American Psychiatric Association. (2022). Diagnostic and statistical manual of mental disorders (5th ed., text rev.). https://doi.org/10.1176/appi.books.9780890425787"
+  },
+  {
+    "author": "Annon, J. S. (1976). The PLISSIT model: A proposed conceptual scheme for the behavioral treatment of sexual problems. Journal of Sex Education and Therapy, 2(1), 1–15. https://doi.org/10.1080/01614576.1976.11074483"
+  },
+  {
+    "author": "Bancroft, J., & Janssen, E. (2000). The dual control model of male sexual response: A theoretical approach to centrally mediated erectile dysfunction. Neuroscience & Biobehavioral Reviews, 24(5), 571–579. https://doi.org/10.1016/S0149-7634(00)00024-5"
+  },
+  {
+    "author": "Barlow, D. H. (1986). Causes of sexual dysfunction: The role of anxiety and cognitive interference. Journal of Consulting and Clinical Psychology, 54(2), 140–148. https://doi.org/10.1037/0022-006X.54.2.140"
+  },
+  {
+    "author": "Basson, R. (2000). The female sexual response: A different model. Journal of Sex & Marital Therapy, 26(1), 51–65. https://doi.org/10.1080/009262300278641"
+  },
+  {
+    "author": "Binik, Y. M., & Hall, K. S. K. (Eds.). (2020). Principles and practice of sex therapy (6th ed.). Guilford Press"
+  },
+  {
+    "author": "Kaplan, H. S. (1974). The new sex therapy: Active treatment of sexual dysfunctions. Brunner/Mazel"
+  },
+  {
+    "author": "Masters, W. H., & Johnson, V. E. (1970). Human sexual inadequacy. Little, Brown"
+  },
+  {
+    "author": "Metz, M. E., & McCarthy, B. W. (2007). The “good-enough sex” model for couple sexual satisfaction. Sexual and Relationship Therapy, 22(3), 351–362. https://doi.org/10.1080/14681990601013492"
+  },
+  {
+    "author": "Weiner, L., & Avery-Clark, C. (2017). Sensate focus in sex therapy: The illustrated manual. Routledge"
+  },
+  {
+    "author": "Wincze, J. P., & Weisberg, R. B. (2015). Sexual dysfunction: A guide for assessment and treatment (3rd ed.). Guilford Press"
+  }
+];
+
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 async function main(){
@@ -1793,6 +1814,7 @@ async function main(){
   if(!doc){ console.error('CR-306 not found:', COURSE_DATA.slug); process.exit(1); }
   for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
   doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  doc.markModified('references');
   await doc.save();
   const fresh=await Course.findById(doc._id).lean();
   console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);

--- a/server/src/scripts/seedCR307-EXPANDED-canonical.js
+++ b/server/src/scripts/seedCR307-EXPANDED-canonical.js
@@ -764,100 +764,73 @@ const COURSE_DATA = {
   },
   "references": [
     {
-      "title": "AASECT position on sex addiction. https://www.aasect.org",
-      "author": "American Association of Sexuality Educators, Counselors and Therapists",
-      "year": 2016,
-      "source": "6). AASECT position on sex addiction. https://www.aasect.org"
+      "citation": "American Association of Sexuality Educators, Counselors and Therapists (2016). AASECT position on sex addiction. https://www.aasect.org"
     },
     {
-      "title": "Sexual addiction, sexual compulsivity, sexual impulsivity, or what? Journal of Sex Research, 41(3), 225–234.",
-      "author": "Bancroft, J",
-      "year": 2004,
-      "source": "pulsivity, or what? Journal of Sex Research, 41(3), 225–234."
+      "citation": "Bancroft, J. (2004). Sexual addiction, sexual compulsivity, sexual impulsivity, or what? Journal of Sex Research, 41(3), 225–234."
     },
     {
-      "title": "Out of the shadows: Understanding sexual addiction. CompCare Publications.",
-      "author": "Carnes, P",
-      "year": 1983,
-      "source": "dows: Understanding sexual addiction. CompCare Publications."
+      "citation": "Briken, P. (2020). An integrated model to assess and treat compulsive sexual behaviour disorder. Nature Reviews Urology, 17(7), 391–406. https://doi.org/10.1038/s41585-020-0343-7"
     },
     {
-      "title": "Is your patient suffering from compulsive sexual behavior? Psychiatric Annals, 22(6), 320–325.",
-      "author": "Coleman, E",
-      "year": 1992,
-      "source": "pulsive sexual behavior? Psychiatric Annals, 22(6), 320–325."
+      "citation": "Carnes, P. (1983). Out of the shadows: Understanding sexual addiction. CompCare Publications."
     },
     {
-      "title": "What's in a name? Terminology for designating a syndrome of driven sexual behavior. Sexual Addiction & Compulsivity, 8(",
-      "author": "Goodman, A",
-      "year": 2001,
-      "source": "behavior. Sexual Addiction & Compulsivity, 8(3–4), 191–213."
+      "citation": "Coleman, E. (1992). Is your patient suffering from compulsive sexual behavior? Psychiatric Annals, 22(6), 320–325."
     },
     {
-      "title": "Hypersexual disorder: A proposed diagnosis for DSM-5. Archives of Sexual Behavior, 39(2), 377–400.",
-      "author": "Kafka, M",
-      "year": 2010,
-      "source": "osis for DSM-5. Archives of Sexual Behavior, 39(2), 377–400."
+      "citation": "Gola, M., & Potenza, M. N. (2018). Promoting educational, classification, treatment, and policy initiatives: Commentary on: Compulsive sexual behaviour disorder in the ICD-11 (Kraus et al., 2018). Journal of Behavioral Addictions, 7(2), 208–210. https://doi.org/10.1556/2006.7.2018.51"
     },
     {
-      "title": "Hypersexuality and recidivism among sexual offenders. Sexual Addiction & Compulsivity, 20(1–2), 91–105.",
-      "author": "Kingston, D",
-      "year": 2013,
-      "source": "offenders. Sexual Addiction & Compulsivity, 20(1–2), 91–105."
+      "citation": "Goodman, A. (2001). What's in a name? Terminology for designating a syndrome of driven sexual behavior. Sexual Addiction & Compulsivity, 8("
     },
     {
-      "title": "Should compulsive sexual behavior be considered an addiction? Addiction, 111(12), 2097–2106.",
-      "author": "Kraus, S",
-      "year": 2016,
-      "source": "r be considered an addiction? Addiction, 111(12), 2097–2106."
+      "citation": "Grubbs, J. B., Hoagland, K. C., Lee, B. N., Grant, J. T., Davison, P., Reid, R. C., & Kraus, S. W. (2020). Sexual addiction 25 years on: A systematic and methodological review of empirical literature and an agenda for future research. Clinical Psychology Review, 82, 101925. https://doi.org/10.1016/j.cpr.2020.101925"
     },
     {
-      "title": "Impulsive-compulsive sexual behavior. CNS Spectrums, 11(12), 944–955.",
-      "author": "Mick, T",
-      "year": 2006,
-      "source": "-compulsive sexual behavior. CNS Spectrums, 11(12), 944–955."
+      "citation": "Grubbs, J. B., Perry, S. L., Wilt, J. A., & Reid, R. C. (2019). Pornography problems due to moral incongruence: An integrative model with a systematic review and meta-analysis. Archives of Sexual Behavior, 48(2), 397–415. https://doi.org/10.1007/s10508-018-1248-x"
     },
     {
-      "title": "Data do not support sex as addictive. Lancet Psychiatry, 4(12), 899.",
-      "author": "Prause, N",
-      "year": 2017,
-      "source": "not support sex as addictive. Lancet Psychiatry, 4(12), 899."
+      "citation": "Hook, J. N., Reid, R. C., Penberthy, J. K., Davis, D. E., & Jennings, D. J., II. (2014). Methodological review of treatments for nonparaphilic hypersexual behavior. Journal of Sex & Marital Therapy, 40(4), 294–308. https://doi.org/10.1080/0092623X.2012.751075"
     },
     {
-      "title": "Reliability, validity, and psychometric development of the Hypersexual Behavior Inventory in an outpatient sample of me",
-      "author": "Reid, R",
-      "year": 2011,
-      "source": "ample of men. Sexual Addiction & Compulsivity, 18(1), 30–51."
+      "citation": "Kafka, M. P. (2010). Hypersexual disorder: A proposed diagnosis for DSM-V. Archives of Sexual Behavior, 39(2), 377–400. https://doi.org/10.1007/s10508-009-9574-7"
     },
     {
-      "title": "Current status and future directions in couple therapy. Annual Review of Psychology, 57, 317–344.",
-      "author": "Snyder, D",
-      "year": 2006,
-      "source": "in couple therapy. Annual Review of Psychology, 57, 317–344."
+      "citation": "Kingston, D. (2013). Hypersexuality and recidivism among sexual offenders. Sexual Addiction & Compulsivity, 20(1–2), 91–105."
     },
     {
-      "title": "The traumatic nature of disclosure for wives of sexual addicts. Sexual Addiction & Compulsivity, 13(2–3), 247–267.",
-      "author": "Steffens, B",
-      "year": 2006,
-      "source": "addicts. Sexual Addiction & Compulsivity, 13(2–3), 247–267."
+      "citation": "Kraus, S. (2016). Should compulsive sexual behavior be considered an addiction? Addiction, 111(12), 2097–2106."
     },
     {
-      "title": "Hypersexuality: A critical review and introduction to the 'Sexhavior Cycle.' Archives of Sexual Behavior, 46(8), 2231–2",
-      "author": "Walton, M",
-      "year": 2017,
-      "source": "avior Cycle.' Archives of Sexual Behavior, 46(8), 2231–2251."
+      "citation": "Kraus, S. W., Krueger, R. B., Briken, P., First, M. B., Stein, D. J., Kaplan, M. S., … Reed, G. M. (2018). Compulsive sexual behaviour disorder in the ICD-11. World Psychiatry, 17(1), 109–110. https://doi.org/10.1002/wps.20499"
     },
     {
-      "title": "International classification of diseases (11th revision). https://icd.who.int",
-      "author": "World Health Organization",
-      "year": 2019,
-      "source": "ssification of diseases (11th revision). https://icd.who.int"
+      "citation": "Mick, T. (2006). Impulsive-compulsive sexual behavior. CNS Spectrums, 11(12), 944–955."
     },
     {
-      "title": "Hypersexual disorder: A more cautious approach. Archives of Sexual Behavior, 39(3), 594–596.",
-      "author": "Winters, J",
-      "year": 2010,
-      "source": "tious approach. Archives of Sexual Behavior, 39(3), 594–596."
+      "citation": "Prause, N. (2017). Data do not support sex as addictive. Lancet Psychiatry, 4(12), 899."
+    },
+    {
+      "citation": "Reid, R. (2011). Reliability, validity, and psychometric development of the Hypersexual Behavior Inventory in an outpatient sample of me"
+    },
+    {
+      "citation": "Reid, R. C., Carpenter, B. N., Hook, J. N., Garos, S., Manning, J. C., Gilliland, R., … Fong, T. (2012). Report of findings in a DSM-5 field trial for hypersexual disorder. The Journal of Sexual Medicine, 9(11), 2868–2877. https://doi.org/10.1111/j.1743-6109.2012.02936.x"
+    },
+    {
+      "citation": "Snyder, D. (2006). Current status and future directions in couple therapy. Annual Review of Psychology, 57, 317–344."
+    },
+    {
+      "citation": "Steffens, B. (2006). The traumatic nature of disclosure for wives of sexual addicts. Sexual Addiction & Compulsivity, 13(2–3), 247–267."
+    },
+    {
+      "citation": "Walton, M. (2017). Hypersexuality: A critical review and introduction to the 'Sexhavior Cycle.' Archives of Sexual Behavior, 46(8), 2231–2"
+    },
+    {
+      "citation": "Winters, J. (2010). Hypersexual disorder: A more cautious approach. Archives of Sexual Behavior, 39(3), 594–596."
+    },
+    {
+      "citation": "World Health Organization. (2019). International classification of diseases (11th rev.). https://icd.who.int/"
     }
   ],
   "sections": [
@@ -1663,6 +1636,36 @@ const COURSE_DATA = {
   ]
 };
 
+COURSE_DATA.references = [
+  {
+    "author": "Briken, P. (2020). An integrated model to assess and treat compulsive sexual behaviour disorder. Nature Reviews Urology, 17(7), 391–406. https://doi.org/10.1038/s41585-020-0343-7"
+  },
+  {
+    "author": "Gola, M., & Potenza, M. N. (2018). Promoting educational, classification, treatment, and policy initiatives: Commentary on compulsive sexual behaviour disorder in the ICD-11. Journal of Behavioral Addictions, 7(2), 208–210. https://doi.org/10.1556/2006.7.2018.51"
+  },
+  {
+    "author": "Grubbs, J. B., Hoagland, K. C., Lee, B. N., Grant, J. T., Davison, P., Reid, R. C., & Kraus, S. W. (2020). Sexual addiction 25 years on: A systematic and methodological review of empirical literature and an agenda for future research. Clinical Psychology Review, 82, 101925. https://doi.org/10.1016/j.cpr.2020.101925"
+  },
+  {
+    "author": "Grubbs, J. B., Perry, S. L., Wilt, J. A., & Reid, R. C. (2019). Pornography problems due to moral incongruence: An integrative model with a systematic review and meta-analysis. Archives of Sexual Behavior, 48(2), 397–415. https://doi.org/10.1007/s10508-018-1248-x"
+  },
+  {
+    "author": "Hook, J. N., Reid, R. C., Penberthy, J. K., Davis, D. E., & Jennings, D. J., II. (2014). Methodological review of treatments for nonparaphilic hypersexual behavior. Journal of Sex & Marital Therapy, 40(4), 294–308. https://doi.org/10.1080/0092623X.2012.751075"
+  },
+  {
+    "author": "Kafka, M. P. (2010). Hypersexual disorder: A proposed diagnosis for DSM-V. Archives of Sexual Behavior, 39(2), 377–400. https://doi.org/10.1007/s10508-009-9574-7"
+  },
+  {
+    "author": "Kraus, S. W., Krueger, R. B., Briken, P., First, M. B., Stein, D. J., Kaplan, M. S., … Reed, G. M. (2018). Compulsive sexual behaviour disorder in the ICD-11. World Psychiatry, 17(1), 109–110. https://doi.org/10.1002/wps.20499"
+  },
+  {
+    "author": "Reid, R. C., Carpenter, B. N., Hook, J. N., Garos, S., Manning, J. C., Gilliland, R., … Fong, T. (2012). Report of findings in a DSM-5 field trial for hypersexual disorder. The Journal of Sexual Medicine, 9(11), 2868–2877. https://doi.org/10.1111/j.1743-6109.2012.02936.x"
+  },
+  {
+    "author": "World Health Organization. (2019). International classification of diseases (11th rev.). https://icd.who.int/"
+  }
+];
+
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 async function main(){
@@ -1671,6 +1674,7 @@ async function main(){
   if(!doc){ console.error('CR-307 not found:', COURSE_DATA.slug); process.exit(1); }
   for(const k of Object.keys(COURSE_DATA)) doc[k]=COURSE_DATA[k];
   doc.modules=undefined; doc.markModified('sections'); doc.markModified('assessment');
+  doc.markModified('references');
   await doc.save();
   const fresh=await Course.findById(doc._id).lean();
   console.log('Saved. Sections:',fresh.sections?.length,'| wordCount:',fresh.wordCount,'| accessType:',fresh.accessType,'| status:',fresh.status);


### PR DESCRIPTION
Adds APA-7 reference lists to the 5 canonical CR-303–307 sexual-health CE seed scripts. Each seed now writes a `references` array and `markModified('references')` so the field persists on save. Courses remain `status: draft` — NOT published.

### Scope — exactly 5 modified files
`git diff --stat main` → 5 files changed, 360 insertions(+), 257 deletions(-):
- `seedCR303-EXPANDED-canonical.js`
- `seedCR304-EXPANDED-canonical.js`
- `seedCR305-EXPANDED-canonical.js`
- `seedCR306-EXPANDED-canonical.js`
- `seedCR307-EXPANDED-canonical.js`

No viewer, route, model, or other files touched. Branch cut from current `main` (which already contains #530/#531), so the diff is clean against `main`.

### Pre-flight gates (all pass)
For each of 303–307: `node --check` OK · `grep -c '"references"'` ≥1 (=1) · `grep -c "markModified('references')"` =1 · `grep -c "modules:"` =0.

### ⚠️ Partial deploy — 2 items deferred
This branch was originally scoped for 8 files. The other two items could not be included because their inputs were not provided:
- **CR-401/402 "clean KC explanations"** — the clean overwrite files were not supplied; the versions currently on `main` still carry 20 placeholder flags each.
- **`topUpTierOneCE.js`** — file does not exist in the repo or any upload.

Per Ke's "Proceed", this PR ships the 5 reference files now; 401/402-clean + topUp to follow once the files are provided.

Seeding has NOT been run — awaiting confirmation that Render has deployed the branch.

https://claude.ai/code/session_01TN1G78V1cc3vxm5xC9US9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN1G78V1cc3vxm5xC9US9b)_