### PR TITLE
fix(stage5e): .blocks → .contentBlocks in patchTMH601_Stage5e_AlertBadges.js

### DIFF
--- a/server/src/scripts/patchTMH601_Stage5e_AlertBadges.js
+++ b/server/src/scripts/patchTMH601_Stage5e_AlertBadges.js
@@ -166,14 +166,14 @@ async function run() {
     let inserted = 0, already = 0, missed = 0, changed = false;
 
     for (const ins of INSERTIONS) {
-      const exists = sections.some(s => (s.blocks || []).some(b =>
+      const exists = sections.some(s => (s.contentBlocks || []).some(b =>
         typeof b.content === 'string' && b.content.includes(markerFor(ins.id))));
       if (exists) { already++; console.log(`   ⏭  ${ins.label} — already present`); continue; }
 
       let placed = false;
       for (let si = 0; si < sections.length && !placed; si++) {
         const sec = sections[si];
-        const blocks = sec.blocks || [];
+        const blocks = sec.contentBlocks || [];
         for (let bi = 0; bi < blocks.length && !placed; bi++) {
           const b = blocks[bi];
           if (b.type !== 'text' || typeof b.content !== 'string') continue;


### PR DESCRIPTION
## Summary
- Lines 169 and 176 referenced `s.blocks` / `sec.blocks` which does not exist on the InteractiveCourse section subdocument
- Correct field is `contentBlocks` — without this fix the script iterates empty arrays and reports every insertion as missed (nothing is ever written)

## Changes
- `server/src/scripts/patchTMH601_Stage5e_AlertBadges.js` — 2 lines changed, no logic otherwise altered

## Gates
```
grep -n "\.blocks\b" server/src/scripts/patchTMH601_Stage5e_AlertBadges.js
(no output — clean)

grep -n "\.contentBlocks" server/src/scripts/patchTMH601_Stage5e_AlertBadges.js
169:      const exists = sections.some(s => (s.contentBlocks || []).some(b =>
176:        const blocks = sec.contentBlocks || [];
```

https://claude.ai/code/session_011YskgsdZ1pYsjiXPWiyUAV

---
_Generated by [Claude Code](https://claude.ai/code/session_011YskgsdZ1pYsjiXPWiyUAV)_