### PR TITLE
feat(live-sessions): Whereby live CE sessions + supervision rooms

### DIFF
--- a/client/public/live-room.html
+++ b/client/public/live-room.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Live Room - CounselorReady</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/css/design-tokens.css">
+  <link rel="stylesheet" href="/css/typography.css">
+  <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+  <script src="/js/tailwind-config.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <style>
+    body{background:#F8F7F4; font-family:'Lato', system-ui, sans-serif;}
+    .font-display{font-family:'Cormorant Garamond', Georgia, serif;}
+    #roomFrame, #replayVideo{width:100%;aspect-ratio:16/10;border:0;border-radius:12px;background:#1a1a1a;}
+    .handout-link{display:flex;align-items:center;gap:8px;padding:10px 12px;border-radius:8px;border:1px solid #EDE9E3;background:#fff;color:#284157;font-size:14px;text-decoration:none;transition:background .1s;}
+    .handout-link:hover{background:#F2F7F4;}
+    .handout-link.locked{opacity:.5;cursor:not-allowed;}
+  </style>
+</head>
+<body>
+  <script src="/shared/nav-footer.js"></script>
+
+  <main class="max-w-6xl mx-auto px-4 py-8">
+    <div id="gate" class="text-center py-20" style="color:#284157;">Checking your registration…</div>
+
+    <div id="room" class="hidden">
+      <div class="mb-4">
+        <h1 id="title" class="font-display text-3xl font-bold" style="color:#6B1D34;"></h1>
+        <p id="meta" class="text-sm mt-1" style="color:#284157;"></p>
+      </div>
+      <div class="grid lg:grid-cols-4 gap-6">
+        <div class="lg:col-span-3">
+          <iframe id="roomFrame" class="hidden"
+                  allow="camera; microphone; fullscreen; speaker; display-capture; autoplay"></iframe>
+          <video id="replayVideo" class="hidden" controls playsinline></video>
+        </div>
+        <aside class="lg:col-span-1">
+          <div class="bg-white rounded-xl border p-4" style="border-color:#EDE9E3;">
+            <h2 class="font-display text-lg font-bold mb-3" style="color:#284157;">Handouts</h2>
+            <div id="handouts" class="flex flex-col gap-2">
+              <p class="text-sm" style="color:#57534e;">No handouts for this session.</p>
+            </div>
+          </div>
+          <div id="ceNote" class="hidden mt-4 rounded-xl p-4 text-xs leading-relaxed" style="background:#FBF6EC;color:#7a5c1e;border:1px solid #EFE0C2;">
+            <strong>CE credit requires live attendance.</strong> Your join and leave times are verified automatically. Stay for at least the required portion of the session and your certificate will be issued after the webinar ends — no quiz required for live credit.
+          </div>
+        </aside>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
+    const token = localStorage.getItem('token');
+    const slug = new URLSearchParams(window.location.search).get('session');
+    const wantReplay = new URLSearchParams(window.location.search).get('replay') === '1';
+
+    function gateMsg(html) { const g = document.getElementById('gate'); g.innerHTML = html; g.classList.remove('hidden'); }
+
+    async function init() {
+      if (!slug) return gateMsg('Missing session. <a class="underline" style="color:#4A7C59;" href="/live-sessions.html">Browse live sessions</a>.');
+      if (!token) { window.location.href = '/login.html?next=' + encodeURIComponent(window.location.pathname + window.location.search); return; }
+
+      if (wantReplay) return loadReplay();
+
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}/join`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+          if (data.opensAt) {
+            const opens = new Date(data.opensAt);
+            return gateMsg(`The room opens at <strong>${opens.toLocaleString()}</strong>.<br><span class="text-sm">This page will let you in 15 minutes before the scheduled start.</span>`);
+          }
+          return gateMsg(`${data.error || 'Unable to join this session.'}<br><a class="underline" style="color:#4A7C59;" href="/live-sessions.html">Back to live sessions</a>`);
+        }
+
+        showSession(data.session);
+        const frame = document.getElementById('roomFrame');
+        frame.src = data.roomUrl;
+        frame.classList.remove('hidden');
+        if (data.session.sessionType === 'live-course') document.getElementById('ceNote').classList.remove('hidden');
+        document.getElementById('gate').classList.add('hidden');
+        document.getElementById('room').classList.remove('hidden');
+        loadHandouts(data.session);
+      } catch {
+        gateMsg('Connection problem. Please refresh.');
+      }
+    }
+
+    async function loadReplay() {
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}/replay`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        const data = await res.json();
+        if (!res.ok) return gateMsg(data.error || 'No replay available.');
+
+        const detail = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}`).then(r => r.json());
+        if (detail.session) { showSession(detail.session); loadHandouts(detail.session); }
+        document.getElementById('title').textContent = data.title + ' — Replay';
+
+        const video = document.getElementById('replayVideo');
+        video.src = data.replayUrl;
+        video.classList.remove('hidden');
+        document.getElementById('gate').classList.add('hidden');
+        document.getElementById('room').classList.remove('hidden');
+      } catch {
+        gateMsg('Could not load the replay. Please refresh.');
+      }
+    }
+
+    function showSession(s) {
+      document.getElementById('title').textContent = s.title;
+      document.getElementById('meta').textContent =
+        (s.sessionType === 'supervision' ? 'Clinical Supervision Session' : `${s.ceuHours} CE Hours · Live Webinar`) +
+        ' · ' + new Date(s.scheduledStart).toLocaleString();
+    }
+
+    function loadHandouts(s) {
+      const wrap = document.getElementById('handouts');
+      if (!s.handouts || s.handouts.length === 0) return;
+      wrap.innerHTML = '';
+      for (const h of s.handouts) {
+        const a = document.createElement('a');
+        a.className = 'handout-link';
+        a.href = '#';
+        a.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4A7C59" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg><span>${esc(h.title)}</span>`;
+        a.onclick = async (e) => {
+          e.preventDefault();
+          const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}/handouts/${h._id}`, {
+            headers: { 'Authorization': `Bearer ${token}` }
+          });
+          const data = await res.json();
+          if (res.ok && data.fileUrl) window.open(data.fileUrl, '_blank');
+          else alert(data.error || 'This handout is not available yet.');
+        };
+        wrap.appendChild(a);
+      }
+    }
+
+    function esc(s){const d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+    init();
+  </script>
+</body>
+</html>

--- a/client/public/live-sessions.html
+++ b/client/public/live-sessions.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Live Sessions - CounselorReady</title>
+  <meta name="description" content="Live, interactive NBCC-approved continuing education webinars for counselors. Earn synchronous CE hours from licensed presenters.">
+  <link rel="stylesheet" href="/css/design-tokens.css">
+  <link rel="stylesheet" href="/css/typography.css">
+  <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+  <script src="/js/tailwind-config.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <style>
+    body{background:#F8F7F4; font-family:'Lato', system-ui, sans-serif;}
+    .font-display{font-family:'Cormorant Garamond', Georgia, serif;}
+    .badge-live{background:#FDF5F7;color:#6B1D34;border:1px solid #F0D9DF;}
+    .badge-ce{background:#FBF6EC;color:#B8903A;border:1px solid #EFE0C2;}
+    .cta{background:#4A7C59;color:#fff;transition:background .15s;}
+    .cta:hover{background:#3D6A4A;}
+    .cta:disabled{background:#CBD5D0;cursor:not-allowed;}
+  </style>
+</head>
+<body>
+  <script src="/shared/nav-footer.js"></script>
+
+  <main class="max-w-5xl mx-auto px-4 py-10">
+    <header class="mb-8">
+      <span class="inline-block badge-live text-xs font-semibold tracking-wide uppercase rounded-full px-3 py-1 mb-3">Live &amp; Interactive</span>
+      <h1 class="font-display text-4xl md:text-5xl font-bold" style="color:#6B1D34;">Live Sessions</h1>
+      <p class="mt-3 max-w-2xl" style="color:#284157;">Synchronous, NBCC-approved webinars with real-time interaction, verified attendance, and automatic certificate delivery. Attend live in your browser — no downloads required.</p>
+    </header>
+
+    <div id="alert" class="hidden mb-6 rounded-lg px-4 py-3 text-sm"></div>
+    <div id="sessions" class="grid gap-5">
+      <div class="text-center py-16" style="color:#284157;" id="loading">Loading upcoming sessions…</div>
+    </div>
+  </main>
+
+  <script>
+    const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
+    const token = localStorage.getItem('token');
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('registered')) showAlert('You are registered! A confirmation is on its way to your inbox.', true);
+    if (params.get('canceled')) showAlert('Checkout was canceled. Your seat was not reserved.', false);
+
+    function showAlert(msg, ok) {
+      const el = document.getElementById('alert');
+      el.textContent = msg;
+      el.className = 'mb-6 rounded-lg px-4 py-3 text-sm ' + (ok
+        ? 'bg-green-50 text-green-800 border border-green-200'
+        : 'bg-red-50 text-red-800 border border-red-200');
+    }
+
+    function fmtDate(iso) {
+      return new Date(iso).toLocaleString('en-US', {
+        weekday:'short', month:'short', day:'numeric',
+        hour:'numeric', minute:'2-digit', timeZoneName:'short'
+      });
+    }
+
+    async function load() {
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/upcoming`);
+        const data = await res.json();
+        const wrap = document.getElementById('sessions');
+        wrap.innerHTML = '';
+
+        if (!data.sessions || data.sessions.length === 0) {
+          wrap.innerHTML = '<div class="text-center py-16 rounded-xl bg-white border" style="color:#284157;border-color:#EDE9E3;">No live sessions are scheduled right now. Check back soon — new webinars are added regularly.</div>';
+          return;
+        }
+
+        for (const s of data.sessions) {
+          const full = s.seatsRemaining <= 0;
+          const card = document.createElement('div');
+          card.className = 'bg-white rounded-xl border p-6 flex flex-col md:flex-row md:items-center gap-4';
+          card.style.borderColor = '#EDE9E3';
+          card.innerHTML = `
+            <div class="flex-1">
+              <div class="flex flex-wrap items-center gap-2 mb-2">
+                <span class="badge-ce text-xs font-semibold rounded-full px-2.5 py-0.5">${s.ceuHours} CE Hour${s.ceuHours === 1 ? '' : 's'} · Live</span>
+                ${s.recordingEnabled ? '<span class="text-xs rounded-full px-2.5 py-0.5" style="background:#F2F7F4;color:#4A7C59;border:1px solid #DCE9E0;">Replay included</span>' : ''}
+              </div>
+              <h2 class="font-display text-2xl font-bold" style="color:#284157;">${esc(s.title)}</h2>
+              <p class="text-sm mt-1" style="color:#57534e;">${esc(s.description || '')}</p>
+              <p class="text-sm mt-2 font-medium" style="color:#6B1D34;">${fmtDate(s.scheduledStart)}</p>
+              <p class="text-xs mt-1" style="color:#57534e;">${full ? 'Session full' : s.seatsRemaining + ' seats remaining'} · Presented by ${esc(s.presenter?.name || 'CounselorReady')}</p>
+            </div>
+            <div class="flex flex-col items-stretch gap-2 md:w-44">
+              <div class="text-center font-semibold" style="color:#284157;">${s.price > 0 ? '$' + s.price.toFixed(2) : 'Free'}</div>
+              <button class="cta rounded-lg px-4 py-2.5 font-semibold text-sm" ${full ? 'disabled' : ''} onclick="register('${s._id}')">${full ? 'Full' : 'Register'}</button>
+              <a class="text-center text-sm underline" style="color:#4A7C59;" href="/live-room.html?session=${esc(s.slug)}">Enter room</a>
+            </div>`;
+          wrap.appendChild(card);
+        }
+      } catch (e) {
+        document.getElementById('sessions').innerHTML = '<div class="text-center py-16 text-red-700">Could not load sessions. Please refresh.</div>';
+      }
+    }
+
+    async function register(id) {
+      if (!token) { window.location.href = '/login.html?next=' + encodeURIComponent('/live-sessions.html'); return; }
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${id}/register`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
+        });
+        const data = await res.json();
+        if (data.checkoutUrl) { window.location.href = data.checkoutUrl; return; }
+        if (data.registered) { showAlert(data.message || 'You are registered! See you in the room.', true); load(); }
+        else showAlert(data.error || 'Registration failed.', false);
+      } catch { showAlert('Registration failed. Please try again.', false); }
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    function esc(s){const d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+    load();
+  </script>
+</body>
+</html>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -83,6 +83,8 @@ import securityRoutes from './routes/security.js';
 import adminUsersRoutes from './routes/adminUsers.js';
 import adminRewardsRoutes from './routes/adminRewards.js';
 import supervisionRoutes from './routes/supervision.js';
+import liveSessionRoutes from './routes/liveSessions.js';
+import webhooksWherebyRoutes from './routes/webhooksWhereby.js';
 import insuranceCredentialsRoutes from './routes/insuranceCredentials.js';
 import legacyVaultRoutes from './routes/legacyVault.js';
 import groupLicensesRoutes from './routes/groupLicenses.js';
@@ -158,6 +160,7 @@ app.use(cors({
 
 app.use('/api/payments/webhook', express.raw({ type: 'application/json' }));
 app.use('/api/webhooks/resend', express.raw({ type: 'application/json' }));
+app.use('/api/webhooks/whereby', express.raw({ type: 'application/json' }));
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
@@ -282,6 +285,8 @@ app.use('/api/security', securityRoutes);
 app.use('/api/admin', adminUsersRoutes);
 app.use('/api/admin/rewards', adminRewardsRoutes);
 app.use('/api/supervision', supervisionRoutes);
+app.use('/api/live-sessions', liveSessionRoutes);
+app.use('/api/webhooks/whereby', webhooksWherebyRoutes);
 app.use('/api/insurance-credentials', insuranceCredentialsRoutes);
 app.use('/api/legacy-vault', legacyVaultRoutes);
 app.use('/api/group-licenses', groupLicensesRoutes);

--- a/server/src/models/Certificate.js
+++ b/server/src/models/Certificate.js
@@ -17,6 +17,11 @@ const certificateSchema = new mongoose.Schema({
     ref: 'Course',
     index: true
   },
+  liveSessionId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'LiveSession',
+    index: true
+  },
   title: {
     type: String,
     required: true,

--- a/server/src/models/LiveSession.js
+++ b/server/src/models/LiveSession.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ * Unauthorized copying or distribution is strictly prohibited.
+ */
+
+/**
+ * LiveSession — synchronous Whereby-backed sessions (live CE courses + clinical supervision).
+ *
+ * HIPAA architecture: PHI never touches this collection. We store only session
+ * metadata (who registered, join/leave timestamps, durations). The PHI surface
+ * is the live video stream itself, covered by the Whereby BAA.
+ *
+ * Hard-locked invariants (enforced in pre('validate'), NOT admin-configurable):
+ *   - sessionType 'supervision'  => recordingEnabled is forced false
+ *   - sessionType 'supervision'  => handouts are rejected (Cloudinary has no BAA)
+ */
+import mongoose from 'mongoose';
+
+const registrantSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  registeredAt: { type: Date, default: Date.now },
+  paid: { type: Boolean, default: false },
+  stripeCheckoutSessionId: String
+}, { _id: false });
+
+const attendanceSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  // Whereby participant/display metadata so admins can reconcile edge cases
+  displayName: String,
+  wherebyParticipantId: String,
+  joinedAt: { type: Date, required: true },
+  leftAt: Date,
+  durationMin: { type: Number, default: 0 }
+}, { _id: true });
+
+const handoutSchema = new mongoose.Schema({
+  title: { type: String, required: true, trim: true },
+  cloudinaryPublicId: { type: String, required: true },
+  fileUrl: { type: String, required: true },
+  fileType: { type: String, enum: ['pdf', 'docx', 'pptx', 'xlsx', 'png', 'jpg'], default: 'pdf' },
+  sizeKB: Number,
+  availability: { type: String, enum: ['before', 'during', 'after'], default: 'during' }
+}, { _id: true });
+
+const recordingSchema = new mongoose.Schema({
+  s3Key: { type: String, required: true },
+  s3Bucket: String,
+  durationMin: Number,
+  recordedAt: { type: Date, default: Date.now },
+  status: { type: String, enum: ['processing', 'ready', 'archived'], default: 'ready' },
+  replayEnabled: { type: Boolean, default: false }
+}, { _id: true });
+
+const liveSessionSchema = new mongoose.Schema({
+  title: { type: String, required: true, trim: true },
+  slug: { type: String, required: true, unique: true, lowercase: true, trim: true },
+  description: { type: String, default: '' },
+  presenter: {
+    name: { type: String, default: 'Kejuiana Johnson, MA, LPC, NCC, CPCS, BC-TMH' },
+    credentials: String
+  },
+
+  sessionType: {
+    type: String,
+    enum: ['live-course', 'supervision'],
+    required: true,
+    index: true
+  },
+
+  // Live-course CE metadata (ignored for supervision)
+  courseRef: { type: mongoose.Schema.Types.ObjectId, ref: 'InteractiveCourse' },
+  ceuHours: { type: Number, min: 0, default: 0 },
+  nbccContentAreas: [String],
+  category: { type: String, default: 'Other' },
+
+  // Supervision metadata (ignored for live-course)
+  supervisionFormat: {
+    type: String,
+    enum: ['individual', 'group', 'triadic', null],
+    default: null
+  },
+
+  // Scheduling
+  scheduledStart: { type: Date, required: true, index: true },
+  scheduledEnd: { type: Date, required: true },
+  timezone: { type: String, default: 'America/New_York' },
+
+  // Whereby room (URLs are NEVER sent to unauthenticated clients;
+  // viewerRoomUrl/hostRoomUrl only leave the server via the gated /join endpoint)
+  whereby: {
+    meetingId: { type: String, index: true },
+    roomName: String,
+    viewerRoomUrl: String,
+    hostRoomUrl: String
+  },
+
+  // Access & pricing
+  capacity: { type: Number, default: 50, min: 1, max: 200 },
+  price: { type: Number, default: 0, min: 0 }, // USD; 0 = free / included
+  isPublished: { type: Boolean, default: false, index: true },
+
+  registrants: [registrantSchema],
+  attendance: [attendanceSchema],
+
+  // Certificate eligibility: % of scheduled duration attended
+  attendanceThresholdPct: { type: Number, default: 90, min: 50, max: 100 },
+  certificatesIssuedAt: Date,
+
+  // Recording — live-course only; hard-locked off for supervision
+  recordingEnabled: { type: Boolean, default: false },
+  recordings: [recordingSchema],
+
+  // Handouts — live-course only; hard-locked empty for supervision
+  handouts: [handoutSchema],
+
+  status: {
+    type: String,
+    enum: ['scheduled', 'live', 'completed', 'cancelled'],
+    default: 'scheduled',
+    index: true
+  }
+}, { timestamps: true });
+
+/* ── Hard-locked compliance invariants ─────────────────────────────────── */
+liveSessionSchema.pre('validate', function (next) {
+  if (this.sessionType === 'supervision') {
+    // Recording physically impossible for supervision — Whereby room is also
+    // created with recording.type='none' in wherebyService; this is defense in depth.
+    this.recordingEnabled = false;
+    if (this.recordings && this.recordings.length > 0) {
+      return next(new Error('Recordings are not permitted on supervision sessions (HIPAA hard-lock).'));
+    }
+    if (this.handouts && this.handouts.length > 0) {
+      return next(new Error('Handouts are not permitted on supervision sessions — Cloudinary has no BAA (HIPAA hard-lock).'));
+    }
+    this.ceuHours = 0;
+  }
+  if (this.scheduledEnd <= this.scheduledStart) {
+    return next(new Error('scheduledEnd must be after scheduledStart.'));
+  }
+  next();
+});
+
+/* ── Helpers ───────────────────────────────────────────────────────────── */
+liveSessionSchema.methods.isRegistered = function (userId) {
+  return this.registrants.some(r => r.user && r.user.toString() === userId.toString());
+};
+
+liveSessionSchema.methods.scheduledDurationMin = function () {
+  return Math.round((this.scheduledEnd - this.scheduledStart) / 60000);
+};
+
+/** Total verified minutes for a user across all join/leave segments. */
+liveSessionSchema.methods.attendedMinutes = function (userId) {
+  return this.attendance
+    .filter(a => a.user && a.user.toString() === userId.toString())
+    .reduce((sum, a) => sum + (a.durationMin || 0), 0);
+};
+
+liveSessionSchema.methods.meetsAttendanceThreshold = function (userId) {
+  const required = this.scheduledDurationMin() * (this.attendanceThresholdPct / 100);
+  return this.attendedMinutes(userId) >= required;
+};
+
+/** Public-safe projection — strips room URLs and other server-only fields. */
+liveSessionSchema.methods.toPublicJSON = function () {
+  return {
+    _id: this._id,
+    title: this.title,
+    slug: this.slug,
+    description: this.description,
+    presenter: this.presenter,
+    sessionType: this.sessionType,
+    ceuHours: this.ceuHours,
+    category: this.category,
+    scheduledStart: this.scheduledStart,
+    scheduledEnd: this.scheduledEnd,
+    timezone: this.timezone,
+    capacity: this.capacity,
+    seatsRemaining: Math.max(0, this.capacity - this.registrants.length),
+    price: this.price,
+    status: this.status,
+    recordingEnabled: this.recordingEnabled,
+    handouts: (this.handouts || []).map(h => ({
+      _id: h._id, title: h.title, fileType: h.fileType, availability: h.availability
+    }))
+  };
+};
+
+liveSessionSchema.index({ status: 1, scheduledStart: 1 });
+
+const LiveSession = mongoose.model('LiveSession', liveSessionSchema);
+export default LiveSession;

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -81,6 +81,8 @@ import uploadsRoutes from './routes/uploads.js';
 import videoAuditRoutes from './routes/videoAudit.js';
 import orgRoutes from './routes/orgRoutes.js';
 import complianceRoutes from './routes/complianceRoutes.js';
+import liveSessionRoutes from './routes/liveSessions.js';
+import webhooksWherebyRoutes from './routes/webhooksWhereby.js';
 
 /**
  * Route Manifest — declared route registrations.
@@ -163,6 +165,8 @@ export const ROUTE_MANIFEST = [
   ['/api/admin/video-audit',      videoAuditRoutes,          'Video Link Audit'],
   ['/api/orgs',                  orgRoutes,                 'Practice Compliance — Orgs/Roster/Tracks/Assignments'],
   ['/api',                       complianceRoutes,          'Practice Compliance — Credentials/Policies/Supervision/Audit Binder'],
+  ['/api/live-sessions',         liveSessionRoutes,         'Live Sessions (Whereby)'],
+  ['/api/webhooks/whereby',      webhooksWherebyRoutes,     'Whereby attendance + recording webhook'],
 ];
 
 /**

--- a/server/src/routes/liveSessions.js
+++ b/server/src/routes/liveSessions.js
@@ -1,0 +1,350 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * liveSessions — synchronous sessions (live CE webinars + clinical supervision).
+ * Mounted at /api/live-sessions (see WIRING.md for index.js + routeManifest entries).
+ *
+ * ROUTE ORDER RULE: named routes (/upcoming, /mine) MUST precede /:id routes.
+ *
+ * Access-control architecture:
+ *   - Whereby room URLs, S3 replay URLs, and Cloudinary handout URLs NEVER
+ *     appear in public payloads or page source. They are returned only from
+ *     the gated endpoints below, to authenticated registered users, inside
+ *     the appropriate time/availability window.
+ */
+import express from 'express';
+import Stripe from 'stripe';
+import LiveSession from '../models/LiveSession.js';
+import { protect, requireAdmin } from '../middleware/auth.js';
+import { createMeeting, deleteMeeting } from '../services/wherebyService.js';
+import { issueLiveSessionCertificates } from '../services/liveSessionCompletionService.js';
+
+const router = express.Router();
+const stripe = process.env.STRIPE_SECRET_KEY ? new Stripe(process.env.STRIPE_SECRET_KEY) : null;
+
+const JOIN_WINDOW_BEFORE_MIN = 15; // doors open 15 min early
+const JOIN_WINDOW_AFTER_MIN = 30;  // grace after scheduled end (overruns)
+
+/* ════════════════════════ PUBLIC / LEARNER ════════════════════════ */
+
+// GET /api/live-sessions/upcoming — published upcoming live courses (catalog)
+router.get('/upcoming', async (req, res) => {
+  try {
+    const sessions = await LiveSession.find({
+      isPublished: true,
+      sessionType: 'live-course',
+      status: { $in: ['scheduled', 'live'] },
+      scheduledEnd: { $gte: new Date() }
+    }).sort({ scheduledStart: 1 }).limit(50);
+    res.json({ sessions: sessions.map(s => s.toPublicJSON()) });
+  } catch (err) {
+    console.error('[live] upcoming:', err.message);
+    res.status(500).json({ error: 'Failed to load upcoming sessions' });
+  }
+});
+
+// GET /api/live-sessions/mine — sessions the user is registered for (incl. supervision)
+router.get('/mine', protect, async (req, res) => {
+  try {
+    const sessions = await LiveSession.find({
+      'registrants.user': req.user._id
+    }).sort({ scheduledStart: -1 }).limit(100);
+    res.json({
+      sessions: sessions.map(s => ({
+        ...s.toPublicJSON(),
+        attendedMinutes: s.attendedMinutes(req.user._id),
+        hasReplay: s.recordings.some(r => r.replayEnabled && r.status === 'ready')
+      }))
+    });
+  } catch (err) {
+    console.error('[live] mine:', err.message);
+    res.status(500).json({ error: 'Failed to load your sessions' });
+  }
+});
+
+// GET /api/live-sessions/:id — public-safe detail (by id or slug)
+router.get('/:id', async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session || (!session.isPublished && session.sessionType === 'live-course')) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+    res.json({ session: session.toPublicJSON() });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load session' });
+  }
+});
+
+// POST /api/live-sessions/:id/register
+router.post('/:id/register', protect, async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session || !session.isPublished) return res.status(404).json({ error: 'Session not found' });
+    if (!['scheduled', 'live'].includes(session.status)) {
+      return res.status(400).json({ error: 'Registration is closed for this session.' });
+    }
+    if (session.isRegistered(req.user._id)) {
+      return res.json({ registered: true, message: 'Already registered.' });
+    }
+    if (session.registrants.length >= session.capacity) {
+      return res.status(400).json({ error: 'This session is full.' });
+    }
+
+    // Paid sessions → Stripe Checkout; fulfillment registers via webhook (WIRING.md)
+    if (session.price > 0) {
+      if (!stripe) return res.status(500).json({ error: 'Payments unavailable' });
+      const checkout = await stripe.checkout.sessions.create({
+        payment_method_types: ['card'],
+        mode: 'payment',
+        line_items: [{
+          price_data: {
+            currency: 'usd',
+            unit_amount: Math.round(session.price * 100),
+            product_data: { name: `Live Session: ${session.title}` }
+          },
+          quantity: 1
+        }],
+        success_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/live-sessions.html?registered=${session.slug}`,
+        cancel_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/live-sessions.html?canceled=true`,
+        metadata: {
+          type: 'live-session',
+          liveSessionId: session._id.toString(),
+          userId: req.user._id.toString()
+        }
+      });
+      return res.json({ checkoutUrl: checkout.url });
+    }
+
+    session.registrants.push({ user: req.user._id, paid: false });
+    await session.save();
+    res.json({ registered: true });
+  } catch (err) {
+    console.error('[live] register:', err.message);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+// POST /api/live-sessions/:id/join — mint the room URL (the access-control gate)
+router.post('/:id/join', protect, async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    const isAdmin = req.user.role === 'admin';
+    if (!isAdmin && !session.isRegistered(req.user._id)) {
+      return res.status(403).json({ error: 'You are not registered for this session.' });
+    }
+    if (session.status === 'cancelled') {
+      return res.status(400).json({ error: 'This session was cancelled.' });
+    }
+
+    const now = Date.now();
+    const opens = session.scheduledStart.getTime() - JOIN_WINDOW_BEFORE_MIN * 60000;
+    const closes = session.scheduledEnd.getTime() + JOIN_WINDOW_AFTER_MIN * 60000;
+    if (!isAdmin && (now < opens || now > closes)) {
+      return res.status(400).json({
+        error: 'The room is not open yet.',
+        opensAt: new Date(opens).toISOString()
+      });
+    }
+
+    const displayName = `${(req.user.profile?.firstName || '')} ${(req.user.profile?.lastName || '')}`.trim() || req.user.email;
+    const baseUrl = isAdmin ? (session.whereby.hostRoomUrl || session.whereby.viewerRoomUrl) : session.whereby.viewerRoomUrl;
+    if (!baseUrl) return res.status(500).json({ error: 'Room not provisioned. Contact support.' });
+
+    const sep = baseUrl.includes('?') ? '&' : '?';
+    const roomUrl = `${baseUrl}${sep}displayName=${encodeURIComponent(displayName)}`;
+
+    if (session.status === 'scheduled' && now >= opens) {
+      session.status = 'live';
+      await session.save();
+    }
+
+    res.json({
+      roomUrl,
+      isHost: isAdmin,
+      session: session.toPublicJSON()
+    });
+  } catch (err) {
+    console.error('[live] join:', err.message);
+    res.status(500).json({ error: 'Failed to join session' });
+  }
+});
+
+// GET /api/live-sessions/:id/replay — presigned S3 URL, registrants only
+router.get('/:id/replay', protect, async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+    if (session.sessionType !== 'live-course') return res.status(403).json({ error: 'No replay available.' });
+
+    const isAdmin = req.user.role === 'admin';
+    if (!isAdmin && !session.isRegistered(req.user._id)) {
+      return res.status(403).json({ error: 'Replays are available to registered attendees only.' });
+    }
+
+    const recording = session.recordings.find(r => r.status === 'ready' && (r.replayEnabled || isAdmin));
+    if (!recording) return res.status(404).json({ error: 'No replay is available for this session.' });
+
+    // Lazy-import AWS SDK so the server boots fine before deps are installed
+    const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
+    const { getSignedUrl } = await import('@aws-sdk/s3-request-presigner');
+
+    const s3 = new S3Client({ region: process.env.AWS_REGION || 'us-east-1' });
+    const url = await getSignedUrl(
+      s3,
+      new GetObjectCommand({
+        Bucket: recording.s3Bucket || process.env.AWS_S3_RECORDINGS_BUCKET,
+        Key: recording.s3Key
+      }),
+      { expiresIn: 3600 } // 1 hour
+    );
+
+    res.json({ replayUrl: url, expiresInSeconds: 3600, title: session.title });
+  } catch (err) {
+    console.error('[live] replay:', err.message);
+    res.status(500).json({ error: 'Failed to load replay' });
+  }
+});
+
+// GET /api/live-sessions/:id/handouts/:handoutId — gated handout URL
+router.get('/:id/handouts/:handoutId', protect, async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    const isAdmin = req.user.role === 'admin';
+    if (!isAdmin && !session.isRegistered(req.user._id)) {
+      return res.status(403).json({ error: 'Handouts are available to registered attendees only.' });
+    }
+
+    const handout = session.handouts.id(req.params.handoutId);
+    if (!handout) return res.status(404).json({ error: 'Handout not found' });
+
+    if (!isAdmin) {
+      const now = Date.now();
+      const started = now >= session.scheduledStart.getTime() - JOIN_WINDOW_BEFORE_MIN * 60000;
+      const ended = session.status === 'completed' || now > session.scheduledEnd.getTime();
+      const ok =
+        handout.availability === 'before' ||
+        (handout.availability === 'during' && started) ||
+        (handout.availability === 'after' && ended);
+      if (!ok) return res.status(403).json({ error: 'This handout is not available yet.' });
+    }
+
+    res.json({ title: handout.title, fileUrl: handout.fileUrl, fileType: handout.fileType });
+  } catch (err) {
+    console.error('[live] handout:', err.message);
+    res.status(500).json({ error: 'Failed to load handout' });
+  }
+});
+
+/* ════════════════════════ ADMIN ════════════════════════ */
+
+// POST /api/live-sessions — create session + provision Whereby room
+router.post('/', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = new LiveSession(req.body);
+    await session.validate(); // run hard-lock invariants BEFORE provisioning the room
+
+    const room = await createMeeting(session);
+    session.whereby = room;
+    await session.save();
+
+    res.status(201).json({ session });
+  } catch (err) {
+    console.error('[live] create:', err.message);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PATCH /api/live-sessions/:id — update metadata/handouts/publish state
+router.patch('/:id', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    // Never allow client payloads to overwrite room URLs or attendance
+    const { whereby, attendance, registrants, recordings, ...safe } = req.body;
+    Object.assign(session, safe);
+    await session.save(); // pre-validate re-runs hard-locks
+
+    res.json({ session });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /api/live-sessions/:id — cancel + tear down Whereby room
+router.delete('/:id', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    await deleteMeeting(session.whereby?.meetingId);
+    session.status = 'cancelled';
+    session.isPublished = false;
+    await session.save();
+
+    res.json({ cancelled: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to cancel session' });
+  }
+});
+
+// GET /api/live-sessions/:id/attendance — verified attendance report
+router.get('/:id/attendance', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id)
+      .populate('registrants.user', 'email profile.firstName profile.lastName')
+      .populate('attendance.user', 'email profile.firstName profile.lastName');
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    const scheduledMin = session.scheduledDurationMin();
+    const report = session.registrants.map(r => {
+      const attended = session.attendedMinutes(r.user._id);
+      return {
+        user: r.user,
+        registeredAt: r.registeredAt,
+        paid: r.paid,
+        attendedMinutes: attended,
+        attendancePct: scheduledMin ? Math.round((attended / scheduledMin) * 100) : 0,
+        qualifies: session.meetsAttendanceThreshold(r.user._id)
+      };
+    });
+
+    res.json({
+      session: { title: session.title, sessionType: session.sessionType, scheduledMin, thresholdPct: session.attendanceThresholdPct },
+      report,
+      rawAttendance: session.attendance
+    });
+  } catch (err) {
+    console.error('[live] attendance:', err.message);
+    res.status(500).json({ error: 'Failed to load attendance' });
+  }
+});
+
+// POST /api/live-sessions/:id/issue-certificates — cert qualifying attendees
+router.post('/:id/issue-certificates', protect, requireAdmin, async (req, res) => {
+  try {
+    const result = await issueLiveSessionCertificates(req.params.id);
+    res.json(result);
+  } catch (err) {
+    console.error('[live] issue-certificates:', err.message);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+/* ── helpers ── */
+async function findByIdOrSlug(idOrSlug) {
+  if (/^[0-9a-fA-F]{24}$/.test(idOrSlug)) {
+    const byId = await LiveSession.findById(idOrSlug);
+    if (byId) return byId;
+  }
+  return LiveSession.findOne({ slug: idOrSlug.toLowerCase() });
+}
+
+export default router;

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -751,6 +751,23 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
           break;
         }
 
+        // Live session seat purchase
+        if (session.metadata?.type === 'live-session') {
+          const { liveSessionId, userId: liveUserId } = session.metadata;
+          const LiveSession = (await import('../models/LiveSession.js')).default;
+          const live = await LiveSession.findById(liveSessionId);
+          if (live && !live.isRegistered(liveUserId)) {
+            live.registrants.push({
+              user: liveUserId,
+              paid: true,
+              stripeCheckoutSessionId: session.id
+            });
+            await live.save();
+            logger.info({ liveSessionId, userId: liveUserId, requestId: req.requestId }, 'Live session seat purchased');
+          }
+          break;
+        }
+
         // Handle subscription purchase
         if (userId && plan) {
           await User.findByIdAndUpdate(userId, {

--- a/server/src/routes/webhooksWhereby.js
+++ b/server/src/routes/webhooksWhereby.js
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * Whereby Webhook — receives room/recording lifecycle events and writes the
+ * verified attendance trail used for NBCC live-CE certificate eligibility.
+ *
+ * Mounted at /api/webhooks/whereby. Raw body parser applied at the app level
+ * in index.js (before express.json), mirroring the Stripe + Resend webhooks,
+ * so req.body here is a Buffer.
+ *
+ * Signature: Whereby signs with a `whereby-signature` header of the form
+ *   t=<unix-ts>,v1=<hmac-sha256-hex of "<ts>.<rawBody>">
+ * Set WHEREBY_WEBHOOK_SECRET from Dashboard → Configure → Webhooks.
+ *
+ * Events handled:
+ *   room.client.joined   → open an attendance segment
+ *   room.client.left     → close the segment, compute durationMin
+ *   room.session.ended   → close any dangling segments, mark session completed
+ *   recording.finished   → record S3 key on the session
+ * Unknown event types are acknowledged (200) and ignored.
+ */
+import express from 'express';
+import crypto from 'crypto';
+import LiveSession from '../models/LiveSession.js';
+import User from '../models/User.js';
+
+const router = express.Router();
+const TOLERANCE_SECONDS = 5 * 60;
+
+function verifyWherebySignature(payload, headers, secret) {
+  const header = headers['whereby-signature'];
+  if (!header || !secret) return false;
+
+  const parts = Object.fromEntries(
+    header.split(',').map(kv => kv.split('=').map(s => s.trim()))
+  );
+  const ts = parts.t;
+  const sig = parts.v1;
+  if (!ts || !sig) return false;
+
+  const age = Math.abs(Math.floor(Date.now() / 1000) - parseInt(ts, 10));
+  if (Number.isNaN(age) || age > TOLERANCE_SECONDS) return false;
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${ts}.${payload.toString('utf8')}`)
+    .digest('hex');
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(sig, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+router.post('/', async (req, res) => {
+  const secret = process.env.WHEREBY_WEBHOOK_SECRET;
+  const raw = Buffer.isBuffer(req.body)
+    ? req.body
+    : Buffer.from(typeof req.body === 'string' ? req.body : JSON.stringify(req.body || {}));
+
+  if (secret && !verifyWherebySignature(raw, req.headers, secret)) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  let event;
+  try {
+    event = JSON.parse(raw.toString('utf8'));
+  } catch {
+    return res.status(400).json({ error: 'Invalid JSON' });
+  }
+
+  // Ack fast; process inline (events are small) but never let errors 500 a retry storm
+  try {
+    await handleEvent(event);
+  } catch (err) {
+    console.error('[whereby-webhook] handler error:', err.message);
+  }
+  res.json({ received: true });
+});
+
+async function handleEvent(event) {
+  const type = event.type;
+  const data = event.data || {};
+  const meetingId = String(data.meetingId || '');
+  if (!meetingId) return;
+
+  const session = await LiveSession.findOne({ 'whereby.meetingId': meetingId });
+  if (!session) {
+    console.warn(`[whereby-webhook] no LiveSession for meetingId ${meetingId} (${type})`);
+    return;
+  }
+
+  switch (type) {
+    case 'room.client.joined': {
+      const displayName = data.displayName || '';
+      const user = await matchUser(session, displayName);
+      session.attendance.push({
+        user: user?._id,
+        displayName,
+        wherebyParticipantId: data.participantId || data.id || '',
+        joinedAt: new Date(event.createdAt || Date.now())
+      });
+      if (session.status === 'scheduled') session.status = 'live';
+      await session.save();
+      break;
+    }
+
+    case 'room.client.left': {
+      const pid = data.participantId || data.id || '';
+      const leftAt = new Date(event.createdAt || Date.now());
+      // Close the most recent open segment for this participant
+      const segment = [...session.attendance]
+        .reverse()
+        .find(a => !a.leftAt && (pid ? a.wherebyParticipantId === pid : a.displayName === (data.displayName || '')));
+      if (segment) {
+        segment.leftAt = leftAt;
+        segment.durationMin = Math.max(0, Math.round((leftAt - segment.joinedAt) / 60000));
+        await session.save();
+      }
+      break;
+    }
+
+    case 'room.session.ended': {
+      const endedAt = new Date(event.createdAt || Date.now());
+      let dirty = false;
+      for (const a of session.attendance) {
+        if (!a.leftAt) {
+          a.leftAt = endedAt;
+          a.durationMin = Math.max(0, Math.round((endedAt - a.joinedAt) / 60000));
+          dirty = true;
+        }
+      }
+      if (session.status === 'live') { session.status = 'completed'; dirty = true; }
+      if (dirty) await session.save();
+      break;
+    }
+
+    case 'recording.finished': {
+      // Defense in depth: supervision sessions can never persist recordings.
+      if (session.sessionType === 'supervision') {
+        console.error(`[whereby-webhook] recording.finished on SUPERVISION session ${session._id} — refusing to store. Investigate Whereby room config immediately.`);
+        return;
+      }
+      session.recordings.push({
+        s3Key: data.key || data.s3Key || data.fileName || '',
+        s3Bucket: data.bucket || process.env.AWS_S3_RECORDINGS_BUCKET,
+        durationMin: data.duration ? Math.round(data.duration / 60) : undefined,
+        recordedAt: new Date(event.createdAt || Date.now()),
+        status: 'ready',
+        replayEnabled: false // admin flips this on after review
+      });
+      await session.save();
+      break;
+    }
+
+    default:
+      break; // acknowledged, ignored
+  }
+}
+
+/**
+ * Match a Whereby participant back to a registered user by display name.
+ * /join injects "FirstName LastName" (or email) as displayName, so this is
+ * deterministic for participants who entered through our gated flow.
+ */
+async function matchUser(session, displayName) {
+  if (!displayName) return null;
+  const registrantIds = session.registrants.map(r => r.user);
+  const candidates = await User.find({ _id: { $in: registrantIds } })
+    .select('email profile.firstName profile.lastName');
+
+  const norm = s => (s || '').trim().toLowerCase();
+  const target = norm(displayName);
+
+  return candidates.find(u => {
+    const full = norm(`${u.profile?.firstName || ''} ${u.profile?.lastName || ''}`);
+    return full === target || norm(u.email) === target;
+  }) || null;
+}
+
+export default router;

--- a/server/src/services/liveSessionCompletionService.js
+++ b/server/src/services/liveSessionCompletionService.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * liveSessionCompletionService — issues certificates to live-session attendees
+ * who meet the verified attendance threshold (Whereby webhook join/leave data).
+ *
+ * Mirrors the canonical certificateSelfHeal pipeline:
+ *   generateCertificateNumber + generateCertificate (utils/certificate.js)
+ *   → Cloudinary upload_stream → Certificate doc → CE auto-apply to credentials.
+ *
+ * Supervision sessions never issue certificates here — supervision hours are
+ * logged via SupervisionLog, not the CE certificate pipeline.
+ */
+import { Readable } from 'stream';
+import { v2 as cloudinary } from 'cloudinary';
+import User from '../models/User.js';
+import Certificate from '../models/Certificate.js';
+import UserCredential from '../models/UserCredential.js';
+import LiveSession from '../models/LiveSession.js';
+import {
+  generateCertificate,
+  generateCertificateNumber,
+  buildApprovalBlock
+} from '../utils/certificate.js';
+
+const LOG = '[LiveCert]';
+
+/**
+ * Issue certificates for all qualifying registrants of a completed live course.
+ * Idempotent: skips users who already hold a non-revoked certificate for this session.
+ *
+ * @param {string} liveSessionId
+ * @returns {{issued: Array, skipped: Array, failed: Array}}
+ */
+export async function issueLiveSessionCertificates(liveSessionId) {
+  const session = await LiveSession.findById(liveSessionId);
+  if (!session) throw new Error('Live session not found');
+  if (session.sessionType !== 'live-course') {
+    throw new Error('Certificates are only issued for live-course sessions, not supervision.');
+  }
+  if (!['completed', 'live'].includes(session.status)) {
+    throw new Error(`Session status is '${session.status}' — must be live or completed before issuing certificates.`);
+  }
+
+  const issued = [];
+  const skipped = [];
+  const failed = [];
+
+  for (const registrant of session.registrants) {
+    const userId = registrant.user;
+    try {
+      if (!session.meetsAttendanceThreshold(userId)) {
+        skipped.push({
+          userId,
+          reason: 'attendance-below-threshold',
+          attendedMin: session.attendedMinutes(userId),
+          requiredMin: Math.round(session.scheduledDurationMin() * session.attendanceThresholdPct / 100)
+        });
+        continue;
+      }
+
+      // Idempotency: title + user + platform source (no courseId for live sessions;
+      // liveSessionId field added to CertificateSchema — see WIRING.md)
+      const existing = await Certificate.findOne({
+        userId,
+        liveSessionId: session._id,
+        isRevoked: { $ne: true }
+      });
+      if (existing) {
+        skipped.push({ userId, reason: 'already-issued', certificateNumber: existing.certificateNumber });
+        continue;
+      }
+
+      const user = await User.findById(userId);
+      if (!user) { skipped.push({ userId, reason: 'user-not-found' }); continue; }
+
+      const certificateNumber = await generateCertificateNumber(session._id, user._id);
+
+      const userName =
+        (user.profile?.certificateName?.trim()) ||
+        `${user.profile?.firstName || ''} ${user.profile?.lastName || ''}`.trim() ||
+        user.email;
+
+      const pdfBuffer = await generateCertificate({
+        holderName: userName,
+        courseName: session.title,
+        completionDate: session.scheduledEnd,
+        ceHours: session.ceuHours,
+        certificateNumber,
+        acepNumber: 'ACEP #7760',
+        ceCategory:
+          session.nbccContentAreas?.[0] ||
+          'Counseling Theory/Practice and the Counseling Relationship',
+        objectives: [],
+        // NBCC fallback row, stamped as a live webinar so the certificate
+        // shows the synchronous delivery format (LPCA-GA taxonomy)
+        approvals: buildApprovalBlock(null, 'NBCC', session.ceuHours).map(a => ({
+          ...a,
+          deliveryFormat: 'live-webinar'
+        }))
+      });
+
+      const uploadResult = await new Promise((resolve, reject) => {
+        const uploadStream = cloudinary.uploader.upload_stream(
+          {
+            resource_type: 'raw',
+            folder: 'certificates',
+            public_id: `cert_${certificateNumber}_live_${Date.now()}`,
+            format: 'pdf'
+          },
+          (error, result) => (error ? reject(error) : resolve(result))
+        );
+        const readable = new Readable();
+        readable.push(pdfBuffer);
+        readable.push(null);
+        readable.pipe(uploadStream);
+      });
+
+      const certificate = new Certificate({
+        userId: user._id,
+        liveSessionId: session._id,
+        title: session.title,
+        provider: 'Ga Integrated Therapeutic Perspectives, LLC',
+        completionDate: session.scheduledEnd,
+        ceHours: session.ceuHours,
+        category: session.category || 'Other',
+        nbccApproved: true,
+        acepNumber: '7760',
+        approvingBody: 'NBCC',
+        approvalNumber: '#7760',
+        certificateNumber,
+        source: 'platform',
+        fileUrl: uploadResult.secure_url
+      });
+      await certificate.save();
+
+      // CE auto-apply to active credentials (same pattern as self-heal)
+      try {
+        const credentials = await UserCredential.find({
+          userId,
+          status: { $in: ['active', 'expiring_soon'] }
+        });
+        for (const credential of credentials) {
+          try {
+            await credential.addCEU({
+              certificateId: certificate._id,
+              hours: certificate.ceHours,
+              category: certificate.category || 'Other',
+              description: `${session.title} - CounselorReady Live Webinar`,
+              provider: 'CounselorReady',
+              date: certificate.completionDate,
+              source: 'internal'
+            });
+          } catch (credErr) {
+            console.error(`${LOG} addCEU failed for credential ${credential._id}:`, credErr.message);
+          }
+        }
+      } catch (credLookupErr) {
+        console.error(`${LOG} credential lookup failed:`, credLookupErr.message);
+      }
+
+      issued.push({ userId, certificateNumber, certificateId: certificate._id });
+      console.log(`${LOG} issued ${certificateNumber} to ${user.email} for "${session.title}"`);
+    } catch (err) {
+      console.error(`${LOG} failed for user ${userId}:`, err.message);
+      failed.push({ userId, error: err.message });
+    }
+  }
+
+  session.status = 'completed';
+  session.certificatesIssuedAt = new Date();
+  await session.save();
+
+  return { issued, skipped, failed };
+}
+
+export default { issueLiveSessionCertificates };

--- a/server/src/services/wherebyService.js
+++ b/server/src/services/wherebyService.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * wherebyService — thin wrapper around the Whereby Embedded REST API.
+ *
+ * Env required:
+ *   WHEREBY_API_KEY  — API key from the Whereby Embedded dashboard
+ *
+ * HIPAA notes:
+ *   - The account-level HIPAA add-on + signed BAA must be active in the
+ *     Whereby dashboard before supervision sessions go live.
+ *   - Cloud recording destination (your S3 bucket) is configured account-wide
+ *     in Whereby Dashboard → Configure → Recording. Recordings to
+ *     Whereby-provided storage are NOT HIPAA-compliant — always use own S3.
+ *   - Supervision rooms are created with recording.type='none' so recording
+ *     is impossible at the provider level, not just hidden in our UI.
+ */
+
+const WHEREBY_API_BASE = 'https://api.whereby.dev/v1';
+
+function apiKey() {
+  const key = process.env.WHEREBY_API_KEY;
+  if (!key) throw new Error('WHEREBY_API_KEY is not set');
+  return key;
+}
+
+async function wherebyFetch(path, options = {}) {
+  const res = await fetch(`${WHEREBY_API_BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey()}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {})
+    }
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Whereby API ${res.status} on ${path}: ${body}`);
+  }
+  // DELETE returns 204 No Content
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+/**
+ * Create a Whereby meeting for a LiveSession.
+ * @param {object} session - LiveSession doc (pre-save is fine; needs type/dates/slug)
+ * @returns {{meetingId, roomName, viewerRoomUrl, hostRoomUrl}}
+ */
+export async function createMeeting(session) {
+  const isSupervision = session.sessionType === 'supervision';
+
+  const body = {
+    isLocked: true, // knock-to-enter; host admits participants
+    roomNamePrefix: `cr-${session.slug}`.slice(0, 39),
+    roomMode: 'group',
+    // Whereby pads availability around these; we gate the real window in /join
+    startDate: session.scheduledStart.toISOString(),
+    endDate: session.scheduledEnd.toISOString(),
+    fields: ['hostRoomUrl'],
+    recording: isSupervision
+      ? { type: 'none' } // HIPAA hard-lock — supervision can never record
+      : (session.recordingEnabled
+          ? {
+              type: 'cloud',
+              // Destination (own S3 bucket) is configured account-wide in the
+              // Whereby dashboard. Verify against current Whereby docs if this
+              // request is rejected — destination may also be settable here.
+              startTrigger: 'automatic-2nd-participant'
+            }
+          : { type: 'none' })
+  };
+
+  const data = await wherebyFetch('/meetings', {
+    method: 'POST',
+    body: JSON.stringify(body)
+  });
+
+  return {
+    meetingId: data.meetingId,
+    roomName: data.roomName,
+    viewerRoomUrl: data.roomUrl,
+    hostRoomUrl: data.hostRoomUrl
+  };
+}
+
+/** Delete a Whereby meeting (cancellation cleanup). Safe to call twice. */
+export async function deleteMeeting(meetingId) {
+  if (!meetingId) return;
+  try {
+    await wherebyFetch(`/meetings/${meetingId}`, { method: 'DELETE' });
+  } catch (err) {
+    // 404 = already gone; anything else is logged but non-fatal for cancel flow
+    console.warn(`[whereby] deleteMeeting(${meetingId}): ${err.message}`);
+  }
+}
+
+export default { createMeeting, deleteMeeting };


### PR DESCRIPTION
## Summary

- **LiveSession model** — schema with supervision hard-locks (recording forced OFF, handouts blocked at schema level)
- **wherebyService** — Whereby Embedded REST wrapper (create/delete rooms)
- **liveSessionCompletionService** — cert issuance for attendees meeting threshold (≥90% attendance by default); mirrors certificateSelfHeal pipeline (generateCertificate + Cloudinary + addCEU)
- **liveSessions router** — full CRUD + enroll/join/attendance/issue-certificates (named routes before `/:id`)
- **webhooksWhereby router** — HMAC-verified attendance + recording webhook (raw-body, mirrors Resend pattern)
- **live-sessions.html** — public catalog page
- **live-room.html** — gated join page (Whereby iframe) + replay mode (`?replay=1`) + handouts sidebar
- **index.js** — raw-body parser + imports + mounts for both new routes
- **routeManifest.js** — two new entries so boot integrity check passes
- **Certificate.js** — `liveSessionId` field added (ObjectId → LiveSession)
- **payments.js** — live-session seat purchase handler inside `checkout.session.completed`

## ENV vars to set (Render backend)

```
WHEREBY_API_KEY=
WHEREBY_WEBHOOK_SECRET=
AWS_REGION=us-east-1
AWS_S3_RECORDINGS_BUCKET=counselorready-recordings
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=
```

## Dependencies to install

```
cd server && npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
```
(Lazy-imported in replay route — server boots fine before install; replay 500s until installed.)

## Whereby dashboard checklist (one-time, manual)

- [ ] Sign up for Whereby Embedded (Build plan) + purchase HIPAA add-on
- [ ] Sign the BAA — file executed copy with GAITP compliance docs
- [ ] Configure Recording → destination = your own S3 bucket (NOT Whereby-provided — voids HIPAA)
- [ ] Configure Webhook → `https://api.counselorready.com/api/webhooks/whereby`, subscribe to `room.client.joined`, `room.client.left`, `room.session.ended`, `recording.finished` → copy signing secret → `WHEREBY_WEBHOOK_SECRET`

## Test plan

- [ ] Boot log: routeManifest integrity check passes (2 new mounts)
- [ ] `POST /api/live-sessions` (admin token) → `whereby.meetingId` populated
- [ ] Create $0 session, register with test user, open `/live-room.html?session=<slug>` inside join window → iframe loads
- [ ] Join/leave two browsers → `GET /api/live-sessions/:id/attendance` shows segments with durations
- [ ] End room → status flips to `completed`
- [ ] `POST /api/live-sessions/:id/issue-certificates` → cert PDF in Cloudinary, CE hours applied
- [ ] `sessionType: 'supervision'` with `recordingEnabled: true` → saves with recording forced OFF

https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV

---
_Generated by [Claude Code](https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV)_