### PR TITLE
Practice Compliance module foundation (CR Teams) — data model, API, cron, dashboards

### DIFF
--- a/client/public/my-compliance.html
+++ b/client/public/my-compliance.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+  Practice Compliance — Member Self-View (NEW additive page; touches no existing pages).
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>My Compliance — CounselorReady</title>
+<style>
+  :root { --burgundy:#8B2542; --burgundy-dark:#6B1D34; --navy:#284157; --stone:#f5f3f0; --green:#2f7d51; --amber:#b8860b; --red:#a3302f; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:var(--navy); background:var(--stone); }
+  header.app { background:linear-gradient(135deg,#8B2542,#6B1D34); color:#fff; padding:18px 24px; }
+  header.app h1 { font-size:20px; margin:0; }
+  .wrap { max-width:920px; margin:0 auto; padding:24px; }
+  .card { background:#fff; border:1px solid #e6e2dc; border-radius:12px; padding:18px; margin-bottom:20px; }
+  .card h2 { margin:0 0 4px; font-size:17px; }
+  .muted { color:#7a8591; font-size:13px; }
+  table { width:100%; border-collapse:collapse; font-size:14px; }
+  th,td { text-align:left; padding:9px 8px; border-bottom:1px solid #eee; }
+  th { font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:#7a8591; }
+  .pill { display:inline-block; padding:3px 10px; border-radius:999px; font-size:12px; font-weight:700; }
+  .pill.completed { background:#e7f4ec; color:var(--green); }
+  .pill.assigned, .pill.in_progress { background:#eef1f4; color:var(--navy); }
+  .pill.overdue { background:#f9e6e6; color:var(--red); }
+  .pill.waived { background:#f3eef7; color:#6b4f8a; }
+  .ce { background:#fcf3df; color:#7a5a00; border:1px solid #ecd9a6; padding:2px 8px; border-radius:6px; font-size:11px; font-weight:700; }
+  .ext { background:#eef4fb; color:#2c5a86; border:1px solid #cfe0f0; padding:2px 8px; border-radius:6px; font-size:11px; }
+  .banner { background:#f9e6e6; border:1px solid #e7bcbc; color:var(--red); border-radius:10px; padding:12px 16px; margin-bottom:16px; font-weight:600; }
+  .counter { font-size:13px; background:#eef1f4; padding:4px 10px; border-radius:999px; }
+</style>
+</head>
+<body>
+<header class="app"><h1>My Compliance</h1></header>
+<div class="wrap" id="root">
+  <div class="card"><p class="muted">Loading…</p></div>
+</div>
+
+<script>
+const API = location.hostname==='localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
+const token = localStorage.getItem('token');
+const esc = s => String(s==null?'':s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+async function api(path) {
+  const ctrl = new AbortController(); const t = setTimeout(()=>ctrl.abort(), 20000);
+  try {
+    const res = await fetch(API + path, { headers: { 'Authorization': 'Bearer ' + token }, signal: ctrl.signal });
+    if (!res.ok) throw new Error(res.status);
+    return res.json();
+  } finally { clearTimeout(t); }
+}
+const fmt = d => d ? new Date(d).toLocaleDateString() : '';
+
+async function init() {
+  const root = document.getElementById('root');
+  if (!token) { root.innerHTML = '<div class="card"><h2>Sign in required</h2><p class="muted"><a href="/signin.html">Sign in</a> to view your assigned training.</p></div>'; return; }
+  let data;
+  try { data = await api('/api/me/compliance'); } catch (e) { root.innerHTML = '<div class="card"><p class="muted">Could not load your compliance data.</p></div>'; return; }
+  if (!data.orgs || !data.orgs.length) { root.innerHTML = '<div class="card"><h2>No assigned training</h2><p class="muted">You have no practice-assigned training. Your personal CE history is unaffected and remains in your dashboard.</p></div>'; return; }
+
+  root.innerHTML = data.orgs.map(o => {
+    const isAgency = o.segment === 'dbhdd_agency';
+    const banner = o.recoupmentRisk ? `<div class="banner">⚠ BILLING AT RISK — you have an overdue Standard Training Requirement. Complete it to restore billing eligibility.</div>` : '';
+    const counter = isAgency ? `<span class="counter">Annual hours: ${o.annualHours||0}/16</span>` : '';
+    const rows = (o.assignments||[]).map(a => `
+      <tr>
+        <td><strong>${esc(a.label||a.courseCode)}</strong>${a.external?' <span class="ext">tracked externally</span>':''}
+            ${a.creditedHours? `<span class="ce">Counts toward license renewal — ${a.creditedHours} CE hrs (NBCC ACEP #7760)</span>`:''}</td>
+        <td><span class="pill ${a.status}">${a.status.replace('_',' ')}</span></td>
+        <td>${fmt(a.dueDate)}</td>
+        <td>${a.completedAt?fmt(a.completedAt):'—'}</td>
+      </tr>`).join('') || '<tr><td colspan="4" class="muted">No assignments.</td></tr>';
+    return `<div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;">
+        <h2>Assigned by ${esc(o.name)}</h2>${counter}
+      </div>
+      <p class="muted">${isAgency?'DBHDD/DCH Agency compliance':'Practice compliance'}</p>
+      ${banner}
+      <table><thead><tr><th>Training</th><th>Status</th><th>Due</th><th>Completed</th></tr></thead><tbody>${rows}</tbody></table>
+    </div>`;
+  }).join('');
+}
+init().catch(e => { console.error(e); document.getElementById('root').innerHTML = '<div class="card"><p class="muted">Error loading compliance data.</p></div>'; });
+</script>
+</body>
+</html>

--- a/client/public/team-compliance.html
+++ b/client/public/team-compliance.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+  Practice Compliance — Owner Dashboard (NEW additive page; touches no existing pages).
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Practice Compliance — CounselorReady</title>
+<style>
+  :root { --burgundy:#8B2542; --burgundy-dark:#6B1D34; --navy:#284157; --stone:#f5f3f0; --green:#2f7d51; --amber:#b8860b; --red:#a3302f; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:var(--navy); background:var(--stone); }
+  header.app { background:linear-gradient(135deg,#8B2542,#6B1D34); color:#fff; padding:18px 24px; display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px; }
+  header.app h1 { font-size:20px; margin:0; font-weight:700; }
+  .wrap { max-width:1180px; margin:0 auto; padding:24px; }
+  select, button, input { font:inherit; }
+  select { padding:8px 10px; border-radius:8px; border:1px solid #cbd2d9; background:#fff; }
+  .btn { background:var(--burgundy); color:#fff; border:none; padding:9px 16px; border-radius:8px; cursor:pointer; font-weight:600; }
+  .btn:hover { background:var(--burgundy-dark); }
+  .btn.ghost { background:#fff; color:var(--burgundy); border:1px solid var(--burgundy); }
+  .strip { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:14px; margin:20px 0; }
+  .stat { background:#fff; border:1px solid #e6e2dc; border-radius:12px; padding:16px; }
+  .stat .n { font-size:28px; font-weight:800; }
+  .stat .l { font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:#7a8591; }
+  .card { background:#fff; border:1px solid #e6e2dc; border-radius:12px; padding:18px; margin-bottom:20px; }
+  .card h2 { margin:0 0 12px; font-size:16px; }
+  table { width:100%; border-collapse:collapse; font-size:14px; }
+  th,td { text-align:left; padding:10px 8px; border-bottom:1px solid #eee; }
+  th { font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:#7a8591; }
+  .pill { display:inline-block; padding:3px 10px; border-radius:999px; font-size:12px; font-weight:700; }
+  .pill.compliant { background:#e7f4ec; color:var(--green); }
+  .pill.at_risk { background:#fcf3df; color:var(--amber); }
+  .pill.non_compliant { background:#f9e6e6; color:var(--red); }
+  .risk { color:var(--red); font-weight:700; }
+  .muted { color:#7a8591; font-size:13px; }
+  .banner { background:#f9e6e6; border:1px solid #e7bcbc; color:var(--red); border-radius:10px; padding:12px 16px; margin-bottom:16px; font-weight:600; display:none; }
+  .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+  .seg { font-size:12px; background:#eef1f4; color:var(--navy); padding:3px 10px; border-radius:999px; }
+</style>
+</head>
+<body>
+<header class="app">
+  <h1>Practice Compliance</h1>
+  <div class="row">
+    <select id="orgPicker" aria-label="Select organization"></select>
+    <button class="btn ghost" id="binderBtn">⬇ Audit Binder</button>
+  </div>
+</header>
+
+<div class="wrap">
+  <div id="needAuth" class="card" style="display:none;">
+    <h2>Sign in required</h2>
+    <p class="muted">Please <a href="/signin.html">sign in</a> to view your practice compliance dashboard.</p>
+  </div>
+
+  <div id="noOrg" class="card" style="display:none;">
+    <h2>No practice yet</h2>
+    <p class="muted">You're not a member of a practice compliance organization. Create one to start tracking staff training, credentials, and audit-readiness.</p>
+  </div>
+
+  <div id="main" style="display:none;">
+    <div id="recoupBanner" class="banner"></div>
+
+    <div class="row" style="justify-content:space-between;">
+      <div class="muted">Next expiration: <strong id="nextExp">—</strong></div>
+      <div><span class="seg" id="segBadge">—</span></div>
+    </div>
+
+    <div class="strip" id="strip"></div>
+
+    <div class="card">
+      <h2>Staff compliance matrix</h2>
+      <div style="overflow-x:auto;">
+        <table id="matrix">
+          <thead><tr>
+            <th>Member</th><th>Role</th><th>Status</th><th>Trainings</th><th>Overdue</th>
+            <th>Credentials</th><th>Annual hrs</th><th>Flags</th>
+          </tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Training tracks</h2>
+      <p class="muted">Assign a track to apply its required trainings to matching members. Recurring items auto-renew on completion.</p>
+      <table id="tracks">
+        <thead><tr><th>Track</th><th>Segment</th><th>Applies to</th><th>Items</th><th></th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h2>State-mandate suggestions</h2>
+      <div id="suggestions" class="muted">—</div>
+    </div>
+  </div>
+</div>
+
+<script>
+const API = location.hostname==='localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
+const token = localStorage.getItem('token');
+let currentOrgId = null;
+
+function authHeaders(extra) { return Object.assign({ 'Authorization': 'Bearer ' + token }, extra||{}); }
+async function api(path, opts) {
+  const ctrl = new AbortController(); const t = setTimeout(()=>ctrl.abort(), 20000);
+  try {
+    const res = await fetch(API + path, Object.assign({ headers: authHeaders({'Content-Type':'application/json'}), signal: ctrl.signal }, opts||{}));
+    if (!res.ok) throw new Error((await res.json().catch(()=>({}))).error || res.status);
+    return res.json();
+  } finally { clearTimeout(t); }
+}
+const esc = s => String(s==null?'':s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+async function init() {
+  if (!token) { document.getElementById('needAuth').style.display='block'; return; }
+  let orgs = [];
+  try { orgs = await api('/api/organizations/mine'); } catch (e) { document.getElementById('needAuth').style.display='block'; return; }
+  if (!orgs.length) { document.getElementById('noOrg').style.display='block'; return; }
+  const picker = document.getElementById('orgPicker');
+  picker.innerHTML = orgs.map(o => `<option value="${o._id}">${esc(o.name)}</option>`).join('');
+  picker.onchange = () => loadOrg(picker.value);
+  document.getElementById('main').style.display='block';
+  loadOrg(orgs[0]._id);
+}
+
+async function loadOrg(orgId) {
+  currentOrgId = orgId;
+  const [data, tracks, suggestions] = await Promise.all([
+    api('/api/orgs/'+orgId+'/members'),
+    api('/api/orgs/'+orgId+'/tracks').catch(()=>[]),
+    api('/api/orgs/'+orgId+'/suggestions').catch(()=>({states:[],tracks:[]}))
+  ]);
+  const isAgency = data.organization.settings && data.organization.settings.segment === 'dbhdd_agency';
+  document.getElementById('segBadge').textContent = isAgency ? 'DBHDD/DCH Agency' : 'Private Practice';
+
+  const r = data.rollup;
+  document.getElementById('strip').innerHTML = [
+    ['Members', r.totalMembers], ['Compliant', r.compliant], ['At risk', r.atRisk],
+    ['Non-compliant', r.nonCompliant], ['Recoupment exposure', r.recoupmentExposure]
+  ].map(([l,n]) => `<div class="stat"><div class="n">${n}</div><div class="l">${l}</div></div>`).join('');
+
+  const banner = document.getElementById('recoupBanner');
+  if (r.recoupmentExposure > 0) { banner.style.display='block'; banner.textContent = `⚠ BILLING AT RISK — ${r.recoupmentExposure} member(s) have overdue Standard Training Requirement items. Services billed past the grace period are subject to recoupment.`; }
+  else banner.style.display='none';
+
+  // matrix
+  document.querySelector('#matrix tbody').innerHTML = data.members.map(m => `
+    <tr>
+      <td><strong>${esc(m.name)}</strong><div class="muted">${esc(m.email)}</div></td>
+      <td>${esc(m.role)}${m.title?`<div class="muted">${esc(m.title)}</div>`:''}</td>
+      <td><span class="pill ${m.status}">${m.status.replace('_',' ')}</span></td>
+      <td>${m.completed}/${m.totalAssignments}</td>
+      <td>${m.overdue>0?`<span class="risk">${m.overdue}</span>`:'0'}</td>
+      <td>${m.credentials}${m.expiredCredentials>0?` <span class="risk">(${m.expiredCredentials} expired)</span>`:''}</td>
+      <td>${isAgency ? (m.annualHours+'/16') : (m.annualHours||0)}</td>
+      <td>${m.recoupmentRisk?'<span class="risk">RECOUPMENT</span>':''}${!m.directContactCleared && isAgency?'<span class="muted"> · pre-contact</span>':''}</td>
+    </tr>`).join('') || '<tr><td colspan="8" class="muted">No members yet.</td></tr>';
+
+  // next expiration (soonest expiring among at-risk members is approximated via overall)
+  document.getElementById('nextExp').textContent = r.atRisk>0 || r.nonCompliant>0 ? 'review at-risk members below' : 'all current';
+
+  // tracks
+  document.querySelector('#tracks tbody').innerHTML = tracks.map(t => `
+    <tr>
+      <td><strong>${esc(t.name)}</strong>${t.manualVersion?`<div class="muted">${esc(t.manualVersion)}</div>`:''}</td>
+      <td><span class="seg">${esc((t.segment||'').replace('_',' '))}</span></td>
+      <td>${esc((t.appliesToRoles||[]).join(', ')||'—')}</td>
+      <td>${(t.items||[]).length}</td>
+      <td><button class="btn ghost" onclick="assignTrack('${t._id}','${esc(t.name).replace(/'/g,'')}')">Assign</button></td>
+    </tr>`).join('') || '<tr><td colspan="5" class="muted">No tracks available.</td></tr>';
+
+  // suggestions
+  const sug = suggestions || {};
+  document.getElementById('suggestions').innerHTML = (sug.states&&sug.states.length)
+    ? sug.states.map(s=>`<div><strong>${esc(s.name)}</strong>: ${esc(s.notes)}</div>`).join('') + `<div style="margin-top:8px;">Suggested tracks: ${esc((sug.tracks||[]).join(', ')||'—')}</div>`
+    : 'Set your states of operation in org settings to see suggestions.';
+}
+
+async function assignTrack(trackId, name) {
+  if (!confirm('Assign "'+name+'" to all matching active members?')) return;
+  try {
+    const out = await api('/api/orgs/'+currentOrgId+'/tracks/'+trackId+'/assign', { method:'POST', body: JSON.stringify({}) });
+    alert(out.message + (out.skipped?` (${out.skipped} already assigned)`:''));
+    loadOrg(currentOrgId);
+  } catch (e) { alert('Assign failed: ' + e.message); }
+}
+
+document.getElementById('binderBtn').onclick = async () => {
+  if (!currentOrgId) return;
+  try {
+    const res = await fetch(API+'/api/orgs/'+currentOrgId+'/audit-binder', { headers: authHeaders() });
+    if (!res.ok) throw new Error('Export failed');
+    const blob = await res.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = 'audit-binder.zip'; a.click();
+    URL.revokeObjectURL(a.href);
+  } catch (e) { alert('Audit binder export failed: ' + e.message); }
+};
+
+init().catch(e => { console.error(e); document.getElementById('needAuth').style.display='block'; });
+</script>
+</body>
+</html>

--- a/server/src/data/complianceCatalog.js
+++ b/server/src/data/complianceCatalog.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * Practice Compliance catalog metadata — CR-PC### series.
+ *
+ * DATA ONLY. This is the source-of-truth definition consumed by the idempotent
+ * seed script (scripts/seedComplianceCatalog.js). It does NOT author course
+ * CONTENT and it does NOT write to the database on import.
+ *
+ * `ceEligible` stays FALSE here for every entry — it only flips true in
+ * production after the owner's CE sign-off (Catalog spec §3). Course CONTENT
+ * (the InteractiveCourse documents) is authored separately and linked via
+ * ComplianceCourseMeta.courseRef.
+ *
+ * `complianceHours` for GA agency provider-based modules (PC401–PC409) are
+ * placeholders pending authoring; PC410 reflects the manual's stated bundle
+ * (Documentation 2h + Explanation of Services 1h + Service Coordination 1h +
+ * Safety 6h). Adjust at authoring time.
+ */
+
+// ── Layer 1: Private-practice board-CE compliance (Catalog spec §2) ──
+export const PRIVATE_PRACTICE_CATALOG = [
+  // Tier 1 — Annual Compliance Core
+  { code: 'CR-PC101',    title: 'HIPAA Privacy & Security: Annual Clinical Refresher', ceHours: 1.5, complianceHours: 1.5, recurrence: 'annual',   roleTargets: ['clinician', 'associate', 'supervisor'], tier: 1, segment: 'private_practice' },
+  { code: 'CR-PC101A',   title: 'HIPAA Essentials for Admin & Front Desk',            ceHours: 0,   complianceHours: 1.0, recurrence: 'annual',   roleTargets: ['admin', 'staff'], tier: 1, segment: 'private_practice' },
+  { code: 'CR-PC102-GA', title: 'Mandated Reporter: Georgia',  ceHours: 1.0, complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice', stateVariantOf: 'CR-PC102', state: 'GA' },
+  { code: 'CR-PC102-TX', title: 'Mandated Reporter: Texas',    ceHours: 1.0, complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice', stateVariantOf: 'CR-PC102', state: 'TX' },
+  { code: 'CR-PC102-FL', title: 'Mandated Reporter: Florida',  ceHours: 1.0, complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice', stateVariantOf: 'CR-PC102', state: 'FL' },
+  { code: 'CR-PC102-ID', title: 'Mandated Reporter: Idaho',    ceHours: 1.0, complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice', stateVariantOf: 'CR-PC102', state: 'ID' },
+  { code: 'CR-PC103',    title: 'Suicide Risk Assessment & Safety Planning',          ceHours: 2.0, complianceHours: 2.0, recurrence: 'annual',   roleTargets: ['clinician', 'associate', 'supervisor'], tier: 1, segment: 'private_practice' },
+  { code: 'CR-PC104',    title: 'Telehealth Annual Competency Refresher',             ceHours: 1.5, complianceHours: 1.5, recurrence: 'annual',   roleTargets: ['clinician', 'associate', 'supervisor'], tier: 1, segment: 'private_practice' },
+  { code: 'CR-PC105',    title: 'Breach Response & Incident Reporting: The First 24 Hours', ceHours: 0, complianceHours: 0.75, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice' },
+  { code: 'CR-PC106',    title: 'Cybersecurity Hygiene for Behavioral Health Practices',    ceHours: 0, complianceHours: 0.75, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'private_practice' },
+
+  // Tier 2 — Clinical Risk Management
+  { code: 'CR-PC201',    title: 'Documentation for Medical Necessity: Annual Refresher', ceHours: 1.5, complianceHours: 1.5, recurrence: 'annual',  roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice' },
+  { code: 'CR-PC202-GA', title: 'Duty to Warn & Duty to Protect: Georgia',  ceHours: 1.0, complianceHours: 1.0, recurrence: 'biennial', roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice', stateVariantOf: 'CR-PC202', state: 'GA' },
+  { code: 'CR-PC202-TX', title: 'Duty to Warn & Duty to Protect: Texas',    ceHours: 1.0, complianceHours: 1.0, recurrence: 'biennial', roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice', stateVariantOf: 'CR-PC202', state: 'TX' },
+  { code: 'CR-PC202-FL', title: 'Duty to Warn & Duty to Protect: Florida',  ceHours: 1.0, complianceHours: 1.0, recurrence: 'biennial', roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice', stateVariantOf: 'CR-PC202', state: 'FL' },
+  { code: 'CR-PC202-ID', title: 'Duty to Warn & Duty to Protect: Idaho',    ceHours: 1.0, complianceHours: 1.0, recurrence: 'biennial', roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice', stateVariantOf: 'CR-PC202', state: 'ID' },
+  { code: 'CR-PC203',    title: 'Boundaries, Ethics & Dual Relationships: Annual Refresher', ceHours: 2.0, complianceHours: 2.0, recurrence: 'annual',  roleTargets: ['clinician', 'associate', 'supervisor'], tier: 2, segment: 'private_practice' },
+  { code: 'CR-PC204',    title: 'Minor Clients: Consent, Custody & Records',  ceHours: 1.5, complianceHours: 1.5, recurrence: 'biennial', roleTargets: ['clinician', 'associate', 'admin'], tier: 2, segment: 'private_practice' },
+  { code: 'CR-PC205',    title: 'Records, Releases & Subpoenas',              ceHours: 1.0, complianceHours: 1.0, recurrence: 'biennial', roleTargets: ['all'], tier: 2, segment: 'private_practice' },
+  { code: 'CR-PC206',    title: 'Crisis De-escalation & Workplace Violence Prevention', ceHours: 1.5, complianceHours: 1.5, recurrence: 'annual', roleTargets: ['all'], tier: 2, segment: 'private_practice' },
+
+  // Tier 3 — Role-Specific
+  { code: 'CR-PC301',    title: 'Supervisor Essentials: Org-Based Supervision Practice', ceHours: 3.0, complianceHours: 3.0, recurrence: 'once',   roleTargets: ['supervisor'], tier: 3, segment: 'private_practice' },
+  { code: 'CR-PC302',    title: 'Front Desk Onboarding Bundle',               ceHours: 0,   complianceHours: 1.5, recurrence: 'once',   roleTargets: ['admin', 'staff'], tier: 3, segment: 'private_practice' },
+  { code: 'CR-PC303',    title: '42 CFR Part 2: SUD Confidentiality',         ceHours: 1.0, complianceHours: 1.0, recurrence: 'annual', roleTargets: ['clinician', 'associate'], tier: 3, segment: 'private_practice' }
+];
+
+// ── Layer 2: GA DBHDD/DCH agency provider-based modules (GA doc §5) ──
+// All compliance-only (ceEligible stays false), CR-delivered provider-based hours.
+const FY27Q1 = 'FY27-Q1';
+export const GA_AGENCY_CATALOG = [
+  { code: 'CR-PC401', title: 'Person-Centered Values & Holistic Treatment',                          complianceHours: 1.0, recurrence: 'once',   roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC402', title: 'Human Rights & Responsibilities of Individuals Served',                complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC403', title: 'Communication Skills for BH Staff',                                    complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC404', title: 'Crisis De-escalation Techniques',                                      complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC405', title: 'Fire Safety + Emergency & Disaster Procedures',                        complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC406', title: 'Standard Precautions & Infection Control',                             complianceHours: 1.0, recurrence: 'once',   roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC407', title: 'Medications & Side Effects Awareness (non-prescriber)',               complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC408', title: 'Recovery, Resiliency & Relapse Prevention Foundations',               complianceHours: 1.0, recurrence: 'once',   roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC409', title: 'Recognizing & Reporting Abuse, Neglect, Exploitation (GA/DBHDD reporting chain)', complianceHours: 1.0, recurrence: 'annual', roleTargets: ['all'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', manualVersion: FY27Q1 },
+  { code: 'CR-PC410', title: 'STR Provider-Based Bundle (Documentation · Explanation of Services · Service Coordination · Safety)', complianceHours: 10.0, recurrence: 'once', roleTargets: ['associate', 'staff'], tier: 1, segment: 'dbhdd_agency', deliveryMode: 'provider_based', subjectArea: 'STR Provider-Based', manualVersion: FY27Q1 }
+];
+
+// Full catalog with defaults applied. ceEligible ALWAYS false here (owner gate).
+export const COMPLIANCE_CATALOG = [...PRIVATE_PRACTICE_CATALOG, ...GA_AGENCY_CATALOG].map(c => ({
+  isComplianceCourse: true,
+  ceEligible: false,
+  ceHours: 0,
+  complianceHours: 0,
+  recurrence: 'annual',
+  roleTargets: [],
+  stateVariantOf: null,
+  state: null,
+  tier: 1,
+  segment: 'all',
+  subjectArea: null,
+  deliveryMode: 'cr_delivered',
+  crDelivered: true,
+  manualVersion: null,
+  active: true,
+  ...c
+}));
+
+export default COMPLIANCE_CATALOG;

--- a/server/src/data/complianceTracks.js
+++ b/server/src/data/complianceTracks.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * Global TrainingTrack seed templates (orgId: null).
+ *
+ * DATA ONLY — consumed by the idempotent seed script. The `{STATE}` placeholder
+ * in a courseCode resolves at assignment time from the org's primary state
+ * (organization.settings.statesOfOperation[0]); see complianceService.resolveCourseCode.
+ */
+
+// ── Layer 1: Private-practice templates (Catalog spec §4) ──
+export const PRIVATE_PRACTICE_TRACKS = [
+  {
+    name: 'Annual Compliance Core — Clinical',
+    segment: 'private_practice',
+    appliesToRoles: ['clinician', 'associate', 'supervisor'],
+    items: [
+      { courseCode: 'CR-PC101',        required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC102-{STATE}', required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC103',        required: true, dueDays: 45, recurrence: 'annual' },
+      { courseCode: 'CR-PC104',        required: true, dueDays: 45, recurrence: 'annual' },
+      { courseCode: 'CR-PC105',        required: true, dueDays: 60, recurrence: 'annual' },
+      { courseCode: 'CR-PC106',        required: true, dueDays: 60, recurrence: 'annual' }
+    ]
+  },
+  {
+    name: 'Annual Compliance Core — Admin/Staff',
+    segment: 'private_practice',
+    appliesToRoles: ['admin', 'staff'],
+    items: [
+      { courseCode: 'CR-PC101A',       required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC102-{STATE}', required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC105',        required: true, dueDays: 60, recurrence: 'annual' },
+      { courseCode: 'CR-PC106',        required: true, dueDays: 60, recurrence: 'annual' }
+    ]
+  },
+  {
+    name: 'New Clinician Onboarding',
+    segment: 'private_practice',
+    appliesToRoles: ['clinician', 'associate'],
+    items: [
+      { courseCode: 'CR-PC101',        required: true, dueDays: 14, recurrence: 'annual' },
+      { courseCode: 'CR-PC102-{STATE}', required: true, dueDays: 14, recurrence: 'annual' },
+      { courseCode: 'CR-PC103',        required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC104',        required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC201',        required: true, dueDays: 30, recurrence: 'annual' },
+      { courseCode: 'CR-PC204',        required: true, dueDays: 60, recurrence: 'biennial' },
+      { courseCode: 'CR-PC205',        required: true, dueDays: 60, recurrence: 'biennial' }
+    ]
+  },
+  {
+    name: 'Front Desk Onboarding',
+    segment: 'private_practice',
+    appliesToRoles: ['admin', 'staff'],
+    items: [
+      { courseCode: 'CR-PC302',        required: true, dueDays: 14, recurrence: 'none' },
+      { courseCode: 'CR-PC101A',       required: true, dueDays: 14, recurrence: 'annual' },
+      { courseCode: 'CR-PC205',        required: true, dueDays: 30, recurrence: 'biennial' }
+    ]
+  },
+  {
+    name: 'Supervisor Track',
+    segment: 'private_practice',
+    appliesToRoles: ['supervisor'],
+    items: [
+      { courseCode: 'CR-PC301',        required: true, dueDays: 60, recurrence: 'none' },
+      { courseCode: 'CR-PC203',        required: true, dueDays: 60, recurrence: 'annual' }
+    ]
+  }
+];
+
+// ── Layer 2: GA DBHDD/DCH agency seed tracks (GA doc §5) ──
+const FY27Q1 = 'FY27-Q1';
+export const GA_AGENCY_TRACKS = [
+  {
+    name: 'GA Agency — Orientation (pre-contact)',
+    segment: 'dbhdd_agency',
+    manualVersion: FY27Q1,
+    appliesToRoles: ['all'],
+    items: [
+      // dueDays: 0 — blocks direct-contact clearance until complete.
+      { courseCode: 'CR-PC409',  required: true, dueDays: 0, recurrence: 'annual', deliveryMode: 'provider_based' },
+      { courseCode: 'CR-PC101A', required: true, dueDays: 0, recurrence: 'annual', deliveryMode: 'provider_based' }
+      // + org policy attestation handled via the PolicyDoc / Attestation feature.
+    ]
+  },
+  {
+    name: 'GA Agency — First 60 Days',
+    segment: 'dbhdd_agency',
+    manualVersion: FY27Q1,
+    appliesToRoles: ['all'],
+    items: [
+      { courseCode: 'CR-PC401', required: true, dueDays: 60, recurrence: 'none',   deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC402', required: true, dueDays: 60, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC403', required: true, dueDays: 60, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC404', required: true, dueDays: 60, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC405', required: true, dueDays: 60, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC406', required: true, dueDays: 60, recurrence: 'none',   deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC407', required: true, dueDays: 60, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC408', required: true, dueDays: 60, recurrence: 'none',   deliveryMode: 'provider_based', hours: 1 },
+      // CPR / First Aid credential due — tracked, never delivered.
+      { courseCode: 'EXT-CPR-FA', label: 'CPR/First Aid (AHA/HSI/Red Cross)', required: true, dueDays: 60, recurrence: 'none', deliveryMode: 'external', external: true }
+    ]
+  },
+  {
+    name: 'GA Agency — Annual 16-Hour',
+    segment: 'dbhdd_agency',
+    manualVersion: FY27Q1,
+    annualHoursTarget: 16,
+    appliesToRoles: ['all'],
+    items: [
+      // The (*) annual topics; dashboard shows an hour counter x/16 per member.
+      { courseCode: 'CR-PC402', required: true, dueDays: 365, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC403', required: true, dueDays: 365, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC404', required: true, dueDays: 365, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC405', required: true, dueDays: 365, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 },
+      { courseCode: 'CR-PC407', required: true, dueDays: 365, recurrence: 'annual', deliveryMode: 'provider_based', hours: 1 }
+      // + makeup hours to reach 16 — surfaced by the annual hour counter.
+    ]
+  },
+  {
+    name: 'GA Paraprofessional STR (90-day)',
+    segment: 'dbhdd_agency',
+    manualVersion: FY27Q1,
+    strHoursTarget: 46,
+    appliesToRoles: ['associate', 'staff'],
+    items: [
+      // Provider-based bundle CR delivers (17 provider-based hours envelope).
+      { courseCode: 'CR-PC410', required: true, dueDays: 90, recurrence: 'none', deliveryMode: 'provider_based', subjectArea: 'STR Provider-Based', hours: 10 },
+      // External Relias online subject-area tracking (29 hrs) — tracked, never delivered.
+      { courseCode: 'EXT-RELIAS-STR', label: 'DBHDD Relias STR online (29 hrs)', required: true, dueDays: 90, recurrence: 'none', deliveryMode: 'relias_online', external: true, subjectArea: 'STR Online (Relias)', hours: 29 },
+      // CPR/First Aid credential due — external.
+      { courseCode: 'EXT-CPR-FA', label: 'CPR/First Aid (AHA/HSI/Red Cross)', required: true, dueDays: 90, recurrence: 'none', deliveryMode: 'external', external: true, subjectArea: 'First Aid and CPR', hours: 6 }
+    ]
+  },
+  {
+    name: 'GA Residential/24-hr add-on',
+    segment: 'dbhdd_agency',
+    manualVersion: FY27Q1,
+    appliesToRoles: ['all'],
+    items: [
+      // BLS-level CPR enforcement for all direct care + clinical staff (§2.D).
+      { courseCode: 'EXT-CPR-BLS', label: 'BLS-level CPR + First Aid (written + hands-on)', required: true, dueDays: 60, recurrence: 'none', deliveryMode: 'external', external: true }
+    ]
+  }
+];
+
+export const GLOBAL_TRACKS = [...PRIVATE_PRACTICE_TRACKS, ...GA_AGENCY_TRACKS];
+export default GLOBAL_TRACKS;

--- a/server/src/data/stateMandates.js
+++ b/server/src/data/stateMandates.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * State-mandate suggestion map (Practice Compliance §3.9).
+ *
+ * DATA ONLY. Starts with the owner's licensure states (GA, TX, FL, ID) and is
+ * easily extended. Drives "suggested global tracks" from an org's
+ * settings.statesOfOperation. Suggestions are advisory — never auto-assigned.
+ */
+export const STATE_MANDATES = {
+  GA: {
+    name: 'Georgia',
+    suggestedTracks: ['Annual Compliance Core — Clinical', 'New Clinician Onboarding'],
+    suggestedCourses: ['CR-PC102-GA', 'CR-PC202-GA'],
+    notes: 'GA Composite Board Rule 135-9/135-11. Ethics hours must be synchronous. Agency orgs add the DBHDD/DCH layer.'
+  },
+  TX: {
+    name: 'Texas',
+    suggestedTracks: ['Annual Compliance Core — Clinical', 'Supervisor Track'],
+    suggestedCourses: ['CR-PC102-TX', 'CR-PC202-TX'],
+    notes: 'Texas LPC rules. Supervision of associates documented per board requirements.'
+  },
+  FL: {
+    name: 'Florida',
+    suggestedTracks: ['Annual Compliance Core — Clinical'],
+    suggestedCourses: ['CR-PC102-FL', 'CR-PC202-FL'],
+    notes: 'Florida 491 board. Telehealth registration tracked as a credential.'
+  },
+  ID: {
+    name: 'Idaho',
+    suggestedTracks: ['Annual Compliance Core — Clinical'],
+    suggestedCourses: ['CR-PC102-ID', 'CR-PC202-ID'],
+    notes: 'Idaho counseling board requirements.'
+  }
+};
+
+/**
+ * Suggest global track names + state-variant courses for an org's states.
+ * @param {string[]} states - e.g. ['GA','TX']
+ * @returns {{ tracks: string[], courses: string[], states: object[] }}
+ */
+export function suggestForStates(states = []) {
+  const tracks = new Set();
+  const courses = new Set();
+  const stateInfo = [];
+  for (const raw of states) {
+    const code = String(raw || '').toUpperCase();
+    const entry = STATE_MANDATES[code];
+    if (!entry) continue;
+    entry.suggestedTracks.forEach(t => tracks.add(t));
+    entry.suggestedCourses.forEach(c => courses.add(c));
+    stateInfo.push({ code, name: entry.name, notes: entry.notes });
+  }
+  return { tracks: [...tracks], courses: [...courses], states: stateInfo };
+}
+
+export default STATE_MANDATES;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -95,6 +95,8 @@ import organizationsRoutes from './routes/organizations.js';
 import auditKitRoutes from './routes/auditKit.js';
 import uploadsRoutes from './routes/uploads.js';
 import videoAuditRoutes from './routes/videoAudit.js';
+import orgRoutes from './routes/orgRoutes.js';
+import complianceRoutes from './routes/complianceRoutes.js';
 import { runVideoLinkAudit } from './jobs/videoLinkAuditJob.js';
 
 // ═══════════════════════════════════════════════════════════════
@@ -108,6 +110,7 @@ import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
 import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
 import { runHardshipPauseResume } from './jobs/hardshipPauseResume.js';
 import { runCertificateSelfHeal } from './jobs/certificateSelfHeal.js';
+import { runComplianceDailyJob } from './services/complianceService.js';
 
 import { ROUTE_MANIFEST } from './routeManifest.js';
 
@@ -287,6 +290,8 @@ app.use('/api/organizations', organizationsRoutes);
 app.use('/api/audit-kit', auditKitRoutes);
 app.use('/api/uploads', uploadsRoutes);
 app.use('/api/admin/video-audit', videoAuditRoutes);
+app.use('/api/orgs', orgRoutes);
+app.use('/api', complianceRoutes);
 
 app.use('/templates', express.static(path.join(__dirname, 'templates')));
 
@@ -432,6 +437,14 @@ const startServer = async () => {
       .catch(err => console.error('[VideoAudit] Weekly cron error:', err.message));
   }, { timezone: 'America/New_York' });
   logger.info('Video link audit cron scheduled (Mondays 3 AM ET)');
+
+  // Practice Compliance daily job — cert→assignment reconciliation, overdue
+  // flips, due/expiry alerts, annual recurrence, GA STR recoupment alerts —
+  // daily at 7 AM ET.
+  cron.schedule('0 7 * * *', () => {
+    runComplianceDailyJob().catch(err => console.error('Compliance daily job error:', err.message));
+  }, { timezone: 'America/New_York' });
+  logger.info('Practice Compliance daily job cron scheduled (daily 7 AM ET)');
   // PostHog server-side analytics
   const phKey = process.env.POSTHOG_API_KEY || 'phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb';
   global.posthog = new PostHog(phKey, { host: 'https://us.i.posthog.com' });

--- a/server/src/middleware/requireOrgRole.js
+++ b/server/src/middleware/requireOrgRole.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * requireOrgRole(...roles) — Practice Compliance org-membership authorization.
+ *
+ * Layers ON TOP OF the existing `protect` auth middleware (which sets req.user).
+ * It does NOT modify or replace any existing auth middleware. It loads the
+ * Organization seat (membership) for (req.user, :orgId) and enforces role.
+ *
+ * Attaches:
+ *   req.org        — the Organization document
+ *   req.membership — the matching seat subdocument (the membership)
+ *   req.orgRole    — the member's role string
+ *
+ * Usage:
+ *   router.get('/:orgId/members', protect, requireOrgRole('owner','admin','manager'), handler)
+ *   router.get('/:orgId',         protect, requireOrgRole(),                          handler) // any active member
+ *
+ * The org owner is always authorized regardless of the requested role list.
+ */
+import Organization from '../models/Organization.js';
+
+// Roles that can administer an org (manage members, tracks, assignments, policies).
+export const ORG_ADMIN_ROLES = ['owner', 'admin', 'manager'];
+
+export function requireOrgRole(...roles) {
+  return async (req, res, next) => {
+    try {
+      const orgId = req.params.orgId || req.params.id;
+      if (!orgId) {
+        return res.status(400).json({ error: 'Organization id required' });
+      }
+      if (!req.user) {
+        return res.status(401).json({ error: 'Not authorized' });
+      }
+
+      const org = await Organization.findById(orgId);
+      if (!org) {
+        return res.status(404).json({ error: 'Organization not found' });
+      }
+
+      // Platform admins may access any org (parity with existing admin patterns).
+      const isPlatformAdmin = req.user.role === 'admin';
+
+      const seat = org.seats.find(
+        s => s.userId && s.userId.equals(req.user._id) && s.status === 'active'
+      );
+
+      if (!seat && !isPlatformAdmin) {
+        return res.status(403).json({ error: 'Not a member of this organization' });
+      }
+
+      const effectiveRole = seat ? seat.role : 'admin';
+      const isOwner = org.ownerId.equals(req.user._id) || effectiveRole === 'owner';
+
+      // No specific roles requested ⇒ any active member (or platform admin) passes.
+      if (roles.length > 0 && !isOwner && !isPlatformAdmin && !roles.includes(effectiveRole)) {
+        return res.status(403).json({
+          error: 'Insufficient organization role for this action',
+          required: roles
+        });
+      }
+
+      req.org = org;
+      req.membership = seat || null;
+      req.orgRole = effectiveRole;
+      next();
+    } catch (error) {
+      console.error('requireOrgRole error:', error);
+      res.status(500).json({ error: error.message });
+    }
+  };
+}
+
+export default requireOrgRole;

--- a/server/src/models/Assignment.js
+++ b/server/src/models/Assignment.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * Assignment — one person, one training, one due date.
+ *
+ * NEW additive collection. The membership reference is the Organization seat
+ * subdocument (`seatId`) — per the chosen "extend Organization.seats[]" model —
+ * plus `userId` for convenient joins with Certificate/CourseProgress.
+ *
+ * Completion is wired via the NIGHTLY CRON reconciliation in
+ * services/complianceService.js — NOT by editing the locked certificate
+ * issuance pipeline.
+ */
+import mongoose from 'mongoose';
+
+const assignmentSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true, index: true },
+  seatId: { type: mongoose.Schema.Types.ObjectId }, // Organization.seats[]._id (the membership)
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+
+  courseCode: { type: String, trim: true, uppercase: true },
+  courseRef: { type: mongoose.Schema.Types.ObjectId, ref: 'InteractiveCourse', default: null },
+  // Snapshot title for robust cert-matching when courseRef is not yet linked.
+  courseTitle: { type: String, trim: true },
+  label: { type: String, trim: true },
+
+  trackId: { type: mongoose.Schema.Types.ObjectId, ref: 'TrainingTrack', default: null },
+
+  dueDate: { type: Date },
+  status: {
+    type: String,
+    enum: ['assigned', 'in_progress', 'completed', 'overdue', 'waived'],
+    default: 'assigned'
+  },
+  completedAt: { type: Date },
+  certificateId: { type: mongoose.Schema.Types.ObjectId, ref: 'Certificate', default: null },
+
+  recurrence: { type: String, enum: ['none', 'annual', 'biennial'], default: 'none' },
+  recurrenceParentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Assignment', default: null },
+
+  // GA DBHDD agency hour accounting (§2c 16-hr annual, §3 STR 46-hr)
+  subjectArea: { type: String, default: null },
+  hours: { type: Number, default: 0 },          // target/seat-time hours for this item
+  creditedHours: { type: Number, default: 0 },  // hours actually credited on completion
+  manualVersion: { type: String, default: null, trim: true },
+
+  deliveryMode: {
+    type: String,
+    enum: ['cr_delivered', 'provider_based', 'relias_online', 'external'],
+    default: 'cr_delivered'
+  },
+  external: { type: Boolean, default: false }, // tracked-not-delivered (Relias/CPR/etc.)
+
+  // GA STR recoupment exposure (§3): overdue STR item past the 90-day grace ⇒
+  // services billed are subject to recoupment. Set by complianceService.
+  recoupmentRisk: { type: Boolean, default: false },
+
+  waivedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  waivedReason: { type: String, trim: true },
+
+  // Dedupe ledger for due/overdue notifications: '14d','7d','1d','overdue'
+  alertsSent: [{ type: String }]
+}, {
+  timestamps: true
+});
+
+assignmentSchema.index({ orgId: 1, status: 1 });
+assignmentSchema.index({ userId: 1, status: 1 });
+assignmentSchema.index({ orgId: 1, seatId: 1 });
+
+const Assignment = mongoose.model('Assignment', assignmentSchema);
+export default Assignment;

--- a/server/src/models/Attestation.js
+++ b/server/src/models/Attestation.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * Attestation — a member's signed acknowledgement of a specific PolicyDoc version.
+ *
+ * NEW additive collection. The unique index on (userId, policyDocId, policyVersion)
+ * means a NEW policy version re-opens the attestation requirement automatically.
+ */
+import mongoose from 'mongoose';
+
+const attestationSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true, index: true },
+  seatId: { type: mongoose.Schema.Types.ObjectId }, // Organization.seats[]._id (the membership)
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+
+  policyDocId: { type: mongoose.Schema.Types.ObjectId, ref: 'PolicyDoc', required: true },
+  policyVersion: { type: Number, required: true },
+
+  signedAt: { type: Date, default: Date.now },
+  signatureName: { type: String, trim: true },
+  ip: { type: String },
+  userAgent: { type: String }
+}, {
+  timestamps: true
+});
+
+// One attestation per member per policy version. New version ⇒ new requirement.
+attestationSchema.index({ userId: 1, policyDocId: 1, policyVersion: 1 }, { unique: true });
+
+const Attestation = mongoose.model('Attestation', attestationSchema);
+export default Attestation;

--- a/server/src/models/ComplianceCourseMeta.js
+++ b/server/src/models/ComplianceCourseMeta.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * ComplianceCourseMeta — Practice Compliance catalog metadata (CR-PC### series).
+ *
+ * NEW additive collection. Intentionally separate from Course.js (hard-locked)
+ * and InteractiveCourse (primary content schema). This holds ONLY the catalog /
+ * compliance metadata for the Practice Compliance module; `courseRef` links to
+ * the actual InteractiveCourse content document once it is authored.
+ *
+ * Nothing here delivers course content — it describes and classifies it.
+ */
+import mongoose from 'mongoose';
+
+const complianceCourseMetaSchema = new mongoose.Schema({
+  // CR-PC### catalog code, e.g. 'CR-PC101', 'CR-PC102-GA', 'CR-PC410'
+  code: { type: String, required: true, unique: true, trim: true, uppercase: true },
+  title: { type: String, required: true, trim: true },
+
+  // CE framing — `ceEligible` only flips true after owner CE sign-off.
+  isComplianceCourse: { type: Boolean, default: true },
+  ceEligible: { type: Boolean, default: false },
+  ceHours: { type: Number, default: 0, min: 0 },        // NBCC CE clock hours (0 if compliance-only)
+  complianceHours: { type: Number, default: 0, min: 0 }, // seat-time for the audit binder
+
+  recurrence: { type: String, enum: ['once', 'annual', 'biennial'], default: 'annual' },
+
+  // 'clinician' | 'associate' | 'admin' | 'staff' | 'supervisor' | 'all'
+  roleTargets: [{ type: String }],
+
+  // State-variant relationship (e.g. CR-PC102-GA is a variant of CR-PC102)
+  stateVariantOf: { type: String, default: null, trim: true, uppercase: true },
+  state: { type: String, default: null, uppercase: true }, // 'GA' | 'TX' | 'FL' | 'ID'
+
+  tier: { type: Number, default: 1 }, // catalog priority 1 | 2 | 3
+
+  // Which compliance layer this course belongs to.
+  segment: {
+    type: String,
+    enum: ['private_practice', 'dbhdd_agency', 'all'],
+    default: 'all'
+  },
+
+  // GA DBHDD agency layer fields (Standard Training Requirement / hour accounting)
+  subjectArea: { type: String, default: null }, // STR subject area, e.g. 'Documentation'
+
+  // CR delivery boundary honesty (GA doc §6.6): CR delivers provider-based hours;
+  // Relias online, CPR/FA, and Deaf Crisis training are TRACKED, never delivered.
+  deliveryMode: {
+    type: String,
+    enum: ['cr_delivered', 'provider_based', 'relias_online', 'external'],
+    default: 'cr_delivered'
+  },
+  crDelivered: { type: Boolean, default: true },
+
+  // Link to the actual content document once authored (null until built).
+  courseRef: { type: mongoose.Schema.Types.ObjectId, ref: 'InteractiveCourse', default: null },
+
+  // Quarterly DBHDD manual versioning, e.g. 'FY27-Q1'. null for board-CE layer.
+  manualVersion: { type: String, default: null, trim: true },
+
+  active: { type: Boolean, default: true }
+}, {
+  timestamps: true
+});
+
+complianceCourseMetaSchema.index({ segment: 1, tier: 1 });
+complianceCourseMetaSchema.index({ stateVariantOf: 1, state: 1 });
+
+const ComplianceCourseMeta = mongoose.model('ComplianceCourseMeta', complianceCourseMetaSchema);
+export default ComplianceCourseMeta;

--- a/server/src/models/OrgCredential.js
+++ b/server/src/models/OrgCredential.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * OrgCredential — org-managed license / insurance / cert vault per member.
+ *
+ * NEW additive collection. Intentionally distinct from the personal
+ * `UserCredential` vault (which is the clinician's own, B2C). This record is
+ * owned and tracked by the ORGANIZATION (verifiedBy, alert ledger, evidence
+ * file), so solo B2C users are completely unaffected.
+ */
+import mongoose from 'mongoose';
+
+const orgCredentialSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true, index: true },
+  seatId: { type: mongoose.Schema.Types.ObjectId }, // Organization.seats[]._id (the membership)
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+
+  type: {
+    type: String,
+    enum: [
+      'license', 'liability_insurance', 'cpr', 'first_aid', 'caqh', 'npi',
+      'background_check', 'drivers_license', 'deaf_crisis', 'relias_str', 'other'
+    ],
+    default: 'other'
+  },
+  label: { type: String, trim: true }, // "GA LPC", "FL Telehealth Registration"
+  state: { type: String, default: null, uppercase: true },
+  identifier: { type: String, trim: true }, // license #, policy #, NPI
+
+  // GA DBHDD CPR/AED level field (§2b item 13): accepted bodies AHA / HSI / Red Cross.
+  level: {
+    type: String,
+    enum: ['professional_rescuer_bls', 'lay_rescuer', 'bls_cla', 'first_aid', null],
+    default: null
+  },
+  issuingBody: { type: String, default: null }, // 'AHA' | 'HSI' | 'Red Cross' | other
+
+  // GA Relias STR external completion tracking (§3): per-subject-area hours.
+  subjectArea: { type: String, default: null },
+  hours: { type: Number, default: 0 },
+  manualVersion: { type: String, default: null, trim: true },
+
+  issuedAt: { type: Date },
+  expiresAt: { type: Date, default: null, index: true },
+
+  fileUrl: { type: String },   // uploaded evidence
+  fileKey: { type: String },
+  fileName: { type: String },
+
+  verifiedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  verifiedAt: { type: Date },
+
+  // Expiry alert dedupe ledger: '90d','60d','30d','7d'
+  alertsSent: [{ type: String }]
+}, {
+  timestamps: true
+});
+
+orgCredentialSchema.index({ orgId: 1, seatId: 1 });
+orgCredentialSchema.index({ orgId: 1, type: 1 });
+
+// Days until expiration (null when no expiry set).
+orgCredentialSchema.virtual('daysUntilExpiration').get(function () {
+  if (!this.expiresAt) return null;
+  return Math.ceil((this.expiresAt.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+});
+
+orgCredentialSchema.set('toJSON', { virtuals: true });
+orgCredentialSchema.set('toObject', { virtuals: true });
+
+const OrgCredential = mongoose.model('OrgCredential', orgCredentialSchema);
+export default OrgCredential;

--- a/server/src/models/OrgSupervisionLog.js
+++ b/server/src/models/OrgSupervisionLog.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * OrgSupervisionLog — org-scoped supervision session with dual sign-off.
+ *
+ * NEW additive collection. Intentionally distinct from the existing personal,
+ * user-scoped `SupervisionLog` (that working model is NOT modified). This one
+ * binds a supervisee membership to a supervisor membership for org/ASO quality
+ * reviews, and supports the GA CADC-T documentation form (Manual Appendix D).
+ *
+ * Running totals are computed on read (aggregate), not stored.
+ */
+import mongoose from 'mongoose';
+
+const orgSupervisionLogSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true, index: true },
+
+  superviseeSeatId: { type: mongoose.Schema.Types.ObjectId },
+  superviseeUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+  supervisorSeatId: { type: mongoose.Schema.Types.ObjectId },
+  supervisorUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  supervisorName: { type: String, trim: true },
+
+  date: { type: Date, required: true },
+  hours: { type: Number, required: true, min: 0 },
+  format: { type: String, enum: ['individual', 'group', 'triadic'], default: 'individual' },
+  modality: { type: String, enum: ['in_person', 'telehealth'], default: 'in_person' },
+
+  // GA DBHDD §II.7–8: CADC-T form (Manual Appendix D) for CADC-trainees.
+  formType: { type: String, enum: ['standard', 'CADC-T'], default: 'standard' },
+
+  notes: { type: String },
+  superviseeSignedAt: { type: Date },
+  supervisorSignedAt: { type: Date }
+}, {
+  timestamps: true
+});
+
+orgSupervisionLogSchema.index({ orgId: 1, superviseeUserId: 1 });
+
+const OrgSupervisionLog = mongoose.model('OrgSupervisionLog', orgSupervisionLogSchema);
+export default OrgSupervisionLog;

--- a/server/src/models/Organization.js
+++ b/server/src/models/Organization.js
@@ -8,10 +8,18 @@ import mongoose from 'mongoose';
 const seatSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   email: { type: String, required: true, lowercase: true },
-  role: { type: String, enum: ['member', 'manager', 'owner'], default: 'member' },
+  role: { type: String, enum: ['member', 'manager', 'owner', 'admin', 'clinician', 'associate', 'staff', 'supervisor'], default: 'member' },
   invitedAt: { type: Date, default: Date.now },
   joinedAt: { type: Date },
-  status: { type: String, enum: ['invited', 'active', 'removed'], default: 'invited' }
+  status: { type: String, enum: ['invited', 'active', 'removed', 'suspended', 'offboarded'], default: 'invited' },
+  // ── Practice Compliance module additions (additive; existing seats unaffected) ──
+  employmentType: { type: String, enum: ['w2', '1099', 'intern', 'volunteer', 'contractor', null], default: null },
+  title: { type: String, trim: true },       // free text: "LPC", "LMSW Associate", "Office Manager"
+  hireDate: { type: Date },
+  offboardedAt: { type: Date },
+  inviteToken: { type: String },             // email invite flow
+  // GA DBHDD §1 agency: block direct contact until orientation track complete
+  directContactCleared: { type: Boolean, default: false }
 }, { _id: true });
 
 const organizationSchema = new mongoose.Schema({
@@ -55,7 +63,13 @@ const organizationSchema = new mongoose.Schema({
     requireCourseApproval: { type: Boolean, default: false },
     sharedCredentialTracking: { type: Boolean, default: true },
     complianceAlerts: { type: Boolean, default: true },
-    allowSelfEnroll: { type: Boolean, default: true }
+    allowSelfEnroll: { type: Boolean, default: true },
+    // ── Practice Compliance module additions (additive) ──
+    // Which compliance layer this org operates under. Drives which global tracks apply.
+    segment: { type: String, enum: ['private_practice', 'dbhdd_agency'], default: 'private_practice' },
+    statesOfOperation: [{ type: String, uppercase: true }], // drives state-mandate suggestions
+    timezone: { type: String, default: 'America/New_York' },
+    alertEmails: [{ type: String, lowercase: true }]        // extra recipients for expiry/overdue digests
   }
 }, {
   timestamps: true

--- a/server/src/models/PolicyDoc.js
+++ b/server/src/models/PolicyDoc.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * PolicyDoc — an org policy document requiring acknowledgement / e-signature.
+ *
+ * NEW additive collection. A new `version` re-opens the attestation requirement
+ * for everyone in scope automatically (see Attestation unique index).
+ */
+import mongoose from 'mongoose';
+
+const policyDocSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true, index: true },
+  title: { type: String, required: true, trim: true },
+  version: { type: Number, default: 1 },
+  fileUrl: { type: String },
+  fileKey: { type: String },
+  fileName: { type: String },
+  requiresSignature: { type: Boolean, default: true },
+  appliesToRoles: [{ type: String }],
+  active: { type: Boolean, default: true }
+}, {
+  timestamps: true
+});
+
+policyDocSchema.index({ orgId: 1, active: 1 });
+
+const PolicyDoc = mongoose.model('PolicyDoc', policyDocSchema);
+export default PolicyDoc;

--- a/server/src/models/TrainingTrack.js
+++ b/server/src/models/TrainingTrack.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * TrainingTrack — reusable bundle of required trainings per role.
+ *
+ * NEW additive collection. `orgId: null` denotes a CR global template
+ * (e.g. "Annual Compliance Core", "GA Agency — First 60 Days"). Items reference
+ * compliance courses by their CR-PC code (and, when authored, by courseRef).
+ */
+import mongoose from 'mongoose';
+
+const trackItemSchema = new mongoose.Schema({
+  courseCode: { type: String, trim: true, uppercase: true }, // 'CR-PC101', or 'CR-PC102-{STATE}' placeholder
+  courseRef: { type: mongoose.Schema.Types.ObjectId, ref: 'InteractiveCourse', default: null },
+  label: { type: String, trim: true },
+  required: { type: Boolean, default: true },
+  dueDays: { type: Number, default: 30 },   // days from assignment to due
+  recurrence: { type: String, enum: ['none', 'annual', 'biennial'], default: 'none' },
+
+  // GA DBHDD agency hour accounting (§3 STR, §2c annual 16-hr)
+  subjectArea: { type: String, default: null },
+  hours: { type: Number, default: 0 },
+
+  deliveryMode: {
+    type: String,
+    enum: ['cr_delivered', 'provider_based', 'relias_online', 'external'],
+    default: 'cr_delivered'
+  },
+  // true = tracked-as-credential, CR does not deliver (Relias online, CPR/FA, Deaf Crisis)
+  external: { type: Boolean, default: false }
+}, { _id: true });
+
+const trainingTrackSchema = new mongoose.Schema({
+  orgId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', default: null, index: true },
+  name: { type: String, required: true, trim: true },
+
+  segment: {
+    type: String,
+    enum: ['private_practice', 'dbhdd_agency'],
+    default: 'private_practice'
+  },
+
+  appliesToRoles: [{ type: String }],
+  items: [trackItemSchema],
+
+  // GA DBHDD quarterly manual versioning, e.g. 'FY27-Q1'
+  manualVersion: { type: String, default: null, trim: true },
+
+  // §2c GA annual 16-hr target / §3 STR 46-hr target — drives the hour counter
+  annualHoursTarget: { type: Number, default: 0 },
+  strHoursTarget: { type: Number, default: 0 },
+
+  active: { type: Boolean, default: true }
+}, {
+  timestamps: true
+});
+
+trainingTrackSchema.index({ orgId: 1, active: 1 });
+trainingTrackSchema.index({ segment: 1, orgId: 1 });
+
+// Convenience flag — global CR template vs org-owned track.
+trainingTrackSchema.virtual('isGlobalTemplate').get(function () {
+  return this.orgId == null;
+});
+
+trainingTrackSchema.set('toJSON', { virtuals: true });
+trainingTrackSchema.set('toObject', { virtuals: true });
+
+const TrainingTrack = mongoose.model('TrainingTrack', trainingTrackSchema);
+export default TrainingTrack;

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -79,6 +79,8 @@ import organizationsRoutes from './routes/organizations.js';
 import auditKitRoutes from './routes/auditKit.js';
 import uploadsRoutes from './routes/uploads.js';
 import videoAuditRoutes from './routes/videoAudit.js';
+import orgRoutes from './routes/orgRoutes.js';
+import complianceRoutes from './routes/complianceRoutes.js';
 
 /**
  * Route Manifest — declared route registrations.
@@ -159,6 +161,8 @@ export const ROUTE_MANIFEST = [
   ['/api/audit-kit',             auditKitRoutes,            'Audit Kit'],
   ['/api/uploads',               uploadsRoutes,             'Uploads'],
   ['/api/admin/video-audit',      videoAuditRoutes,          'Video Link Audit'],
+  ['/api/orgs',                  orgRoutes,                 'Practice Compliance — Orgs/Roster/Tracks/Assignments'],
+  ['/api',                       complianceRoutes,          'Practice Compliance — Credentials/Policies/Supervision/Audit Binder'],
 ];
 
 /**

--- a/server/src/routes/complianceRoutes.js
+++ b/server/src/routes/complianceRoutes.js
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * complianceRoutes — Practice Compliance: credentials, policies/attestations,
+ * supervision, audit binder, and the member self-view.
+ *
+ * NEW additive route file, mounted at /api (so paths are /api/orgs/:orgId/...
+ * and /api/me/compliance, matching the spec API surface). Layers requireOrgRole
+ * on top of the existing `protect` auth middleware. Touches no locked files.
+ */
+import express from 'express';
+import multer from 'multer';
+import Organization from '../models/Organization.js';
+import OrgCredential from '../models/OrgCredential.js';
+import PolicyDoc from '../models/PolicyDoc.js';
+import Attestation from '../models/Attestation.js';
+import OrgSupervisionLog from '../models/OrgSupervisionLog.js';
+import Assignment from '../models/Assignment.js';
+import { protect } from '../middleware/auth.js';
+import { requireOrgRole, ORG_ADMIN_ROLES } from '../middleware/requireOrgRole.js';
+import { uploadFile } from '../utils/r2Storage.js';
+import { generateAuditBinder } from '../services/auditBinderService.js';
+
+const router = express.Router();
+
+// NOTE: this router is mounted at the bare '/api' prefix (so paths read
+// /api/orgs/:orgId/... and /api/me/compliance per the spec). We therefore apply
+// `protect` PER-ROUTE rather than router.use(protect) — a router-level guard at
+// '/api' would run on unmatched /api/* paths and turn the existing 404 contract
+// into a 401. Per-route auth lets unmatched paths fall straight through to the
+// existing 404 handler unchanged.
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 25 * 1024 * 1024 } });
+
+function seatForUser(org, userId) {
+  return org.seats.find(s => s.userId && s.userId.equals(userId) && s.status === 'active');
+}
+
+// ════════════════════════ CREDENTIAL VAULT ════════════════════════
+router.get('/orgs/:orgId/credentials', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const filter = { orgId: req.org._id };
+    if (!ORG_ADMIN_ROLES.includes(req.orgRole) && req.user.role !== 'admin') {
+      filter.userId = req.user._id; // members see only their own
+    } else if (req.query.seatId) {
+      filter.seatId = req.query.seatId;
+    }
+    const creds = await OrgCredential.find(filter).sort({ expiresAt: 1 }).lean();
+    res.json(creds);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/orgs/:orgId/credentials', protect, requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
+  try {
+    const b = req.body || {};
+    let fileUrl = b.fileUrl;
+    let fileKey, fileName;
+    if (req.file) {
+      const key = `org-credentials/${req.org._id}/${Date.now()}-${req.file.originalname.replace(/[^a-z0-9.\-_]/gi, '_')}`;
+      const result = await uploadFile(req.file.buffer, key, req.file.mimetype, { orgId: String(req.org._id) });
+      fileUrl = result.url; fileKey = result.key; fileName = req.file.originalname;
+    }
+    // Resolve seat → userId when a seatId is provided.
+    let userId = b.userId || null;
+    if (b.seatId && !userId) {
+      const seat = req.org.seats.id(b.seatId);
+      userId = seat?.userId || null;
+    }
+    const cred = await OrgCredential.create({
+      orgId: req.org._id,
+      seatId: b.seatId || null,
+      userId,
+      type: b.type || 'other',
+      label: b.label,
+      state: b.state || null,
+      identifier: b.identifier,
+      level: b.level || null,
+      issuingBody: b.issuingBody || null,
+      subjectArea: b.subjectArea || null,
+      hours: b.hours || 0,
+      manualVersion: b.manualVersion || null,
+      issuedAt: b.issuedAt ? new Date(b.issuedAt) : undefined,
+      expiresAt: b.expiresAt ? new Date(b.expiresAt) : null,
+      fileUrl, fileKey, fileName
+    });
+    res.status(201).json(cred);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.patch('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const cred = await OrgCredential.findOne({ _id: req.params.credId, orgId: req.org._id });
+    if (!cred) return res.status(404).json({ error: 'Credential not found' });
+    const allowed = ['type', 'label', 'state', 'identifier', 'level', 'issuingBody', 'subjectArea', 'hours', 'manualVersion'];
+    for (const k of allowed) if (req.body[k] !== undefined) cred[k] = req.body[k];
+    if (req.body.issuedAt) cred.issuedAt = new Date(req.body.issuedAt);
+    if (req.body.expiresAt !== undefined) cred.expiresAt = req.body.expiresAt ? new Date(req.body.expiresAt) : null;
+    if (req.body.verify === true) { cred.verifiedBy = req.user._id; cred.verifiedAt = new Date(); }
+    if (req.body.expiresAt !== undefined) cred.alertsSent = []; // reset alert ledger on renewal
+    await cred.save();
+    res.json(cred);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.delete('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const out = await OrgCredential.deleteOne({ _id: req.params.credId, orgId: req.org._id });
+    if (!out.deletedCount) return res.status(404).json({ error: 'Credential not found' });
+    res.json({ message: 'Credential deleted' });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ════════════════════════ POLICY DOCS + ATTESTATION ════════════════════════
+router.get('/orgs/:orgId/policies', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const policies = await PolicyDoc.find({ orgId: req.org._id, active: true }).sort({ createdAt: -1 }).lean();
+    // Annotate whether the requesting member has attested to the current version.
+    const mine = await Attestation.find({ orgId: req.org._id, userId: req.user._id }).lean();
+    const signed = new Set(mine.map(a => `${a.policyDocId}:${a.policyVersion}`));
+    res.json(policies.map(p => ({ ...p, attestedByMe: signed.has(`${p._id}:${p.version}`) })));
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/orgs/:orgId/policies', protect, requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
+  try {
+    const b = req.body || {};
+    if (!b.title) return res.status(400).json({ error: 'Policy title is required' });
+    let fileUrl = b.fileUrl, fileKey, fileName;
+    if (req.file) {
+      const key = `org-policies/${req.org._id}/${Date.now()}-${req.file.originalname.replace(/[^a-z0-9.\-_]/gi, '_')}`;
+      const result = await uploadFile(req.file.buffer, key, req.file.mimetype, { orgId: String(req.org._id) });
+      fileUrl = result.url; fileKey = result.key; fileName = req.file.originalname;
+    }
+    // New version of an existing policy (by title) bumps version, re-opening attestation.
+    const prev = await PolicyDoc.findOne({ orgId: req.org._id, title: b.title }).sort({ version: -1 }).lean();
+    const version = b.newVersion && prev ? (prev.version + 1) : (b.version || 1);
+    const policy = await PolicyDoc.create({
+      orgId: req.org._id,
+      title: b.title,
+      version,
+      fileUrl, fileKey, fileName,
+      requiresSignature: b.requiresSignature !== false,
+      appliesToRoles: b.appliesToRoles || []
+    });
+    res.status(201).json(policy);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/orgs/:orgId/policies/:policyId/attest', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const policy = await PolicyDoc.findOne({ _id: req.params.policyId, orgId: req.org._id });
+    if (!policy) return res.status(404).json({ error: 'Policy not found' });
+    const seat = seatForUser(req.org, req.user._id);
+    const attestation = await Attestation.findOneAndUpdate(
+      { userId: req.user._id, policyDocId: policy._id, policyVersion: policy.version },
+      {
+        $setOnInsert: {
+          orgId: req.org._id,
+          seatId: seat?._id || null,
+          userId: req.user._id,
+          policyDocId: policy._id,
+          policyVersion: policy.version,
+          signedAt: new Date(),
+          signatureName: req.body.signatureName || req.user.email,
+          ip: req.ip,
+          userAgent: req.headers['user-agent'] || ''
+        }
+      },
+      { upsert: true, new: true }
+    );
+    res.status(201).json(attestation);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ════════════════════════ SUPERVISION (dual sign-off) ════════════════════════
+router.get('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const filter = { orgId: req.org._id };
+    if (!ORG_ADMIN_ROLES.includes(req.orgRole) && req.user.role !== 'admin') {
+      filter.$or = [{ superviseeUserId: req.user._id }, { supervisorUserId: req.user._id }];
+    } else if (req.query.superviseeUserId) {
+      filter.superviseeUserId = req.query.superviseeUserId;
+    }
+    const logs = await OrgSupervisionLog.find(filter).sort({ date: -1 }).lean();
+    const totalHours = logs.reduce((s, l) => s + (l.hours || 0), 0);
+    res.json({ logs, totals: { sessions: logs.length, hours: totalHours } });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const b = req.body || {};
+    const superviseeSeat = b.superviseeSeatId ? req.org.seats.id(b.superviseeSeatId) : seatForUser(req.org, req.user._id);
+    const supervisorSeat = b.supervisorSeatId ? req.org.seats.id(b.supervisorSeatId) : null;
+    const log = await OrgSupervisionLog.create({
+      orgId: req.org._id,
+      superviseeSeatId: superviseeSeat?._id || null,
+      superviseeUserId: superviseeSeat?.userId || null,
+      supervisorSeatId: supervisorSeat?._id || null,
+      supervisorUserId: supervisorSeat?.userId || null,
+      supervisorName: b.supervisorName || '',
+      date: b.date ? new Date(b.date) : new Date(),
+      hours: b.hours || 0,
+      format: b.format || 'individual',
+      modality: b.modality || 'in_person',
+      formType: b.formType === 'CADC-T' ? 'CADC-T' : 'standard',
+      notes: b.notes || ''
+    });
+    res.status(201).json(log);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.patch('/orgs/:orgId/supervision/:id/sign', protect, requireOrgRole(), async (req, res) => {
+  try {
+    const log = await OrgSupervisionLog.findOne({ _id: req.params.id, orgId: req.org._id });
+    if (!log) return res.status(404).json({ error: 'Supervision log not found' });
+    const isSupervisee = log.superviseeUserId && log.superviseeUserId.equals(req.user._id);
+    const isSupervisor = log.supervisorUserId && log.supervisorUserId.equals(req.user._id);
+    if (req.body.as === 'supervisee' && isSupervisee) log.superviseeSignedAt = new Date();
+    else if (req.body.as === 'supervisor' && (isSupervisor || ORG_ADMIN_ROLES.includes(req.orgRole))) log.supervisorSignedAt = new Date();
+    else return res.status(403).json({ error: 'Not authorized to sign in that role' });
+    await log.save();
+    res.json(log);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ════════════════════════ AUDIT BINDER (ZIP) ════════════════════════
+router.get('/orgs/:orgId/audit-binder', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const { buffer, filename } = await generateAuditBinder(req.org);
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(buffer);
+  } catch (error) {
+    console.error('Audit binder error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ════════════════════════ MEMBER SELF-VIEW (across orgs) ════════════════════════
+router.get('/me/compliance', protect, async (req, res) => {
+  try {
+    const orgs = await Organization.find({ 'seats.userId': req.user._id, 'seats.status': 'active' })
+      .select('name settings seats').lean();
+    const orgIds = orgs.map(o => o._id);
+    const [assignments, credentials] = await Promise.all([
+      Assignment.find({ userId: req.user._id, orgId: { $in: orgIds } }).sort({ dueDate: 1 }).lean(),
+      OrgCredential.find({ userId: req.user._id, orgId: { $in: orgIds } }).lean()
+    ]);
+    const byOrg = orgs.map(o => {
+      const aRows = assignments.filter(a => String(a.orgId) === String(o._id));
+      const annualHours = aRows.filter(a => a.status === 'completed').reduce((s, a) => s + (a.creditedHours || a.hours || 0), 0);
+      return {
+        orgId: o._id,
+        name: o.name,
+        segment: o.settings?.segment,
+        assignments: aRows,
+        credentials: credentials.filter(c => String(c.orgId) === String(o._id)),
+        annualHours,
+        overdue: aRows.filter(a => a.status === 'overdue').length,
+        recoupmentRisk: aRows.some(a => a.recoupmentRisk)
+      };
+    });
+    res.json({ orgs: byOrg });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/server/src/routes/orgRoutes.js
+++ b/server/src/routes/orgRoutes.js
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * orgRoutes — Practice Compliance: org, roster, invites, tracks, assignments.
+ *
+ * NEW additive route file, mounted at /api/orgs. Does NOT replace the existing
+ * /api/organizations routes (those remain untouched). Layers requireOrgRole on
+ * top of the existing `protect` auth middleware.
+ */
+import express from 'express';
+import crypto from 'crypto';
+import Organization from '../models/Organization.js';
+import User from '../models/User.js';
+import TrainingTrack from '../models/TrainingTrack.js';
+import Assignment from '../models/Assignment.js';
+import OrgCredential from '../models/OrgCredential.js';
+import { protect } from '../middleware/auth.js';
+import { requireOrgRole, ORG_ADMIN_ROLES } from '../middleware/requireOrgRole.js';
+import { buildAssignmentsForTrack } from '../services/complianceService.js';
+import { suggestForStates } from '../data/stateMandates.js';
+import { logActivity } from '../services/activityTrackingService.js';
+
+const router = express.Router();
+router.use(protect);
+
+function displayName(user) {
+  const p = user?.profile || {};
+  return `${p.firstName || ''} ${p.lastName || ''}`.trim() || user?.email || 'Member';
+}
+
+// ── Create practice (creator becomes owner) ──────────────────────────────────
+router.post('/', async (req, res) => {
+  try {
+    const { name, segment, statesOfOperation, timezone, alertEmails } = req.body;
+    if (!name) return res.status(400).json({ error: 'Organization name is required' });
+
+    const org = await Organization.create({
+      name,
+      ownerId: req.user._id,
+      billingEmail: req.user.email,
+      settings: {
+        segment: segment === 'dbhdd_agency' ? 'dbhdd_agency' : 'private_practice',
+        statesOfOperation: Array.isArray(statesOfOperation) ? statesOfOperation : [],
+        timezone: timezone || 'America/New_York',
+        alertEmails: Array.isArray(alertEmails) ? alertEmails : []
+      },
+      seats: [{
+        userId: req.user._id,
+        email: req.user.email,
+        role: 'owner',
+        status: 'active',
+        joinedAt: new Date(),
+        directContactCleared: true
+      }]
+    });
+
+    await logActivity('org.created', { orgId: org._id, name: org.name, segment: org.settings.segment },
+      { userId: req.user._id, userName: displayName(req.user), userEmail: req.user.email, notifyAdmin: true });
+
+    res.status(201).json(org);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Org detail (any active member) ───────────────────────────────────────────
+router.get('/:orgId', requireOrgRole(), async (req, res) => {
+  res.json(req.org);
+});
+
+// ── Settings (owner / admin / manager) ───────────────────────────────────────
+router.patch('/:orgId', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const org = req.org;
+    const { name } = req.body;
+    if (name) org.name = name;
+    const s = req.body.settings || {};
+    if (s.segment) org.settings.segment = s.segment === 'dbhdd_agency' ? 'dbhdd_agency' : 'private_practice';
+    if (Array.isArray(s.statesOfOperation)) org.settings.statesOfOperation = s.statesOfOperation;
+    if (s.timezone) org.settings.timezone = s.timezone;
+    if (Array.isArray(s.alertEmails)) org.settings.alertEmails = s.alertEmails;
+    await org.save();
+    res.json(org);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Invite a member by email (owner / admin / manager) ───────────────────────
+router.post('/:orgId/invites', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const org = req.org;
+    const { email, role, employmentType, title } = req.body;
+    if (!email) return res.status(400).json({ error: 'Email is required' });
+    if (!org.canAddSeat()) {
+      return res.status(400).json({ error: `Seat limit reached (${org.maxSeats}). Upgrade your plan to add seats.` });
+    }
+    const lower = email.toLowerCase();
+    const existing = org.seats.find(s => s.email === lower && !['removed', 'offboarded'].includes(s.status));
+    if (existing) return res.status(400).json({ error: 'This email is already a member or has a pending invite' });
+
+    const existingUser = await User.findOne({ email: lower });
+    const inviteToken = crypto.randomBytes(24).toString('hex');
+    org.seats.push({
+      userId: existingUser?._id || null,
+      email: lower,
+      role: role || 'clinician',
+      employmentType: employmentType || null,
+      title: title || '',
+      status: 'invited',
+      inviteToken,
+      hireDate: new Date()
+    });
+    await org.save();
+
+    await logActivity('org.member_invited', { orgId: org._id, email: lower, role: role || 'clinician' },
+      { userId: req.user._id, userName: displayName(req.user), userEmail: req.user.email, notifyAdmin: false });
+
+    res.status(201).json({ message: 'Invite created', inviteToken, org });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Accept an invite (any authenticated user) ────────────────────────────────
+router.post('/invites/accept', async (req, res) => {
+  try {
+    const { token } = req.body;
+    if (!token) return res.status(400).json({ error: 'Invite token is required' });
+    const org = await Organization.findOne({ 'seats.inviteToken': token });
+    if (!org) return res.status(404).json({ error: 'Invite not found or already used' });
+    const seat = org.seats.find(s => s.inviteToken === token);
+    if (!seat) return res.status(404).json({ error: 'Invite not found' });
+
+    seat.userId = req.user._id;
+    seat.email = req.user.email.toLowerCase();
+    seat.status = 'active';
+    seat.joinedAt = new Date();
+    seat.inviteToken = undefined;
+    await org.save();
+    res.json({ message: 'Invite accepted', org: { _id: org._id, name: org.name } });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Roster + compliance rollup (any active member) ───────────────────────────
+router.get('/:orgId/members', requireOrgRole(), async (req, res) => {
+  try {
+    const org = req.org;
+    const seats = org.seats.filter(s => !['removed', 'offboarded'].includes(s.status));
+    const userIds = seats.filter(s => s.userId).map(s => s.userId);
+
+    const [assignments, credentials, users] = await Promise.all([
+      Assignment.find({ orgId: org._id }).lean(),
+      OrgCredential.find({ orgId: org._id }).lean(),
+      User.find({ _id: { $in: userIds } }).select('profile email').lean()
+    ]);
+    const userById = new Map(users.map(u => [String(u._id), u]));
+
+    const members = seats.map(seat => {
+      const uid = seat.userId ? String(seat.userId) : null;
+      const u = uid ? userById.get(uid) : null;
+      const aRows = assignments.filter(a => uid && String(a.userId) === uid);
+      const cRows = credentials.filter(c => String(c.seatId) === String(seat._id) || (uid && String(c.userId) === uid));
+      const overdue = aRows.filter(a => a.status === 'overdue').length;
+      const completed = aRows.filter(a => a.status === 'completed' || a.status === 'waived').length;
+      const recoupmentRisk = aRows.some(a => a.recoupmentRisk);
+      const expiredCreds = cRows.filter(c => c.expiresAt && new Date(c.expiresAt) < new Date()).length;
+      const expiringCreds = cRows.filter(c => {
+        if (!c.expiresAt) return false;
+        const days = Math.ceil((new Date(c.expiresAt) - Date.now()) / 86400000);
+        return days > 0 && days <= 30;
+      }).length;
+      const annualHours = aRows.filter(a => a.status === 'completed').reduce((s, a) => s + (a.creditedHours || a.hours || 0), 0);
+      const status = (overdue > 0 || expiredCreds > 0) ? 'non_compliant'
+        : (aRows.length > completed || expiringCreds > 0) ? 'at_risk' : 'compliant';
+      return {
+        seatId: seat._id,
+        userId: seat.userId || null,
+        name: u ? `${u.profile.firstName} ${u.profile.lastName || ''}`.trim() : seat.email,
+        email: seat.email,
+        role: seat.role,
+        employmentType: seat.employmentType,
+        title: seat.title,
+        seatStatus: seat.status,
+        directContactCleared: seat.directContactCleared,
+        totalAssignments: aRows.length,
+        completed,
+        overdue,
+        credentials: cRows.length,
+        expiringCredentials: expiringCreds,
+        expiredCredentials: expiredCreds,
+        annualHours,
+        recoupmentRisk,
+        status
+      };
+    });
+
+    const rollup = {
+      totalMembers: members.length,
+      compliant: members.filter(m => m.status === 'compliant').length,
+      atRisk: members.filter(m => m.status === 'at_risk').length,
+      nonCompliant: members.filter(m => m.status === 'non_compliant').length,
+      recoupmentExposure: members.filter(m => m.recoupmentRisk).length
+    };
+    res.json({ organization: { _id: org._id, name: org.name, settings: org.settings, maxSeats: org.maxSeats }, rollup, members });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Update a member (role / status / offboard) ───────────────────────────────
+router.patch('/:orgId/members/:membershipId', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const org = req.org;
+    const seat = org.seats.id(req.params.membershipId);
+    if (!seat) return res.status(404).json({ error: 'Member not found' });
+    if (seat.role === 'owner' && req.body.role && req.body.role !== 'owner') {
+      return res.status(400).json({ error: 'Cannot change the owner role' });
+    }
+    const { role, status, employmentType, title, directContactCleared } = req.body;
+    if (role) seat.role = role;
+    if (employmentType !== undefined) seat.employmentType = employmentType;
+    if (title !== undefined) seat.title = title;
+    if (typeof directContactCleared === 'boolean') seat.directContactCleared = directContactCleared;
+    if (status) {
+      seat.status = status;
+      if (status === 'offboarded') seat.offboardedAt = new Date();
+    }
+    await org.save();
+    res.json({ message: 'Member updated', member: seat });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Tracks: list (org tracks + applicable global templates) ──────────────────
+router.get('/:orgId/tracks', requireOrgRole(), async (req, res) => {
+  try {
+    const segment = req.org.settings?.segment || 'private_practice';
+    const tracks = await TrainingTrack.find({
+      $or: [{ orgId: req.org._id }, { orgId: null, segment }]
+    }).sort({ orgId: 1, name: 1 }).lean();
+    res.json(tracks);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Tracks: create (owner / admin / manager) ─────────────────────────────────
+router.post('/:orgId/tracks', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const { name, appliesToRoles, items, segment, manualVersion, annualHoursTarget, strHoursTarget } = req.body;
+    if (!name) return res.status(400).json({ error: 'Track name is required' });
+    const track = await TrainingTrack.create({
+      orgId: req.org._id,
+      name,
+      segment: segment || req.org.settings?.segment || 'private_practice',
+      appliesToRoles: appliesToRoles || [],
+      items: items || [],
+      manualVersion: manualVersion || null,
+      annualHoursTarget: annualHoursTarget || 0,
+      strHoursTarget: strHoursTarget || 0
+    });
+    res.status(201).json(track);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Tracks: update (owner / admin / manager) ─────────────────────────────────
+router.patch('/:orgId/tracks/:trackId', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const track = await TrainingTrack.findOne({ _id: req.params.trackId, orgId: req.org._id });
+    if (!track) return res.status(404).json({ error: 'Track not found (global templates are read-only)' });
+    const allowed = ['name', 'appliesToRoles', 'items', 'active', 'manualVersion', 'annualHoursTarget', 'strHoursTarget'];
+    for (const k of allowed) if (req.body[k] !== undefined) track[k] = req.body[k];
+    await track.save();
+    res.json(track);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Bulk-assign a track to memberships (owner / admin / manager) ─────────────
+router.post('/:orgId/tracks/:trackId/assign', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const org = req.org;
+    const track = await TrainingTrack.findOne({
+      _id: req.params.trackId,
+      $or: [{ orgId: org._id }, { orgId: null }]
+    }).lean();
+    if (!track) return res.status(404).json({ error: 'Track not found' });
+
+    const { seatIds, roles } = req.body;
+    let seats = org.seats.filter(s => s.status === 'active' && s.userId);
+    if (Array.isArray(seatIds) && seatIds.length) {
+      const set = new Set(seatIds.map(String));
+      seats = seats.filter(s => set.has(String(s._id)));
+    } else if (Array.isArray(roles) && roles.length) {
+      seats = seats.filter(s => roles.includes(s.role));
+    } else if (Array.isArray(track.appliesToRoles) && track.appliesToRoles.length && !track.appliesToRoles.includes('all')) {
+      seats = seats.filter(s => track.appliesToRoles.includes(s.role));
+    }
+    if (!seats.length) return res.status(400).json({ error: 'No matching active members to assign' });
+
+    const payloads = buildAssignmentsForTrack(org, track, seats);
+    // Skip duplicates: an open assignment already exists for the same user + course code.
+    const created = [];
+    for (const p of payloads) {
+      const dup = await Assignment.exists({
+        orgId: org._id, userId: p.userId, courseCode: p.courseCode,
+        status: { $in: ['assigned', 'in_progress', 'overdue'] }
+      });
+      if (dup) continue;
+      created.push(await Assignment.create(p));
+    }
+
+    await logActivity('compliance.track_assigned', { orgId: org._id, trackId: track._id, trackName: track.name, count: created.length },
+      { userId: req.user._id, userName: displayName(req.user), userEmail: req.user.email, notifyAdmin: false });
+
+    res.status(201).json({ message: `Assigned ${created.length} item(s)`, created: created.length, skipped: payloads.length - created.length });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Assignments: filterable matrix feed ──────────────────────────────────────
+router.get('/:orgId/assignments', requireOrgRole(), async (req, res) => {
+  try {
+    const filter = { orgId: req.org._id };
+    if (req.query.status) filter.status = req.query.status;
+    if (req.query.seatId) filter.seatId = req.query.seatId;
+    // Non-admins only see their own assignments.
+    if (!ORG_ADMIN_ROLES.includes(req.orgRole) && req.user.role !== 'admin') {
+      filter.userId = req.user._id;
+    } else if (req.query.userId) {
+      filter.userId = req.query.userId;
+    }
+    const assignments = await Assignment.find(filter).sort({ dueDate: 1 }).lean();
+    res.json(assignments);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Assignments: waive / change due date (owner / admin / manager) ───────────
+router.patch('/:orgId/assignments/:id', requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+  try {
+    const a = await Assignment.findOne({ _id: req.params.id, orgId: req.org._id });
+    if (!a) return res.status(404).json({ error: 'Assignment not found' });
+    if (req.body.dueDate) a.dueDate = new Date(req.body.dueDate);
+    if (req.body.waive === true) {
+      a.status = 'waived';
+      a.waivedBy = req.user._id;
+      a.waivedReason = req.body.waivedReason || '';
+      a.recoupmentRisk = false;
+    }
+    if (req.body.status && ['assigned', 'in_progress', 'completed', 'overdue', 'waived'].includes(req.body.status)) {
+      a.status = req.body.status;
+    }
+    await a.save();
+    res.json(a);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── State-mandate suggestions (§3.9) ─────────────────────────────────────────
+router.get('/:orgId/suggestions', requireOrgRole(), async (req, res) => {
+  try {
+    const states = req.org.settings?.statesOfOperation || [];
+    res.json(suggestForStates(states));
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/server/src/scripts/seedComplianceCatalog.js
+++ b/server/src/scripts/seedComplianceCatalog.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * seedComplianceCatalog — idempotent upsert of Practice Compliance catalog
+ * metadata (ComplianceCourseMeta) and global TrainingTrack templates.
+ *
+ * UPSERT-ONLY. Performs NO deletes. Safe to re-run (no duplicate tracks/courses).
+ * Does NOT author course CONTENT and does NOT flip ceEligible (owner CE gate).
+ *
+ * NOT run automatically. Invoke explicitly:
+ *   node server/src/scripts/seedComplianceCatalog.js
+ *
+ * Re-running is idempotent: ComplianceCourseMeta is keyed by `code`; global
+ * TrainingTracks are keyed by (orgId:null, name).
+ */
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import ComplianceCourseMeta from '../models/ComplianceCourseMeta.js';
+import TrainingTrack from '../models/TrainingTrack.js';
+import { COMPLIANCE_CATALOG } from '../data/complianceCatalog.js';
+import { GLOBAL_TRACKS } from '../data/complianceTracks.js';
+
+dotenv.config();
+
+export async function seedComplianceCatalog() {
+  let courses = 0;
+  let tracks = 0;
+
+  for (const c of COMPLIANCE_CATALOG) {
+    await ComplianceCourseMeta.updateOne(
+      { code: c.code },
+      { $set: c },
+      { upsert: true }
+    );
+    courses++;
+  }
+
+  for (const t of GLOBAL_TRACKS) {
+    await TrainingTrack.updateOne(
+      { orgId: null, name: t.name },
+      { $set: { ...t, orgId: null, active: true } },
+      { upsert: true }
+    );
+    tracks++;
+  }
+
+  return { courses, tracks };
+}
+
+// Run directly (node server/src/scripts/seedComplianceCatalog.js)
+const isDirect = process.argv[1] && process.argv[1].endsWith('seedComplianceCatalog.js');
+if (isDirect) {
+  (async () => {
+    try {
+      await mongoose.connect(process.env.MONGODB_URI);
+      const result = await seedComplianceCatalog();
+      console.log(`✅ Compliance catalog seeded (idempotent): ${result.courses} courses, ${result.tracks} global tracks`);
+      await mongoose.connection.close();
+      process.exit(0);
+    } catch (err) {
+      console.error('❌ Seed failed:', err);
+      process.exit(1);
+    }
+  })();
+}
+
+export default seedComplianceCatalog;

--- a/server/src/services/auditBinderService.js
+++ b/server/src/services/auditBinderService.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * auditBinderService — one-click compliance audit binder (ZIP).
+ *
+ * NEW additive service. A report template over data CR already holds. Builds:
+ *   compliance-summary.pdf            (org rollup, generated date, ACEP #7760 footer)
+ *   <Member Name>/training-record.csv (name, topic, date, hours — the §9 spreadsheet)
+ *   <Member Name>/credentials.csv     (license/insurance/CPR with expiry + evidence URL)
+ *   <Member Name>/attestations.csv    (policy acknowledgements)
+ *   <Member Name>/supervision.csv     (dual-signoff hour summary)
+ *   <Member Name>/certificates.csv    (issued certificate references)
+ *
+ * Uses adm-zip + pdfkit (already in dependencies). Certificate / evidence PDFs
+ * are referenced by URL (the locked cert pipeline owns the binaries); this
+ * binder is the index auditors ask for.
+ */
+import AdmZip from 'adm-zip';
+import PDFDocument from 'pdfkit';
+import Assignment from '../models/Assignment.js';
+import OrgCredential from '../models/OrgCredential.js';
+import Attestation from '../models/Attestation.js';
+import PolicyDoc from '../models/PolicyDoc.js';
+import OrgSupervisionLog from '../models/OrgSupervisionLog.js';
+import Certificate from '../models/Certificate.js';
+
+function csvEscape(v) {
+  const s = v == null ? '' : String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+function toCsv(headers, rows) {
+  const lines = [headers.map(csvEscape).join(',')];
+  for (const r of rows) lines.push(r.map(csvEscape).join(','));
+  return lines.join('\n');
+}
+function safeFolder(name) {
+  return String(name || 'member').replace(/[^a-z0-9 _-]/gi, '').trim() || 'member';
+}
+function fmtDate(d) {
+  return d ? new Date(d).toLocaleDateString() : '';
+}
+
+// Build the rollup summary PDF into a Buffer.
+function buildSummaryPdf(org, memberSummaries) {
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ margin: 50 });
+      const chunks = [];
+      doc.on('data', c => chunks.push(c));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      doc.fontSize(20).text('Compliance Audit Binder', { align: 'center' });
+      doc.moveDown(0.3);
+      doc.fontSize(14).text(org.name || 'Organization', { align: 'center' });
+      doc.moveDown(0.2);
+      doc.fontSize(10).fillColor('#555')
+        .text(`Generated ${new Date().toLocaleString()}`, { align: 'center' })
+        .text(`Compliance layer: ${org.settings?.segment === 'dbhdd_agency' ? 'DBHDD/DCH Agency' : 'Private Practice'}`, { align: 'center' });
+      doc.fillColor('#000').moveDown(1);
+
+      const compliant = memberSummaries.filter(m => m.status === 'compliant').length;
+      const atRisk = memberSummaries.filter(m => m.status === 'at_risk').length;
+      const nonCompliant = memberSummaries.filter(m => m.status === 'non_compliant').length;
+
+      doc.fontSize(12).text(`Members: ${memberSummaries.length}`);
+      doc.text(`Fully compliant: ${compliant}`);
+      doc.text(`At risk (due soon): ${atRisk}`);
+      doc.text(`Non-compliant (overdue/expired): ${nonCompliant}`);
+      doc.moveDown(0.8);
+
+      doc.fontSize(13).text('Per-member status', { underline: true });
+      doc.moveDown(0.3);
+      doc.fontSize(10);
+      for (const m of memberSummaries) {
+        doc.text(`• ${m.name} — ${m.status.replace('_', ' ')} · ${m.completed}/${m.total} trainings · ${m.openCredentials} credentials${m.recoupmentRisk ? ' · ⚠ BILLING AT RISK' : ''}`);
+      }
+
+      doc.moveDown(2);
+      doc.fontSize(8).fillColor('#777')
+        .text('GA Integrated Therapeutic Perspectives LLC · NBCC ACEP Provider #7760', { align: 'center' })
+        .text('This binder indexes compliance records held by CounselorReady. Certificate and evidence files are referenced by URL.', { align: 'center' });
+
+      doc.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Generate the audit binder ZIP for an organization.
+ * @param {Organization} org - a loaded Organization document
+ * @returns {Promise<{ buffer: Buffer, filename: string }>}
+ */
+export async function generateAuditBinder(org) {
+  const zip = new AdmZip();
+  const activeSeats = (org.seats || []).filter(s => s.status === 'active' && s.userId);
+  const userIds = activeSeats.map(s => s.userId);
+
+  const [assignments, credentials, attestations, policies, supervision, certificates] = await Promise.all([
+    Assignment.find({ orgId: org._id }).populate('userId', 'email profile').lean(),
+    OrgCredential.find({ orgId: org._id }).lean(),
+    Attestation.find({ orgId: org._id }).lean(),
+    PolicyDoc.find({ orgId: org._id }).lean(),
+    OrgSupervisionLog.find({ orgId: org._id }).lean(),
+    Certificate.find({ userId: { $in: userIds } }).lean()
+  ]);
+
+  const policyById = new Map(policies.map(p => [String(p._id), p]));
+  const memberSummaries = [];
+
+  for (const seat of activeSeats) {
+    const uid = String(seat.userId);
+    const seatId = String(seat._id);
+    const aRows = assignments.filter(a => String(a.userId) === uid);
+    const cRows = credentials.filter(c => String(c.seatId) === seatId || String(c.userId) === uid);
+    const tRows = attestations.filter(a => String(a.userId) === uid);
+    const sRows = supervision.filter(s => String(s.superviseeUserId) === uid);
+    const certRows = certificates.filter(c => String(c.userId) === uid);
+
+    const name = seat.title
+      ? `${seat.email} (${seat.title})`
+      : seat.email;
+    const folder = safeFolder(name) + '/';
+
+    // §9 training record spreadsheet: name, topic, date, hours
+    zip.addFile(folder + 'training-record.csv', Buffer.from(toCsv(
+      ['Member', 'Topic / Course', 'Status', 'Due', 'Completed', 'Hours', 'Delivery', 'Manual Version'],
+      aRows.map(a => [seat.email, a.label || a.courseCode, a.status, fmtDate(a.dueDate), fmtDate(a.completedAt), a.creditedHours || a.hours || 0, a.deliveryMode, a.manualVersion || ''])
+    ), 'utf-8'));
+
+    zip.addFile(folder + 'credentials.csv', Buffer.from(toCsv(
+      ['Type', 'Label', 'State', 'Identifier', 'Level', 'Issuing Body', 'Issued', 'Expires', 'Verified', 'Evidence URL'],
+      cRows.map(c => [c.type, c.label || '', c.state || '', c.identifier || '', c.level || '', c.issuingBody || '', fmtDate(c.issuedAt), fmtDate(c.expiresAt), c.verifiedAt ? 'yes' : 'no', c.fileUrl || ''])
+    ), 'utf-8'));
+
+    zip.addFile(folder + 'attestations.csv', Buffer.from(toCsv(
+      ['Policy', 'Version', 'Signed At', 'Signature', 'IP'],
+      tRows.map(t => [policyById.get(String(t.policyDocId))?.title || t.policyDocId, t.policyVersion, fmtDate(t.signedAt), t.signatureName || '', t.ip || ''])
+    ), 'utf-8'));
+
+    zip.addFile(folder + 'supervision.csv', Buffer.from(toCsv(
+      ['Date', 'Hours', 'Format', 'Modality', 'Form', 'Supervisor', 'Supervisee Signed', 'Supervisor Signed'],
+      sRows.map(s => [fmtDate(s.date), s.hours, s.format, s.modality, s.formType, s.supervisorName || '', fmtDate(s.superviseeSignedAt), fmtDate(s.supervisorSignedAt)])
+    ), 'utf-8'));
+
+    zip.addFile(folder + 'certificates.csv', Buffer.from(toCsv(
+      ['Title', 'Provider', 'CE Hours', 'Completion Date', 'Certificate #', 'Verification', 'File URL'],
+      certRows.map(c => [c.title, c.provider, c.ceHours, fmtDate(c.completionDate), c.certificateNumber || '', c.verificationCode || '', c.fileUrl || ''])
+    ), 'utf-8'));
+
+    const total = aRows.length;
+    const completed = aRows.filter(a => a.status === 'completed' || a.status === 'waived').length;
+    const overdue = aRows.filter(a => a.status === 'overdue').length;
+    const recoupmentRisk = aRows.some(a => a.recoupmentRisk);
+    const expiredCreds = cRows.filter(c => c.expiresAt && new Date(c.expiresAt) < new Date()).length;
+    const status = (overdue > 0 || expiredCreds > 0) ? 'non_compliant'
+      : (total > completed) ? 'at_risk' : 'compliant';
+
+    memberSummaries.push({ name, status, total, completed, openCredentials: cRows.length, recoupmentRisk });
+  }
+
+  const summaryPdf = await buildSummaryPdf(org, memberSummaries);
+  zip.addFile('compliance-summary.pdf', summaryPdf);
+
+  const slug = safeFolder(org.name).replace(/\s+/g, '-').toLowerCase() || 'organization';
+  return {
+    buffer: zip.toBuffer(),
+    filename: `audit-binder-${slug}-${new Date().toISOString().slice(0, 10)}.zip`
+  };
+}
+
+export default { generateAuditBinder };

--- a/server/src/services/complianceService.js
+++ b/server/src/services/complianceService.js
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * complianceService — Practice Compliance nightly job + assignment helpers.
+ *
+ * NEW additive service. Does NOT touch the locked certificate issuance
+ * pipeline. Cert → Assignment linking is done here by RECONCILIATION: each
+ * night we match newly-issued Certificates against open Assignments and close
+ * them out (the chosen approach — no edits to interactiveCourseRoutes.js or
+ * courseCompletionService.js).
+ *
+ * Nightly stages (each independently guarded — one failure never aborts the rest):
+ *   1. reconcileCertCompletions  — close assignments completed via the cert pipeline
+ *   2. flipOverdueAssignments    — assigned/in_progress → overdue past dueDate; STR recoupment flag
+ *   3. sendAssignmentDueAlerts   — due in 14 / 7 / 1 days (dedupe via alertsSent)
+ *   4. sendCredentialExpiryAlerts— credentials expiring 90 / 60 / 30 / 7 days (dedupe)
+ *   5. sendRecoupmentAlerts      — GA STR overdue ⇒ "billing at risk" to owner + alertEmails
+ */
+import { Resend } from 'resend';
+import Organization from '../models/Organization.js';
+import Assignment from '../models/Assignment.js';
+import OrgCredential from '../models/OrgCredential.js';
+import Certificate from '../models/Certificate.js';
+
+const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
+const FROM = 'CounselorReady <noreply@counselorready.com>';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+// Best-effort email — never throws, never blocks the job.
+async function sendEmail(to, subject, html) {
+  try {
+    if (!resend || !to || (Array.isArray(to) && to.length === 0)) return;
+    await resend.emails.send({ from: FROM, to, subject, html });
+  } catch (err) {
+    console.error('[complianceService] email failed:', err.message);
+  }
+}
+
+/**
+ * Resolve a {STATE} placeholder in a course code from the org's primary state.
+ * 'CR-PC102-{STATE}' + org GA  ->  'CR-PC102-GA'
+ */
+export function resolveCourseCode(code, org) {
+  if (!code || !code.includes('{STATE}')) return code;
+  const state = (org?.settings?.statesOfOperation || [])[0] || (org?.address?.state) || 'GA';
+  return code.replace('{STATE}', String(state).toUpperCase());
+}
+
+/**
+ * Build Assignment payloads for one track applied to a set of seats.
+ * Returns an array of plain objects (caller does the insert). Idempotency is the
+ * caller's responsibility (skip seats with an open assignment for the same code).
+ */
+export function buildAssignmentsForTrack(org, track, seats) {
+  const now = Date.now();
+  const out = [];
+  for (const seat of seats) {
+    for (const item of (track.items || [])) {
+      const code = resolveCourseCode(item.courseCode, org);
+      out.push({
+        orgId: org._id,
+        seatId: seat._id,
+        userId: seat.userId || null,
+        courseCode: code,
+        courseRef: item.courseRef || null,
+        label: item.label || code,
+        trackId: track._id || null,
+        dueDate: new Date(now + (item.dueDays ?? 30) * DAY_MS),
+        status: 'assigned',
+        recurrence: item.recurrence || 'none',
+        subjectArea: item.subjectArea || null,
+        hours: item.hours || 0,
+        manualVersion: track.manualVersion || null,
+        deliveryMode: item.deliveryMode || 'cr_delivered',
+        external: !!item.external,
+        alertsSent: []
+      });
+    }
+  }
+  return out;
+}
+
+// ── Stage 1: reconcile cert completions ──────────────────────────────────────
+async function reconcileCertCompletions() {
+  const open = await Assignment.find({
+    status: { $in: ['assigned', 'in_progress', 'overdue'] },
+    external: { $ne: true } // external items (Relias/CPR) are closed via credential vault, not certs
+  }).lean();
+  if (open.length === 0) return { linked: 0, recurred: 0 };
+
+  let linked = 0;
+  let recurred = 0;
+
+  for (const a of open) {
+    if (!a.userId) continue;
+    // Find a matching certificate issued at/after this assignment was created.
+    const certs = await Certificate.find({
+      userId: a.userId,
+      isRevoked: { $ne: true },
+      completionDate: { $gte: a.createdAt || new Date(0) }
+    }).select('courseId title ceHours completionDate').lean();
+
+    const match = certs.find(c =>
+      (a.courseRef && c.courseId && String(c.courseId) === String(a.courseRef)) ||
+      (a.courseTitle && c.title && c.title.trim().toLowerCase() === a.courseTitle.trim().toLowerCase()) ||
+      (a.courseCode && c.title && c.title.toUpperCase().includes(a.courseCode))
+    );
+    if (!match) continue;
+
+    await Assignment.updateOne(
+      { _id: a._id, status: { $ne: 'completed' } },
+      {
+        $set: {
+          status: 'completed',
+          completedAt: match.completionDate || new Date(),
+          certificateId: match._id,
+          creditedHours: match.ceHours || a.hours || 0,
+          recoupmentRisk: false
+        }
+      }
+    );
+    linked++;
+
+    // Annual / biennial recurrence — create the next cycle immediately (idempotent).
+    if (a.recurrence === 'annual' || a.recurrence === 'biennial') {
+      const exists = await Assignment.exists({ recurrenceParentId: a._id });
+      if (!exists) {
+        const years = a.recurrence === 'biennial' ? 2 : 1;
+        const base = match.completionDate || new Date();
+        const nextDue = new Date(base.getTime());
+        nextDue.setFullYear(nextDue.getFullYear() + years);
+        await Assignment.create({
+          orgId: a.orgId,
+          seatId: a.seatId,
+          userId: a.userId,
+          courseCode: a.courseCode,
+          courseRef: a.courseRef,
+          courseTitle: a.courseTitle,
+          label: a.label,
+          trackId: a.trackId,
+          dueDate: nextDue,
+          status: 'assigned',
+          recurrence: a.recurrence,
+          recurrenceParentId: a._id,
+          subjectArea: a.subjectArea,
+          hours: a.hours,
+          manualVersion: a.manualVersion,
+          deliveryMode: a.deliveryMode,
+          external: a.external,
+          alertsSent: []
+        });
+        recurred++;
+      }
+    }
+  }
+  return { linked, recurred };
+}
+
+// ── Stage 2: flip overdue + STR recoupment flag ──────────────────────────────
+async function flipOverdueAssignments() {
+  const now = new Date();
+  const res = await Assignment.updateMany(
+    { status: { $in: ['assigned', 'in_progress'] }, dueDate: { $lt: now } },
+    { $set: { status: 'overdue' } }
+  );
+  // GA STR exposure: overdue dbhdd-agency items (esp. STR) ⇒ recoupment risk.
+  await Assignment.updateMany(
+    { status: 'overdue', $or: [{ subjectArea: { $ne: null } }, { deliveryMode: { $in: ['relias_online', 'provider_based', 'external'] } }], manualVersion: { $ne: null } },
+    { $set: { recoupmentRisk: true } }
+  );
+  return { flipped: res.modifiedCount || 0 };
+}
+
+// ── Stage 3: assignment due-soon alerts ──────────────────────────────────────
+async function sendAssignmentDueAlerts() {
+  const now = Date.now();
+  const windows = [{ days: 14, tag: '14d' }, { days: 7, tag: '7d' }, { days: 1, tag: '1d' }];
+  let sent = 0;
+  for (const w of windows) {
+    const lo = new Date(now);
+    const hi = new Date(now + w.days * DAY_MS);
+    const due = await Assignment.find({
+      status: { $in: ['assigned', 'in_progress'] },
+      dueDate: { $gte: lo, $lte: hi },
+      alertsSent: { $ne: w.tag }
+    }).populate('userId', 'email profile').lean();
+    for (const a of due) {
+      const email = a.userId?.email;
+      if (email) {
+        await sendEmail(email, `Training due soon: ${a.label || a.courseCode}`,
+          `<p>Your assigned training <strong>${a.label || a.courseCode}</strong> is due ${a.dueDate ? new Date(a.dueDate).toLocaleDateString() : 'soon'}.</p>`);
+      }
+      await Assignment.updateOne({ _id: a._id }, { $addToSet: { alertsSent: w.tag } });
+      sent++;
+    }
+  }
+  return { sent };
+}
+
+// ── Stage 4: credential expiry alerts ────────────────────────────────────────
+async function sendCredentialExpiryAlerts() {
+  const now = Date.now();
+  const windows = [{ days: 90, tag: '90d' }, { days: 60, tag: '60d' }, { days: 30, tag: '30d' }, { days: 7, tag: '7d' }];
+  let sent = 0;
+  for (const w of windows) {
+    const hi = new Date(now + w.days * DAY_MS);
+    const lo = new Date(now);
+    const creds = await OrgCredential.find({
+      expiresAt: { $gte: lo, $lte: hi },
+      alertsSent: { $ne: w.tag }
+    }).populate('userId', 'email profile').lean();
+    for (const c of creds) {
+      const org = await Organization.findById(c.orgId).select('settings alertEmails name').lean();
+      const recipients = [c.userId?.email, ...(org?.settings?.alertEmails || [])].filter(Boolean);
+      await sendEmail(recipients, `Credential expiring: ${c.label || c.type}`,
+        `<p>The credential <strong>${c.label || c.type}</strong> expires on ${c.expiresAt ? new Date(c.expiresAt).toLocaleDateString() : 'soon'} (${w.days} days).</p>`);
+      await OrgCredential.updateOne({ _id: c._id }, { $addToSet: { alertsSent: w.tag } });
+      sent++;
+    }
+  }
+  return { sent };
+}
+
+// ── Stage 5: GA STR recoupment "billing at risk" alerts ──────────────────────
+async function sendRecoupmentAlerts() {
+  const atRisk = await Assignment.find({ status: 'overdue', recoupmentRisk: true, alertsSent: { $ne: 'recoupment' } })
+    .populate('userId', 'email profile').lean();
+  let sent = 0;
+  for (const a of atRisk) {
+    const org = await Organization.findById(a.orgId).select('ownerId settings name billingEmail').lean();
+    if (!org) continue;
+    const owner = await Organization.db.model('User').findById(org.ownerId).select('email').lean().catch(() => null);
+    const recipients = [owner?.email, org.billingEmail, ...(org?.settings?.alertEmails || [])].filter(Boolean);
+    const who = a.userId?.profile ? `${a.userId.profile.firstName || ''} ${a.userId.profile.lastName || ''}`.trim() : 'A staff member';
+    await sendEmail(recipients, `⚠️ BILLING AT RISK — recoupment exposure (${org.name})`,
+      `<p><strong>${who}</strong> has an overdue Standard Training Requirement item (<strong>${a.label || a.courseCode}</strong>) past its deadline.</p>
+       <p>Per the DBHDD Provider Manual, services billed outside the grace period are subject to <strong>recoupment</strong>. Resolve this training to restore billing eligibility.</p>`);
+    await Assignment.updateOne({ _id: a._id }, { $addToSet: { alertsSent: 'recoupment' } });
+    sent++;
+  }
+  return { sent };
+}
+
+/**
+ * Nightly entry point. Wired from index.js cron. Each stage is independently
+ * guarded so a failure in one never aborts the others.
+ */
+export async function runComplianceDailyJob() {
+  const results = {};
+  const stages = [
+    ['reconcile', reconcileCertCompletions],
+    ['overdue', flipOverdueAssignments],
+    ['dueAlerts', sendAssignmentDueAlerts],
+    ['credentialAlerts', sendCredentialExpiryAlerts],
+    ['recoupmentAlerts', sendRecoupmentAlerts]
+  ];
+  for (const [name, fn] of stages) {
+    try {
+      results[name] = await fn();
+    } catch (err) {
+      console.error(`[complianceService] stage ${name} failed:`, err.message);
+      results[name] = { error: err.message };
+    }
+  }
+  console.log('[complianceService] daily job complete:', JSON.stringify(results));
+  return results;
+}
+
+export default { runComplianceDailyJob, resolveCourseCode, buildAssignmentsForTrack };


### PR DESCRIPTION
## Practice Compliance module — additive B2B foundation (CR Teams)

Implements the **shared backend + frontend foundation** for the Practice Compliance / Clinical-HR module across all three spec docs (Data Model V1, Training Catalog, GA DBHDD/DCH Agency layer). Everything is **new-files-only** except three previously-authorized integration points, all touched with **additive-only** diffs.

### Decisions confirmed with owner before building
1. **Membership lives on `Organization.seats[]`** (extended additively) — not a new `memberships` collection.
2. **Cert→assignment linking via nightly cron reconciliation** — no edits to the locked certificate pipeline.
3. **Compliance/catalog metadata in a new `ComplianceCourseMeta` collection** — `Course.js` is hard-locked and real content lives in `InteractiveCourse`.
4. **Course content deferred** — structure + idempotent seed scripts/data only; `ceEligible` stays false pending owner CE sign-off.
5. **GA DBHDD/DCH agency layer baked in now** (segment, hour counters, STR, recoupment alerts, `manualVersion`).

### New collections
`ComplianceCourseMeta`, `TrainingTrack`, `Assignment`, `OrgCredential`, `PolicyDoc`, `Attestation`, `OrgSupervisionLog` (org-scoped dual sign-off + CADC-T form; **distinct from** the working personal `SupervisionLog`, which is untouched).

### API (new route files)
- `orgRoutes.js` → `/api/orgs`: create org, detail/settings, invites + accept, roster w/ compliance rollup, member update/offboard, tracks CRUD, **bulk-assign**, assignments feed/waive, state-mandate suggestions.
- `complianceRoutes.js` → `/api`: credential vault (CRUD + R2 file upload), policy docs + **e-attestation with versioning**, supervision dual sign-off, **audit-binder ZIP export**, **`/api/me/compliance`** member self-view.
- New `requireOrgRole(...)` middleware layered on top of existing `protect` (existing auth untouched).
- `protect` applied **per-route** in `complianceRoutes` (mounted at bare `/api`) so unmatched `/api/*` paths still hit the existing 404 handler — no contract change.

### Services + cron
- `complianceService.runComplianceDailyJob()` — cert→assignment reconciliation, overdue flips, due (14/7/1d) + credential expiry (90/60/30/7d) alerts with dedupe ledgers, annual/biennial recurrence chaining, **GA STR "BILLING AT RISK — recoupment exposure"** alerts. Wired as daily 7 AM ET cron.
- `auditBinderService` — one-click ZIP (adm-zip + pdfkit): per-member training-record/credentials/attestations/supervision/certificates CSVs + `compliance-summary.pdf` with ACEP #7760 footer.

### GA agency layer
`org.settings.segment`, `Assignment.subjectArea`/`hours` (16-hr annual + 46-hr STR counters), `recoupmentRisk`, `manualVersion: FY27-Q1`, GA seed tracks/catalog, CR delivery-boundary honesty (provider-based delivered vs Relias/CPR/Deaf-Crisis tracked-not-delivered).

### Seed data / scripts (NOT executed)
`data/complianceCatalog.js` (32 CR-PC### entries), `data/complianceTracks.js` (10 global tracks), `data/stateMandates.js` (GA/TX/FL/ID), and **upsert-only idempotent** `scripts/seedComplianceCatalog.js`.

### Frontend (new static pages)
`team-compliance.html` (owner dashboard: rollup strip, staff matrix, tracks/assign, audit-binder download, recoupment banner) and `my-compliance.html` (member "Assigned by [Practice]" view with CE dual-credit badge + agency hour counter). Both on-brand, AbortController-timed fetches, token-auth.

### Anti-lying gates
- `node --check` ✅ clean on all 19 touched JS files.
- Runtime import smoke test ✅ — all routers/services/models load, no model-name collisions, helpers compute (`CR-PC102-{STATE}`→`CR-PC102-GA`).
- `git diff --stat HEAD` → **only** `index.js`, `Organization.js`, `routeManifest.js` modified (+34/−3, all additive; the 3 "deletions" are lines replaced-and-expanded). **No enum value removed. No locked file touched.**

### Deferred (follow-ups)
CR-PC course content authoring + `ceEligible` sign-off; running the seed script on staging; member-block embed into the existing React dashboard (built as standalone pages here to avoid touching existing pages); quarterly manual-version review automation.

### Acceptance gates to run on staging
Solo-user regression (zero memberships → zero new UI); cert→assignment link on a real posttest pass; cron dedupe; audit binder with ≥2 members / ≥3 cert types; `{STATE}` resolution GA vs TX.

https://claude.ai/code/session_012vDzqRAm2TYCBb7oWm2Nyy

---
_Generated by [Claude Code](https://claude.ai/code/session_012vDzqRAm2TYCBb7oWm2Nyy)_