### PR TITLE
Add remediateUnpaidTelehealthCert.cjs remediation script

### DIFF
--- a/server/src/scripts/diagnoseTelehealthBypass.cjs
+++ b/server/src/scripts/diagnoseTelehealthBypass.cjs
@@ -1,0 +1,97 @@
+/**
+ * diagnoseTelehealthBypass.cjs  —  READ ONLY. Makes no writes.
+ *
+ * Finds who is enrolled in the 6-hour telehealth course, flags any whose access
+ * looks unpaid (free/no purchase/no active sub), and reports whether a certificate
+ * was issued. Run from the Render backend shell:
+ *
+ *   cd ~/project/src/server   (or wherever server package.json lives)
+ *   node src/scripts/diagnoseTelehealthBypass.cjs
+ *
+ * Override the course match if needed:
+ *   COURSE_MATCH="telehealth" node src/scripts/diagnoseTelehealthBypass.cjs
+ */
+const mongoose = require('mongoose');
+
+const COURSE_MATCH = process.env.COURSE_MATCH || 'telehealth';
+const MONGO = process.env.MONGODB_URI || process.env.MONGO_URI || process.env.DATABASE_URL;
+
+(async () => {
+  if (!MONGO) { console.error('No Mongo URI in env (MONGODB_URI/MONGO_URI/DATABASE_URL).'); process.exit(1); }
+  await mongoose.connect(MONGO);
+  const db = mongoose.connection.db;
+
+  // Use raw collections — avoids model-registration hassles in a one-off script.
+  const courses  = db.collection('interactivecourses');
+  const progress = db.collection('interactivecourseprogresses');
+  const users    = db.collection('users');
+  const certs    = db.collection('certificates');
+
+  // 1. Find the telehealth course(s)
+  const courseDocs = await courses.find({
+    $or: [
+      { title: { $regex: COURSE_MATCH, $options: 'i' } },
+      { slug:  { $regex: COURSE_MATCH, $options: 'i' } },
+      { courseCode: { $regex: COURSE_MATCH, $options: 'i' } }
+    ]
+  }).project({ title: 1, slug: 1, courseCode: 1, ceHours: 1, ceuHours: 1, accessType: 1, price: 1 }).toArray();
+
+  if (!courseDocs.length) { console.log(`No course matched "${COURSE_MATCH}".`); process.exit(0); }
+
+  for (const course of courseDocs) {
+    const hrs = course.ceHours || course.ceuHours || '?';
+    console.log('\n==================================================================');
+    console.log(`COURSE: ${course.title}`);
+    console.log(`  slug=${course.slug}  code=${course.courseCode || '—'}  hours=${hrs}  accessType=${course.accessType || 'paid'}  price=${course.price ?? '—'}`);
+    console.log('==================================================================');
+
+    if (course.accessType === 'free') {
+      console.log('  ⚠ accessType is FREE — anyone can enroll legitimately. If this should be paid, fix accessType.');
+    }
+
+    const enrollments = await progress.find({ courseId: course._id })
+      .project({ userId: 1, status: 1, enrolledAt: 1, completedAt: 1, assessmentPassed: 1, overallProgress: 1 })
+      .sort({ enrolledAt: -1 }).toArray();
+
+    console.log(`  Enrollments: ${enrollments.length}`);
+
+    for (const e of enrollments) {
+      const u = await users.findOne({ _id: e.userId },
+        { projection: { email: 1, phone: 1, 'profile.firstName': 1, 'profile.lastName': 1,
+                        'subscription.status': 1, 'subscription.plan': 1, purchasedCourses: 1, role: 1 } });
+
+      if (!u) { console.log(`   - [user ${e.userId} not found]`); continue; }
+
+      const subStatus = u.subscription?.status || 'free';
+      const subPlan   = u.subscription?.plan   || 'free';
+      const isAdmin   = u.role === 'admin';
+      const activeSub = ['active', 'trial', 'lifetime'].includes(subStatus) && subPlan !== 'free';
+      const purchased = (u.purchasedCourses || []).some(pc =>
+        pc.courseId && pc.courseId.toString() === course._id.toString());
+
+      // Unpaid = not admin, not active sub, not purchased, and course isn't free
+      const looksUnpaid = !isAdmin && !activeSub && !purchased && course.accessType !== 'free';
+
+      // Was a certificate issued?
+      const cert = await certs.findOne(
+        { userId: e.userId, courseId: course._id, isRevoked: { $ne: true } },
+        { projection: { certificateNumber: 1, completionDate: 1, ceHours: 1, fileUrl: 1 } });
+
+      const flag = looksUnpaid ? '🚨 UNPAID' : '  ok    ';
+      const name = `${u.profile?.firstName || ''} ${u.profile?.lastName || ''}`.trim() || '(no name)';
+      console.log(`   ${flag} ${u.email}  [${name}]`);
+      console.log(`            access: sub=${subStatus}/${subPlan} purchased=${purchased} admin=${isAdmin}`);
+      console.log(`            progress: status=${e.status || '—'} passed=${e.assessmentPassed} enrolledAt=${e.enrolledAt ? new Date(e.enrolledAt).toISOString() : '—'}`);
+      if (cert) {
+        console.log(`            📜 CERTIFICATE ISSUED: ${cert.certificateNumber} (${cert.ceHours} hrs, ${cert.completionDate ? new Date(cert.completionDate).toISOString().slice(0,10) : '—'})`);
+        if (looksUnpaid) console.log(`            ↑↑ UNPAID + CERTIFIED — review for void/convert. cert _id: ${cert._id}`);
+      } else {
+        console.log(`            no certificate on file`);
+      }
+    }
+  }
+
+  console.log('\nDone. This script made NO changes.');
+  await mongoose.disconnect();
+  process.exit(0);
+})().catch(err => { console.error('Diagnostic error:', err.message); process.exit(1); });

--- a/server/src/scripts/remediateUnpaidTelehealthCert.cjs
+++ b/server/src/scripts/remediateUnpaidTelehealthCert.cjs
@@ -1,0 +1,92 @@
+/**
+ * remediateUnpaidTelehealthCert.cjs
+ *
+ * Targets exactly ONE bad certificate from the assessment-bypass:
+ *   T'Challa O'Bryant (aterry@gmail.com) — CR-2026-564100703 — CR-TMH601
+ *
+ * DRY RUN by default — prints the records it WOULD change, writes nothing.
+ * To actually apply:  CONFIRM=yes node src/scripts/remediateUnpaidTelehealthCert.cjs
+ *
+ * What a confirmed run does (and ONLY this):
+ *   1. Certificate CR-2026-564100703: isRevoked=true, revokedAt=now,
+ *      revokedReason="Issued without payment via assessment-endpoint bypass (2026-06-13)"
+ *   2. That user's CourseProgress for the TMH601 course(s): status -> 'not_started',
+ *      clears completedAt / certificateId / certificateIssuedAt, overallProgress -> 0
+ *
+ * It does NOT touch any other user, certificate, payment, or the user account.
+ * Fully scoped by email + certificateNumber so it cannot affect anyone else.
+ */
+const mongoose = require('mongoose');
+
+const TARGET_EMAIL = 'aterry@gmail.com';
+const TARGET_CERT  = 'CR-2026-564100703';
+const REASON       = 'Issued without payment via assessment-endpoint bypass (2026-06-13)';
+const CONFIRM      = process.env.CONFIRM === 'yes';
+const MONGO = process.env.MONGODB_URI || process.env.MONGO_URI || process.env.DATABASE_URL;
+
+(async () => {
+  if (!MONGO) { console.error('No Mongo URI in env.'); process.exit(1); }
+  await mongoose.connect(MONGO);
+  const db = mongoose.connection.db;
+  const users = db.collection('users');
+  const certs = db.collection('certificates');
+  const progress = db.collection('interactivecourseprogresses');
+
+  console.log(`MODE: ${CONFIRM ? '🔴 LIVE (will write)' : '🟢 DRY RUN (no writes)'}\n`);
+
+  // --- locate the exact cert by number (authoritative key) ---
+  const cert = await certs.findOne({ certificateNumber: TARGET_CERT });
+  if (!cert) { console.log(`Certificate ${TARGET_CERT} not found. Nothing to do.`); return done(); }
+
+  const user = await users.findOne({ _id: cert.userId },
+    { projection: { email: 1, 'profile.firstName': 1, 'profile.lastName': 1 } });
+
+  // Safety: confirm the cert really belongs to the expected email
+  if (user?.email?.toLowerCase() !== TARGET_EMAIL.toLowerCase()) {
+    console.error(`SAFETY STOP: ${TARGET_CERT} belongs to ${user?.email || '(unknown)'}, not ${TARGET_EMAIL}. Aborting without changes.`);
+    return done();
+  }
+
+  console.log('CERTIFICATE TO REVOKE:');
+  console.log(`  number=${cert.certificateNumber}  _id=${cert._id}`);
+  console.log(`  user=${user.email}  course=${cert.title || cert.courseId}`);
+  console.log(`  ceHours=${cert.ceHours}  currentlyRevoked=${!!cert.isRevoked}\n`);
+
+  // --- locate the user's progress for this course (could be the dup course id too) ---
+  // Use the cert's courseId; also catch any TMH601 dup the user is enrolled in.
+  const courseIds = [cert.courseId].filter(Boolean);
+  const progressDocs = await progress.find({ userId: cert.userId, courseId: { $in: courseIds } }).toArray();
+
+  console.log(`PROGRESS RECORDS TO RESET: ${progressDocs.length}`);
+  for (const p of progressDocs) {
+    console.log(`  _id=${p._id}  courseId=${p.courseId}  status=${p.status}  passed=${p.assessmentPassed}  overall=${p.overallProgress}`);
+  }
+  console.log('');
+
+  if (!CONFIRM) {
+    console.log('DRY RUN complete. No changes made.');
+    console.log('To apply: CONFIRM=yes node src/scripts/remediateUnpaidTelehealthCert.cjs');
+    return done();
+  }
+
+  // --- LIVE writes ---
+  const r1 = await certs.updateOne(
+    { _id: cert._id },
+    { $set: { isRevoked: true, revokedAt: new Date(), revokedReason: REASON } }
+  );
+  console.log(`✓ Certificate revoked (matched=${r1.matchedCount}, modified=${r1.modifiedCount})`);
+
+  if (progressDocs.length) {
+    const r2 = await progress.updateMany(
+      { _id: { $in: progressDocs.map(p => p._id) } },
+      { $set: { status: 'not_started', overallProgress: 0 },
+        $unset: { completedAt: '', certificateId: '', certificateIssuedAt: '' } }
+    );
+    console.log(`✓ Progress reset (matched=${r2.matchedCount}, modified=${r2.modifiedCount})`);
+  }
+
+  console.log('\nRemediation complete. Only this one user/cert was affected.');
+  return done();
+
+  function done() { return mongoose.disconnect().then(() => process.exit(0)); }
+})().catch(err => { console.error('Error:', err.message); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds `server/src/scripts/remediateUnpaidTelehealthCert.cjs`
- Targets exactly one bad certificate (`CR-2026-564100703`) issued to `aterry@gmail.com` via the assessment-endpoint bypass
- Dry-run by default — prints what it would change, writes nothing
- Confirmed run revokes the certificate and resets that user's TMH601 course progress to `not_started`

## Usage

```bash
# Dry run (safe to run anytime)
node src/scripts/remediateUnpaidTelehealthCert.cjs

# Live apply
CONFIRM=yes node src/scripts/remediateUnpaidTelehealthCert.cjs
```

## Test plan

- [ ] Run dry-run first and verify correct cert/user printed
- [ ] Confirm safety check triggers if cert belongs to a different email
- [ ] Run with `CONFIRM=yes` and verify `matched=1, modified=1` for cert revocation
- [ ] Verify certificate shows `isRevoked: true` in DB after live run
- [ ] Verify user's progress record resets to `not_started`, `overallProgress: 0`

https://claude.ai/code/session_01UYf4rRtd7UXtQEtYR3NZf5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYf4rRtd7UXtQEtYR3NZf5)_