### PR TITLE
feat(live-sessions): add Host Console button to admin session list

### DIFF
--- a/client/public/admin-live-sessions.html
+++ b/client/public/admin-live-sessions.html
@@ -343,6 +343,10 @@
           <td class="px-4 py-3 text-center text-forest-700">${s.ceuHours || '—'}</td>
           <td class="px-4 py-3 text-right">
             <div class="flex items-center justify-end gap-2">
+              <a href="/live-host.html?session=${encodeURIComponent(s.slug)}"
+                class="px-2.5 py-1.5 rounded-lg text-xs font-semibold flex items-center gap-1" style="background:#6B1D34;color:#fff;">
+                <i class="fas fa-video text-xs"></i> Host Console
+              </a>
               <a href="/admin-live-sessions.html?attendance=${s._id}"
                 class="px-2.5 py-1.5 rounded-lg border border-gray-200 text-xs text-forest-700 hover:bg-stone-50 transition-colors flex items-center gap-1"
                 onclick="viewAttendance(event,'${s._id}')">


### PR DESCRIPTION
## Summary
- Adds a burgundy **Host Console** button to every row in `admin-live-sessions.html`
- Links to `/live-host.html?session={slug}` so admins can enter the host panel directly from the session list
- No backend changes — the join endpoint (`POST /api/live-sessions/:id/join`) and `live-host.html` were already wired correctly

## What was missing
Admins had no way to navigate to the host console from the admin UI. The button was simply absent from the session table.

## Test plan
- [ ] Go to `/admin-live-sessions.html` — each session row should show a burgundy "Host Console" button
- [ ] Click it — should land on `/live-host.html?session=<slug>` with the host panel loading
- [ ] "Enter Video Room" button on the host panel should call `/api/live-sessions/:id/join` and embed the Whereby iframe

---
_Generated by [Claude Code](https://claude.ai/code/session_013aPXs1X2qZfPgVbdththfz)_