### PR TITLE
feat(watch-party): agenda engine + watch-party player (Phase 3)

### DIFF
--- a/client/public/live-host.html
+++ b/client/public/live-host.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Host Console - CounselorReady</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/css/design-tokens.css">
+  <link rel="stylesheet" href="/css/typography.css">
+  <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+  <script src="/js/tailwind-config.js"></script>
+  <style>
+    body{background:#F8F7F4;font-family:'Lato',system-ui,sans-serif;}
+    .font-display{font-family:'Cormorant Garamond',Georgia,serif;}
+    .seg-row{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;border:1px solid #EDE9E3;background:#fff;margin-bottom:6px;cursor:pointer;transition:background .1s;}
+    .seg-row.active{background:#F2F7F4;border-color:#4A7C59;}
+    .seg-row:hover:not(.active){background:#fafaf9;}
+    .seg-badge{font-size:11px;font-weight:700;padding:2px 7px;border-radius:4px;text-transform:uppercase;letter-spacing:.04em;}
+    .badge-lecture{background:#EDE9E3;color:#57534e;}
+    .badge-clip{background:#EDF2FF;color:#3B5FCC;}
+    .badge-discussion{background:#F0FDF4;color:#166534;}
+    .badge-breakout{background:#FFF7ED;color:#c2410c;}
+    .badge-break{background:#F9F5FF;color:#7e22ce;}
+    .transport-btn{padding:8px 18px;border-radius:8px;border:none;font-weight:700;cursor:pointer;font-size:14px;}
+    .btn-play{background:#4A7C59;color:#fff;}
+    .btn-play:hover{background:#3d6b4b;}
+    .btn-pause{background:#8B2542;color:#fff;}
+    .btn-pause:hover{background:#7a1d38;}
+    #seekBar{width:100%;accent-color:#284157;}
+  </style>
+</head>
+<body>
+  <script src="/shared/nav-footer.js"></script>
+
+  <main class="max-w-5xl mx-auto px-4 py-8">
+    <div id="gate" class="text-center py-20" style="color:#284157;">Checking admin access…</div>
+
+    <div id="console" class="hidden">
+      <div class="mb-6 flex items-start justify-between flex-wrap gap-4">
+        <div>
+          <h1 id="sessionTitle" class="font-display text-3xl font-bold" style="color:#6B1D34;"></h1>
+          <p id="sessionMeta" class="text-sm mt-1" style="color:#284157;"></p>
+        </div>
+        <div class="flex gap-3 items-center">
+          <span id="attendeeCount" class="text-sm font-semibold" style="color:#284157;">– attendees</span>
+          <span id="elapsed" class="text-sm font-mono" style="color:#7a5c1e;"></span>
+        </div>
+      </div>
+
+      <div class="grid lg:grid-cols-5 gap-6">
+
+        <!-- Agenda -->
+        <div class="lg:col-span-2">
+          <h2 class="font-display text-lg font-bold mb-3" style="color:#284157;">Agenda</h2>
+          <div id="agendaList"></div>
+          <p id="noAgenda" class="text-sm" style="color:#57534e;display:none;">No agenda configured for this session.</p>
+        </div>
+
+        <!-- Transport + Clip Player -->
+        <div class="lg:col-span-3">
+          <div id="clipPanel" class="hidden mb-4 bg-white rounded-xl border p-4" style="border-color:#EDE9E3;">
+            <h2 class="font-display text-lg font-bold mb-3" style="color:#284157;">Clip Transport</h2>
+            <p id="clipTitle" class="text-sm font-semibold mb-3" style="color:#284157;"></p>
+            <video id="hostClipPlayer" class="w-full rounded-lg mb-3" style="background:#000;max-height:240px;" controls playsinline></video>
+            <input type="range" id="seekBar" min="0" step="0.5" value="0">
+            <div class="flex gap-3 mt-3">
+              <button id="playBtn" class="transport-btn btn-play flex-1">▶ Play for everyone</button>
+              <button id="pauseBtn" class="transport-btn btn-pause flex-1">⏸ Pause for everyone</button>
+            </div>
+            <p class="text-xs mt-2" style="color:#57534e;">Your seek position is broadcast to attendees. Use the timeline to jump to a specific moment, then click Play.</p>
+          </div>
+
+          <!-- Now summary -->
+          <div class="bg-white rounded-xl border p-4" style="border-color:#EDE9E3;">
+            <h2 class="font-display text-lg font-bold mb-2" style="color:#284157;">Current segment</h2>
+            <div id="nowSummary" class="text-sm" style="color:#57534e;">No segment selected.</div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
+    const token = localStorage.getItem('token');
+    const slug = new URLSearchParams(window.location.search).get('session');
+
+    let session = null;
+    let currentSegIdx = 0;
+    let sessionStartedAt = null;
+    let attendanceTimer = null;
+    let elapsedTimer = null;
+    let hostClipLoaded = null;
+
+    function gateMsg(html) { const g = document.getElementById('gate'); g.innerHTML = html; g.classList.remove('hidden'); }
+
+    async function init() {
+      if (!slug) return gateMsg('Missing session parameter. <a href="/live-sessions.html" class="underline" style="color:#4A7C59;">Browse sessions</a>.');
+      if (!token) { window.location.href = '/login.html?next=' + encodeURIComponent(window.location.pathname + window.location.search); return; }
+
+      try {
+        // Verify admin
+        const meRes = await fetch(`${API_URL}/api/auth/me`, { headers: { 'Authorization': `Bearer ${token}` } });
+        const me = await meRes.json();
+        if (!meRes.ok || me.role !== 'admin') return gateMsg('Admin access required.');
+
+        // Load session
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        const data = await res.json();
+        if (!res.ok) return gateMsg(data.error || 'Session not found.');
+        session = data.session;
+
+        document.getElementById('sessionTitle').textContent = session.title;
+        document.getElementById('sessionMeta').textContent =
+          new Date(session.scheduledStart).toLocaleString() + ' · ' +
+          (session.ceuHours || 0) + ' CE hrs · ' + session.status;
+
+        sessionStartedAt = new Date(session.scheduledStart);
+        startElapsedTimer();
+
+        renderAgenda();
+        document.getElementById('gate').classList.add('hidden');
+        document.getElementById('console').classList.remove('hidden');
+
+        // Poll attendance count every 10s
+        pollAttendance();
+        attendanceTimer = setInterval(pollAttendance, 10000);
+
+        // Wire transport
+        document.getElementById('playBtn').addEventListener('click', broadcastPlay);
+        document.getElementById('pauseBtn').addEventListener('click', broadcastPause);
+        document.getElementById('seekBar').addEventListener('input', onSeekInput);
+
+      } catch (e) {
+        gateMsg('Could not load session. Please refresh.');
+      }
+    }
+
+    function renderAgenda() {
+      const list = document.getElementById('agendaList');
+      const noAgenda = document.getElementById('noAgenda');
+      if (!session.agenda || session.agenda.length === 0) {
+        noAgenda.style.display = '';
+        return;
+      }
+      list.innerHTML = '';
+      session.agenda.forEach((seg, idx) => {
+        const row = document.createElement('div');
+        row.className = 'seg-row' + (idx === 0 ? ' active' : '');
+        row.dataset.idx = idx;
+        row.innerHTML = `
+          <span class="seg-badge badge-${seg.type}">${seg.type}</span>
+          <span class="flex-1 text-sm font-medium" style="color:#284157;">${esc(seg.title || seg.type)}</span>
+          ${seg.durationMin ? `<span class="text-xs" style="color:#7a5c1e;">${seg.durationMin}m</span>` : ''}
+          <button class="text-xs font-semibold px-3 py-1 rounded" style="background:#284157;color:#fff;" onclick="advanceSegment(${idx},event)">▶ Go</button>`;
+        list.appendChild(row);
+      });
+      selectSegment(0);
+    }
+
+    async function advanceSegment(idx, e) {
+      e.stopPropagation();
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(session._id)}/live-state/segment`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ segment: idx })
+        });
+        if (res.ok) {
+          currentSegIdx = idx;
+          selectSegment(idx);
+          showSegmentInClipPanel(idx);
+        }
+      } catch {}
+    }
+
+    function selectSegment(idx) {
+      document.querySelectorAll('.seg-row').forEach((r, i) => {
+        r.classList.toggle('active', i === idx);
+      });
+      const seg = session.agenda?.[idx];
+      const nowSummary = document.getElementById('nowSummary');
+      if (!seg) { nowSummary.textContent = 'No segment.'; return; }
+      nowSummary.innerHTML = `<strong>${esc(seg.title || seg.type)}</strong>${seg.prompt ? `<br><em>Prompt: ${esc(seg.prompt)}</em>` : ''}${seg.durationMin ? ` · ${seg.durationMin} min` : ''}`;
+    }
+
+    async function showSegmentInClipPanel(idx) {
+      const seg = session.agenda?.[idx];
+      const panel = document.getElementById('clipPanel');
+      const player = document.getElementById('hostClipPlayer');
+      const seekBar = document.getElementById('seekBar');
+
+      if (!seg || seg.type !== 'clip' || seg.clipIndex == null) {
+        panel.classList.add('hidden');
+        hostClipLoaded = null;
+        return;
+      }
+
+      panel.classList.remove('hidden');
+      document.getElementById('clipTitle').textContent = session.clips?.[seg.clipIndex]?.title || `Clip ${seg.clipIndex}`;
+
+      if (hostClipLoaded !== seg.clipIndex) {
+        hostClipLoaded = seg.clipIndex;
+        try {
+          const res = await fetch(
+            `${API_URL}/api/live-sessions/${encodeURIComponent(session._id)}/clips/${seg.clipIndex}/url`,
+            { headers: { 'Authorization': `Bearer ${token}` } }
+          );
+          if (res.ok) {
+            const d = await res.json();
+            player.src = d.clipUrl;
+            seekBar.max = d.durationSec || 600;
+            seekBar.value = 0;
+          }
+        } catch {}
+      }
+
+      // Sync seek bar with host player time
+      player.addEventListener('timeupdate', () => {
+        seekBar.value = player.currentTime;
+      }, { passive: true });
+    }
+
+    async function broadcastPlay() {
+      const player = document.getElementById('hostClipPlayer');
+      await player.play().catch(() => {});
+      const seg = session.agenda?.[currentSegIdx];
+      if (seg?.clipIndex == null) return;
+      await broadcastPlayback(seg.clipIndex, true, player.currentTime);
+    }
+
+    async function broadcastPause() {
+      const player = document.getElementById('hostClipPlayer');
+      player.pause();
+      const seg = session.agenda?.[currentSegIdx];
+      if (seg?.clipIndex == null) return;
+      await broadcastPlayback(seg.clipIndex, false, player.currentTime);
+    }
+
+    function onSeekInput() {
+      const player = document.getElementById('hostClipPlayer');
+      player.currentTime = parseFloat(document.getElementById('seekBar').value);
+    }
+
+    async function broadcastPlayback(clipIndex, playing, positionSec) {
+      try {
+        await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(session._id)}/live-state/playback`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ clipIndex, playing, positionSec })
+        });
+      } catch {}
+    }
+
+    async function pollAttendance() {
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(session._id)}/attendance`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (res.ok) {
+          const d = await res.json();
+          const live = d.rawAttendance?.filter(a => !a.leftAt).length ?? '–';
+          document.getElementById('attendeeCount').textContent = `${live} live`;
+        }
+      } catch {}
+    }
+
+    function startElapsedTimer() {
+      elapsedTimer = setInterval(() => {
+        const elapsed = Math.floor((Date.now() - sessionStartedAt.getTime()) / 1000);
+        if (elapsed < 0) { document.getElementById('elapsed').textContent = 'Not started'; return; }
+        const m = Math.floor(elapsed / 60), s = elapsed % 60;
+        document.getElementById('elapsed').textContent = `${m}:${s.toString().padStart(2,'0')} elapsed`;
+      }, 1000);
+    }
+
+    function esc(s){const d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+    init();
+  </script>
+</body>
+</html>

--- a/client/public/live-room.html
+++ b/client/public/live-room.html
@@ -16,9 +16,18 @@
     body{background:#F8F7F4; font-family:'Lato', system-ui, sans-serif;}
     .font-display{font-family:'Cormorant Garamond', Georgia, serif;}
     #roomFrame, #replayVideo{width:100%;aspect-ratio:16/10;border:0;border-radius:12px;background:#1a1a1a;}
+    #clipPlayer{width:100%;aspect-ratio:16/9;border-radius:12px;background:#000;display:none;}
+    .clip-active #roomFrame{aspect-ratio:auto;height:140px;margin-top:12px;}
+    .clip-active #clipPlayer{display:block;}
     .handout-link{display:flex;align-items:center;gap:8px;padding:10px 12px;border-radius:8px;border:1px solid #EDE9E3;background:#fff;color:#284157;font-size:14px;text-decoration:none;transition:background .1s;}
     .handout-link:hover{background:#F2F7F4;}
     .handout-link.locked{opacity:.5;cursor:not-allowed;}
+    #nowCard{background:#F2F7F4;border:1px solid #C7DDD0;border-radius:12px;padding:14px;margin-bottom:12px;}
+    #nowCard h3{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:#4A7C59;margin-bottom:4px;}
+    #nowSegTitle{font-size:15px;font-weight:600;color:#284157;margin-bottom:6px;}
+    #nowPrompt{font-size:13px;color:#44403c;line-height:1.5;margin-bottom:6px;}
+    #nowCountdown{font-size:12px;color:#7a5c1e;font-weight:600;}
+    #breakoutBadge{display:none;background:#EDF2FF;color:#3B5FCC;border-radius:6px;padding:4px 8px;font-size:11px;font-weight:700;margin-bottom:6px;}
   </style>
 </head>
 <body>
@@ -33,12 +42,21 @@
         <p id="meta" class="text-sm mt-1" style="color:#284157;"></p>
       </div>
       <div class="grid lg:grid-cols-4 gap-6">
-        <div class="lg:col-span-3">
+        <div id="mainCol" class="lg:col-span-3">
+          <video id="clipPlayer" playsinline></video>
           <iframe id="roomFrame" class="hidden"
                   allow="camera; microphone; fullscreen; speaker; display-capture; autoplay"></iframe>
           <video id="replayVideo" class="hidden" controls playsinline></video>
+          <p id="muteReminder" class="hidden text-xs mt-2 text-center" style="color:#7a5c1e;">🔇 Mute your mic in the video call while watching the clip.</p>
         </div>
         <aside class="lg:col-span-1">
+          <div id="nowCard" class="hidden">
+            <h3>Now</h3>
+            <div id="breakoutBadge">Breakout</div>
+            <div id="nowSegTitle"></div>
+            <div id="nowPrompt"></div>
+            <div id="nowCountdown"></div>
+          </div>
           <div class="bg-white rounded-xl border p-4" style="border-color:#EDE9E3;">
             <h2 class="font-display text-lg font-bold mb-3" style="color:#284157;">Handouts</h2>
             <div id="handouts" class="flex flex-col gap-2">
@@ -90,6 +108,7 @@
         document.getElementById('gate').classList.add('hidden');
         document.getElementById('room').classList.remove('hidden');
         loadHandouts(data.session);
+        if (data.session.sessionType === 'live-course') startSyncLoop(data.session._id);
       } catch {
         gateMsg('Connection problem. Please refresh.');
       }
@@ -147,6 +166,112 @@
     }
 
     function esc(s){const d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+    /* ── Watch-party sync loop ─────────────────────────────────────────── */
+    let syncInterval = null;
+    let lastClipIndex = null;
+    let currentSessionId = null;
+
+    function startSyncLoop(sessionId) {
+      currentSessionId = sessionId;
+      syncInterval = setInterval(() => pollLiveState(sessionId), 3000);
+    }
+
+    async function pollLiveState(sessionId) {
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(sessionId)}/live-state`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        updateNowCard(data.currentSegment, data.liveState);
+        updateWatchParty(data.liveState);
+        if (data.status === 'completed' && syncInterval) {
+          clearInterval(syncInterval);
+          syncInterval = null;
+        }
+      } catch { /* network hiccup — try again next tick */ }
+    }
+
+    function updateNowCard(seg, liveState) {
+      const card = document.getElementById('nowCard');
+      if (!seg) { card.classList.add('hidden'); return; }
+      card.classList.remove('hidden');
+
+      document.getElementById('nowSegTitle').textContent = seg.title || seg.type;
+      const prompt = seg.prompt || '';
+      const promptEl = document.getElementById('nowPrompt');
+      promptEl.textContent = prompt;
+      promptEl.style.display = prompt ? '' : 'none';
+
+      const badge = document.getElementById('breakoutBadge');
+      badge.style.display = seg.type === 'breakout' ? '' : 'none';
+
+      // Countdown
+      const countEl = document.getElementById('nowCountdown');
+      if (seg.durationMin && liveState?.segmentStartedAt) {
+        const elapsed = (Date.now() - new Date(liveState.segmentStartedAt).getTime()) / 1000;
+        const remaining = Math.max(0, seg.durationMin * 60 - elapsed);
+        const m = Math.floor(remaining / 60), s = Math.floor(remaining % 60);
+        countEl.textContent = `${m}:${s.toString().padStart(2, '0')} remaining`;
+      } else {
+        countEl.textContent = '';
+      }
+    }
+
+    async function updateWatchParty(liveState) {
+      if (!liveState?.playback) return;
+      const { clipIndex, playing, positionSec, stateUpdatedAt } = liveState.playback;
+      const player = document.getElementById('clipPlayer');
+      const mainCol = document.getElementById('mainCol');
+      const muteReminder = document.getElementById('muteReminder');
+
+      if (clipIndex == null) {
+        // No clip — hide player
+        mainCol.classList.remove('clip-active');
+        muteReminder.classList.add('hidden');
+        return;
+      }
+
+      // Load clip URL if clipIndex changed
+      if (clipIndex !== lastClipIndex) {
+        lastClipIndex = clipIndex;
+        try {
+          const res = await fetch(
+            `${API_URL}/api/live-sessions/${encodeURIComponent(slug)}/clips/${clipIndex}/url`,
+            { headers: { 'Authorization': `Bearer ${token}` } }
+          );
+          if (res.ok) {
+            const data = await res.json();
+            player.src = data.clipUrl;
+            mainCol.classList.add('clip-active');
+            muteReminder.classList.remove('hidden');
+          }
+        } catch { /* retry next poll */ }
+      }
+
+      // Sync play/pause
+      if (playing && player.paused) {
+        player.play().catch(() => {});
+      } else if (!playing && !player.paused) {
+        player.pause();
+      }
+
+      // Drift correction — only seek if drift > 1.5s to avoid constant stuttering
+      if (stateUpdatedAt && playing) {
+        const elapsed = (Date.now() - new Date(stateUpdatedAt).getTime()) / 1000;
+        const target = (positionSec || 0) + elapsed;
+        if (Math.abs(player.currentTime - target) > 1.5) {
+          player.currentTime = target;
+        }
+      } else if (!playing && stateUpdatedAt) {
+        const target = positionSec || 0;
+        if (Math.abs(player.currentTime - target) > 1.5) {
+          player.currentTime = target;
+        }
+      }
+    }
+
     init();
   </script>
 </body>

--- a/server/src/models/LiveSession.js
+++ b/server/src/models/LiveSession.js
@@ -114,6 +114,37 @@ const liveSessionSchema = new mongoose.Schema({
   // Handouts — live-course only; hard-locked empty for supervision
   handouts: [handoutSchema],
 
+  // Watch-party clips (live-course only; hard-locked empty for supervision)
+  // 10-min ceiling enforced in pre-validate; URLs served via presigned endpoint only
+  clips: [{
+    title: { type: String, required: true },
+    s3Key: { type: String, required: true },
+    s3Bucket: String,
+    durationSec: { type: Number, required: true, min: 1, max: 600 }
+  }],
+
+  // Run-of-show agenda (live-course only; hard-locked empty for supervision)
+  agenda: [{
+    order: { type: Number, required: true },
+    type: { type: String, enum: ['lecture', 'clip', 'discussion', 'breakout', 'break'], required: true },
+    title: String,
+    durationMin: { type: Number, min: 1 },
+    prompt: String,
+    clipIndex: Number
+  }],
+
+  // Live sync state — host writes, attendees poll via GET /:id/live-state
+  liveState: {
+    currentSegment: { type: Number, default: 0 },
+    segmentStartedAt: Date,
+    playback: {
+      clipIndex: Number,
+      playing: { type: Boolean, default: false },
+      positionSec: { type: Number, default: 0 },
+      stateUpdatedAt: Date
+    }
+  },
+
   status: {
     type: String,
     enum: ['scheduled', 'live', 'completed', 'cancelled'],
@@ -134,7 +165,21 @@ liveSessionSchema.pre('validate', function (next) {
     if (this.handouts && this.handouts.length > 0) {
       return next(new Error('Handouts are not permitted on supervision sessions — Cloudinary has no BAA (HIPAA hard-lock).'));
     }
+    if (this.clips && this.clips.length > 0) {
+      return next(new Error('Watch-party clips are not permitted on supervision sessions (compliance hard-lock).'));
+    }
+    if (this.agenda && this.agenda.length > 0) {
+      return next(new Error('Agenda is not permitted on supervision sessions (compliance hard-lock).'));
+    }
     this.ceuHours = 0;
+  }
+  // Clip duration ceiling
+  if (this.clips) {
+    for (const clip of this.clips) {
+      if (clip.durationSec > 600) {
+        return next(new Error(`Clip "${clip.title}" exceeds the 10-minute ceiling (durationSec must be ≤ 600). CounselorReady shows clips only, not full films.`));
+      }
+    }
   }
   if (this.scheduledEnd <= this.scheduledStart) {
     return next(new Error('scheduledEnd must be after scheduledStart.'));

--- a/server/src/routes/liveSessions.js
+++ b/server/src/routes/liveSessions.js
@@ -338,6 +338,169 @@ router.post('/:id/issue-certificates', protect, requireAdmin, async (req, res) =
   }
 });
 
+/* ════════════════════════ WATCH PARTY — ATTENDEE ════════════════════════ */
+
+// GET /api/live-sessions/:id/live-state — lean poll endpoint (3s interval)
+router.get('/:id/live-state', protect, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id)
+      .select('liveState agenda status scheduledStart scheduledEnd registrants')
+      .lean();
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    const isAdmin = req.user.role === 'admin';
+    const registered = session.registrants.some(
+      r => r.user && r.user.toString() === req.user._id.toString()
+    );
+    if (!isAdmin && !registered) {
+      return res.status(403).json({ error: 'Not registered for this session.' });
+    }
+
+    const seg = session.agenda?.[session.liveState?.currentSegment ?? 0] ?? null;
+    res.json({
+      liveState: session.liveState,
+      currentSegment: seg,
+      status: session.status
+    });
+  } catch (err) {
+    console.error('[live] live-state:', err.message);
+    res.status(500).json({ error: 'Failed to load live state' });
+  }
+});
+
+// GET /api/live-sessions/:id/clips/:clipIndex/url — presigned S3 URL, 15-min expiry
+router.get('/:id/clips/:clipIndex/url', protect, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id)
+      .select('clips registrants status scheduledStart scheduledEnd sessionType')
+      .lean();
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+    if (session.sessionType !== 'live-course') {
+      return res.status(403).json({ error: 'No clips on supervision sessions.' });
+    }
+
+    const isAdmin = req.user.role === 'admin';
+    const registered = session.registrants.some(
+      r => r.user && r.user.toString() === req.user._id.toString()
+    );
+    if (!isAdmin && !registered) {
+      return res.status(403).json({ error: 'Clips are available to registered attendees only.' });
+    }
+
+    // Session window check
+    if (!isAdmin) {
+      const now = Date.now();
+      const opens = new Date(session.scheduledStart).getTime() - JOIN_WINDOW_BEFORE_MIN * 60000;
+      const closes = new Date(session.scheduledEnd).getTime() + JOIN_WINDOW_AFTER_MIN * 60000;
+      if (now < opens || now > closes) {
+        return res.status(403).json({ error: 'Clips are only available during the session window.' });
+      }
+    }
+
+    const clipIndex = parseInt(req.params.clipIndex, 10);
+    const clip = session.clips?.[clipIndex];
+    if (!clip) return res.status(404).json({ error: 'Clip not found.' });
+
+    const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
+    const { getSignedUrl } = await import('@aws-sdk/s3-request-presigner');
+    const s3 = new S3Client({ region: process.env.AWS_REGION || 'us-east-1' });
+    const url = await getSignedUrl(
+      s3,
+      new GetObjectCommand({
+        Bucket: clip.s3Bucket || process.env.AWS_S3_RECORDINGS_BUCKET,
+        Key: clip.s3Key
+      }),
+      { expiresIn: 900 } // 15 minutes
+    );
+
+    res.json({ clipUrl: url, title: clip.title, durationSec: clip.durationSec, expiresInSeconds: 900 });
+  } catch (err) {
+    console.error('[live] clip-url:', err.message);
+    res.status(500).json({ error: 'Failed to load clip URL' });
+  }
+});
+
+/* ════════════════════════ WATCH PARTY — HOST (admin) ════════════════════════ */
+
+// POST /api/live-sessions/:id/live-state/segment — host advances segment
+router.post('/:id/live-state/segment', protect, requireAdmin, async (req, res) => {
+  try {
+    const { segment } = req.body;
+    if (typeof segment !== 'number') {
+      return res.status(400).json({ error: 'segment must be a number.' });
+    }
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    session.liveState = {
+      ...(session.liveState?.toObject?.() ?? session.liveState ?? {}),
+      currentSegment: segment,
+      segmentStartedAt: new Date()
+    };
+    session.markModified('liveState');
+    await session.save();
+
+    res.json({ liveState: session.liveState });
+  } catch (err) {
+    console.error('[live] segment:', err.message);
+    res.status(500).json({ error: 'Failed to update segment' });
+  }
+});
+
+// POST /api/live-sessions/:id/live-state/playback — host controls clip playback
+router.post('/:id/live-state/playback', protect, requireAdmin, async (req, res) => {
+  try {
+    const { clipIndex, playing, positionSec } = req.body;
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    session.liveState = {
+      ...(session.liveState?.toObject?.() ?? session.liveState ?? {}),
+      playback: { clipIndex, playing: !!playing, positionSec: positionSec ?? 0, stateUpdatedAt: new Date() }
+    };
+    session.markModified('liveState');
+    await session.save();
+
+    res.json({ playback: session.liveState.playback });
+  } catch (err) {
+    console.error('[live] playback:', err.message);
+    res.status(500).json({ error: 'Failed to update playback state' });
+  }
+});
+
+// POST /api/live-sessions/:id/clips — add clip metadata
+router.post('/:id/clips', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+    const { title, s3Key, s3Bucket, durationSec } = req.body;
+    session.clips.push({ title, s3Key, s3Bucket, durationSec });
+    await session.save(); // pre-validate enforces supervision lock + 600s ceiling
+    res.status(201).json({ clips: session.clips, clipIndex: session.clips.length - 1 });
+  } catch (err) {
+    console.error('[live] add-clip:', err.message);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /api/live-sessions/:id/clips/:clipIndex — remove clip metadata
+router.delete('/:id/clips/:clipIndex', protect, requireAdmin, async (req, res) => {
+  try {
+    const session = await LiveSession.findById(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+    const idx = parseInt(req.params.clipIndex, 10);
+    if (isNaN(idx) || idx < 0 || idx >= session.clips.length) {
+      return res.status(404).json({ error: 'Clip index out of range.' });
+    }
+    session.clips.splice(idx, 1);
+    await session.save();
+    res.json({ clips: session.clips });
+  } catch (err) {
+    console.error('[live] delete-clip:', err.message);
+    res.status(500).json({ error: 'Failed to delete clip' });
+  }
+});
+
 /* ── helpers ── */
 async function findByIdOrSlug(idOrSlug) {
   if (/^[0-9a-fA-F]{24}$/.test(idOrSlug)) {


### PR DESCRIPTION
## Summary

Phase 3 of live sessions — watch-party player and agenda engine on top of the Phase 2 Whereby infrastructure.

**Schema additions (`LiveSession.js`):**
- `clips[]` — S3 clip metadata with 10-min ceiling hard-lock (`durationSec ≤ 600`); clips-only posture enforced with a clear error message
- `agenda[]` — run-of-show segments: `lecture / clip / discussion / breakout / break`
- `liveState` — single source of truth for sync: `currentSegment`, `segmentStartedAt`, `playback` (clipIndex / playing / positionSec / stateUpdatedAt)
- Supervision pre-validate hard-lock: non-empty `clips` or `agenda` rejected

**New routes (`liveSessions.js`):**
- `GET /:id/live-state` — lean poll endpoint (projection only; ~17 req/s at 50 attendees × 3s is fine for Render)
- `GET /:id/clips/:clipIndex/url` — presigned S3 URL, 15-min expiry, session-window + registered guard
- `POST /:id/live-state/segment` — host advances segment (sets `segmentStartedAt`)
- `POST /:id/live-state/playback` — host broadcasts play/pause/seek
- `POST /:id/clips` / `DELETE /:id/clips/:clipIndex` — clip metadata management

**`live-room.html` additions:**
- Sync loop polling `/live-state` every 3s while session is live
- Sidebar "Now" card: segment title, prompt, countdown from `segmentStartedAt + durationMin`, breakout badge
- `<video id="clipPlayer">` watch-party player (attendee controls disabled — host drives)
- CSS `.clip-active` layout: clip player prominent, Whereby iframe shrinks to strip
- Drift correction: seek only when `|currentTime - target| > 1.5s`

**New `live-host.html`:**
- Admin producer panel (no React, static vanilla JS)
- Agenda list with per-segment "▶ Go" buttons that call the segment endpoint
- Clip transport: local `<video>` + Play/Pause buttons broadcast state to all attendees; seek bar syncs
- Live attendee count (polls `/attendance` every 10s), elapsed session timer

## Compliance

- Attendance/certificate math is unaffected — `liveState` carries no eligibility data
- Supervision sessions: `clips` and `agenda` hard-locked empty at pre-validate (same pattern as recordings/handouts)
- Clip URLs never in page source — served exclusively via the presigned endpoint inside the session window

## Test plan

- [ ] Supervision session with `agenda` or `clips` → validation error
- [ ] Clip `durationSec > 600` → validation error with clips-only message
- [ ] Host advances segment on `/live-host.html` → attendee sidebar "Now" card updates within 3s; countdown correct
- [ ] Host play/pause/seek → attendee `<video>` follows; drift correction triggers only beyond 1.5s
- [ ] Clip URL endpoint: 403 outside session window / unregistered; presigned URL returned for valid request
- [ ] Attendance/certificate math identical with and without agenda usage
- [ ] `/live-state` response is lean (projection, ~2KB or under)

https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV

---
_Generated by [Claude Code](https://claude.ai/code/session_012PWGT3x2LU3FLtC5YA9GQV)_