### PR TITLE
fix(partner): billing page 500 for free-plan partners

### DIFF
--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -1052,15 +1052,16 @@ router.get('/my/billing', protect, requirePartnerAdmin, async (req, res) => {
     const courseCount = await InteractiveCourse.countDocuments({ partnerId });
     const userCount = await User.countDocuments({ partnerId });
     const currentPlan = partner.billing?.plan || 'free';
+    const currentLimits = getPlanLimits(currentPlan); // free-safe (PARTNER_PLANS has no 'free' key)
 
     res.json({
       billing: partner.billing || { plan: 'free', status: 'trial' },
       plans: PARTNER_PLANS,
       usage: {
         courses: courseCount,
-        maxCourses: PARTNER_PLANS[currentPlan].maxCourses,
+        maxCourses: currentLimits.maxCourses,
         users: userCount,
-        maxUsers: PARTNER_PLANS[currentPlan].maxUsers
+        maxUsers: currentLimits.maxUsers
       }
     });
   } catch (error) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `GET /api/partners/my/billing` returned 500 for any partner on the `free` plan because `PARTNER_PLANS[currentPlan]` has no `free` key
- Fix: use the already-imported `getPlanLimits(currentPlan)` helper which handles the free tier safely
- One file changed, 3 lines touched — no logic changes beyond the direct fix

## Verify
```
git diff --cached --stat        → 1 file, 3 insertions / 2 deletions
node --check partners.js        → ok
grep getPlanLimits(currentPlan) → line 1055 (fix present)
grep PARTNER_PLANS[currentPlan].maxCourses → 0 (removed)
```

## Test plan
- [ ] Sign up as a new self-serve partner (free/trial plan)
- [ ] Navigate to the billing page → should return 200 with plan cards visible
- [ ] Existing paid-plan partners: billing page still loads correctly
- [ ] Checkout flow unchanged (Stripe URL still returned)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8iPMuv8iLtFxABgXZz3US)_