### PR TITLE
feat(partner): funnel discoverability + polish

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -37,6 +37,7 @@
 /partner             /partner.html              200
 /partners            /partner.html              200
 /become-a-partner    /partner.html              200
+/legal/partner-marketplace-agreement   /legal/partner-marketplace-agreement.html   200
 /partner-dashboard   /partner-dashboard.html    200
 # ── Partner portal sub-pages (slash paths used by dashboard links + backend redirects) ──
 /partner/users       /partner-users.html        200

--- a/client/public/js/stripe-config.js
+++ b/client/public/js/stripe-config.js
@@ -1,0 +1,13 @@
+/**
+ * CounselorReady — public Stripe configuration.
+ *
+ * The publishable key is SAFE to expose in client-side code (it can only tokenize/initialize
+ * Stripe.js, never charge or read data). Paste your key below.
+ *
+ *   • Live key starts with  pk_live_
+ *   • Test key starts with   pk_test_
+ *
+ * Leave it blank to disable client-side Stripe.js on pages that use it (the partner billing flow
+ * uses Stripe's hosted Checkout and does NOT need this).
+ */
+window.STRIPE_PUBLISHABLE_KEY = '';

--- a/client/public/legal/partner-marketplace-agreement.html
+++ b/client/public/legal/partner-marketplace-agreement.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Partner Marketplace Agreement | CounselorReady™</title>
+  <meta name="description" content="The CounselorReady™ Partner Marketplace Agreement governing course syndication, revenue share, and partner responsibilities.">
+  <link rel="canonical" href="https://counselorready.com/legal/partner-marketplace-agreement">
+  <link rel="stylesheet" href="/css/design-tokens.css">
+  <link rel="stylesheet" href="/css/typography.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <style>
+    body { background:#F8F7F4; color:#292524; font-family:'Lato', system-ui, sans-serif; line-height:1.7; margin:0; }
+    .wrap { max-width:820px; margin:0 auto; padding:48px 24px 80px; }
+    .font-display { font-family:'Cormorant Garamond', Georgia, serif; }
+    h1 { font-family:'Cormorant Garamond', Georgia, serif; color:#6B1D34; font-size:2.4rem; font-weight:700; margin:0 0 .25rem; line-height:1.15; }
+    h2 { font-family:'Cormorant Garamond', Georgia, serif; color:#284157; font-size:1.5rem; font-weight:700; margin:2.2rem 0 .6rem; }
+    .meta { color:#78716c; font-size:.9rem; margin-bottom:2rem; padding-bottom:1.5rem; border-bottom:1px solid #e7e5e0; }
+    p, li { font-size:1rem; color:#3f3c38; }
+    ul { padding-left:1.2rem; }
+    li { margin-bottom:.4rem; }
+    strong { color:#292524; }
+    a { color:#6B1D34; }
+    .home { display:inline-block; margin-bottom:1.5rem; font-size:.9rem; color:#4A7C59; text-decoration:none; }
+    .sig { margin-top:1rem; padding:1.2rem 1.4rem; background:#fff; border:1px solid #e7e5e0; border-radius:10px; font-size:.95rem; }
+    footer { margin-top:3rem; padding-top:1.5rem; border-top:1px solid #e7e5e0; font-size:.8rem; color:#78716c; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <a href="/" class="home">← CounselorReady</a>
+    <h1>Partner Marketplace Agreement</h1>
+    <div class="meta">Version 1.0 · Effective June 11, 2026 · Questions: <a href="mailto:legal@counselorready.com">legal@counselorready.com</a></div>
+
+    <p>This <strong>Partner Marketplace Agreement</strong> ("Agreement") is entered into as of the date of electronic acceptance ("Effective Date") between <strong>GA Integrated Therapeutic Perspectives, LLC</strong> d/b/a <strong>CounselorReady™</strong> ("CounselorReady," "we," "us") and the partner organization accepting it ("Partner," "you"). It supplements, and is incorporated into, the CounselorReady Terms of Service and any Partner/White-Label Order or subscription between the parties. If this Agreement conflicts with the general Terms of Service on marketplace matters, this Agreement controls.</p>
+
+    <h2>1. Definitions</h2>
+    <ul>
+      <li><strong>Marketplace</strong> — the reciprocal course-syndication program operated by CounselorReady.</li>
+      <li><strong>Platform Course</strong> — a continuing-education course owned by CounselorReady.</li>
+      <li><strong>Partner Course</strong> — a course owned by Partner and hosted on the platform.</li>
+      <li><strong>Distributor</strong> — the party that lists and sells a course to its audience.</li>
+      <li><strong>Owner</strong> — the party that owns the course content.</li>
+      <li><strong>Syndicated Sale</strong> — a completed, paid enrollment in which the Distributor and Owner differ.</li>
+      <li><strong>Distributor Share</strong> — 15% of the gross sale price, retained by the Distributor. <strong>Owner Share</strong> — the remaining 85%, retained by the Owner.</li>
+      <li><strong>Net Sale</strong> — gross sale price actually collected, after discounts/coupons and after refunds, chargebacks, and processor fees as described in Sections 4 and 7.</li>
+    </ul>
+
+    <h2>2. The two opt-in programs (each independent and revocable)</h2>
+    <p><strong>2.1 Import Platform Courses.</strong> If Partner enables "add CounselorReady courses to your library," Partner becomes the Distributor of Platform Courses to Partner's audience and earns the Distributor Share (15%) on those Syndicated Sales; CounselorReady (Owner) retains 85%.</p>
+    <p><strong>2.2 List in Marketplace.</strong> If Partner enables "list your courses in the CounselorReady marketplace," Partner's published Partner Courses may be offered to CounselorReady's audience. CounselorReady becomes the Distributor and retains 15%; Partner (Owner) retains 85%.</p>
+    <p><strong>2.3 Opt-in &amp; opt-out.</strong> Both programs are off by default and may be toggled by Partner at any time. Electronic acceptance and the toggle state are recorded. Opting out is prospective only and does not affect (a) existing enrollments, which remain accessible to enrolled learners, or (b) amounts already accrued.</p>
+
+    <h2>3. License grants</h2>
+    <p><strong>3.1 By CounselorReady to Partner.</strong> For Platform Courses Partner is authorized to distribute, CounselorReady grants Partner a limited, non-exclusive, non-transferable, revocable license to market and sell access to those courses under Partner's branding solely through the platform during the term. No right to download, modify, copy, sublicense (except to enrolled learners as access), or create derivative works is granted.</p>
+    <p><strong>3.2 By Partner to CounselorReady.</strong> For Partner Courses Partner lists in the Marketplace, Partner grants CounselorReady a limited, non-exclusive, revocable license to host, display, market, and sell access to those courses to CounselorReady's audience during the term and to issue certificates as provided in Section 6.</p>
+    <p><strong>3.3 Ownership.</strong> Each party retains all right, title, and interest in its own content, trademarks, and brand. No ownership transfers under this Agreement.</p>
+    <p><strong>3.4 Warranty of rights.</strong> Each party represents that it owns or has licensed all rights necessary to grant the licenses above and that its content does not infringe third-party rights.</p>
+
+    <h2>4. Fees, splits, and settlement</h2>
+    <p><strong>4.1 Split.</strong> The Distributor retains 15% and the Owner retains 85% of each Net Sale, unless a different rate is agreed in writing for a specific partner or course.</p>
+    <p><strong>4.2 Collection.</strong> CounselorReady collects all Marketplace payments through its payment processor. Amounts owed to a party accrue to that party's ledger balance.</p>
+    <p><strong>4.3 Processor fees.</strong> Payment-processing fees are deducted from the gross sale price before the split, unless otherwise agreed in writing and reflected in the Revenue Share &amp; Payout Policy.</p>
+    <p><strong>4.4 Settlement.</strong> Amounts owed are settled per the Revenue Share &amp; Payout Policy — by default as account credit toward Partner's CounselorReady invoice, or by payout on the stated schedule and above the stated minimum threshold.</p>
+    <p><strong>4.5 No guarantee.</strong> CounselorReady makes no representation or guarantee as to sales volume, revenue, placement, or that any particular course will be listed or remain listed.</p>
+
+    <h2>5. Taxes</h2>
+    <p>Each party is responsible for its own taxes on amounts it retains. Partner will provide a completed IRS Form W-9 (or W-8 series, if applicable) before any cash payout. CounselorReady may issue Form 1099 (or equivalent) as required by law and may withhold where required. Amounts settled as account credit may be reported differently than cash payouts; consult your tax advisor.</p>
+
+    <h2>6. CE compliance, certificates, and provider responsibility</h2>
+    <p><strong>6.1</strong> All courses offered through the Marketplace must meet the Content &amp; CE Compliance Standards, including NBCC/ACEP requirements where CE credit is represented.</p>
+    <p><strong>6.2 Provider of record.</strong> For courses awarding NBCC CE under ACEP Provider #7760, CounselorReady (GAITP LLC) is solely responsible for all aspects of the program as required by NBCC, regardless of which party distributed the sale. Courses not eligible for NBCC credit must be clearly identified.</p>
+    <p><strong>6.3</strong> Partner will not represent that a course awards credit it does not award, or misuse the ACEP provider number or CounselorReady's accreditation.</p>
+
+    <h2>7. Refunds, chargebacks, and clawbacks</h2>
+    <p><strong>7.1</strong> Refunds and chargebacks are governed by the Refund, Chargeback &amp; Clawback Policy.</p>
+    <p><strong>7.2</strong> When a Syndicated Sale is refunded or charged back, the related commission is reduced or reversed proportionally. If a party was already paid its share, that amount is a <strong>clawback</strong> and may be recovered from the party's ledger balance or future settlements, or invoiced if no balance is available.</p>
+
+    <h2>8. Conduct &amp; brand</h2>
+    <p><strong>8.1</strong> Partner will market courses lawfully and accurately, will not make false or misleading claims, spam, or engage in deceptive practices, and will comply with applicable advertising, consumer-protection, and professional-licensing rules.</p>
+    <p><strong>8.2</strong> Each party will use the other's trademarks only as permitted and in accordance with any brand guidelines provided. Branding within the platform follows the partner's configured white-label settings; CounselorReady's accreditation identity may not be altered or obscured where CE credit is represented.</p>
+
+    <h2>9. Term &amp; termination</h2>
+    <p><strong>9.1</strong> This Agreement begins on the Effective Date and continues until terminated. Either party may terminate the Marketplace programs for convenience on 30 days' notice, or immediately for material breach not cured within 15 days of notice, or immediately if required for legal/accreditation compliance.</p>
+    <p><strong>9.2 Effect of termination.</strong> Active learner enrollments are honored through completion or for the period required by NBCC record-keeping rules. Accrued, undisputed amounts are settled in the next cycle. Licenses for new sales end; record-keeping and audit obligations survive.</p>
+
+    <h2>10. Confidentiality</h2>
+    <p>Each party will protect the other's non-public business information and use it only to perform under this Agreement, surviving termination for three years (trade secrets, indefinitely).</p>
+
+    <h2>11. Warranties, disclaimers &amp; limitation of liability</h2>
+    <p><strong>11.1</strong> Except as expressly stated, the platform and courses are provided "as is." CounselorReady disclaims implied warranties to the maximum extent permitted by law.</p>
+    <p><strong>11.2 Liability cap.</strong> Except for indemnification obligations, breach of confidentiality, or a party's infringement/IP warranties, each party's aggregate liability is limited to the amounts paid or payable to the claiming party under the Marketplace in the 12 months preceding the claim. Neither party is liable for indirect, incidental, or consequential damages.</p>
+
+    <h2>12. Indemnification</h2>
+    <p>Each party will defend and indemnify the other against third-party claims arising from (a) its own content's infringement or illegality, (b) its breach of this Agreement, or (c) its violation of law, subject to prompt notice and reasonable cooperation.</p>
+
+    <h2>13. Independent contractors</h2>
+    <p>The parties are independent contractors. Nothing creates a partnership, joint venture, employment, or agency relationship. Neither party may bind the other.</p>
+
+    <h2>14. Governing law &amp; disputes</h2>
+    <p>This Agreement is governed by the laws of the State of Georgia, without regard to conflicts rules. Exclusive jurisdiction and venue lie in the state and federal courts located in Georgia. The prevailing party may recover reasonable fees where permitted.</p>
+
+    <h2>15. General</h2>
+    <p>Entire agreement (with the incorporated Terms and Policies); amendments in writing or via posted updates with notice; assignment only with consent (except to an affiliate or successor); severability; no waiver by inaction; notices to the addresses below or the account email.</p>
+
+    <div class="sig">
+      <strong>Acceptance.</strong> By enabling a Marketplace program in the partner portal, the authorized representative accepts this Agreement on behalf of Partner. Acceptance is recorded electronically as a clickwrap record capturing the agreement version, the accepting user's identity, the timestamp, the originating IP address, and the device (user agent).
+    </div>
+
+    <footer>
+      GA Integrated Therapeutic Perspectives, LLC · CounselorReady™ · PO Box 1417, Hinesville, GA 31310<br>
+      legal@counselorready.com · (678) 664-4003 · NBCC ACEP Provider #7760
+    </footer>
+  </div>
+</body>
+</html>

--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -38,6 +38,7 @@
 
   // ── POLICY LINKS (footer) ────────────────────────────────
   const policyLinks = [
+    { label: 'Become a Partner', href: '/partner' },
     { label: 'Privacy', href: '/privacy.html' },
     { label: 'Terms', href: '/terms.html' },
     { label: 'Refunds', href: '/refund-policy.html' },

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -391,4 +391,14 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://counselorready.com/partner</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://counselorready.com/legal/partner-marketplace-agreement</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
 </urlset>

--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -308,6 +308,7 @@
   </div>
 
   <script src="https://js.stripe.com/v3/"></script>
+  <script src="/js/stripe-config.js"></script>
   <script>
     const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
     let stripe = null;
@@ -545,9 +546,11 @@
     }
 
     function initStripe() {
-      // Initialize Stripe - replace with your publishable key
-      if (typeof Stripe !== 'undefined') {
-        stripe = Stripe('pk_test_placeholder'); // Replace with actual key
+      const pk = window.STRIPE_PUBLISHABLE_KEY || '';
+      if (typeof Stripe !== 'undefined' && pk) {
+        stripe = Stripe(pk);
+      } else if (!pk) {
+        console.warn('Stripe publishable key not set — add it in /js/stripe-config.js');
       }
     }
 

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -4,6 +4,7 @@
  * Unauthorized copying or distribution is strictly prohibited.
  */
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import mongoose from 'mongoose';
 import crypto from 'crypto';
 import dns from 'dns/promises';
@@ -37,7 +38,19 @@ router.get('/plans', (req, res) => {
  * trial) and its first partner-admin user, and returns an auth token so they land logged in and can
  * subscribe. They activate a paid plan from the billing page.
  */
-router.post('/signup', async (req, res) => {
+/**
+ * Rate limiter for the public self-serve signup endpoint: caps account-creation attempts per IP to
+ * blunt abuse/spam without affecting legitimate single signups.
+ */
+const signupLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 8,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many signup attempts. Please wait a few minutes and try again.' }
+});
+
+router.post('/signup', signupLimiter, async (req, res) => {
   let createdPartnerId = null;
   try {
     const { companyName, subdomain, firstName, lastName, email, password } = req.body || {};

--- a/tools/generate-sitemap.cjs
+++ b/tools/generate-sitemap.cjs
@@ -28,6 +28,8 @@ const STATIC_PAGES = [
   ['/blog',                    'weekly',  '0.6'],
   ['/about',                   'monthly', '0.5'],
   ['/subscription',            'monthly', '0.7'],
+  ['/partner',                 'monthly', '0.7'],
+  ['/legal/partner-marketplace-agreement', 'yearly', '0.2'],
   ['/register',                'monthly', '0.6'],
   ['/ada-accommodations',      'yearly',  '0.2'],
   ['/non-discrimination',      'yearly',  '0.2'],


### PR DESCRIPTION
## Summary

- Footer "Become a Partner" link added to `nav-footer.js` (funnel entry point)
- `/partner` and agreement page added to `sitemap.xml` + `generate-sitemap.cjs`
- `POST /api/partners/signup` rate-limited: 8 requests / 15 min per IP
- New `client/public/js/stripe-config.js` centralizes the Stripe publishable key; `subscription.html` reads from it instead of a hardcoded `pk_test_placeholder`
- New hosted `client/public/legal/partner-marketplace-agreement.html` for the clickwrap link
- Clean URL `/legal/partner-marketplace-agreement` added to `_redirects`

## Test plan

- [ ] Footer shows "Become a Partner" link pointing to `/partner`
- [ ] `/partner` and `/legal/partner-marketplace-agreement` appear in sitemap
- [ ] Rate limiter blocks >8 signup requests in 15 min from same IP (429 response)
- [ ] `subscription.html` loads Stripe key from `window.STRIPE_PUBLISHABLE_KEY` (no hardcoded placeholder)
- [ ] `/legal/partner-marketplace-agreement` resolves to the hosted agreement page

## Post-merge config (not code)

1. Paste live key (`pk_live_…`) into `client/public/js/stripe-config.js`
2. Set `MARKETPLACE_AGREEMENT_URL=https://counselorready.com/legal/partner-marketplace-agreement` in Render backend env

https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV

---
_Generated by [Claude Code](https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV)_