### PR TITLE
Fix 404 on admin live sessions — /auth.html → /login.html

### DIFF
--- a/client/public/admin-live-sessions.html
+++ b/client/public/admin-live-sessions.html
@@ -273,13 +273,13 @@
         const tid = setTimeout(() => controller.abort(), 8000);
         const r = await fetch('/api/auth/me', { credentials: 'include', signal: controller.signal });
         clearTimeout(tid);
-        if (!r.ok) { window.location.href = '/auth.html'; return; }
+        if (!r.ok) { window.location.href = '/login.html'; return; }
         const d = await r.json();
         if (d.user?.role !== 'admin') { window.location.href = '/dashboard.html'; return; }
         document.getElementById('adminEmail').textContent = d.user.email || 'Admin';
         loadSessions();
       } catch {
-        window.location.href = '/auth.html';
+        window.location.href = '/login.html';
       }
     }
 


### PR DESCRIPTION
## Summary
- `admin-live-sessions.html` redirected unauthenticated users to `/auth.html`, which doesn't exist — causing the Netlify 404 seen on mobile
- Fixed both redirect locations to `/login.html` (the actual login page)

## Root cause
The page loads, fires `checkAuth()`, the `/api/auth/me` call either fails or returns non-OK, and the redirect to the nonexistent `/auth.html` triggers a platform 404. The content flashes briefly because the fetch is async.

## Files changed
- `client/public/admin-live-sessions.html` — 2 lines changed

https://claude.ai/code/session_01GkJRKVBii6G6UryDWo3RqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkJRKVBii6G6UryDWo3RqJ)_