### PR TITLE
🔒 SECURITY: Fix trial gate — trial users no longer bypass course limits (priority)

### DIFF
--- a/TECH_MANUAL.md
+++ b/TECH_MANUAL.md
@@ -110,3 +110,6 @@ also supports `sectionDivider` banner images and ~7 block types the builder does
 
 ### 2026-06-13 — Payment bypass via POST /:id/assessment (FIXED)
 Assessment endpoint auto-created completed enrollments with no access check; free users could certify on paid courses without paying. Added hasPaidOrFreeAccess + freeTierDecision gate matching /enroll and /progress. Lesson: EVERY route that can create a CourseProgress must run the access gate — there are 3 such paths.
+
+### 2026-06-13 — Trial gate over-granted (FIXED); seat-timer still broken
+hasPaidOrFreeAccess listed 'trial' as unlimited, bypassing the 1-CE-hour cap and course count. A no-card trial user took 10 CE hours free. Policy enforced now: no-card trial = 2 one-CE courses lifetime (trialCoursesUsed); card-on-file = 4 one-CE/month. Distinguish via subscription.stripeCustomerId. SEPARATE open issue: totalTimeSpent reads 0 platform-wide (front-end not posting timeSpent) — contact-hour evidence gap, cert-issuance chain (assessment+evaluation+attestation) itself is sound. Lesson: every CourseProgress-creating route (3 of them) must run the shared gate; fixing the shared fns fixed all three.

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -87,6 +87,7 @@ const userSchema = new mongoose.Schema({
   freeCoursesThisMonth: { type: Number, default: 0, min: 0 },
   freeCoursesResetMonth: { type: String, default: '' }, // format: "2026-04"
   freeCoursesUsedThisMonth: { type: Number, default: 0 },
+  trialCoursesUsed: { type: Number, default: 0 }, // lifetime no-card trial courses used (cap 2)
   freeLimitEmailSentThisMonth: { type: Boolean, default: false },
 
   // Subscription

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -38,6 +38,7 @@ async function findCourseByIdOrSlug(param) {
 // ── CONTENT GATING ──────────────────────────────────────────
 const FREE_COURSES_PER_MONTH = 4;   // free plan: 4 courses/month
 const FREE_MAX_COURSE_HOURS  = 1;   // free plan covers 1-CE-hour courses only
+const TRIAL_COURSES_TOTAL    = 2;   // no-card trial: 2 one-CE courses, lifetime
 
 /**
  * Strip sensitive content from course for preview/unauthenticated users.
@@ -81,16 +82,30 @@ function effectiveFreeCoursesUsed(user) {
   return user.freeCoursesUsedThisMonth ?? 0;
 }
 
+function hasCardOnFile(user) {
+  return !!user?.subscription?.stripeCustomerId;
+}
+
 // Free-tier eligibility for a PAID course. Read-only (does NOT consume a slot).
 function freeTierDecision(user, course) {
   const courseHours = course.ceHours || course.ceuHours || 1;
   if (courseHours > FREE_MAX_COURSE_HOURS) {
     return { allowed: false, code: 'OVER_FREE_HOUR_LIMIT',
-      message: 'Free plan covers 1-hour courses only. Subscribe or purchase this course to enroll.' };
+      message: 'Free access covers 1 CE-hour courses only. Purchase this course or upgrade to enroll.' };
   }
+  const status = user?.subscription?.status || 'free';
+  // No-card trial: 2 one-CE courses, lifetime (tracked on trialCoursesUsed)
+  if (status === 'trial' && !hasCardOnFile(user)) {
+    if ((user.trialCoursesUsed ?? 0) >= TRIAL_COURSES_TOTAL) {
+      return { allowed: false, code: 'TRIAL_LIMIT',
+        message: `Your free trial includes ${TRIAL_COURSES_TOTAL} one-hour courses. Add a card for 4 free courses every month, or purchase this course.` };
+    }
+    return { allowed: true, code: 'TRIAL_OK' };
+  }
+  // free plan OR card-on-file: 4 one-CE courses per month
   if (effectiveFreeCoursesUsed(user) >= FREE_COURSES_PER_MONTH) {
     return { allowed: false, code: 'MONTHLY_LIMIT',
-      message: `You've used your ${FREE_COURSES_PER_MONTH} free courses this month. Subscribe for unlimited access.` };
+      message: `You've used your ${FREE_COURSES_PER_MONTH} free courses this month. Purchase this course or upgrade for unlimited access.` };
   }
   return { allowed: true, code: 'FREE_OK' };
 }
@@ -105,11 +120,18 @@ function hasPaidOrFreeAccess(user, course) {
   if (purchased) return true;
   const status = user.subscription?.status || 'free';
   const plan   = user.subscription?.plan   || 'free';
-  return ['active','trial','lifetime'].includes(status) && plan !== 'free';
+  // trial is NOT unlimited — it routes through freeTierDecision (2-course / 1-hr caps)
+  return ['active','lifetime'].includes(status) && plan !== 'free';
 }
 
 // Atomically persist consumption of one monthly free slot (month-aware).
 async function consumeFreeSlot(user) {
+  const status = user?.subscription?.status || 'free';
+  // No-card trial consumes a lifetime trial slot, NOT a monthly slot
+  if (status === 'trial' && !hasCardOnFile(user)) {
+    return User.updateOne({ _id: user._id },
+      { $inc: { trialCoursesUsed: 1 } });
+  }
   const month = currentMonthKey();
   const sameMonth = user.freeCoursesResetMonth === month;
   const newCount = (sameMonth ? (user.freeCoursesUsedThisMonth ?? 0) : 0) + 1;

--- a/server/src/scripts/gateLogic.test.cjs
+++ b/server/src/scripts/gateLogic.test.cjs
@@ -1,0 +1,103 @@
+// Standalone test of the CORRECTED gate logic against Ke's real policy:
+//   - No-card trial: 2 courses lifetime, each <= 1 CE hour
+//   - Card on file:  4 courses/month, each <= 1 CE hour
+//   - active/lifetime paid plan: unlimited
+//   - purchased / admin / accessType:free: always
+
+const FREE_COURSES_PER_MONTH = 4;
+const TRIAL_COURSES_TOTAL    = 2;
+const FREE_MAX_COURSE_HOURS  = 1;
+function currentMonthKey(){ return new Date().toISOString().slice(0,7); }
+function effectiveFreeCoursesUsed(u){
+  if(!u) return 0;
+  if(u.freeCoursesResetMonth !== currentMonthKey()) return 0;
+  return u.freeCoursesUsedThisMonth ?? 0;
+}
+function hasCardOnFile(u){ return !!u?.subscription?.stripeCustomerId; }
+
+// CORRECTED hasPaidOrFreeAccess: trial NO LONGER unlimited
+function hasPaidOrFreeAccess(user, course){
+  if(!user) return false;
+  if(user.role === 'admin') return true;
+  if(course.accessType === 'free') return true;
+  const purchased = user.purchasedCourses?.some(pc => pc.courseId?.toString() === course._id.toString());
+  if(purchased) return true;
+  const status = user.subscription?.status || 'free';
+  const plan   = user.subscription?.plan   || 'free';
+  // Only genuinely-paid ongoing plans get unlimited. trial is NOT here anymore.
+  return ['active','lifetime'].includes(status) && plan !== 'free';
+}
+
+// CORRECTED freeTierDecision: handles trial (2 total) vs card-on-file (4/month)
+function freeTierDecision(user, course){
+  const courseHours = course.ceHours || course.ceuHours || 1;
+  if(courseHours > FREE_MAX_COURSE_HOURS){
+    return { allowed:false, code:'OVER_FREE_HOUR_LIMIT',
+      message:'Free access covers 1 CE-hour courses only. Purchase this course or upgrade to enroll.' };
+  }
+  const status = user?.subscription?.status || 'free';
+  if(status === 'trial' && !hasCardOnFile(user)){
+    const usedTrial = user.trialCoursesUsed ?? 0;
+    if(usedTrial >= TRIAL_COURSES_TOTAL){
+      return { allowed:false, code:'TRIAL_LIMIT',
+        message:`Your free trial includes ${TRIAL_COURSES_TOTAL} one-hour courses. Add a card for 4 free courses every month, or purchase this course.` };
+    }
+    return { allowed:true, code:'TRIAL_OK' };
+  }
+  // free plan OR trial-with-card OR card-on-file users: 4/month, 1-hr each
+  if(effectiveFreeCoursesUsed(user) >= FREE_COURSES_PER_MONTH){
+    return { allowed:false, code:'MONTHLY_LIMIT',
+      message:`You've used your ${FREE_COURSES_PER_MONTH} free courses this month. Purchase this course or upgrade for unlimited access.` };
+  }
+  return { allowed:true, code:'FREE_OK' };
+}
+
+// access decision = paid OR free-tier-allowed
+function canEnroll(user, course){
+  if(hasPaidOrFreeAccess(user,course)) return {allowed:true, via:'paid/owned'};
+  return freeTierDecision(user, course);
+}
+
+// ---- TEST CASES ----
+const C1 = { _id:'c1', ceHours:1 };   // 1-CE course
+const C6 = { _id:'c6', ceHours:6 };   // 6-CE TeleMental
+const C4 = { _id:'c4', ceHours:4 };   // 4-CE Neurobiology
+
+let pass=0, fail=0;
+function t(name, got, want){
+  const ok = got.allowed === want;
+  console.log(`${ok?'✓':'✗'} ${name} -> allowed=${got.allowed}${got.code?' ('+got.code+')':''}`);
+  ok?pass++:fail++;
+}
+
+// The T'Challa scenario: no-card trial
+const trialNoCard0 = { subscription:{status:'trial'}, trialCoursesUsed:0 };
+const trialNoCard2 = { subscription:{status:'trial'}, trialCoursesUsed:2 };
+
+t('no-card trial, 1st 1-CE course', canEnroll(trialNoCard0, C1), true);
+t('no-card trial, after 2 used, 1-CE', canEnroll(trialNoCard2, C1), false);
+t('no-card trial, 6-CE TeleMental (THE BUG)', canEnroll(trialNoCard0, C6), false);
+t('no-card trial, 4-CE Neurobiology', canEnroll(trialNoCard0, C4), false);
+
+// Card on file: 4/month, 1-hr each
+const cardFresh = { subscription:{status:'trial', stripeCustomerId:'cus_x'}, freeCoursesResetMonth:currentMonthKey(), freeCoursesUsedThisMonth:0 };
+const cardMaxed = { subscription:{status:'trial', stripeCustomerId:'cus_x'}, freeCoursesResetMonth:currentMonthKey(), freeCoursesUsedThisMonth:4 };
+t('card-on-file, 1-CE within 4/mo', canEnroll(cardFresh, C1), true);
+t('card-on-file, 5th course this month', canEnroll(cardMaxed, C1), false);
+t('card-on-file, 6-CE course', canEnroll(cardFresh, C6), false);
+
+// Paid plans unlimited
+const paid = { subscription:{status:'active', plan:'professional'} };
+t('active paid plan, 6-CE course', canEnroll(paid, C6), true);
+const life = { subscription:{status:'lifetime', plan:'lifetime'} };
+t('lifetime, 6-CE course', canEnroll(life, C6), true);
+
+// Purchased single course
+const bought = { subscription:{status:'free'}, purchasedCourses:[{courseId:'c6'}] };
+t('purchased the 6-CE course', canEnroll(bought, C6), true);
+
+// admin
+t('admin, anything', canEnroll({role:'admin',subscription:{}}, C6), true);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail?1:0);


### PR DESCRIPTION
## ⚠️ Priority — Revenue Fix

### The Bug
`hasPaidOrFreeAccess()` listed `'trial'` alongside `'active'` and `'lifetime'`, granting trial users **unlimited course access** — bypassing both the 1-CE-hour cap and the course-count limit. A no-card trial user took 10 CE hours free (including a 6-CE and a 4-CE course).

### Policy (from Ke, 2026-06-13)
| User type | Limit |
|---|---|
| No-card trial | 2 one-CE courses, **lifetime** |
| Card on file (trial) | 4 one-CE courses/month |
| active / lifetime paid | Unlimited |
| purchased / admin / free course | Always allowed |

Distinguishing signal for card-on-file: `user.subscription.stripeCustomerId` present.

### Changes (surgical — no rewrite)
| # | What | Where |
|---|---|---|
| 1 | `TRIAL_COURSES_TOTAL = 2` constant | `interactiveCourseRoutes.js` ~line 41 |
| 2 | `hasCardOnFile(user)` helper | `interactiveCourseRoutes.js` ~line 85 |
| 3 | Remove `'trial'` from unlimited list | `hasPaidOrFreeAccess()` |
| 4 | Trial-aware branching | `freeTierDecision()` |
| 5 | Trial increments `trialCoursesUsed`, not monthly counter | `consumeFreeSlot()` |
| 6 | `trialCoursesUsed` field | `User.js` |

### Verification (raw output)
```
grep -n "'active','trial','lifetime'" interactiveCourseRoutes.js
→ (nothing — bug line gone) ✅

grep -n "TRIAL_COURSES_TOTAL|hasCardOnFile|trialCoursesUsed"
→ lines 41, 85, 97-101, 131, 133 in route; line 90 in User.js ✅

node --check server/src/routes/interactiveCourseRoutes.js
→ SYNTAX OK ✅

wc -l server/src/routes/interactiveCourseRoutes.js
→ 1670 (above 1518 minimum) ✅

node server/src/scripts/gateLogic.test.cjs
→ 11 passed, 0 failed ✅
```

### Test output
```
✓ no-card trial, 1st 1-CE course -> allowed=true (TRIAL_OK)
✓ no-card trial, after 2 used, 1-CE -> allowed=false (TRIAL_LIMIT)
✓ no-card trial, 6-CE TeleMental (THE BUG) -> allowed=false (OVER_FREE_HOUR_LIMIT)
✓ no-card trial, 4-CE Neurobiology -> allowed=false (OVER_FREE_HOUR_LIMIT)
✓ card-on-file, 1-CE within 4/mo -> allowed=true (FREE_OK)
✓ card-on-file, 5th course this month -> allowed=false (MONTHLY_LIMIT)
✓ card-on-file, 6-CE course -> allowed=false (OVER_FREE_HOUR_LIMIT)
✓ active paid plan, 6-CE course -> allowed=true
✓ lifetime, 6-CE course -> allowed=true
✓ purchased the 6-CE course -> allowed=true
✓ admin, anything -> allowed=true
```

### Files changed
- `server/src/routes/interactiveCourseRoutes.js` — edits 1–5 (surgical only)
- `server/src/models/User.js` — `trialCoursesUsed` field added
- `server/src/scripts/gateLogic.test.cjs` — unit test (11/11)
- `TECH_MANUAL.md` — Tier 3 entry appended

### Note: separate open issue
`totalTimeSpent` reads 0 platform-wide — front-end is not posting `timeSpent`. Contact-hour evidence gap. The cert-issuance chain (assessment → evaluation → attestation → certificate) is itself sound. Needs a separate fix.

https://claude.ai/code/session_0171Abt3pfgGJ1YAFdF3V862

---
_Generated by [Claude Code](https://claude.ai/code/session_0171Abt3pfgGJ1YAFdF3V862)_