### PR TITLE
feat: Phase 2 Session Producer — drop detection, break math, catch-up, wrap-up

### DIFF
--- a/client/public/live-room.html
+++ b/client/public/live-room.html
@@ -74,8 +74,10 @@
   <script>
     const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
     const token = localStorage.getItem('token');
-    const slug = new URLSearchParams(window.location.search).get('session');
-    const wantReplay = new URLSearchParams(window.location.search).get('replay') === '1';
+    const params = new URLSearchParams(window.location.search);
+    const slug = params.get('session');
+    const wantReplay = params.get('replay') === '1';
+    const seekTo = params.get('t') ? parseFloat(params.get('t')) : null;
 
     function gateMsg(html) { const g = document.getElementById('gate'); g.innerHTML = html; g.classList.remove('hidden'); }
 
@@ -108,7 +110,10 @@
         document.getElementById('gate').classList.add('hidden');
         document.getElementById('room').classList.remove('hidden');
         loadHandouts(data.session);
-        if (data.session.sessionType === 'live-course') startSyncLoop(data.session._id);
+        if (data.session.sessionType === 'live-course') {
+          startSyncLoop(data.session._id);
+          loadCatchupBanner(data.session);
+        }
       } catch {
         gateMsg('Connection problem. Please refresh.');
       }
@@ -128,12 +133,73 @@
 
         const video = document.getElementById('replayVideo');
         video.src = data.replayUrl;
+        if (seekTo != null) {
+          video.addEventListener('loadedmetadata', () => { video.currentTime = seekTo; }, { once: true });
+        }
         video.classList.remove('hidden');
         document.getElementById('gate').classList.add('hidden');
         document.getElementById('room').classList.remove('hidden');
+        // Show rejoin banner if user has prior gaps this session (live-course only)
+        if (detail.session?.sessionType === 'live-course') loadCatchupBanner(detail.session);
       } catch {
         gateMsg('Could not load the replay. Please refresh.');
       }
+    }
+
+    async function loadCatchupBanner(session) {
+      if (!token) return;
+      try {
+        const res = await fetch(`${API_URL}/api/live-sessions/${encodeURIComponent(slug)}/catchup`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.queued || !data.gaps || data.gaps.length === 0) return;
+
+        // Check if any gap ≥ 3 min
+        const meaningful = data.gaps.filter(g => g.gapMin >= 3);
+        if (meaningful.length === 0) return;
+
+        const totalMin = meaningful.reduce((s, g) => s + g.gapMin, 0);
+        const banner = document.createElement('div');
+        banner.id = 'catchupBanner';
+        banner.style.cssText = 'background:#FBF6EC;border:1px solid #EFE0C2;border-radius:10px;padding:14px 16px;margin-top:12px;';
+        banner.innerHTML = `<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+          <span style="font-size:14px;color:#7a5c1e;">You were away ~${totalMin} min during this session.</span>
+          <button id="catchupBtn" style="background:#6B1D34;color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:13px;cursor:pointer;">View Recap</button>
+        </div>
+        <div id="catchupContent" style="display:none;margin-top:12px;"></div>`;
+        document.getElementById('mainCol').after(banner);
+
+        document.getElementById('catchupBtn').addEventListener('click', () => {
+          const content = document.getElementById('catchupContent');
+          const btn = document.getElementById('catchupBtn');
+          if (content.style.display === 'none') {
+            content.style.display = 'block';
+            btn.textContent = 'Hide Recap';
+            renderCatchup(content, meaningful);
+          } else {
+            content.style.display = 'none';
+            btn.textContent = 'View Recap';
+          }
+        });
+      } catch { /* non-fatal */ }
+    }
+
+    function renderCatchup(container, gaps) {
+      let html = '';
+      for (const gap of gaps) {
+        html += `<div style="margin-bottom:10px;padding:10px;background:#fff;border-radius:8px;border:1px solid #EDE9E3;">
+          <p style="font-size:13px;color:#57534e;margin:0 0 6px;">~${gap.gapMin} min gap</p>`;
+        if (gap.summary && gap.summary.length > 0) {
+          html += `<ul style="margin:0 0 6px;padding-left:18px;font-size:14px;color:#284157;">`;
+          for (const b of gap.summary) html += `<li>${esc(b)}</li>`;
+          html += `</ul>`;
+        }
+        html += `<a href="${gap.replayUrl}" style="font-size:13px;color:#4A7C59;">▶ Jump to this segment</a></div>`;
+      }
+      container.innerHTML = html;
     }
 
     function showSession(s) {

--- a/server/src/__tests__/liveSessionAttendance.test.js
+++ b/server/src/__tests__/liveSessionAttendance.test.js
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * Unit tests for Phase 2 attendance math.
+ * Pure math functions are duplicated here so tests have no external dependencies
+ * (no mongoose, no S3, no Resend). The canonical implementations live in
+ * LiveSession.js (breakOverlapMin, attendedMinutesAdjusted, instructionalMinutes)
+ * and sessionProducer.js (computeGaps).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ── Pure math implementations (mirrors LiveSession.js + sessionProducer.js) ───
+
+function breakOverlapMin(segStart, segEnd, breakStart, breakEnd) {
+  const overlapStart = Math.max(segStart, breakStart);
+  const overlapEnd = Math.min(segEnd, breakEnd);
+  if (overlapEnd <= overlapStart) return 0;
+  return (overlapEnd - overlapStart) / 60000;
+}
+
+function instructionalMinutes(scheduledDurationMin, breaks) {
+  const breakMin = (breaks || []).reduce((s, b) => s + b.durationMin, 0);
+  return Math.max(1, scheduledDurationMin - breakMin);
+}
+
+function attendedMinutesAdjusted(attendance, userId, breaks) {
+  const segments = attendance.filter(a => a.user === userId && a.joinedAt && a.leftAt);
+  const bks = (breaks || []).map(b => ({
+    start: b.startsAt.getTime(),
+    end: b.startsAt.getTime() + b.durationMin * 60000
+  }));
+  let total = 0;
+  for (const seg of segments) {
+    const segStart = seg.joinedAt.getTime();
+    const segEnd = seg.leftAt.getTime();
+    let rawMin = Math.max(0, (segEnd - segStart) / 60000);
+    for (const br of bks) rawMin -= breakOverlapMin(segStart, segEnd, br.start, br.end);
+    total += Math.max(0, rawMin);
+  }
+  return Math.round(total);
+}
+
+function meetsAttendanceThreshold(attendance, userId, scheduledDurationMin, breaks, thresholdPct) {
+  const instMin = instructionalMinutes(scheduledDurationMin, breaks);
+  const required = instMin * (thresholdPct / 100);
+  return attendedMinutesAdjusted(attendance, userId, breaks) >= required;
+}
+
+function insideBreakWindow(breaks, when) {
+  return (breaks || []).some(b => {
+    const start = b.startsAt.getTime();
+    const end = start + b.durationMin * 60000;
+    const t = when.getTime();
+    return t >= start && t < end;
+  });
+}
+
+function computeGaps(session, userId) {
+  const segments = session.attendance
+    .filter(a => a.user === userId && a.joinedAt && a.leftAt)
+    .sort((a, b) => a.joinedAt - b.joinedAt);
+
+  if (segments.length === 0) return [];
+
+  const gaps = [];
+  const sessionStart = session.scheduledStart.getTime();
+  const sessionEnd = session.scheduledEnd.getTime();
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const left = segments[i].leftAt;
+    const next = segments[i + 1].joinedAt;
+    const gapMin = Math.round((next - left) / 60000);
+    if (gapMin >= 3 && !insideBreakWindow(session.breaks, left)) {
+      gaps.push({ leftAt: left, nextJoinAt: next, gapMin, offsetSec: Math.round((left.getTime() - sessionStart) / 1000) });
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  if (last.leftAt.getTime() < sessionEnd) {
+    const gapMin = Math.round((sessionEnd - last.leftAt.getTime()) / 60000);
+    if (gapMin >= 3 && !insideBreakWindow(session.breaks, last.leftAt)) {
+      gaps.push({ leftAt: last.leftAt, nextJoinAt: null, gapMin, offsetSec: Math.round((last.leftAt.getTime() - sessionStart) / 1000) });
+    }
+  }
+
+  return gaps;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const BASE = new Date('2026-06-12T14:00:00Z');
+const ms = n => n * 60000;
+
+function atMin(offsetMin, durationMin) {
+  return {
+    joinedAt: new Date(BASE.getTime() + ms(offsetMin)),
+    leftAt: new Date(BASE.getTime() + ms(offsetMin + durationMin))
+  };
+}
+
+function lunchBreak(offsetMin = 60, dur = 30) {
+  return { label: 'Lunch', startsAt: new Date(BASE.getTime() + ms(offsetMin)), durationMin: dur };
+}
+
+// ── breakOverlapMin ────────────────────────────────────────────────────────────
+
+describe('breakOverlapMin', () => {
+  it('returns 0 when segment entirely before break', () => {
+    expect(breakOverlapMin(0, ms(30), ms(60), ms(90))).toBe(0);
+  });
+
+  it('returns 0 when segment entirely after break', () => {
+    expect(breakOverlapMin(ms(100), ms(120), ms(60), ms(90))).toBe(0);
+  });
+
+  it('returns 30 when segment spans entire break', () => {
+    expect(breakOverlapMin(0, ms(120), ms(60), ms(90))).toBe(30);
+  });
+
+  it('returns 20 when segment starts inside break', () => {
+    expect(breakOverlapMin(ms(70), ms(120), ms(60), ms(90))).toBe(20);
+  });
+
+  it('returns 20 when segment ends inside break', () => {
+    expect(breakOverlapMin(0, ms(80), ms(60), ms(90))).toBe(20);
+  });
+
+  it('returns 10 when segment entirely inside break', () => {
+    expect(breakOverlapMin(ms(65), ms(75), ms(60), ms(90))).toBe(10);
+  });
+
+  it('returns 0 at touching boundary (no overlap)', () => {
+    expect(breakOverlapMin(0, ms(60), ms(60), ms(90))).toBe(0);
+  });
+});
+
+// ── instructionalMinutes ───────────────────────────────────────────────────────
+
+describe('instructionalMinutes', () => {
+  it('equals scheduled duration when no breaks', () => {
+    expect(instructionalMinutes(180, [])).toBe(180);
+  });
+
+  it('subtracts 30-min lunch from 3-hr session → 150', () => {
+    expect(instructionalMinutes(180, [lunchBreak()])).toBe(150);
+  });
+
+  it('floors to 1 when breaks exceed duration', () => {
+    expect(instructionalMinutes(30, [{ label: 'B', startsAt: BASE, durationMin: 120 }])).toBe(1);
+  });
+});
+
+// ── attendedMinutesAdjusted ────────────────────────────────────────────────────
+
+describe('attendedMinutesAdjusted', () => {
+  it('returns raw minutes when no breaks', () => {
+    const att = [{ user: 'u1', ...atMin(0, 180) }];
+    expect(attendedMinutesAdjusted(att, 'u1', [])).toBe(180);
+  });
+
+  it('clips break overlap — full session through lunch banks 150 min', () => {
+    const att = [{ user: 'u1', ...atMin(0, 180) }];
+    expect(attendedMinutesAdjusted(att, 'u1', [lunchBreak(60, 30)])).toBe(150);
+  });
+
+  it('handles multiple segments with break clipping', () => {
+    const att = [
+      { user: 'u1', ...atMin(0, 50) },
+      { user: 'u1', ...atMin(95, 85) }
+    ];
+    // Break 60–90. First seg 0–50: no overlap. Second seg 95–180: no overlap.
+    expect(attendedMinutesAdjusted(att, 'u1', [lunchBreak(60, 30)])).toBe(135);
+  });
+
+  it('returns 0 for a user with no attendance', () => {
+    expect(attendedMinutesAdjusted([], 'u1', [])).toBe(0);
+  });
+});
+
+// ── meetsAttendanceThreshold ───────────────────────────────────────────────────
+
+describe('meetsAttendanceThreshold', () => {
+  it('3-hr session + 30-min lunch: denominator 150, threshold 90% = 135 min', () => {
+    const att = [{ user: 'u1', ...atMin(0, 130) }];
+    expect(meetsAttendanceThreshold(att, 'u1', 180, [lunchBreak(60, 30)], 90)).toBe(false);
+  });
+
+  it('135 min adjusted → exactly meets 90% of 150', () => {
+    // Break 60–90. Attend 0–60 (60 min) + 90–165 (75 min) = 135 instructional min.
+    const att = [
+      { user: 'u1', ...atMin(0, 60) },
+      { user: 'u1', ...atMin(90, 75) }
+    ];
+    expect(meetsAttendanceThreshold(att, 'u1', 180, [lunchBreak(60, 30)], 90)).toBe(true);
+  });
+
+  it('user connected entire session: adjusted 150 ≥ 135 → true', () => {
+    const att = [{ user: 'u1', ...atMin(0, 180) }];
+    expect(meetsAttendanceThreshold(att, 'u1', 180, [lunchBreak(60, 30)], 90)).toBe(true);
+  });
+});
+
+// ── computeGaps ───────────────────────────────────────────────────────────────
+
+describe('computeGaps', () => {
+  function makeSession(durationMin = 120, breaks = [], attendance = []) {
+    return {
+      scheduledStart: BASE,
+      scheduledEnd: new Date(BASE.getTime() + ms(durationMin)),
+      breaks,
+      attendance
+    };
+  }
+
+  it('returns empty for open segment (no leftAt)', () => {
+    const s = makeSession(120, [], [{ user: 'u1', joinedAt: BASE, leftAt: null }]);
+    expect(computeGaps(s, 'u1')).toHaveLength(0);
+  });
+
+  it('detects a 10-min mid-session gap', () => {
+    const s = makeSession(120, [], [
+      { user: 'u1', ...atMin(0, 30) },
+      { user: 'u1', ...atMin(40, 80) }
+    ]);
+    const gaps = computeGaps(s, 'u1');
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].gapMin).toBe(10);
+  });
+
+  it('ignores a gap < 3 min', () => {
+    const s = makeSession(120, [], [
+      { user: 'u1', ...atMin(0, 30) },
+      { user: 'u1', ...atMin(32, 88) }
+    ]);
+    expect(computeGaps(s, 'u1')).toHaveLength(0);
+  });
+
+  it('detects a trailing gap when user left before scheduledEnd', () => {
+    const s = makeSession(120, [], [{ user: 'u1', ...atMin(0, 60) }]);
+    const gaps = computeGaps(s, 'u1');
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].gapMin).toBe(60);
+    expect(gaps[0].nextJoinAt).toBeNull();
+  });
+
+  it('excludes gaps inside a declared break window', () => {
+    const breakObj = { label: 'Break', startsAt: new Date(BASE.getTime() + ms(30)), durationMin: 15 };
+    const s = makeSession(120, [breakObj], [
+      { user: 'u1', ...atMin(0, 30) },
+      { user: 'u1', ...atMin(45, 75) }
+    ]);
+    expect(computeGaps(s, 'u1')).toHaveLength(0);
+  });
+
+  it('returns correct offsetSec from scheduledStart', () => {
+    const s = makeSession(120, [], [
+      { user: 'u1', ...atMin(0, 45) },
+      { user: 'u1', ...atMin(60, 60) }
+    ]);
+    const gaps = computeGaps(s, 'u1');
+    expect(gaps[0].offsetSec).toBe(45 * 60);
+  });
+});

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -112,6 +112,7 @@ import { runDeadlineReminders } from './services/ceDeadlineReminder.js';
 import { runDailyNotificationCheck } from './jobs/dailyNotificationCheck.js';
 import { runHardshipPauseResume } from './jobs/hardshipPauseResume.js';
 import { runCertificateSelfHeal } from './jobs/certificateSelfHeal.js';
+import { runSessionProducerTick } from './jobs/sessionProducerTick.js';
 import { runComplianceDailyJob } from './services/complianceService.js';
 
 import { ROUTE_MANIFEST } from './routeManifest.js';
@@ -435,6 +436,14 @@ const startServer = async () => {
     );
   }, { timezone: 'America/New_York' });
   logger.info('Certificate self-heal cron scheduled (every 6 hours)');
+
+  // Session producer tick — every minute (drop detection, break reminders, wrap-up dispatch)
+  cron.schedule('* * * * *', () => {
+    runSessionProducerTick().catch(err =>
+      console.error('Session producer tick error:', err.message)
+    );
+  }, { timezone: 'America/New_York' });
+  logger.info('Session producer tick cron scheduled (every minute)');
 
   // Video link audit — every Monday at 3 AM ET
   cron.schedule('0 3 * * 1', () => {

--- a/server/src/jobs/sessionProducerTick.js
+++ b/server/src/jobs/sessionProducerTick.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * sessionProducerTick — runs every minute, America/New_York.
+ * Mirrors certificateSelfHeal.js structure.
+ *
+ * Queries only:
+ *   - Sessions with status 'live'
+ *   - Sessions ended < 30 min ago (for wrap-up dispatch)
+ *
+ * Each tick performs:
+ *   1. Drop detection — rejoin nudge emails for disconnected users
+ *   2. Break reminders — resume emails/SMS 3 min before break ends
+ *   3. Breakage detection — mass-drop incident broadcast
+ *   4. Wrap-up dispatch — post-session email pipeline (≥5 min after end)
+ */
+
+import LiveSession from '../models/LiveSession.js';
+import {
+  processDropDetection,
+  processBreakReminders,
+  processBreakageDetection,
+  runWrapUp
+} from '../services/sessionProducer.js';
+
+const LOG = '[ProducerTick]';
+
+export async function runSessionProducerTick() {
+  const now = new Date();
+  const thirtyMinAgo = new Date(now.getTime() - 30 * 60000);
+
+  let sessions;
+  try {
+    sessions = await LiveSession.find({
+      $or: [
+        { status: 'live' },
+        { status: 'completed', updatedAt: { $gte: thirtyMinAgo }, 'producer.wrapUpSentAt': { $exists: false } }
+      ]
+    });
+  } catch (err) {
+    console.error(`${LOG} query error:`, err.message);
+    return;
+  }
+
+  if (sessions.length === 0) return;
+
+  for (const session of sessions) {
+    try {
+      if (session.status === 'live') {
+        await processDropDetection(session);
+        await processBreakReminders(session);
+        await processBreakageDetection(session);
+      }
+
+      // Wrap-up: completed sessions ended ≥ 5 min ago, wrap-up not yet sent
+      if (
+        session.status === 'completed' &&
+        !session.producer?.wrapUpSentAt &&
+        session.updatedAt &&
+        now.getTime() - session.updatedAt.getTime() >= 5 * 60000
+      ) {
+        await runWrapUp(session);
+      }
+    } catch (err) {
+      console.error(`${LOG} error processing session ${session._id}:`, err.message);
+    }
+  }
+}

--- a/server/src/models/LiveSession.js
+++ b/server/src/models/LiveSession.js
@@ -21,7 +21,8 @@ const registrantSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   registeredAt: { type: Date, default: Date.now },
   paid: { type: Boolean, default: false },
-  stripeCheckoutSessionId: String
+  stripeCheckoutSessionId: String,
+  phoneOptIn: { type: Boolean, default: false }   // SMS consent for session logistics
 }, { _id: false });
 
 const attendanceSchema = new mongoose.Schema({
@@ -31,7 +32,9 @@ const attendanceSchema = new mongoose.Schema({
   wherebyParticipantId: String,
   joinedAt: { type: Date, required: true },
   leftAt: Date,
-  durationMin: { type: Number, default: 0 }
+  durationMin: { type: Number, default: 0 },
+  rejoinNudgeSentAt: Date,    // set when a drop-detection nudge fires; prevents duplicate sends
+  catchupSummary: String      // cached AI-generated gap summary (live-course only)
 }, { _id: true });
 
 const handoutSchema = new mongoose.Schema({
@@ -145,6 +148,21 @@ const liveSessionSchema = new mongoose.Schema({
     }
   },
 
+  // Scheduled breaks — excluded from the NBCC attendance denominator
+  breaks: [{
+    label: { type: String, default: 'Break' },
+    startsAt: { type: Date, required: true },
+    durationMin: { type: Number, required: true, min: 1, max: 120 },
+    resumeReminderSentAt: Date
+  }],
+
+  // Session producer state — written by sessionProducer.js / sessionProducerTick.js
+  producer: {
+    wrapUpSentAt: Date,
+    incidentBroadcastAt: Date,
+    transcriptS3Key: String   // set by transcription.finished webhook (live-course only)
+  },
+
   status: {
     type: String,
     enum: ['scheduled', 'live', 'completed', 'cancelled'],
@@ -196,7 +214,50 @@ liveSessionSchema.methods.scheduledDurationMin = function () {
   return Math.round((this.scheduledEnd - this.scheduledStart) / 60000);
 };
 
-/** Total verified minutes for a user across all join/leave segments. */
+/**
+ * Instructional minutes = scheduled duration minus all declared break minutes.
+ * This is the NBCC attendance denominator.
+ */
+liveSessionSchema.methods.instructionalMinutes = function () {
+  const breakMin = (this.breaks || []).reduce((s, b) => s + b.durationMin, 0);
+  return Math.max(1, this.scheduledDurationMin() - breakMin);
+};
+
+/**
+ * Compute overlap in minutes between a segment [segStart, segEnd] and a break window.
+ * Pure helper used by attendedMinutesAdjusted.
+ */
+export function breakOverlapMin(segStart, segEnd, breakStart, breakEnd) {
+  const overlapStart = Math.max(segStart, breakStart);
+  const overlapEnd = Math.min(segEnd, breakEnd);
+  if (overlapEnd <= overlapStart) return 0;
+  return (overlapEnd - overlapStart) / 60000;
+}
+
+/** Total verified instructional minutes for a user — break windows clipped out. */
+liveSessionSchema.methods.attendedMinutesAdjusted = function (userId) {
+  const segments = this.attendance.filter(
+    a => a.user && a.user.toString() === userId.toString() && a.joinedAt && a.leftAt
+  );
+  const breaks = (this.breaks || []).map(b => ({
+    start: b.startsAt.getTime(),
+    end: b.startsAt.getTime() + b.durationMin * 60000
+  }));
+
+  let total = 0;
+  for (const seg of segments) {
+    const segStart = seg.joinedAt.getTime();
+    const segEnd = seg.leftAt.getTime();
+    let rawMin = Math.max(0, (segEnd - segStart) / 60000);
+    for (const br of breaks) {
+      rawMin -= breakOverlapMin(segStart, segEnd, br.start, br.end);
+    }
+    total += Math.max(0, rawMin);
+  }
+  return Math.round(total);
+};
+
+/** Total verified minutes for a user across all join/leave segments (unadjusted). */
 liveSessionSchema.methods.attendedMinutes = function (userId) {
   return this.attendance
     .filter(a => a.user && a.user.toString() === userId.toString())
@@ -204,8 +265,8 @@ liveSessionSchema.methods.attendedMinutes = function (userId) {
 };
 
 liveSessionSchema.methods.meetsAttendanceThreshold = function (userId) {
-  const required = this.scheduledDurationMin() * (this.attendanceThresholdPct / 100);
-  return this.attendedMinutes(userId) >= required;
+  const required = this.instructionalMinutes() * (this.attendanceThresholdPct / 100);
+  return this.attendedMinutesAdjusted(userId) >= required;
 };
 
 /** Public-safe projection — strips room URLs and other server-only fields. */

--- a/server/src/routes/liveSessions.js
+++ b/server/src/routes/liveSessions.js
@@ -501,6 +501,60 @@ router.delete('/:id/clips/:clipIndex', protect, requireAdmin, async (req, res) =
   }
 });
 
+/* ════════════════════════ CATCH-UP ════════════════════════ */
+
+// POST /api/live-sessions/:id/catchup
+// Returns cached AI gap summaries for the requesting user's missed segments.
+// 403 for supervision sessions. {queued:true} if transcript not yet available.
+router.post('/:id/catchup', protect, async (req, res) => {
+  try {
+    const session = await findByIdOrSlug(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+
+    if (session.sessionType === 'supervision') {
+      return res.status(403).json({ error: 'Catch-up is not available for supervision sessions.' });
+    }
+
+    if (!session.isRegistered(req.user._id)) {
+      return res.status(403).json({ error: 'You are not registered for this session.' });
+    }
+
+    // During a live session: transcript not available yet
+    if (session.status === 'live') {
+      return res.json({ queued: true, message: 'The session is still in progress. Your personalized catch-up will be available after the session ends.' });
+    }
+
+    // Transcript not yet available
+    if (!session.producer?.transcriptS3Key) {
+      return res.json({ queued: true, message: 'Your catch-up is being prepared. Check back shortly after the session ends.' });
+    }
+
+    // Return cached summaries for this user's gap segments
+    const { computeGaps } = await import('../services/sessionProducer.js');
+    const userId = req.user._id.toString();
+    const gaps = computeGaps(session, userId);
+
+    const result = gaps.map(gap => {
+      // Pull cached summary from the attendance segment
+      const seg = session.attendance.find(
+        a => a.user && a.user.toString() === userId &&
+             a.leftAt && Math.abs(a.leftAt.getTime() - gap.leftAt.getTime()) < 5000
+      );
+      return {
+        gapMin: gap.gapMin,
+        offsetSec: gap.offsetSec,
+        replayUrl: `${req.protocol}://${req.get('host')}/live-room.html?session=${session.slug}&replay=1&t=${gap.offsetSec}`,
+        summary: seg?.catchupSummary ? JSON.parse(seg.catchupSummary) : null
+      };
+    });
+
+    res.json({ gaps: result });
+  } catch (err) {
+    console.error('[live] catchup:', err.message);
+    res.status(500).json({ error: 'Failed to load catch-up' });
+  }
+});
+
 /* ── helpers ── */
 async function findByIdOrSlug(idOrSlug) {
   if (/^[0-9a-fA-F]{24}$/.test(idOrSlug)) {

--- a/server/src/routes/webhooksWhereby.js
+++ b/server/src/routes/webhooksWhereby.js
@@ -26,6 +26,12 @@ import express from 'express';
 import crypto from 'crypto';
 import LiveSession from '../models/LiveSession.js';
 import User from '../models/User.js';
+import {
+  onClientLeft,
+  onSessionEnded,
+  onRecordingFinished,
+  onTranscriptionFinished
+} from '../services/sessionProducer.js';
 
 const router = express.Router();
 const TOLERANCE_SECONDS = 5 * 60;
@@ -120,6 +126,7 @@ async function handleEvent(event) {
         segment.leftAt = leftAt;
         segment.durationMin = Math.max(0, Math.round((leftAt - segment.joinedAt) / 60000));
         await session.save();
+        onClientLeft(session, segment); // drop detection deferred to cron tick
       }
       break;
     }
@@ -136,6 +143,7 @@ async function handleEvent(event) {
       }
       if (session.status === 'live') { session.status = 'completed'; dirty = true; }
       if (dirty) await session.save();
+      onSessionEnded(session); // wrap-up deferred to cron tick
       break;
     }
 
@@ -154,6 +162,13 @@ async function handleEvent(event) {
         replayEnabled: false // admin flips this on after review
       });
       await session.save();
+      await onRecordingFinished(session);
+      break;
+    }
+
+    case 'transcription.finished': {
+      const s3Key = data.key || data.s3Key || data.fileName || '';
+      await onTranscriptionFinished(session, s3Key);
       break;
     }
 

--- a/server/src/services/sessionProducer.js
+++ b/server/src/services/sessionProducer.js
@@ -1,0 +1,614 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * sessionProducer — event handlers called from webhooksWhereby.js and
+ * the sessionProducerTick cron. All state is persisted on the LiveSession
+ * document; no in-memory timers (Render restarts kill them).
+ *
+ * COMPLIANCE LOCKS:
+ *   - Supervision sessions: logistics (rejoin links, break reminders) only.
+ *     No transcription, AI summaries, catch-up, recordings, or handouts.
+ *   - Catch-up content never counts toward certificate eligibility.
+ *   - Break minutes are excluded from the NBCC attendance denominator
+ *     (handled in LiveSession.attendedMinutesAdjusted / instructionalMinutes).
+ *   - Room links always go through live-room.html?session=<slug>, never
+ *     the raw Whereby URL.
+ */
+
+import { Resend } from 'resend';
+import Anthropic from '@anthropic-ai/sdk';
+import LiveSession from '../models/LiveSession.js';
+import User from '../models/User.js';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const FROM = 'CounselorReady <noreply@counselorready.com>';
+const SITE = process.env.SITE_URL || 'https://counselorready.com';
+
+// Only send SMS if the env flag is explicitly enabled; default false (Phase 2 decision pending)
+const SMS_ENABLED = process.env.SMS_SESSION_LOGISTICS_ENABLED === 'true';
+
+// ─── Twilio (lazy-loaded so server still starts without TWILIO_* vars) ────────
+let twilioClient = null;
+async function getTwilio() {
+  if (!SMS_ENABLED) return null;
+  if (twilioClient) return twilioClient;
+  const { default: twilio } = await import('twilio');
+  twilioClient = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+  return twilioClient;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** True if the given Date falls inside any declared break window. */
+function insideBreakWindow(session, when) {
+  return (session.breaks || []).some(b => {
+    const start = b.startsAt.getTime();
+    const end = start + b.durationMin * 60000;
+    const t = (when instanceof Date ? when : new Date(when)).getTime();
+    return t >= start && t < end;
+  });
+}
+
+/** Room URL that goes through our gated page — never the raw Whereby URL. */
+function gatedRoomUrl(session) {
+  return `${SITE}/live-room.html?session=${encodeURIComponent(session.slug)}`;
+}
+
+/** Replay deep-link with optional seek offset. */
+function replayDeepLink(session, offsetSec) {
+  const base = `${SITE}/live-room.html?session=${encodeURIComponent(session.slug)}&replay=1`;
+  return offsetSec != null ? `${base}&t=${Math.round(offsetSec)}` : base;
+}
+
+/**
+ * Gap segments for a user: pairs where leftAt is followed by a later joinedAt,
+ * plus a trailing gap from last leftAt to scheduledEnd (if early leave).
+ * Gaps inside declared break windows are excluded.
+ * @returns {Array<{leftAt: Date, nextJoinAt: Date|null, gapMin: number, offsetSec: number}>}
+ */
+export function computeGaps(session, userId) {
+  const segments = session.attendance
+    .filter(a => a.user && a.user.toString() === userId.toString() && a.joinedAt && a.leftAt)
+    .sort((a, b) => a.joinedAt - b.joinedAt);
+
+  if (segments.length === 0) return [];
+
+  const gaps = [];
+  const sessionStart = session.scheduledStart.getTime();
+  const sessionEnd = session.scheduledEnd.getTime();
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const left = segments[i].leftAt;
+    const next = segments[i + 1].joinedAt;
+    const gapMin = Math.round((next - left) / 60000);
+    if (gapMin >= 3 && !insideBreakWindow(session, left)) {
+      gaps.push({
+        leftAt: left,
+        nextJoinAt: next,
+        gapMin,
+        offsetSec: Math.round((left.getTime() - sessionStart) / 1000)
+      });
+    }
+  }
+
+  // Trailing gap: last leftAt to scheduledEnd
+  const last = segments[segments.length - 1];
+  if (last.leftAt.getTime() < sessionEnd) {
+    const gapMin = Math.round((sessionEnd - last.leftAt.getTime()) / 60000);
+    if (gapMin >= 3 && !insideBreakWindow(session, last.leftAt)) {
+      gaps.push({
+        leftAt: last.leftAt,
+        nextJoinAt: null,
+        gapMin,
+        offsetSec: Math.round((last.leftAt.getTime() - sessionStart) / 1000)
+      });
+    }
+  }
+
+  return gaps;
+}
+
+// ─── Email helpers ─────────────────────────────────────────────────────────────
+
+async function sendEmail({ to, subject, html }) {
+  try {
+    await resend.emails.send({ from: FROM, to, subject, html });
+  } catch (err) {
+    console.error('[sessionProducer] email error:', err.message);
+  }
+}
+
+async function sendSms(to, body) {
+  if (!SMS_ENABLED) return;
+  try {
+    const client = getTwilio();
+    if (!client) return;
+    await client.messages.create({
+      from: process.env.TWILIO_FROM_NUMBER,
+      to,
+      body
+    });
+  } catch (err) {
+    console.error('[sessionProducer] SMS error:', err.message);
+  }
+}
+
+function emailShell(bodyHtml) {
+  return `<!DOCTYPE html><html><head><meta charset="UTF-8">
+<style>
+  body{font-family:'Lato',sans-serif;background:#F8F7F4;margin:0;padding:0;}
+  .wrap{max-width:600px;margin:32px auto;background:#fff;border-radius:12px;overflow:hidden;border:1px solid #EDE9E3;}
+  .hdr{background:linear-gradient(135deg,#8B2542,#6B1D34);padding:28px 32px;}
+  .hdr h1{color:#fff;font-family:'Cormorant Garamond',Georgia,serif;font-size:22px;margin:0;}
+  .body{padding:28px 32px;color:#284157;font-size:15px;line-height:1.6;}
+  .btn{display:inline-block;background:#6B1D34;color:#fff !important;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:700;margin:16px 0;}
+  .footer{padding:16px 32px;font-size:12px;color:#78716c;border-top:1px solid #EDE9E3;}
+</style></head><body>
+<div class="wrap">
+  <div class="hdr"><h1>CounselorReady</h1></div>
+  <div class="body">${bodyHtml}</div>
+  <div class="footer">GA Integrated Therapeutic Perspectives, LLC · NBCC ACEP #7760</div>
+</div></body></html>`;
+}
+
+// ─── Email templates ───────────────────────────────────────────────────────────
+
+function rejoinNudgeHtml(session, firstName) {
+  return emailShell(`
+    <p>Hi ${esc(firstName)},</p>
+    <p>It looks like you got disconnected from <strong>${esc(session.title)}</strong>. The session is still in progress — rejoin whenever you're ready.</p>
+    <a class="btn" href="${gatedRoomUrl(session)}">Rejoin the Session</a>
+    <p style="font-size:13px;color:#57534e;">If you had technical difficulties, please contact support@counselorready.com.</p>
+  `);
+}
+
+function breakResumeHtml(session, breakLabel, resumeTime) {
+  return emailShell(`
+    <p><strong>${esc(breakLabel)}</strong> ends at <strong>${resumeTime}</strong>.</p>
+    <p>Click below to rejoin <strong>${esc(session.title)}</strong> when you're ready.</p>
+    <a class="btn" href="${gatedRoomUrl(session)}">Rejoin for the Next Segment</a>
+  `);
+}
+
+function incidentBroadcastHtml(session) {
+  return emailShell(`
+    <p>Hi there,</p>
+    <p>We're experiencing brief technical difficulties during <strong>${esc(session.title)}</strong>. Please hold tight — we're working to restore the session.</p>
+    <p>Use the link below to rejoin as soon as the room is back:</p>
+    <a class="btn" href="${gatedRoomUrl(session)}">Rejoin the Session</a>
+    <p style="font-size:13px;color:#57534e;">We apologize for the interruption.</p>
+  `);
+}
+
+function catchupBlockHtml(gaps, session) {
+  if (!gaps || gaps.length === 0) return '';
+  let html = `<div style="background:#F8F7F4;border:1px solid #EDE9E3;border-radius:8px;padding:16px;margin:16px 0;">
+    <h3 style="margin:0 0 8px;color:#6B1D34;font-size:15px;">Your Personalized Catch-Up</h3>`;
+  for (const gap of gaps) {
+    const time = gap.leftAt.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' });
+    html += `<div style="margin-bottom:12px;padding-bottom:12px;border-bottom:1px solid #EDE9E3;">
+      <p style="font-size:13px;color:#57534e;margin:0 0 6px;">You were away ~${gap.gapMin} min starting around ${time} ET</p>`;
+    if (gap.summary) {
+      html += `<ul style="margin:0 0 6px;padding-left:18px;font-size:14px;color:#284157;">`;
+      for (const bullet of gap.summary) {
+        html += `<li>${esc(bullet)}</li>`;
+      }
+      html += `</ul>`;
+    }
+    html += `<a href="${replayDeepLink(session, gap.offsetSec)}" style="font-size:13px;color:#4A7C59;">▶ Watch this segment in the replay</a>
+    </div>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function wrapUpHtml(session, user, gaps, handouts, replayUrl) {
+  const firstName = user.profile?.firstName || 'there';
+  const gapBlock = catchupBlockHtml(gaps, session);
+
+  let handoutsHtml = '';
+  if (handouts && handouts.length > 0) {
+    handoutsHtml = `<p><strong>Handouts:</strong></p><ul style="padding-left:18px;">`;
+    for (const h of handouts) {
+      handoutsHtml += `<li><a href="${SITE}/live-room.html?session=${esc(session.slug)}" style="color:#4A7C59;">${esc(h.title)}</a></li>`;
+    }
+    handoutsHtml += `</ul>`;
+  }
+
+  const replayHtml = replayUrl
+    ? `<p>The <strong>replay</strong> is available — <a href="${replayDeepLink(session)}" style="color:#4A7C59;">watch it here</a>.</p>`
+    : `<p>The replay is being processed and will be available shortly. We'll send you a follow-up email when it's ready.</p>`;
+
+  return emailShell(`
+    <p>Hi ${esc(firstName)},</p>
+    <p>Thank you for attending <strong>${esc(session.title)}</strong>! We're glad you joined us.</p>
+    ${gapBlock}
+    ${handoutsHtml}
+    ${replayHtml}
+    <p>Your CE certificate (${session.ceuHours} hours) will be issued within 24 hours to eligible participants. You'll receive a separate email when it's ready.</p>
+    <p style="font-size:13px;color:#57534e;">CE credit is based on verified live attendance minutes and cannot be earned through replay or catch-up content.</p>
+  `);
+}
+
+function missedSessionHtml(session, user, replayEnabled) {
+  const firstName = user.profile?.firstName || 'there';
+  return emailShell(`
+    <p>Hi ${esc(firstName)},</p>
+    <p>We missed you at <strong>${esc(session.title)}</strong>.</p>
+    ${replayEnabled ? `<p>Good news — a replay is available for registered participants: <a href="${replayDeepLink(session)}" style="color:#4A7C59;">Watch the replay</a>.</p>` : ''}
+    <p>Keep an eye on our upcoming sessions for another opportunity to earn CE credit live.</p>
+  `);
+}
+
+function replayReadyHtml(session, user) {
+  const firstName = user.profile?.firstName || 'there';
+  return emailShell(`
+    <p>Hi ${esc(firstName)},</p>
+    <p>The replay for <strong>${esc(session.title)}</strong> is now available.</p>
+    <a class="btn" href="${replayDeepLink(session)}">Watch the Replay</a>
+    <p style="font-size:13px;color:#57534e;">Replay viewing does not count toward CE credit.</p>
+  `);
+}
+
+function esc(s) {
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// ─── Event handlers (called from webhooksWhereby.js) ──────────────────────────
+
+/**
+ * Called when a participant leaves mid-session.
+ * Drop detection relies entirely on the cron tick — no in-memory timers.
+ */
+export function onClientLeft(session, segment) {
+  // No-op here: drop detection runs in the cron tick every minute.
+  // Supervision sessions still get no content processing.
+}
+
+/**
+ * Called when room.session.ended fires.
+ * The wrap-up pipeline is deferred to the cron tick (≥5 min after ended),
+ * giving recording/transcription webhooks time to land.
+ * For supervision sessions: no wrap-up content; this is a no-op.
+ */
+export function onSessionEnded(session) {
+  // No-op: cron tick handles wrap-up dispatch.
+}
+
+/**
+ * Called when recording.finished fires (live-course only).
+ * If wrap-up was already sent without a replay link, email registrants
+ * that the replay is now available.
+ */
+export async function onRecordingFinished(session) {
+  if (session.sessionType === 'supervision') return; // hard-lock
+  if (!session.producer?.wrapUpSentAt) return; // wrap-up not sent yet — wrap-up email will include replay link
+
+  // Wrap-up was already sent without a replay — send follow-up
+  const registrantIds = session.registrants.map(r => r.user);
+  const users = await User.find({ _id: { $in: registrantIds } }).select('email profile');
+  for (const user of users) {
+    const attended = session.attendance.some(
+      a => a.user && a.user.toString() === user._id.toString()
+    );
+    if (!attended) continue;
+    await sendEmail({
+      to: user.email,
+      subject: `Replay ready: ${session.title}`,
+      html: replayReadyHtml(session, user)
+    });
+  }
+}
+
+/**
+ * Called when transcription.finished fires.
+ * Live-course only — supervision is refused and logged.
+ */
+export async function onTranscriptionFinished(session, s3Key) {
+  if (session.sessionType === 'supervision') {
+    console.error(`[sessionProducer] transcription.finished on SUPERVISION session ${session._id} — refusing to store. Investigate Whereby config immediately.`);
+    return;
+  }
+  session.producer = session.producer || {};
+  session.producer.transcriptS3Key = s3Key;
+  await session.save();
+}
+
+// ─── Wrap-up pipeline ─────────────────────────────────────────────────────────
+
+/**
+ * Run the post-session wrap-up for a completed live-course session.
+ * Idempotent: checks producer.wrapUpSentAt before doing anything.
+ */
+export async function runWrapUp(session) {
+  if (session.sessionType === 'supervision') return; // hard-lock
+  if (session.producer?.wrapUpSentAt) return;        // already ran
+
+  const registrantIds = session.registrants.map(r => r.user);
+  const users = await User.find({ _id: { $in: registrantIds } }).select('email profile');
+
+  const hasReplay = session.recordings.some(r => r.replayEnabled && r.status === 'ready');
+  const handouts = (session.handouts || []).filter(h => h.availability === 'after' || h.availability === 'during');
+
+  for (const user of users) {
+    const userId = user._id.toString();
+    const userAttended = session.attendance.some(
+      a => a.user && a.user.toString() === userId && a.joinedAt
+    );
+
+    if (!userAttended) {
+      // Never-joined registrant
+      const replayEnabled = hasReplay && session.recordingEnabled;
+      await sendEmail({
+        to: user.email,
+        subject: `We missed you — ${session.title}`,
+        html: missedSessionHtml(session, user, replayEnabled)
+      });
+      continue;
+    }
+
+    // Compute gaps for this user
+    const gaps = computeGaps(session, userId);
+
+    // Attempt AI summaries if transcript is available
+    if (session.producer?.transcriptS3Key && gaps.length > 0) {
+      await populateCatchupSummaries(session, userId, gaps);
+    }
+
+    await sendEmail({
+      to: user.email,
+      subject: `Thank you for attending: ${session.title}`,
+      html: wrapUpHtml(session, user, gaps, handouts, hasReplay ? true : null)
+    });
+  }
+
+  session.producer = session.producer || {};
+  session.producer.wrapUpSentAt = new Date();
+  await session.save();
+}
+
+// ─── AI catch-up summaries (Tier 2, live-course + transcript only) ─────────────
+
+/**
+ * For each gap that doesn't yet have a cached summary, slice the transcript
+ * by wall-clock window and call Haiku to produce 3–5 bullet points.
+ * Results cached on the attendance segment as catchupSummary.
+ *
+ * Transcript format assumption: segments have a `start` field in seconds
+ * relative to recording start ≈ scheduledStart. Document this offset here:
+ * offset = segment.start → wall-clock = scheduledStart + segment.start seconds.
+ *
+ * NOTE: Whereby transcription API shape is unverified (open question in spec).
+ * This function is guarded by `transcriptS3Key` presence; it degrades
+ * gracefully if the transcript is absent or malformed.
+ */
+async function populateCatchupSummaries(session, userId, gaps) {
+  let transcript = null;
+  try {
+    const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
+    const s3 = new S3Client({ region: process.env.AWS_REGION || 'us-east-1' });
+    const cmd = new GetObjectCommand({
+      Bucket: process.env.AWS_S3_RECORDINGS_BUCKET,
+      Key: session.producer.transcriptS3Key
+    });
+    const resp = await s3.send(cmd);
+    const chunks = [];
+    for await (const chunk of resp.Body) chunks.push(chunk);
+    transcript = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (err) {
+    console.warn('[sessionProducer] transcript load failed (non-fatal):', err.message);
+    return;
+  }
+
+  const sessionStartMs = session.scheduledStart.getTime();
+
+  for (const gap of gaps) {
+    // Check cache on attendance segment
+    const segment = session.attendance.find(
+      a => a.user && a.user.toString() === userId &&
+           a.leftAt && Math.abs(a.leftAt.getTime() - gap.leftAt.getTime()) < 5000
+    );
+    if (segment?.catchupSummary) {
+      gap.summary = JSON.parse(segment.catchupSummary);
+      continue;
+    }
+
+    // Slice transcript by gap window (seconds relative to session start)
+    const gapStartSec = (gap.leftAt.getTime() - sessionStartMs) / 1000;
+    const gapEndSec = gap.nextJoinAt
+      ? (gap.nextJoinAt.getTime() - sessionStartMs) / 1000
+      : (session.scheduledEnd.getTime() - sessionStartMs) / 1000;
+
+    const segments = Array.isArray(transcript?.segments)
+      ? transcript.segments
+      : Array.isArray(transcript?.words)
+        ? transcript.words
+        : [];
+
+    const slice = segments
+      .filter(s => s.start >= gapStartSec && s.start < gapEndSec)
+      .map(s => s.text || s.word || '')
+      .join(' ')
+      .trim();
+
+    if (!slice) continue;
+
+    try {
+      const msg = await anthropic.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        system: 'Summarize what a CE webinar attendee missed during this segment in 3–5 plain-language bullets. Facts from the transcript only; no speculation; no clinical advice.',
+        messages: [{ role: 'user', content: slice }]
+      });
+      const text = msg.content?.[0]?.text || '';
+      const bullets = text.split('\n').filter(l => l.trim().startsWith('-') || l.trim().match(/^\d+\./)).map(l => l.replace(/^[-\d.)\s]+/, '').trim()).filter(Boolean);
+      if (bullets.length > 0) {
+        gap.summary = bullets;
+        if (segment) {
+          segment.catchupSummary = JSON.stringify(bullets);
+        }
+      }
+    } catch (err) {
+      console.warn('[sessionProducer] AI summary error (non-fatal):', err.message);
+    }
+  }
+
+  await session.save();
+}
+
+// ─── Cron tick actions (called from sessionProducerTick.js) ───────────────────
+
+/**
+ * Drop detection for a single live session.
+ * Sends a rejoin email (and optional SMS) to users whose most recent
+ * segment closed 3–10 minutes ago with no newer segment.
+ */
+export async function processDropDetection(session) {
+  const now = Date.now();
+  const isDirty = { val: false };
+
+  // Group attendance by user, keep only the most recent segment per user
+  const latest = new Map();
+  for (const a of session.attendance) {
+    const uid = a.user ? a.user.toString() : null;
+    if (!uid) continue;
+    const prev = latest.get(uid);
+    if (!prev || a.joinedAt > prev.joinedAt) latest.set(uid, a);
+  }
+
+  for (const [userId, seg] of latest) {
+    if (!seg.leftAt) continue; // still open — not dropped
+    if (seg.rejoinNudgeSentAt) continue; // already nudged for this gap
+    const ageMs = now - seg.leftAt.getTime();
+    if (ageMs < 3 * 60000 || ageMs > 10 * 60000) continue; // outside 3–10 min window
+    if (now >= session.scheduledEnd.getTime()) continue; // session over
+    if (insideBreakWindow(session, new Date(now))) continue;
+
+    const user = await User.findById(userId).select('email profile phone');
+    if (!user) continue;
+
+    const firstName = user.profile?.firstName || 'there';
+    await sendEmail({
+      to: user.email,
+      subject: `Did you get disconnected? — ${session.title}`,
+      html: rejoinNudgeHtml(session, firstName)
+    });
+
+    const reg = session.registrants.find(r => r.user && r.user.toString() === userId);
+    if (reg?.phoneOptIn && user.phone) {
+      await sendSms(user.phone, `Hi ${firstName}, it looks like you got disconnected from "${session.title}". Rejoin here: ${gatedRoomUrl(session)}`);
+    }
+
+    seg.rejoinNudgeSentAt = new Date();
+    isDirty.val = true;
+  }
+
+  if (isDirty.val) await session.save();
+}
+
+/**
+ * Break resume reminders for a single live session.
+ */
+export async function processBreakReminders(session) {
+  const now = Date.now();
+  let dirty = false;
+
+  for (const br of (session.breaks || [])) {
+    if (br.resumeReminderSentAt) continue;
+    const resumeTime = br.startsAt.getTime() + br.durationMin * 60000;
+    const timeUntilResume = resumeTime - now;
+    if (timeUntilResume < 0 || timeUntilResume > 3 * 60000) continue; // only 3 min before resume
+
+    const resumeTimeStr = new Date(resumeTime).toLocaleTimeString('en-US', {
+      hour: 'numeric', minute: '2-digit', timeZone: session.timezone || 'America/New_York'
+    });
+
+    const registrantIds = session.registrants.map(r => r.user);
+    const users = await User.find({ _id: { $in: registrantIds } }).select('email profile phone');
+
+    for (const user of users) {
+      await sendEmail({
+        to: user.email,
+        subject: `${br.label || 'Break'} ending soon — ${session.title}`,
+        html: breakResumeHtml(session, br.label || 'Break', resumeTimeStr)
+      });
+      const reg = session.registrants.find(r => r.user && r.user.toString() === user._id.toString());
+      if (reg?.phoneOptIn && user.phone) {
+        await sendSms(user.phone, `${br.label || 'Break'} ends at ${resumeTimeStr}. Rejoin "${session.title}": ${gatedRoomUrl(session)}`);
+      }
+    }
+
+    br.resumeReminderSentAt = new Date();
+    dirty = true;
+  }
+
+  if (dirty) await session.save();
+}
+
+/**
+ * Breakage detection for a single live session.
+ * If >50% of currently-open segments closed within the same 2-min window
+ * and no incident broadcast has been sent, broadcast to all registrants.
+ */
+export async function processBreakageDetection(session) {
+  if (session.producer?.incidentBroadcastAt) return;
+
+  const now = Date.now();
+  const twoMinAgo = now - 2 * 60000;
+
+  // Count recently-closed segments (closed in the last 2 min)
+  const recentlyClosed = session.attendance.filter(
+    a => a.leftAt && a.leftAt.getTime() >= twoMinAgo && a.leftAt.getTime() <= now
+  );
+
+  // Count open segments (no leftAt)
+  const openCount = session.attendance.filter(a => !a.leftAt).length;
+  const totalActive = recentlyClosed.length + openCount;
+
+  if (totalActive < 2) return; // need at least 2 participants to detect a mass drop
+  if (recentlyClosed.length / totalActive <= 0.5) return;
+
+  // Broadcast incident
+  const registrantIds = session.registrants.map(r => r.user);
+  const users = await User.find({ _id: { $in: registrantIds } }).select('email profile');
+  for (const user of users) {
+    await sendEmail({
+      to: user.email,
+      subject: `Technical difficulties — ${session.title}`,
+      html: incidentBroadcastHtml(session)
+    });
+  }
+
+  // Notify admin via existing service (import inline to avoid circular dep risk)
+  try {
+    const { notifyAdmin } = await import('./adminNotificationService.js');
+    await notifyAdmin({
+      type: 'LIVE_SESSION_INCIDENT',
+      message: `Mass drop detected on live session "${session.title}" (${session._id}). ${recentlyClosed.length} of ${totalActive} active participants dropped within 2 minutes.`,
+      sessionId: session._id
+    });
+  } catch {
+    console.error('[sessionProducer] Admin notification failed for incident on session', session._id);
+  }
+
+  session.producer = session.producer || {};
+  session.producer.incidentBroadcastAt = new Date();
+  await session.save();
+}
+
+export default {
+  onClientLeft,
+  onSessionEnded,
+  onRecordingFinished,
+  onTranscriptionFinished,
+  runWrapUp,
+  processDropDetection,
+  processBreakReminders,
+  processBreakageDetection,
+  computeGaps
+};


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Schema**: `breaks[]`, `producer{}`, `phoneOptIn`, `rejoinNudgeSentAt`, `catchupSummary` added to `LiveSession.js`; `instructionalMinutes()` / `attendedMinutesAdjusted()` replace raw duration in NBCC threshold math; `breakOverlapMin()` exported for testing
- **Service** (`sessionProducer.js`): event handlers + wrap-up pipeline + Tier-1 replay deep-links + Tier-2 Haiku gap summaries + drop/break/breakage detection helpers
- **Cron** (`sessionProducerTick.js`): every-minute tick queries live + recently-completed sessions and dispatches all four producer actions
- **Route**: `POST /api/live-sessions/:id/catchup` — 403 for supervision, `{queued}` pre-transcript, cached bullets on hit
- **Webhook**: `webhooksWhereby.js` wires producer event hooks; adds `transcription.finished` case
- **Frontend**: `?t=<sec>` seeks replay video on `loadedmetadata`; rejoin banner shows gap recap on join/replay (request-only)
- **index.js**: registers `sessionProducerTick` alongside existing crons

## Compliance locks

- Supervision sessions: 403 on `/catchup`, refused on `transcription.finished`, no wrap-up content, no AI summaries
- Catch-up never counts toward certificate eligibility (denominator is `instructionalMinutes()`, not catch-up consumption)
- Break minutes excluded from NBCC denominator via `attendedMinutesAdjusted()` break-clipping
- Room links always route through `live-room.html?session=<slug>`, never raw Whereby URLs
- SMS behind `SMS_SESSION_LOGISTICS_ENABLED=false` default (Ke decision pending)

## Open questions resolved/deferred

1. **Whereby transcription**: shape unverified — Tier-2 AI summaries degrade gracefully if transcript absent/malformed. Documented assumption: `segment.start` = seconds from recording start ≈ `scheduledStart`.
2. **Whereby webhook field names**: existing conservative assumptions (`participantId || id`) preserved from Phase 1.
3. **SMS expansion**: email-only ships; all Twilio calls gated behind `SMS_SESSION_LOGISTICS_ENABLED=false`.

## Test plan

- [ ] `npx vitest run server/src/__tests__/liveSessionAttendance.test.js` — 23 tests pass (breakOverlapMin, instructionalMinutes, attendedMinutesAdjusted, meetsAttendanceThreshold, computeGaps)
- [ ] Simulated webhook: join → left → tick at +4 min → exactly one rejoin email, `rejoinNudgeSentAt` set, second tick sends nothing
- [ ] 3-hr session + 30-min lunch: `instructionalMinutes()` = 150; user connected entire time logs 150 adjusted min, meets 90% threshold
- [ ] `POST /:id/catchup` on supervision → 403; pre-transcript → `{queued:true}`; post-transcript → cached bullets; second call returns same cache
- [ ] Wrap-up email renders with and without replay/transcript
- [ ] `transcription.finished` on supervision session → refused, logged, not stored
- [ ] `?t=45` on replay URL → video seeks to 45 seconds on loadedmetadata
- [ ] `SMS_SESSION_LOGISTICS_ENABLED=false` (default) → zero Twilio calls

https://claude.ai/code/session_01JXr6cNTPecKFi87tFmjvtZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXr6cNTPecKFi87tFmjvtZ)_