### PR TITLE
feat: outline import — paste + .docx, 3 modes (AI Assistant tab)

### DIFF
--- a/TECH_MANUAL.md
+++ b/TECH_MANUAL.md
@@ -111,5 +111,8 @@ also supports `sectionDivider` banner images and ~7 block types the builder does
 ### 2026-06-13 — Payment bypass via POST /:id/assessment (FIXED)
 Assessment endpoint auto-created completed enrollments with no access check; free users could certify on paid courses without paying. Added hasPaidOrFreeAccess + freeTierDecision gate matching /enroll and /progress. Lesson: EVERY route that can create a CourseProgress must run the access gate — there are 3 such paths.
 
+### 2026-06-13 — Outline import added (paste + docx, 3 modes)
+AI Assistant tab now accepts an existing outline by paste or .docx upload instead of only generating from a topic. Modes: full-generate / shells-only / docx-convert. All feed the existing outline→generate→LOAD_COURSE pipeline; convert mode preserves prose verbatim. Endpoints: POST /course-builder/parse-outline, /import-docx.
+
 ### 2026-06-13 — Trial gate over-granted (FIXED); seat-timer still broken
 hasPaidOrFreeAccess listed 'trial' as unlimited, bypassing the 1-CE-hour cap and course count. A no-card trial user took 10 CE hours free. Policy enforced now: no-card trial = 2 one-CE courses lifetime (trialCoursesUsed); card-on-file = 4 one-CE/month. Distinguish via subscription.stripeCustomerId. SEPARATE open issue: totalTimeSpent reads 0 platform-wide (front-end not posting timeSpent) — contact-hour evidence gap, cert-issuance chain (assessment+evaluation+attestation) itself is sound. Lesson: every CourseProgress-creating route (3 of them) must run the shared gate; fixing the shared fns fixed all three.

--- a/client/src/components/course-builder/tabs/AIAssistantTab.jsx
+++ b/client/src/components/course-builder/tabs/AIAssistantTab.jsx
@@ -101,7 +101,7 @@ function GeneratingProgress({ progress, currentTask }) {
 
 // ─── Outline editor ───────────────────────────────────────────────────────
 
-function OutlineEditor({ outline, onOutlineChange, onGenerate, onBack, generating }) {
+function OutlineEditor({ outline, onOutlineChange, onGenerate, onBack, generating, actionLabel }) {
   const updateSection = (i, changes) => {
     const sections = [...outline.sections];
     sections[i] = { ...sections[i], ...changes };
@@ -278,7 +278,7 @@ function OutlineEditor({ outline, onOutlineChange, onGenerate, onBack, generatin
           onClick={onGenerate}
           disabled={generating}
         >
-          {generating ? "Generating..." : "✨ Generate Full Course"}
+          {generating ? "Working..." : (actionLabel || "✨ Generate Full Course")}
         </button>
       </div>
     </div>
@@ -292,6 +292,16 @@ export default function AIAssistantTab() {
 
   const [step, setStep] = useState(0); // 0=params, 1=outline, 2=generating, 3=done
   const [error, setError] = useState(null);
+
+  // Entry mode: 'generate' (existing) | 'import' (new)
+  const [entryMode, setEntryMode] = useState("generate");
+
+  // Import-specific state
+  const [importMode, setImportMode]   = useState("full"); // 'full' | 'shells' | 'convert'
+  const [importText, setImportText]   = useState("");
+  const [importFile, setImportFile]   = useState(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const fileInputRef = useRef(null);
 
   // Params
   const [topic, setTopic]               = useState("");
@@ -349,6 +359,120 @@ export default function AIAssistantTab() {
     } finally {
       setGeneratingOutline(false);
     }
+  };
+
+  // ── Import: submit paste or file → outline or course ─────────────────────
+
+  const handleImportSubmit = async () => {
+    setError(null);
+    setImportLoading(true);
+    try {
+      let result;
+
+      if (importFile) {
+        // File path → /import-docx
+        const fd = new FormData();
+        fd.append("file", importFile);
+        fd.append("mode", importMode);
+        fd.append("ceHours", ceHours);
+        fd.append("category", category);
+        fd.append("level", level);
+        if (title.trim()) fd.append("title", title.trim());
+
+        const res = await fetch(`${API_BASE}/course-builder/import-docx`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${getToken()}` },
+          body: fd,
+        });
+        if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.error || `HTTP ${res.status}`); }
+        result = await res.json();
+      } else if (importText.trim()) {
+        // Paste path → /parse-outline (modes full & shells) or treat as convert text
+        if (importMode === "convert") {
+          // Convert mode from paste: segment inline without AI
+          const lines = importText.split("\n").map(l => l.trim()).filter(Boolean);
+          const sections = [];
+          let cur = null;
+          for (const line of lines) {
+            const isH = line.length < 80 && !line.endsWith(".") && !line.endsWith(",") &&
+              (line === line.toUpperCase() || /^(section|chapter|module|part|\d+\.)\s/i.test(line));
+            if (isH) { if (cur) sections.push(cur); cur = { title: line, paragraphs: [] }; }
+            else if (!cur) { cur = { title: title.trim() || "Section 1", paragraphs: [line] }; }
+            else { cur.paragraphs.push(line); }
+          }
+          if (cur) sections.push(cur);
+          if (!sections.length) sections.push({ title: title.trim() || "Course Content", paragraphs: lines });
+
+          const course = {
+            title:       title.trim() || sections[0]?.title || "Imported Course",
+            description: "", ceHours, ceuHours: ceHours, category, level,
+            objectives: [], deliveryMethod: "online", accessType: "subscription",
+            status: "draft", isPublished: false,
+            sections: sections.map((s, i) => ({
+              title: s.title, order: i + 1,
+              contentBlocks: s.paragraphs.length
+                ? [{ type: "text", content: s.paragraphs.map(p => `<p>${p}</p>`).join("\n") }]
+                : [],
+            })),
+            assessment: { questions: [], passThreshold: 0.80, passingScore: 80, maxAttempts: 3 },
+            references: [],
+          };
+          result = { mode: "convert", course };
+        } else {
+          const res = await fetch(`${API_BASE}/course-builder/parse-outline`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
+            body: JSON.stringify({ text: importText.trim(), ceHours, category, level }),
+          });
+          if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.error || `HTTP ${res.status}`); }
+          const outline = await res.json();
+          result = { mode: importMode, outline };
+        }
+      } else {
+        throw new Error("Paste an outline or upload a .docx file.");
+      }
+
+      if (result.mode === "convert") {
+        // Mode 3: load directly into builder — no generate step
+        dispatch({ type: "LOAD_COURSE", courseData: result.course });
+        setStep(3);
+      } else if (result.mode === "shells") {
+        // Mode 2: show OutlineEditor for review; Build Shells dispatches LOAD_COURSE
+        setOutline(result.outline);
+        setStep(1);
+      } else {
+        // Mode 1 (full): show OutlineEditor → user triggers /generate
+        setOutline(result.outline);
+        setStep(1);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setImportLoading(false);
+    }
+  };
+
+  // ── Shells mode: build empty-block course from reviewed outline → LOAD_COURSE
+  const handleBuildShells = () => {
+    if (!outline) return;
+    const course = {
+      title:       outline.title || "Imported Course",
+      description: outline.description || "",
+      ceHours:     outline.ceHours || ceHours,
+      ceuHours:    outline.ceHours || ceHours,
+      category:    outline.category || category,
+      level:       outline.level || level,
+      objectives:  outline.objectives || [],
+      deliveryMethod: "online", accessType: "subscription",
+      status: "draft", isPublished: false,
+      sections: (outline.sections || []).map((sec, i) => ({
+        title: sec.title, order: i + 1, contentBlocks: [],
+      })),
+      assessment: { questions: [], passThreshold: 0.80, passingScore: 80, maxAttempts: 3 },
+      references: [],
+    };
+    dispatch({ type: "LOAD_COURSE", courseData: course });
+    setStep(3);
   };
 
   // ── Step 2: Generate full course ─────────────────────────────────────────
@@ -423,6 +547,9 @@ export default function AIAssistantTab() {
     setCurrentTask("");
     setError(null);
     setGeneratingCourse(false);
+    setImportText("");
+    setImportFile(null);
+    setImportMode("full");
   };
 
   // ─── Render ───────────────────────────────────────────────────────────────
@@ -441,6 +568,135 @@ export default function AIAssistantTab() {
       {/* ── Step 0: Parameters ── */}
       {step === 0 && (
         <div>
+          {/* Entry mode toggle */}
+          <div style={{ display: "flex", gap: 0, marginBottom: 18, borderRadius: 9, overflow: "hidden", border: `1px solid ${C.border}` }}>
+            {[
+              { key: "generate", label: "✨ Generate from topic" },
+              { key: "import",   label: "📄 Import my outline" },
+            ].map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setEntryMode(key)}
+                style={{
+                  flex: 1, padding: "10px 16px", border: "none", cursor: "pointer",
+                  fontSize: 13, fontWeight: 600,
+                  background: entryMode === key ? C.burgundy : C.stone,
+                  color: entryMode === key ? "#fff" : C.textMuted,
+                  transition: "all 0.15s",
+                }}
+              >{label}</button>
+            ))}
+          </div>
+
+          {/* ── Import mode UI ── */}
+          {entryMode === "import" && (
+            <div style={S.card}>
+              <div style={S.cardHeader}>
+                <span style={{ fontWeight: 700, fontSize: 15, color: C.navy }}>Import Your Outline</span>
+                <span style={S.badge(C.hunterGreen)}>NBCC ACEP #7760</span>
+              </div>
+              <div style={S.cardBody}>
+                {/* Mode selector */}
+                <div style={{ marginBottom: 16 }}>
+                  <label style={S.label}>What do you want to do with your outline?</label>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {[
+                      { value: "full",    label: "Build full course",      desc: "AI writes prose from your structure (fastest path to a complete course)" },
+                      { value: "shells",  label: "Section shells only",    desc: "Create titled sections with empty content — you write the prose" },
+                      { value: "convert", label: "Convert finished docx",  desc: "Your docx already contains the course text — map it verbatim to sections (no AI rewrite)" },
+                    ].map(opt => (
+                      <label key={opt.value} style={{ display: "flex", gap: 10, alignItems: "flex-start", cursor: "pointer", padding: "10px 12px", borderRadius: 8, border: `1.5px solid ${importMode === opt.value ? C.burgundy : C.border}`, background: importMode === opt.value ? C.burgundy + "08" : "#fff" }}>
+                        <input
+                          type="radio" name="importMode" value={opt.value}
+                          checked={importMode === opt.value}
+                          onChange={() => setImportMode(opt.value)}
+                          style={{ marginTop: 2, accentColor: C.burgundy }}
+                        />
+                        <div>
+                          <div style={{ fontSize: 13, fontWeight: 700, color: C.navy }}>{opt.label}</div>
+                          <div style={{ fontSize: 12, color: C.textMuted }}>{opt.desc}</div>
+                        </div>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* CE Hours / Category / Level */}
+                <div style={{ ...S.grid3, marginBottom: 14 }}>
+                  <div>
+                    <label style={S.label}>CE Hours</label>
+                    <select style={S.input} value={ceHours} onChange={e => setCeHours(Number(e.target.value))}>
+                      {CE_HOURS_OPTIONS.map(h => <option key={h} value={h}>{h} CE Hour{h > 1 ? "s" : ""}</option>)}
+                    </select>
+                  </div>
+                  <div>
+                    <label style={S.label}>Category</label>
+                    <select style={S.input} value={category} onChange={e => setCategory(e.target.value)}>
+                      {CATEGORIES.map(c => <option key={c}>{c}</option>)}
+                    </select>
+                  </div>
+                  <div>
+                    <label style={S.label}>Level</label>
+                    <select style={S.input} value={level} onChange={e => setLevel(e.target.value)}>
+                      {["Introductory", "Intermediate", "Advanced"].map(l => <option key={l}>{l}</option>)}
+                    </select>
+                  </div>
+                </div>
+
+                {/* Paste textarea */}
+                <div style={{ marginBottom: 12 }}>
+                  <label style={S.label}>
+                    {importMode === "convert" ? "Paste full course text (or upload .docx below)" : "Paste your outline here"}
+                  </label>
+                  <textarea
+                    style={{ ...S.textarea, minHeight: 160 }}
+                    placeholder={importMode === "convert"
+                      ? "Paste the complete course prose. Section headings should appear on their own lines (all caps or short lines). Paragraphs follow each heading."
+                      : "Paste your outline — section titles, topics, objectives. The AI will preserve your structure exactly."}
+                    value={importText}
+                    onChange={e => setImportText(e.target.value)}
+                  />
+                </div>
+
+                {/* File picker */}
+                <div style={{ marginBottom: 20 }}>
+                  <label style={S.label}>{importText.trim() ? "Or upload a .docx (overrides paste above)" : "Upload a .docx file"}</label>
+                  <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    <input
+                      ref={fileInputRef} type="file" accept=".docx"
+                      style={{ display: "none" }}
+                      onChange={e => setImportFile(e.target.files?.[0] || null)}
+                    />
+                    <button
+                      style={{ ...S.btn(C.borderLight, C.navy, false), fontSize: 13 }}
+                      onClick={() => fileInputRef.current?.click()}
+                    >📎 Choose .docx</button>
+                    {importFile && (
+                      <span style={{ fontSize: 13, color: C.hunterGreen, display: "flex", alignItems: "center", gap: 6 }}>
+                        ✓ {importFile.name}
+                        <button onClick={() => { setImportFile(null); if (fileInputRef.current) fileInputRef.current.value = ""; }}
+                          style={{ background: "none", border: "none", cursor: "pointer", color: C.textMuted, fontSize: 14 }}>✕</button>
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <button
+                  style={S.btn(C.burgundy, "#fff", importLoading || (!importText.trim() && !importFile))}
+                  onClick={handleImportSubmit}
+                  disabled={importLoading || (!importText.trim() && !importFile)}
+                >
+                  {importLoading
+                    ? <><span style={{ display: "inline-block", animation: "spin 1s linear infinite" }}>⟳</span> Processing...</>
+                    : importMode === "convert" ? "Import & Load →" : "Parse Outline →"}
+                </button>
+                <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+              </div>
+            </div>
+          )}
+
+          {/* ── Generate from topic (existing UI) ── */}
+          {entryMode === "generate" && (
           <div style={S.card}>
             <div style={S.cardHeader}>
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -555,6 +811,7 @@ export default function AIAssistantTab() {
               <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
             </div>
           </div>
+          )} {/* end entryMode === "generate" */}
         </div>
       )}
 
@@ -563,9 +820,10 @@ export default function AIAssistantTab() {
         <OutlineEditor
           outline={outline}
           onOutlineChange={setOutline}
-          onGenerate={handleGenerateCourse}
+          onGenerate={importMode === "shells" ? handleBuildShells : handleGenerateCourse}
           onBack={() => setStep(0)}
           generating={generatingCourse}
+          actionLabel={importMode === "shells" ? "🗂 Build Shells →" : "✨ Generate Full Course"}
         />
       )}
 

--- a/server/src/routes/courseBuilder.js
+++ b/server/src/routes/courseBuilder.js
@@ -9,6 +9,8 @@
 
 import express from 'express';
 import Anthropic from '@anthropic-ai/sdk';
+import multer from 'multer';
+import mammoth from 'mammoth';
 import { protect } from '../middleware/auth.js';
 import { countCourseWords, requiredWordsFor } from '../utils/courseWordCount.js';
 
@@ -1166,6 +1168,215 @@ router.get('/:id', protect, adminOnly, async (req, res) => {
   } catch (error) {
     console.error('Load course error:', error);
     res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// OUTLINE IMPORT — /parse-outline + /import-docx
+// ═══════════════════════════════════════════════════════════════════
+
+// ── Helper: convert author text → outline JSON via Anthropic ─────────────────
+// Preserves the author's section titles, ordering, and topics verbatim.
+async function parseOutlineText(text, { ceHours = 3, category = 'Clinical Practice', level = 'Intermediate' } = {}) {
+  const contentSections = ceHours * 2;
+  const wordsPerSection = Math.round((ceHours * 6000) / contentSections);
+
+  const prompt = `Convert this author's course outline into the EXACT outline JSON structure below.
+Preserve their section titles, ordering, and topics EXACTLY as written.
+Do NOT invent content — only structure what they wrote.
+If objectives are present, keep them; if not, leave objectives:[].
+
+Author's outline:
+"""
+${text}
+"""
+
+Return ONLY valid JSON with EXACTLY this structure:
+{
+  "title": "Course title from the outline",
+  "description": "Course description if present, else empty string",
+  "objectives": ["objective 1", "objective 2"],
+  "sections": [
+    {
+      "title": "Section title verbatim",
+      "order": 1,
+      "topics": ["topic1", "topic2"],
+      "estimatedWords": ${wordsPerSection},
+      "kcCount": 2
+    }
+  ]
+}
+
+Rules:
+- Use the author's section titles verbatim
+- If no explicit conclusion section exists, add one as the last section with kcCount:0
+- Content sections: kcCount 2, conclusion: kcCount 0
+- Return ONLY valid JSON, no markdown`;
+
+  const response = await anthropic.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const raw = response.content[0].text;
+  const match = raw.match(/\{[\s\S]*\}/);
+  const outline = JSON.parse(match ? match[0] : raw);
+  outline.ceHours = ceHours;
+  outline.category = category;
+  outline.level = level;
+  return outline;
+}
+
+// ── Helper: build section shells from outline (mode 2) ────────────────────────
+// Returns a course object with empty contentBlocks — author fills content.
+function buildShellsFromOutline(outline) {
+  return {
+    title:          outline.title || 'Imported Course',
+    slug:           slugify(outline.title || 'imported-course'),
+    description:    outline.description || '',
+    ceHours:        outline.ceHours || 3,
+    ceuHours:       outline.ceHours || 3,
+    category:       outline.category || 'Clinical Practice',
+    level:          outline.level || 'Intermediate',
+    objectives:     outline.objectives || [],
+    deliveryMethod: 'online',
+    accessType:     'subscription',
+    status:         'draft',
+    isPublished:    false,
+    sections: (outline.sections || []).map((sec, i) => ({
+      title:         sec.title,
+      order:         i + 1,
+      contentBlocks: [],
+    })),
+    assessment: { questions: [], passThreshold: 0.80, passingScore: 80, maxAttempts: 3 },
+    references: [],
+  };
+}
+
+// ── Helper: map docx prose → sections + text blocks (mode 3 — verbatim) ─────
+// Never rewrites author prose. Maps headings → section titles, body → text.content.
+// BLOCK_FIELD_REFERENCE.md: text block prose field = 'content' (not textContent).
+function buildCourseFromDocxProse(extractedText, { ceHours = 3, category = 'Clinical Practice', level = 'Intermediate', title: courseTitle } = {}) {
+  const lines = extractedText.split('\n').map(l => l.trim()).filter(Boolean);
+
+  const sections = [];
+  let current = null;
+
+  for (const line of lines) {
+    // Detect headings: ALL CAPS, or short (<80 chars) non-sentence lines, or section/chapter/module prefix
+    const isHeading = (
+      line.length < 80 &&
+      !line.endsWith('.') &&
+      !line.endsWith(',') &&
+      (line === line.toUpperCase() || /^(section|chapter|module|part|\d+\.)\s/i.test(line))
+    );
+
+    if (isHeading) {
+      if (current) sections.push(current);
+      current = { title: line, paragraphs: [] };
+    } else if (!current) {
+      current = { title: courseTitle || 'Section 1', paragraphs: [line] };
+    } else {
+      current.paragraphs.push(line);
+    }
+  }
+  if (current) sections.push(current);
+
+  // Fallback: no heading structure found — treat all as one section
+  if (sections.length === 0 || (sections.length === 1 && sections[0].paragraphs.length === 0 && lines.length > 0)) {
+    sections.length = 0;
+    sections.push({ title: courseTitle || 'Course Content', paragraphs: lines });
+  }
+
+  return {
+    title:          courseTitle || sections[0]?.title || 'Imported Course',
+    slug:           slugify(courseTitle || sections[0]?.title || 'imported-course'),
+    description:    '',
+    ceHours,
+    ceuHours:       ceHours,
+    category,
+    level,
+    objectives:     [],
+    deliveryMethod: 'online',
+    accessType:     'subscription',
+    status:         'draft',
+    isPublished:    false,
+    sections: sections.map((sec, i) => ({
+      title: sec.title,
+      order: i + 1,
+      contentBlocks: sec.paragraphs.length > 0
+        ? [{
+            type:    'text',
+            // text block canonical field from BLOCK_FIELD_REFERENCE.md
+            content: sec.paragraphs.map(p => `<p>${p}</p>`).join('\n'),
+          }]
+        : [],
+    })),
+    assessment: { questions: [], passThreshold: 0.80, passingScore: 80, maxAttempts: 3 },
+    references: [],
+  };
+}
+
+// ── Multer instance for docx uploads ─────────────────────────────────────────
+const docxUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (
+      file.mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+      file.originalname?.endsWith('.docx')
+    ) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only .docx files are accepted'));
+    }
+  },
+});
+
+// ── POST /parse-outline — paste path, modes 1 & 2 ────────────────────────────
+router.post('/parse-outline', protect, adminOnly, async (req, res) => {
+  try {
+    const { text, ceHours = 3, category = 'Clinical Practice', level = 'Intermediate' } = req.body;
+    if (!text || !text.trim()) {
+      return res.status(400).json({ error: 'text is required' });
+    }
+    const outline = await parseOutlineText(text.trim(), {
+      ceHours: Number(ceHours) || 3,
+      category,
+      level,
+    });
+    res.json(outline);
+  } catch (error) {
+    console.error('parse-outline error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── POST /import-docx — file path, all modes ─────────────────────────────────
+router.post('/import-docx', protect, adminOnly, docxUpload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No .docx file uploaded (field name: file)' });
+    }
+    const { mode = 'outline', ceHours = 3, category = 'Clinical Practice', level = 'Intermediate', title } = req.body;
+    const ceH = Number(ceHours) || 3;
+
+    const { value: extractedText } = await mammoth.extractRawText({ buffer: req.file.buffer });
+
+    if (mode === 'convert') {
+      // Mode 3: preserve author prose verbatim — map to sections + text blocks
+      const course = buildCourseFromDocxProse(extractedText, { ceHours: ceH, category, level, title });
+      return res.json({ mode: 'convert', course });
+    }
+
+    // Modes 'outline' / 'shells': parse extracted text → outline JSON for OutlineEditor
+    const outline = await parseOutlineText(extractedText, { ceHours: ceH, category, level });
+    res.json({ mode, outline });
+
+  } catch (error) {
+    console.error('import-docx error:', error);
+    res.status(500).json({ error: error.message });
   }
 });
 


### PR DESCRIPTION
## Summary

Adds a second entry path to the AI Assistant tab. Authors can now paste or upload a `.docx` of an outline they already wrote, instead of generating from scratch.

## The 3 modes

| Mode | Flow | AI involvement |
|---|---|---|
| **Build full course** | parse-outline → OutlineEditor review → existing `/generate` → LOAD_COURSE | AI writes prose from author's structure |
| **Shells only** | parse-outline → OutlineEditor review → empty `contentBlocks` → LOAD_COURSE | AI only structures the outline |
| **Convert finished docx** | mammoth → headings→sections, paragraphs→`text.content` verbatim → LOAD_COURSE | No AI rewrite — prose preserved exactly |

## Architecture

All three modes feed the **existing** outline→generate→LOAD_COURSE pipeline. Nothing saves until the author hits Save (existing `/save` → `InteractiveCourse.save()`, fires word-count hook).

## Backend additions — `courseBuilder.js` (surgical, before `export default router`)

- `parseOutlineText()` — Anthropic converts author text → outline JSON, preserves their section titles verbatim
- `buildShellsFromOutline()` — builds course with `contentBlocks: []` per section
- `buildCourseFromDocxProse()` — maps headings → section titles, paragraphs → `text` blocks (field: `content` per BLOCK_FIELD_REFERENCE.md). **Never rewrites prose.**
- `POST /parse-outline` — paste path, modes 1 & 2
- `POST /import-docx` — multer memory + mammoth extraction, all modes

## Frontend additions — `AIAssistantTab.jsx` (surgical)

- Entry-mode toggle: "Generate from topic" (existing, untouched) / "Import my outline" (new)
- Mode selector (radio): full / shells / convert + descriptions
- Large textarea (paste) + `.docx` file picker (ref-driven, overrides paste if both provided)
- CE hours / category / level fields reused from existing params
- `handleImportSubmit` — routes to `/parse-outline` or `/import-docx` per input type + mode
- `handleBuildShells` — client-side: builds shell course from reviewed outline → LOAD_COURSE
- `OutlineEditor` gains `actionLabel` prop → shows "🗂 Build Shells →" for shells mode, "✨ Generate Full Course" otherwise

## Constraints honored
- ✅ BLOCK_FIELD_REFERENCE.md read: `text` block prose field = `content`
- ✅ Convert mode never rewrites author prose (ACEP Gold Standard)
- ✅ `interactive-course.html` not touched
- ✅ `interactiveCourseRoutes.js` not touched
- ✅ mammoth already installed (confirmed in node_modules); multer already in package.json
- ✅ No new save path — all saves go through existing `/save`

## Verification
```
node --check server/src/routes/courseBuilder.js
→ SYNTAX OK, 1383 lines ✅

git diff --stat origin/main...HEAD
→ courseBuilder.js + AIAssistantTab.jsx (+ TECH_MANUAL.md) only ✅

Symbol check (AIAssistantTab.jsx):
→ entryMode, importMode, handleImportSubmit, handleBuildShells,
  parse-outline, import-docx, actionLabel, fileInputRef, useRef — all present ✅
```

## TECH_MANUAL.md
Tier 3 entry appended.

## Note on live testing
The verify checklist items requiring a running server + DB (POST /parse-outline, auditCourse.js) can't run in this container — those need to be tested against staging with the Mongo URI present.

https://claude.ai/code/session_0171Abt3pfgGJ1YAFdF3V862

---
_Generated by [Claude Code](https://claude.ai/code/session_0171Abt3pfgGJ1YAFdF3V862)_