### PR TITLE
Make Resources drawer tab always visible

### DIFF
--- a/client/public/interactive-course.html
+++ b/client/public/interactive-course.html
@@ -8538,7 +8538,7 @@ function dismissNPS() {
           });
         }
         if (refsData.length > 0) tabR.style.display = 'block';
-        if (resData.length > 0) tabS.style.display = 'block';
+        tabS.style.display = 'block'; // required drawer — always visible; panel shows empty state when course has no resources
       })
       .catch(function() {});
   }


### PR DESCRIPTION
## Summary
- Removed the `if (resData.length > 0)` guard on `tabS.style.display = 'block'` in `interactive-course.html` (line 8541)
- Resources tab is now always shown; the panel handles empty-state display when a course has no resources

## Verification
```
grep "tabS.style.display" client/public/interactive-course.html
```

https://claude.ai/code/session_015pXm1SZnS32cWM3vEpCSJq

---
_Generated by [Claude Code](https://claude.ai/code/session_015pXm1SZnS32cWM3vEpCSJq)_