### PR TITLE
Add Tier 1/2/3 technical manual system and block field reference

### DIFF
--- a/BLOCK_FIELD_REFERENCE.md
+++ b/BLOCK_FIELD_REFERENCE.md
@@ -1,0 +1,222 @@
+# BLOCK FIELD REFERENCE (Tier 1 — GENERATED, DO NOT HAND-EDIT)
+
+> Source hash `a0753da348c3` (sha256 of interactive-course.html, first 12) by `server/src/scripts/generateBlockFieldReference.js`.
+> **Source of truth:** the `renderX()` functions in `client/public/interactive-course.html`.
+> Field names below are extracted from `block.<field>` reads in those functions.
+> If a seed or the builder writes a field NOT listed here, the viewer ignores it
+> and the block renders incomplete or blank. **The viewer wins over every spec doc.**
+>
+> Regenerate after ANY change to a block render function. Never edit this file by hand.
+
+## ⚠ Cross-block field-name divergence (the silent-blank trap)
+
+The `image` and `imageText` blocks use DIFFERENT names for the same concepts.
+Wiring an uploader's generic `{url, alt}` output to the wrong names = block saves,
+word count unaffected, but renders blank.
+
+| Concept | `image` block | `imageText` block |
+|---|---|---|
+| image source | `imageUrl` | `image` |
+| alt text | `imageAltText` | `imageAlt` |
+| caption | `imageCaption` | (none) |
+| size control | `imageSize` ('small'|'medium'|'large') | (none) |
+| alignment | `imageAlignment` ('left'|'center'|'right') | (none) |
+| position flip | (none) | `imagePosition` ('left'|'right') |
+| highlight bg | (none) | `highlight` (boolean) |
+
+## All block types (extracted)
+
+### `sectionDivider`  ·  renders via `renderSectionDivider()`
+| field | classification |
+|---|---|
+| `bannerAlt` | data |
+| `bannerImage` | data |
+| `sectionNumber` | data |
+| `subtitle` | prose (word-counted) |
+| `title` | prose (word-counted) |
+
+### `text`  ·  renders via `renderText()`
+| field | classification |
+|---|---|
+| `callouts` | data |
+| `content` | prose (word-counted) |
+| `textContent` | data |
+
+### `imageText`  ·  renders via `renderImageText()`
+| field | classification |
+|---|---|
+| `callouts` | data |
+| `content` | prose (word-counted) |
+| `highlight` | layout/asset (not counted) |
+| `image` | layout/asset (not counted) |
+| `imageAlt` | layout/asset (not counted) |
+| `imagePosition` | layout/asset (not counted) |
+| `title` | prose (word-counted) |
+
+### `image`  ·  renders via `renderImage()`
+| field | classification |
+|---|---|
+| `imageAlignment` | layout/asset (not counted) |
+| `imageAltText` | layout/asset (not counted) |
+| `imageCaption` | data |
+| `imageSize` | layout/asset (not counted) |
+| `imageUrl` | layout/asset (not counted) |
+
+### `accordion`  ·  renders via `renderAccordion()`
+| field | classification |
+|---|---|
+| `accordionItems` | data |
+
+### `multipleChoice`  ·  renders via `renderMultipleChoice()`
+| field | classification |
+|---|---|
+| `correctAnswer` | data |
+| `explanation` | data |
+| `options` | data |
+| `question` | prose (word-counted) |
+
+### `multiSelect`  ·  renders via `renderMultiSelect()`
+| field | classification |
+|---|---|
+| `explanation` | data |
+| `options` | data |
+| `question` | prose (word-counted) |
+
+### `matching`  ·  renders via `renderMatching()`
+| field | classification |
+|---|---|
+| `matchingInstructions` | data |
+| `matchingPairs` | data |
+
+### `flashcardDeck`  ·  renders via `renderFlashcardDeck()`
+| field | classification |
+|---|---|
+| `flashcards` | data |
+| `instructions` | data |
+
+### `scenarioTree`  ·  renders via `renderScenarioTree()`
+| field | classification |
+|---|---|
+| `instructions` | data |
+| `nodes` | data |
+| `scenarioTitle` | data |
+| `startNode` | data |
+
+### `cardSort`  ·  renders via `renderCardSort()`
+| field | classification |
+|---|---|
+| `cards` | data |
+| `categories` | data |
+| `explanation` | data |
+| `instructions` | data |
+
+### `sequencing`  ·  renders via `renderSequencing()`
+| field | classification |
+|---|---|
+| `explanation` | data |
+| `instructions` | data |
+| `steps` | data |
+
+### `timeline`  ·  renders via `renderTimeline()`
+| field | classification |
+|---|---|
+| `events` | data |
+
+### `hotspot`  ·  renders via `renderHotspot()`
+| field | classification |
+|---|---|
+| `hotspotImage` | data |
+| `hotspots` | layout/asset (not counted) |
+| `imageDescription` | data |
+| `instructions` | data |
+
+### `reflection`  ·  renders via `renderReflection()`
+| field | classification |
+|---|---|
+| `minLength` | data |
+| `question` | prose (word-counted) |
+
+### `callout`  ·  renders via `renderCallout()`
+| field | classification |
+|---|---|
+| `calloutItems` | data |
+| `calloutType` | data |
+| `content` | prose (word-counted) |
+| `items` | data |
+| `title` | prose (word-counted) |
+| `variant` | data |
+
+### `fillInBlank`  ·  renders via `renderFillInBlank()`
+| field | classification |
+|---|---|
+| `blanks` | data |
+| `title` | prose (word-counted) |
+
+### `keyTakeaway`  ·  renders via `renderKeyTakeaway()`
+| field | classification |
+|---|---|
+| `content` | prose (word-counted) |
+| `items` | data |
+| `takeaways` | data |
+| `title` | prose (word-counted) |
+
+### `statCard`  ·  renders via `renderStatCard()`
+| field | classification |
+|---|---|
+| `stats` | data |
+| `title` | prose (word-counted) |
+
+### `caseStudy`  ·  renders via `renderCaseStudy()`
+| field | classification |
+|---|---|
+| `caseBackground` | data |
+| `caseClient` | data |
+| `caseClinicianNotes` | data |
+| `caseDiscussion` | data |
+| `casePresentingConcerns` | data |
+| `caseTitle` | data |
+
+### `pullQuote`  ·  renders via `renderPullQuote()`
+| field | classification |
+|---|---|
+| `attribution` | data |
+| `quote` | prose (word-counted) |
+
+### `table`  ·  renders via `renderTableBlock()`
+| field | classification |
+|---|---|
+| `tableCaption` | data |
+| `tableHeaders` | data |
+| `tableRows` | data |
+| `title` | prose (word-counted) |
+
+### `resources`  ·  renders via `renderResources()`
+| field | classification |
+|---|---|
+| `deliverables` | data |
+| `files` | data |
+| `resources` | data |
+
+### `videoEmbed`  ·  renders via `renderVideoEmbed()`
+| field | classification |
+|---|---|
+| `markers` | data |
+| `videoDuration` | data |
+| `videoStatus` | data |
+| `videoTitle` | data |
+| `videoUrl` | layout/asset (not counted) |
+
+## Viewer-supported block types
+
+`sectionDivider`, `text`, `imageText`, `image`, `accordion`, `multipleChoice`, `multiSelect`, `matching`, `flashcardDeck`, `scenarioTree`, `cardSort`, `sequencing`, `timeline`, `hotspot`, `reflection`, `callout`, `fillInBlank`, `keyTakeaway`, `statCard`, `caseStudy`, `pullQuote`, `table`, `resources`, `videoEmbed`
+
+> If the course builder's block picker offers fewer types than this list,
+> the missing ones are unexposed capability — they render fine if seeded, but
+> authors can't add them via the UI. Candidates to expose for layout variety:
+> `statCard`, `pullQuote`, `caseStudy`, `keyTakeaway`, `table`, `timeline`, `callout`.
+
+## Schema-declared top-level paths (context only)
+
+_From InteractiveCourse.js. Strict mode silently drops undeclared fields on save._
+
+`accessType`, `acepNumber`, `action`, `approvalBody`, `approvalDate`, `assessment`, `assessmentPassed`, `attemptedAt`, `attemptsAllowed`, `attestationAgreed`, `attestationRequired`, `attestationText`, `blockId`, `blockIndex`, `blockType`, `body`, `calloutType`, `category`, `ceHours`, `ceProvider`, `certificateEnabled`, `certificateId`, `confidence`, `courseCode`, `courseId`, `currentSectionIndex`, `deliveryFormat`, `description`, `dripEnabled`, `dripIntervalMinutes`, `dripSectionsPerInterval`, `enforceSectionOrder`, `enrolledAt`, `estimatedTime`, `evaluationId`, `evaluationSubmitted`, `expirationDate`, `hasQuiz`, `highlight`, `hours`, `imageAlignment`, `imagePosition`, `imageSize`, `isActive`, `isPublished`, `label`, `lastAccessedAt`, `maxAttempts`, `message`, `minLength`, `minimumTimeMinutes`, `narrationEnabled`, `nodes`, `notes`, `order`, `overallProgress`, `partnerId`, `passThreshold`, `passingScore`, `presenter`, `previousSectionsReviewable`, `providerName`, `providerNumber`, `quizPassThreshold`, `quizPassed`, `sectionId`, `sectionIndex`, `shuffleOptions`, `shuffleQuestions`, `slug`, `source`, `startNode`, `status`, `timeLimit`, `timeSpent`, `timestamp`, `title`, `totalTimeSpent`, `type`, `updatedAt`, `userId`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,3 +376,41 @@ Creating or refactoring such scripts is allowed; running them is not. If you fin
 ## Activity Tracking Wiring — Always Use logActivity
 
 When adding new user-facing endpoints (purchases, signups, tool usage, content generation, etc.), the corresponding activity event MUST be logged via `logActivity()` from `activityTrackingService.js`. Never call `UserActivity.create()` directly, and never write a one-off `Resend.emails.send()` for admin notifications. The central service handles persistence, admin feed, and email alerts uniformly.
+
+## Technical Manual Governance (MANDATORY — applies to every session)
+
+The repo's technical knowledge lives in a three-tier system designed so that no
+single chat session needs to hold all prior corrections. Follow these rules in
+EVERY session, without exception:
+
+### TIER 1 — Generated facts (`BLOCK_FIELD_REFERENCE.md` and any future generated refs)
+- These files are produced by scripts in `server/src/scripts/` (e.g.
+  `generateBlockFieldReference.js`). They are the authoritative field-name source.
+- **Before writing or editing any course block, seed, or builder media code, READ
+  `BLOCK_FIELD_REFERENCE.md`.** It reflects the actual viewer render functions and
+  overrides GOLD_STANDARD_SPEC.md and any other doc on field names.
+- **After ANY change to a block render function in `interactive-course.html` or to
+  block fields in `InteractiveCourse.js`, regenerate the reference:**
+  `node server/src/scripts/generateBlockFieldReference.js`
+  and include the regenerated file in the same PR. Do NOT hand-edit it.
+
+### TIER 2 — Human-owned governance (in `TECH_MANUAL.md`, the section so marked)
+- **Never modify, rewrite, summarize, condense, reorder, or "improve" Tier 2.**
+  It contains Ke's rulings (architecture, compliance, roadmap), not observations.
+- If code appears to contradict a Tier 2 ruling, **FLAG it to Ke in your PR summary.
+  Do NOT edit the manual to match the code.** Rulings outrank code; a contradiction
+  means either the code is wrong or the ruling needs Ke's explicit update.
+
+### TIER 3 — Discovery log (in `TECH_MANUAL.md`, append-only)
+- When a session uncovers something architectural (a gotcha, a field mismatch, a
+  non-obvious constraint), **APPEND a dated entry** at the bottom of the Tier 3 log:
+  `### YYYY-MM-DD — short title` + 1–3 sentences.
+- **Never rewrite, delete, or reorder existing Tier 3 entries.** Append only.
+- Do not promote entries to Tier 1/2 yourself — that is Ke's call.
+
+### Enforcement checklist for PRs that touch blocks, seeds, the builder, or the viewer
+- [ ] Read `BLOCK_FIELD_REFERENCE.md` before coding
+- [ ] Regenerated it if render fns or schema fields changed (file included in PR)
+- [ ] Did not touch Tier 2; flagged any code/ruling contradiction instead
+- [ ] Appended a Tier 3 entry if a new gotcha/constraint was discovered
+- [ ] Verified with raw `grep`/`wc`/`git diff --stat` (CC self-reports are not trusted)

--- a/TECH_MANUAL.md
+++ b/TECH_MANUAL.md
@@ -1,0 +1,109 @@
+# CounselorReady Technical Manual
+
+> **This manual has three tiers with different ownership and edit rules.**
+> The structure exists because earlier hand-maintained manuals degraded: no
+> single chat session held all corrections, so different Claude instances filled
+> gaps with different guesses. The fix is structural — generated facts can't drift,
+> human rulings are walled off, and discoveries only append.
+
+---
+
+## TIER 1 — GENERATED FACTS (never hand-edited)
+
+These are extracted from code by scripts. Do not edit by hand. Do not let any
+LLM rewrite them. Regenerate after the relevant code changes.
+
+| Reference | Generator | Regenerate when |
+|---|---|---|
+| `BLOCK_FIELD_REFERENCE.md` | `server/src/scripts/generateBlockFieldReference.js` | any block render fn or schema change |
+
+**Why generated:** field names, block types, and enums are the facts that bite
+hardest and drift fastest. A script reading `interactive-course.html` produces
+identical output regardless of which Claude runs it, because none of them author —
+they extract. This is the layer that ended the "one Claude would Rembrandt, another
+wouldn't" problem for factual content.
+
+---
+
+## TIER 2 — HUMAN-OWNED GOVERNANCE (Claude: DO NOT MODIFY)
+
+> **Claude / CC instruction:** This section is authored by Ke. Do not rewrite,
+> summarize, condense, "improve," or reorder it. Do not move rulings into Tier 3.
+> If a ruling here appears contradicted by code, FLAG it to Ke — do not silently
+> "fix" the manual to match. These are decisions, not observations.
+
+### Architecture rulings
+- **Static-HTML-first.** Reject any change that adds React routes/providers
+  overriding static `.html`, uses `<Link>` where `<a href>` works, or introduces
+  SPA behavior where static HTML suffices.
+- **CR Viewer (`client/public/interactive-course.html`) is SACRED.** Never rewrite.
+  It is the source of truth for block rendering and field names. Surgical edits only.
+- **`interactiveCourseRoutes.js` is PROTECTED.** Min length enforced. Never rewrite;
+  no inline model declarations.
+- **Canonical collection is `interactivecourses`** (model `InteractiveCourse.js`).
+  Legacy `courses` collection is read-only via the old CourseViewer on `/learn/:slug`
+  and is otherwise dead. The new course builder writes ONLY to `interactivecourses`
+  via `/api/course-builder/save` → `InteractiveCourse.save()` (fires the word-count
+  pre-save hook). No raw `insertOne`; always `.save()` or `recalcAllWordCounts.js`.
+- **Legacy builder is retired.** `CourseViewer.jsx`'s `CourseBuilderV2` export is
+  dead — nothing routes to it. Do not extend it. The live builder is
+  `client/src/components/course-builder/` at route `/admin/course-builder`.
+- **`InteractiveCourse.js` schema wins over GOLD_STANDARD_SPEC.md** wherever they
+  conflict on field names or options shape. The spec is known wrong on media and
+  several block fields; the schema + viewer are truth.
+
+### Compliance rulings
+- **ACEP word floor: 6,000 words per CE hour** (home study / async only). Non-negotiable.
+- **Live CE has NO word floor** — live courses need objectives, run-of-show, slides,
+  prompts, handouts; CE credit = verified instructional minutes, not word count.
+- **References are excluded from word count** (locked policy). Counter walks prose
+  fields only; layout/asset fields (image URLs, positions, alt text) add no words.
+- **Live sessions: PHI never touches CounselorReady infrastructure.** Only PHI surface
+  is the Whereby video stream, covered by the Whereby BAA. Attendance metadata is not PHI.
+- **Supervision sessions are hard-locked**: no recording, no handouts, no clips, no
+  agenda, no transcription, no AI/catch-up. Enforced at schema pre-validate, routes,
+  and webhook. These locks are not optional and not admin-overridable.
+- **ACEP #7760 belongs to GAITP.** Any future partner/marketplace course must issue
+  under the PARTNER's own provider number, never #7760. Hosting partner content under
+  GAITP's number puts GAITP's provider status at audit risk — do not build it that way.
+
+### Course builder / layout roadmap (Ke's decisions)
+- **Media work is two passes.** Pass 1: wire existing `CloudinaryUploader` + expose
+  the size/position/alignment/highlight controls the viewer ALREADY renders (low risk,
+  no viewer change). Pass 2: genuinely new layout variants (two-column, full-bleed
+  banner, variable-width cards) — deliberate additions to the sacred viewer, separate branch.
+- **Block variety already exists in the viewer, unexposed in the builder.** The block
+  picker offers fewer types than the viewer renders. Exposing `statCard`, `pullQuote`,
+  `caseStudy`, `keyTakeaway`, `table`, `timeline`, `callout`, and `sectionDivider`
+  banner images is "surface existing capability," not "build new" (see Tier 1 reference).
+
+### Working agreements with Claude / CC
+- Clone/pull latest before proposing changes; cross-reference code → live API → DB.
+- Deliver complete ready-to-deploy files, not patches (mobile GitHub-web workflow).
+- CC falsely confirms completion — always verify with raw `grep`/`wc`/`git diff --stat`.
+- "pushed ≠ merged" — verify against `origin/main` after every merge.
+
+---
+
+## TIER 3 — DISCOVERY LOG (append-only, dated)
+
+> **Claude / CC instruction:** APPEND new dated entries at the bottom only. Never
+> rewrite, delete, or reorder existing entries. A wrong entry can be added but must
+> not corrupt prior ones. Ke periodically promotes durable discoveries up to Tier 1
+> (codify in a generator) or Tier 2 (a ruling). Format: `### YYYY-MM-DD — short title`.
+
+### 2026-06-12 — Live sessions Phases 1 & 3 merged
+Whereby-backed live sessions live on `api.counselorready.com/api/live-sessions`.
+CC built Phase 1 (sessions/attendance/certs) plus Phase 3 (agenda/watch-party/clips,
+catch-up route, admin-live-sessions.html, live-host.html). Supervision hard-locks
+verified across schema, routes, webhook. Phase 2 (Session Producer cron: drop
+detection, break reminders, wrap-up emails) NOT yet built.
+
+### 2026-06-13 — Media field-name divergence discovered
+`image` and `imageText` blocks use different field names for the same concepts
+(`imageUrl`/`imageAltText` vs `image`/`imageAlt`). Wiring a generic uploader's
+`{url,alt}` to the wrong names = silent blank render (saves fine, word count fine,
+shows nothing). Captured permanently in Tier 1 `BLOCK_FIELD_REFERENCE.md`. Viewer
+also supports `sectionDivider` banner images and ~7 block types the builder doesn't expose.
+
+<!-- APPEND NEW ENTRIES BELOW THIS LINE -->

--- a/server/src/scripts/generateBlockFieldReference.js
+++ b/server/src/scripts/generateBlockFieldReference.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2026 CounselorReady, a subsidiary of Ga Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ */
+
+/**
+ * generateBlockFieldReference.js
+ *
+ * TIER 1 GENERATOR. Reads the canonical sources and emits BLOCK_FIELD_REFERENCE.md.
+ * This file is the bridge between the "sacred" viewer (the real source of truth)
+ * and the spec docs (which are known to be wrong about field names).
+ *
+ * NOTHING HERE IS AUTHORED BY HAND OR BY AN LLM. Every field name is extracted
+ * from the actual render functions in interactive-course.html, so the reference
+ * cannot drift from the code. Two different Claude instances running this produce
+ * byte-identical output, because neither is writing — the script is extracting.
+ *
+ * Run after ANY change to a block render function or the schema:
+ *   node server/src/scripts/generateBlockFieldReference.js
+ *
+ * Sources (read-only):
+ *   - client/public/interactive-course.html   → block.X reads per renderX()
+ *   - server/src/models/InteractiveCourse.js   → declared schema paths (context)
+ *
+ * Output:
+ *   - BLOCK_FIELD_REFERENCE.md  (repo root)
+ *
+ * ESM ("type":"module"). Pure read + write; no DB, no network.
+ */
+import { readFileSync, writeFileSync } from 'fs';
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const VIEWER = join(REPO_ROOT, 'client', 'public', 'interactive-course.html');
+const SCHEMA = join(REPO_ROOT, 'server', 'src', 'models', 'InteractiveCourse.js');
+const OUT = join(REPO_ROOT, 'BLOCK_FIELD_REFERENCE.md');
+
+/** Map renderX function name → block `type` string used in seeds/builder. */
+const RENDER_TO_TYPE = {
+  renderSectionDivider: 'sectionDivider',
+  renderText: 'text',
+  renderImageText: 'imageText',
+  renderImage: 'image',
+  renderAccordion: 'accordion',
+  renderMultipleChoice: 'multipleChoice',
+  renderMultiSelect: 'multiSelect',
+  renderMatching: 'matching',
+  renderFlashcardDeck: 'flashcardDeck',
+  renderScenarioTree: 'scenarioTree',
+  renderCardSort: 'cardSort',
+  renderSequencing: 'sequencing',
+  renderTimeline: 'timeline',
+  renderHotspot: 'hotspot',
+  renderReflection: 'reflection',
+  renderCallout: 'callout',
+  renderFillInBlank: 'fillInBlank',
+  renderKeyTakeaway: 'keyTakeaway',
+  renderStatCard: 'statCard',
+  renderCaseStudy: 'caseStudy',
+  renderPullQuote: 'pullQuote',
+  renderTableBlock: 'table',
+  renderResources: 'resources',
+  renderVideoEmbed: 'videoEmbed'
+};
+
+/** Fields that hold author-visible prose the word counter SHOULD count. */
+const WORD_COUNTED_HINTS = ['content', 'text', 'title', 'subtitle', 'heading', 'front', 'back', 'term', 'definition', 'question', 'prompt', 'quote', 'takeaway', 'caption'];
+/** Fields that are positioning/layout/asset — NOT counted as words. */
+const LAYOUT_HINTS = ['imagePosition', 'imageAlignment', 'imageSize', 'highlight', 'imageUrl', 'image', 'url', 'thumbnailUrl', 'alt', 'imageAlt', 'imageAltText', 'publicId', 'videoUrl', 'embedUrl', 'mediumUrl', 'largeUrl', 'hotspots', 'coords'];
+
+function extractFunctionBody(src, fnName) {
+  const start = src.indexOf(`function ${fnName}(`);
+  if (start === -1) return '';
+  let depth = 0, i = src.indexOf('{', start), began = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; began = true; }
+    else if (src[i] === '}') { depth--; if (began && depth === 0) return src.slice(start, i + 1); }
+  }
+  return src.slice(start);
+}
+
+/** Pull every distinct `block.<field>` reference from a function body. */
+function fieldsFromBody(body) {
+  const re = /\bblock\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  const set = new Set();
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    if (m[1] !== 'type') set.add(m[1]);
+  }
+  return [...set].sort();
+}
+
+function classify(field) {
+  if (LAYOUT_HINTS.includes(field)) return 'layout/asset (not counted)';
+  if (WORD_COUNTED_HINTS.includes(field)) return 'prose (word-counted)';
+  return 'data';
+}
+
+function main() {
+  const viewerSrc = readFileSync(VIEWER, 'utf8');
+  let schemaSrc = '';
+  try { schemaSrc = readFileSync(SCHEMA, 'utf8'); } catch { /* optional */ }
+
+  const rows = [];
+  for (const [fn, type] of Object.entries(RENDER_TO_TYPE)) {
+    const body = extractFunctionBody(viewerSrc, fn);
+    if (!body) { rows.push({ type, fn, fields: [], missing: true }); continue; }
+    rows.push({ type, fn, fields: fieldsFromBody(body), missing: false });
+  }
+
+  // Deterministic stamp: a short hash of the viewer source, NOT a wall-clock time.
+  // This guarantees byte-identical output across runs/instances (the anti-drift
+  // property). The stamp changes only when the underlying viewer changes.
+  const sourceHash = createHash('sha256').update(viewerSrc).digest('hex').slice(0, 12);
+  let md = `# BLOCK FIELD REFERENCE (Tier 1 — GENERATED, DO NOT HAND-EDIT)
+
+> Source hash \`${sourceHash}\` (sha256 of interactive-course.html, first 12) by \`server/src/scripts/generateBlockFieldReference.js\`.
+> **Source of truth:** the \`renderX()\` functions in \`client/public/interactive-course.html\`.
+> Field names below are extracted from \`block.<field>\` reads in those functions.
+> If a seed or the builder writes a field NOT listed here, the viewer ignores it
+> and the block renders incomplete or blank. **The viewer wins over every spec doc.**
+>
+> Regenerate after ANY change to a block render function. Never edit this file by hand.
+
+`;
+
+  // The critical gotcha table — same concept, different field names across blocks.
+  md += `## ⚠ Cross-block field-name divergence (the silent-blank trap)
+
+The \`image\` and \`imageText\` blocks use DIFFERENT names for the same concepts.
+Wiring an uploader's generic \`{url, alt}\` output to the wrong names = block saves,
+word count unaffected, but renders blank.
+
+| Concept | \`image\` block | \`imageText\` block |
+|---|---|---|
+| image source | \`imageUrl\` | \`image\` |
+| alt text | \`imageAltText\` | \`imageAlt\` |
+| caption | \`imageCaption\` | (none) |
+| size control | \`imageSize\` ('small'|'medium'|'large') | (none) |
+| alignment | \`imageAlignment\` ('left'|'center'|'right') | (none) |
+| position flip | (none) | \`imagePosition\` ('left'|'right') |
+| highlight bg | (none) | \`highlight\` (boolean) |
+
+`;
+
+  md += `## All block types (extracted)\n\n`;
+  for (const r of rows) {
+    md += `### \`${r.type}\`  ·  renders via \`${r.fn}()\`\n`;
+    if (r.missing) { md += `> ⚠ render function not found — verify the name in the viewer.\n\n`; continue; }
+    if (r.fields.length === 0) { md += `_No direct \`block.X\` reads (may use helpers — inspect manually)._\n\n`; continue; }
+    md += `| field | classification |\n|---|---|\n`;
+    for (const f of r.fields) md += `| \`${f}\` | ${classify(f)} |\n`;
+    md += `\n`;
+  }
+
+  // Builder-exposure gap: types the viewer renders but the builder may not offer.
+  md += `## Viewer-supported block types\n\n`;
+  md += rows.filter(r => !r.missing).map(r => `\`${r.type}\``).join(', ') + `\n\n`;
+  md += `> If the course builder's block picker offers fewer types than this list,
+> the missing ones are unexposed capability — they render fine if seeded, but
+> authors can't add them via the UI. Candidates to expose for layout variety:
+> \`statCard\`, \`pullQuote\`, \`caseStudy\`, \`keyTakeaway\`, \`table\`, \`timeline\`, \`callout\`.\n\n`;
+
+  if (schemaSrc) {
+    const declared = [...schemaSrc.matchAll(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*\{/gm)].map(m => m[1]);
+    md += `## Schema-declared top-level paths (context only)\n\n`;
+    md += `_From InteractiveCourse.js. Strict mode silently drops undeclared fields on save._\n\n`;
+    md += [...new Set(declared)].sort().map(d => `\`${d}\``).join(', ') + `\n`;
+  }
+
+  writeFileSync(OUT, md, 'utf8');
+  const counted = rows.filter(r => !r.missing).length;
+  console.log(`[block-field-ref] wrote ${OUT}`);
+  console.log(`[block-field-ref] ${counted}/${rows.length} render functions extracted`);
+  const missing = rows.filter(r => r.missing).map(r => r.fn);
+  if (missing.length) console.warn(`[block-field-ref] MISSING (rename check): ${missing.join(', ')}`);
+}
+
+main();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **TECH_MANUAL.md** — three-tier governance doc establishing generated facts (Tier 1), human-owned rulings (Tier 2, Claude must not edit), and append-only discovery log (Tier 3)
- **BLOCK_FIELD_REFERENCE.md** — Tier 1 generated reference for all 24 viewer-supported block types, extracted from `interactive-course.html` render functions; documents the critical `image`/`imageText` field-name divergence that causes silent blank renders
- **server/src/scripts/generateBlockFieldReference.js** — generator script that produces the above; must be re-run after any render function or schema change
- **CLAUDE.md** — appended Technical Manual Governance clause: read `BLOCK_FIELD_REFERENCE.md` before coding blocks/seeds, never modify Tier 2, append-only Tier 3

## Verification

```
git diff --stat main
 BLOCK_FIELD_REFERENCE.md                        | 222 ++++
 CLAUDE.md                                        |  37 +
 TECH_MANUAL.md                                   | 109 ++
 server/src/scripts/generateBlockFieldReference.js| 182 +++
 4 files changed, 550 insertions(+), 0 deletions(-)
```

No existing files modified beyond the CLAUDE.md append.

https://claude.ai/code/session_01Y1BBaN3GKPNnGuxxUCdrbL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1BBaN3GKPNnGuxxUCdrbL)_