### PR TITLE
feat(compliance): admin surfaces — settings, member management, track builder, assignments, credential vault, GA counters

### DIFF
--- a/client/public/organization.html
+++ b/client/public/organization.html
@@ -51,9 +51,24 @@
         <h1 class="font-display text-3xl font-semibold text-burgundy-900">Organization</h1>
         <p class="text-gray-500 mt-1">Manage your group practice or organization</p>
       </div>
-      <button onclick="toggleCreateForm()" id="createOrgBtn" class="flex items-center gap-2 px-4 py-2 bg-burgundy-700 text-white rounded-lg hover:bg-burgundy-800 text-sm font-medium">
-        <i class="fas fa-plus text-xs"></i> New Organization
-      </button>
+      <div class="flex gap-2">
+        <button id="settingsBtn" style="display:none" onclick="toggleSettings()" class="flex items-center gap-2 px-4 py-2 border border-gray-200 text-gray-600 rounded-lg hover:border-burgundy-300 hover:text-burgundy-700 text-sm font-medium">
+          <i class="fas fa-cog text-xs"></i> Settings
+        </button>
+        <button onclick="toggleCreateForm()" id="createOrgBtn" class="flex items-center gap-2 px-4 py-2 bg-burgundy-700 text-white rounded-lg hover:bg-burgundy-800 text-sm font-medium">
+          <i class="fas fa-plus text-xs"></i> New Organization
+        </button>
+      </div>
+    </div>
+
+    <!-- Bilateral nav -->
+    <div class="flex gap-3 mb-6">
+      <a href="/team-compliance.html" class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 text-sm font-medium text-gray-700 rounded-lg hover:border-burgundy-300 hover:text-burgundy-700 transition-colors">
+        <i class="fas fa-shield-alt text-xs text-burgundy-600"></i> Team Compliance
+      </a>
+      <a href="/my-compliance.html" class="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 text-sm font-medium text-gray-700 rounded-lg hover:border-burgundy-300 hover:text-burgundy-700 transition-colors">
+        <i class="fas fa-user-check text-xs text-burgundy-600"></i> My Compliance
+      </a>
     </div>
 
     <!-- Message Toast -->
@@ -191,6 +206,44 @@
         <div id="membersList" class="divide-y divide-gray-100"></div>
       </div>
 
+      <!-- Settings Panel (admin-only) -->
+      <div id="settingsCard" class="hidden bg-white rounded-xl border border-gray-200 mt-6">
+        <div class="p-4 border-b border-gray-200 flex items-center justify-between">
+          <h2 class="font-display text-xl font-semibold text-burgundy-900">Organization Settings</h2>
+          <button onclick="toggleSettings()" class="text-sm text-gray-500 hover:text-gray-700">Close</button>
+        </div>
+        <form id="settingsForm" class="p-6 grid md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Compliance Segment</label>
+            <select id="settingSegment" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-burgundy-300 focus:border-burgundy-400">
+              <option value="private_practice">Private Practice</option>
+              <option value="dbhdd_agency">DBHDD / DCH Agency (GA)</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Timezone</label>
+            <select id="settingTimezone" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-burgundy-300 focus:border-burgundy-400">
+              <option value="America/New_York">Eastern (ET)</option>
+              <option value="America/Chicago">Central (CT)</option>
+              <option value="America/Denver">Mountain (MT)</option>
+              <option value="America/Los_Angeles">Pacific (PT)</option>
+            </select>
+          </div>
+          <div class="md:col-span-2">
+            <label class="block text-sm font-medium text-gray-700 mb-1">States of Operation <span class="text-gray-400 font-normal">(comma-separated, e.g. GA, FL)</span></label>
+            <input type="text" id="settingStates" placeholder="GA, FL" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-burgundy-300 focus:border-burgundy-400">
+          </div>
+          <div class="md:col-span-2">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Alert Emails <span class="text-gray-400 font-normal">(comma-separated — extra recipients for expiry/overdue digests)</span></label>
+            <input type="text" id="settingAlertEmails" placeholder="admin@example.com, hr@example.com" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-burgundy-300 focus:border-burgundy-400">
+          </div>
+          <div class="md:col-span-2 flex justify-end gap-3 pt-2">
+            <button type="button" onclick="toggleSettings()" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
+            <button type="submit" class="px-4 py-2 bg-burgundy-700 text-white rounded-lg hover:bg-burgundy-800 text-sm font-medium">Save Settings</button>
+          </div>
+        </form>
+      </div>
+
     </div><!-- end #content -->
 
   </main>
@@ -203,10 +256,13 @@
     let allOrgs = [];
     let selectedOrg = null;
     let dashboardData = null;
+    let orgMembersData = null;
+    let currentUserEmail = '';
 
     // ── User Avatar from JWT ──
     try {
       const p = JSON.parse(atob(T.split('.')[1]));
+      currentUserEmail = p.email || '';
       document.getElementById('userName').textContent = p.name || '';
       document.getElementById('userAvatar').textContent = (p.name || '--').split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
     } catch (e) {}
@@ -243,6 +299,13 @@
     // ── Init ──
     document.addEventListener('DOMContentLoaded', init);
 
+    async function loadOrgMembers(orgId) {
+      try {
+        const res = await fetch(API + '/api/orgs/' + orgId + '/members', { headers: authHeaders() });
+        orgMembersData = res.ok ? await res.json() : null;
+      } catch (err) { orgMembersData = null; }
+    }
+
     async function init() {
       try {
         const res = await fetch(API + '/api/organizations/mine', { headers: authHeaders() });
@@ -251,7 +314,7 @@
 
         if (allOrgs.length > 0) {
           selectedOrg = allOrgs[0];
-          await loadDashboard(selectedOrg._id);
+          await Promise.all([loadDashboard(selectedOrg._id), loadOrgMembers(selectedOrg._id)]);
         }
 
         document.getElementById('loading').classList.add('hidden');
@@ -305,19 +368,35 @@
         orgSelector.classList.add('hidden');
       }
 
-      // Stats and members
-      if (dashboardData) {
+      // Determine admin status from org members data
+      const isAdminUser = orgMembersData && currentUserEmail &&
+        orgMembersData.members.some(m => m.email === currentUserEmail && ['owner','admin','manager'].includes(m.role));
+
+      // Settings button: show only for admins when an org is selected
+      const settingsBtn = document.getElementById('settingsBtn');
+      if (settingsBtn) settingsBtn.style.display = (isAdminUser ? 'flex' : 'none');
+
+      // Stats and members — show when we have either data source
+      const hasData = dashboardData || orgMembersData;
+      if (hasData) {
         statsCards.classList.remove('hidden');
         membersCard.classList.remove('hidden');
 
-        const stats = dashboardData.stats || {};
-        const members = dashboardData.members || [];
-
-        // Stat values
-        const totalMembers = stats.totalMembers || members.length || 0;
-        const compliant = stats.compliant || 0;
-        const activeMembers = stats.activeMembers || totalMembers;
-        const complianceRate = totalMembers > 0 ? Math.round((compliant / totalMembers) * 100) : 0;
+        // Stats: prefer orgMembersData rollup
+        let totalMembers, compliant, activeMembers, complianceRate;
+        if (orgMembersData) {
+          const r = orgMembersData.rollup || {};
+          totalMembers = r.totalMembers || 0;
+          compliant = r.compliant || 0;
+          activeMembers = orgMembersData.members.filter(m => m.seatStatus === 'active').length;
+        } else {
+          const stats = dashboardData.stats || {};
+          const members = dashboardData.members || [];
+          totalMembers = stats.totalMembers || members.length || 0;
+          compliant = stats.compliant || 0;
+          activeMembers = stats.activeMembers || totalMembers;
+        }
+        complianceRate = totalMembers > 0 ? Math.round((compliant / totalMembers) * 100) : 0;
 
         document.getElementById('statTotalMembers').textContent = totalMembers;
         document.getElementById('statActiveMembers').textContent = activeMembers;
@@ -325,44 +404,95 @@
 
         // Members list
         const membersList = document.getElementById('membersList');
-        if (members.length === 0) {
-          membersList.innerHTML = '<div class="p-8 text-center text-gray-500 text-sm">No team members yet. Invite your first team member above.</div>';
-        } else {
-          membersList.innerHTML = members.map(member => {
-            const statusDot = member.complianceStatus === 'compliant' ? 'bg-green-500'
-              : member.complianceStatus === 'at_risk' ? 'bg-yellow-500'
-              : 'bg-red-500';
-
-            const roleBadge = member.role === 'admin' || member.role === 'owner'
-              ? `<span class="px-2 py-0.5 bg-burgundy-100 text-burgundy-700 text-xs font-medium rounded-full">${esc(member.role)}</span>`
-              : `<span class="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs font-medium rounded-full">${esc(member.role || 'member')}</span>`;
-
-            const statusLabel = member.status === 'active'
-              ? '<span class="text-xs text-green-600 font-medium">Active</span>'
-              : member.status === 'invited'
-                ? '<span class="text-xs text-amber-600 font-medium">Invited</span>'
-                : '<span class="text-xs text-gray-400 font-medium">' + esc(member.status || 'active') + '</span>';
-
-            return `
-            <div class="p-4 hover:bg-gray-50/50 transition-colors">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                  <div class="w-2.5 h-2.5 rounded-full flex-shrink-0 ${statusDot}"></div>
-                  <div>
-                    <div class="flex items-center gap-2">
-                      <p class="font-medium text-gray-900">${esc(member.name || 'Unnamed')}</p>
-                      ${roleBadge}
+        if (orgMembersData) {
+          const members = orgMembersData.members;
+          if (!members.length) {
+            membersList.innerHTML = '<div class="p-8 text-center text-gray-500 text-sm">No team members yet. Invite your first team member above.</div>';
+          } else {
+            membersList.innerHTML = members.map(member => {
+              const seatId = member.seatId;
+              const role = member.role || 'member';
+              const seatStatus = member.seatStatus || 'active';
+              const compliance = member.status || 'compliant';
+              const statusDot = compliance === 'compliant' ? 'bg-green-500'
+                : compliance === 'at_risk' ? 'bg-yellow-500' : 'bg-red-500';
+              const roleBadge = ['owner','admin','manager'].includes(role)
+                ? `<span class="px-2 py-0.5 bg-burgundy-100 text-burgundy-700 text-xs font-medium rounded-full">${esc(role)}</span>`
+                : `<span class="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs font-medium rounded-full">${esc(role)}</span>`;
+              const statusLabel = seatStatus === 'active'
+                ? '<span class="text-xs text-green-600 font-medium">Active</span>'
+                : seatStatus === 'invited'
+                  ? '<span class="text-xs text-amber-600 font-medium">Invited</span>'
+                  : seatStatus === 'suspended'
+                    ? '<span class="text-xs text-orange-500 font-medium">Suspended</span>'
+                    : `<span class="text-xs text-gray-400 font-medium">${esc(seatStatus)}</span>`;
+              const adminControls = isAdminUser && role !== 'owner' ? `
+                <div class="flex items-center gap-1.5 flex-wrap mt-1 sm:mt-0">
+                  <select onchange="changeMemberRole('${seatId}', this.value)" class="text-xs px-2 py-1 border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-burgundy-300 bg-white">
+                    <option value="clinician"${role==='clinician'?' selected':''}>Clinician</option>
+                    <option value="associate"${role==='associate'?' selected':''}>Associate</option>
+                    <option value="supervisor"${role==='supervisor'?' selected':''}>Supervisor</option>
+                    <option value="staff"${role==='staff'?' selected':''}>Staff</option>
+                    <option value="manager"${role==='manager'?' selected':''}>Manager</option>
+                    <option value="admin"${role==='admin'?' selected':''}>Admin</option>
+                    <option value="member"${role==='member'?' selected':''}>Member</option>
+                  </select>
+                  ${seatStatus !== 'suspended'
+                    ? `<button onclick="changeMemberStatus('${seatId}','suspended')" class="px-2 py-1 text-xs text-amber-600 border border-amber-200 rounded-md hover:bg-amber-50">Suspend</button>`
+                    : `<button onclick="changeMemberStatus('${seatId}','active')" class="px-2 py-1 text-xs text-green-600 border border-green-200 rounded-md hover:bg-green-50">Reactivate</button>`}
+                  <button onclick="changeMemberStatus('${seatId}','offboarded')" class="px-2 py-1 text-xs text-red-600 border border-red-200 rounded-md hover:bg-red-50">Offboard</button>
+                  <button onclick="removeMember('${seatId}')" class="p-1.5 text-gray-400 hover:text-red-600 transition-colors" title="Remove"><i class="fas fa-trash-alt text-sm"></i></button>
+                </div>` : (seatId && role !== 'owner' ? `<button onclick="removeMember('${seatId}')" class="p-1.5 text-gray-400 hover:text-red-600 transition-colors" title="Remove"><i class="fas fa-trash-alt text-sm"></i></button>` : '');
+              return `
+              <div class="p-4 hover:bg-gray-50/50 transition-colors">
+                <div class="flex items-center justify-between flex-wrap gap-2">
+                  <div class="flex items-center gap-3">
+                    <div class="w-2.5 h-2.5 rounded-full flex-shrink-0 ${statusDot}"></div>
+                    <div>
+                      <div class="flex items-center gap-2 flex-wrap">
+                        <p class="font-medium text-gray-900">${esc(member.name || 'Unnamed')}</p>
+                        ${roleBadge}
+                      </div>
+                      <p class="text-xs text-gray-500">${esc(member.email || '')}</p>
                     </div>
-                    <p class="text-xs text-gray-500">${esc(member.email || '')}</p>
+                  </div>
+                  <div class="flex items-center gap-3 flex-wrap">
+                    ${statusLabel}
+                    ${adminControls}
                   </div>
                 </div>
-                <div class="flex items-center gap-4">
-                  ${statusLabel}
-                  ${member.seatId ? `<button onclick="removeMember('${member.seatId}')" class="p-1.5 text-gray-400 hover:text-red-600 transition-colors" title="Remove member"><i class="fas fa-trash-alt text-sm"></i></button>` : ''}
+              </div>`;
+            }).join('');
+          }
+        } else {
+          // Fallback: old dashboard shape (no seatIds, no management controls)
+          const members = dashboardData.members || [];
+          if (!members.length) {
+            membersList.innerHTML = '<div class="p-8 text-center text-gray-500 text-sm">No team members yet. Invite your first team member above.</div>';
+          } else {
+            membersList.innerHTML = members.map(member => {
+              const statusDot = member.complianceStatus === 'compliant' ? 'bg-green-500'
+                : member.complianceStatus === 'at_risk' ? 'bg-yellow-500' : 'bg-red-500';
+              const roleBadge = member.role === 'admin' || member.role === 'owner'
+                ? `<span class="px-2 py-0.5 bg-burgundy-100 text-burgundy-700 text-xs font-medium rounded-full">${esc(member.role)}</span>`
+                : `<span class="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs font-medium rounded-full">${esc(member.role || 'member')}</span>`;
+              return `
+              <div class="p-4 hover:bg-gray-50/50 transition-colors">
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-3">
+                    <div class="w-2.5 h-2.5 rounded-full flex-shrink-0 ${statusDot}"></div>
+                    <div>
+                      <div class="flex items-center gap-2">
+                        <p class="font-medium text-gray-900">${esc(member.name || 'Unnamed')}</p>
+                        ${roleBadge}
+                      </div>
+                      <p class="text-xs text-gray-500">${esc(member.email || '')}</p>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>`;
-          }).join('');
+              </div>`;
+            }).join('');
+          }
         }
       } else {
         statsCards.classList.add('hidden');
@@ -373,7 +503,7 @@
     // ── Select Org ──
     async function selectOrg(orgId) {
       selectedOrg = allOrgs.find(o => o._id === orgId);
-      await loadDashboard(orgId);
+      await Promise.all([loadDashboard(orgId), loadOrgMembers(orgId)]);
       render();
     }
 
@@ -440,6 +570,77 @@
       } catch (err) {
         showToast('error', err.message);
       }
+    });
+
+    // ── Change Member Role ──
+    async function changeMemberRole(seatId, role) {
+      if (!selectedOrg) return;
+      try {
+        const res = await fetch(API + '/api/orgs/' + selectedOrg._id + '/members/' + seatId, {
+          method: 'PATCH', headers: authHeaders(), body: JSON.stringify({ role })
+        });
+        if (!res.ok) { const err = await res.json().catch(()=>({})); throw new Error(err.error || 'Update failed'); }
+        await loadOrgMembers(selectedOrg._id);
+        render();
+        showToast('success', 'Role updated');
+      } catch (err) { showToast('error', err.message); }
+    }
+
+    // ── Change Member Status ──
+    async function changeMemberStatus(seatId, status) {
+      if (!selectedOrg) return;
+      const labels = { suspended:'suspend', offboarded:'offboard', active:'reactivate' };
+      if (!confirm('Are you sure you want to ' + (labels[status] || status) + ' this member?')) return;
+      try {
+        const res = await fetch(API + '/api/orgs/' + selectedOrg._id + '/members/' + seatId, {
+          method: 'PATCH', headers: authHeaders(), body: JSON.stringify({ status })
+        });
+        if (!res.ok) { const err = await res.json().catch(()=>({})); throw new Error(err.error || 'Update failed'); }
+        await loadOrgMembers(selectedOrg._id);
+        render();
+        showToast('success', 'Member status updated');
+      } catch (err) { showToast('error', err.message); }
+    }
+
+    // ── Settings panel ──
+    function toggleSettings() {
+      const card = document.getElementById('settingsCard');
+      const isHidden = card.classList.toggle('hidden');
+      if (!isHidden && selectedOrg) populateSettingsForm();
+    }
+
+    function populateSettingsForm() {
+      const s = (selectedOrg && selectedOrg.settings) || {};
+      document.getElementById('settingSegment').value = s.segment || 'private_practice';
+      document.getElementById('settingTimezone').value = s.timezone || 'America/New_York';
+      document.getElementById('settingStates').value = (s.statesOfOperation || []).join(', ');
+      document.getElementById('settingAlertEmails').value = (s.alertEmails || []).join(', ');
+    }
+
+    document.getElementById('settingsForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      if (!selectedOrg) return;
+      const statesRaw = document.getElementById('settingStates').value;
+      const alertsRaw = document.getElementById('settingAlertEmails').value;
+      const body = {
+        settings: {
+          segment: document.getElementById('settingSegment').value,
+          timezone: document.getElementById('settingTimezone').value,
+          statesOfOperation: statesRaw.split(',').map(s => s.trim().toUpperCase()).filter(Boolean),
+          alertEmails: alertsRaw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+        }
+      };
+      try {
+        const res = await fetch(API + '/api/orgs/' + selectedOrg._id, {
+          method: 'PATCH', headers: authHeaders(), body: JSON.stringify(body)
+        });
+        if (!res.ok) { const err = await res.json().catch(()=>({})); throw new Error(err.error || 'Failed to save settings'); }
+        const updated = await res.json();
+        const idx = allOrgs.findIndex(o => o._id === selectedOrg._id);
+        if (idx !== -1) { allOrgs[idx].settings = updated.settings; selectedOrg = allOrgs[idx]; }
+        document.getElementById('settingsCard').classList.add('hidden');
+        showToast('success', 'Settings saved');
+      } catch (err) { showToast('error', err.message); }
     });
 
     // ── Remove Member ──

--- a/client/public/team-compliance.html
+++ b/client/public/team-compliance.html
@@ -39,6 +39,33 @@
   .banner { background:#f9e6e6; border:1px solid #e7bcbc; color:var(--red); border-radius:10px; padding:12px 16px; margin-bottom:16px; font-weight:600; display:none; }
   .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
   .seg { font-size:12px; background:#eef1f4; color:var(--navy); padding:3px 10px; border-radius:999px; }
+  /* ── modals ── */
+  .modal-ov { display:none; position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:100; align-items:center; justify-content:center; }
+  .modal-ov.open { display:flex; }
+  .modal { background:#fff; border-radius:14px; padding:24px; max-width:640px; width:calc(100% - 32px); max-height:90vh; overflow-y:auto; }
+  .modal h3 { margin:0 0 16px; font-size:17px; }
+  .form-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:10px; }
+  .form-grid.one { grid-template-columns:1fr; }
+  .form-field label { display:block; font-size:12px; font-weight:600; color:#7a8591; text-transform:uppercase; letter-spacing:.03em; margin-bottom:4px; }
+  .form-field input, .form-field select, .form-field textarea { width:100%; padding:8px 10px; border:1px solid #cbd2d9; border-radius:8px; font:inherit; font-size:14px; box-sizing:border-box; }
+  .form-field textarea { resize:vertical; min-height:64px; }
+  .modal-foot { display:flex; justify-content:flex-end; gap:8px; margin-top:16px; }
+  /* ── track items ── */
+  .items-list { border:1px solid #e6e2dc; border-radius:8px; overflow:hidden; margin-bottom:8px; }
+  .item-row { display:grid; grid-template-columns:1fr 90px 90px 32px; gap:6px; padding:7px 10px; border-bottom:1px solid #eee; align-items:center; font-size:13px; }
+  .item-row:last-child { border-bottom:none; }
+  .item-row input, .item-row select { padding:5px 7px; border:1px solid #cbd2d9; border-radius:6px; font:inherit; font-size:13px; }
+  /* ── progress bar ── */
+  .pb-wrap { background:#e6e2dc; border-radius:99px; height:7px; overflow:hidden; display:inline-block; width:60px; vertical-align:middle; }
+  .pb { background:var(--green); height:100%; border-radius:99px; }
+  .pb.warn { background:var(--amber); }
+  .pb.risk { background:var(--red); }
+  /* ── credential vault ── */
+  .exp-ok { color:var(--green); font-weight:700; }
+  .exp-warn { color:var(--amber); font-weight:700; }
+  .exp-bad { color:var(--red); font-weight:700; }
+  .tag { display:inline-block; padding:2px 8px; border-radius:999px; font-size:11px; font-weight:700; background:#e7f4ec; color:var(--green); }
+  .tag.unverified { background:#f3eef7; color:#6b4f8a; }
 </style>
 </head>
 <body>
@@ -85,7 +112,10 @@
     </div>
 
     <div class="card">
-      <h2>Training tracks</h2>
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;flex-wrap:wrap;gap:8px;">
+        <h2 style="margin:0;">Training tracks</h2>
+        <button id="newTrackBtn" class="btn" style="display:none;" onclick="openTrackModal()">+ New Track</button>
+      </div>
       <p class="muted">Assign a track to apply its required trainings to matching members. Recurring items auto-renew on completion.</p>
       <table id="tracks">
         <thead><tr><th>Track</th><th>Segment</th><th>Applies to</th><th>Items</th><th></th></tr></thead>
@@ -97,6 +127,154 @@
       <h2>State-mandate suggestions</h2>
       <div id="suggestions" class="muted">—</div>
     </div>
+
+    <!-- ── Assignments drill-down (admin-rendered) ── -->
+    <div id="assignmentsCard" class="card" style="display:none;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;flex-wrap:wrap;gap:8px;">
+        <h2 style="margin:0;">Assignments</h2>
+        <div class="row">
+          <select id="assignFilter" onchange="renderAssignments()" style="font-size:13px;padding:5px 8px;">
+            <option value="">All statuses</option>
+            <option value="assigned">Assigned</option>
+            <option value="in_progress">In Progress</option>
+            <option value="overdue">Overdue</option>
+            <option value="completed">Completed</option>
+            <option value="waived">Waived</option>
+          </select>
+        </div>
+      </div>
+      <div style="overflow-x:auto;">
+        <table id="assignTable">
+          <thead><tr><th>Member</th><th>Course</th><th>Status</th><th>Due</th><th>Recoup risk</th><th id="assignActionsHead" style="display:none;"></th></tr></thead>
+          <tbody id="assignBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- ── Credential vault ── -->
+    <div id="credCard" class="card" style="display:none;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;flex-wrap:wrap;gap:8px;">
+        <h2 style="margin:0;">Credential Vault</h2>
+        <button id="addCredBtn" class="btn" style="display:none;" onclick="openCredModal()">+ Add Credential</button>
+      </div>
+      <div style="overflow-x:auto;">
+        <table id="credTable">
+          <thead><tr><th>Member</th><th>Type</th><th>Label</th><th>Identifier</th><th>Expires</th><th>Level</th><th>Verified</th><th id="credActionsHead" style="display:none;"></th></tr></thead>
+          <tbody id="credBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+  </div><!-- end #main -->
+</div><!-- end .wrap -->
+
+<!-- ══════════════════ TRACK BUILDER MODAL ══════════════════ -->
+<div id="trackModal" class="modal-ov" onclick="if(event.target===this)closeTrackModal()">
+  <div class="modal">
+    <h3 id="trackModalTitle">New Training Track</h3>
+    <input type="hidden" id="trackEditId">
+    <div class="form-grid">
+      <div class="form-field">
+        <label>Track Name *</label>
+        <input type="text" id="tName" placeholder="e.g. Clinical Orientation">
+      </div>
+      <div class="form-field">
+        <label>Segment</label>
+        <select id="tSegment">
+          <option value="private_practice">Private Practice</option>
+          <option value="dbhdd_agency">DBHDD / DCH Agency</option>
+        </select>
+      </div>
+      <div class="form-field">
+        <label>Applies To Roles (comma-separated)</label>
+        <input type="text" id="tRoles" placeholder="clinician, associate, supervisor">
+      </div>
+      <div class="form-field">
+        <label>Manual Version / Policy Ref</label>
+        <input type="text" id="tManual" placeholder="Policy v2.1">
+      </div>
+      <div class="form-field">
+        <label>Annual Hours Target</label>
+        <input type="number" id="tAnnualHrs" value="0" min="0">
+      </div>
+      <div class="form-field">
+        <label>STR Hours Target</label>
+        <input type="number" id="tStrHrs" value="0" min="0">
+      </div>
+    </div>
+    <div style="margin-bottom:8px;font-size:12px;font-weight:600;color:#7a8591;text-transform:uppercase;letter-spacing:.03em;">Track Items</div>
+    <div class="items-list" id="trackItemsList"></div>
+    <button class="btn ghost" onclick="addTrackItem()" style="font-size:13px;padding:6px 12px;margin-bottom:12px;">+ Add Item</button>
+    <div class="modal-foot">
+      <button class="btn ghost" onclick="closeTrackModal()">Cancel</button>
+      <button class="btn" onclick="submitTrack()">Save Track</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════ CREDENTIAL MODAL ══════════════════ -->
+<div id="credModal" class="modal-ov" onclick="if(event.target===this)closeCredModal()">
+  <div class="modal">
+    <h3>Add Credential</h3>
+    <div class="form-grid">
+      <div class="form-field">
+        <label>Member Seat</label>
+        <select id="cSeatId"></select>
+      </div>
+      <div class="form-field">
+        <label>Type</label>
+        <select id="cType">
+          <option value="license">License</option>
+          <option value="certification">Certification</option>
+          <option value="cpr">CPR</option>
+          <option value="ceu">CEU</option>
+          <option value="training">Training</option>
+          <option value="background_check">Background Check</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div class="form-field">
+        <label>Label / Description</label>
+        <input type="text" id="cLabel" placeholder="e.g. LPC License GA">
+      </div>
+      <div class="form-field">
+        <label>Identifier / Number</label>
+        <input type="text" id="cIdentifier" placeholder="e.g. LPC-12345">
+      </div>
+      <div class="form-field">
+        <label>CPR Level</label>
+        <select id="cLevel">
+          <option value="">— N/A —</option>
+          <option value="bls">BLS / Healthcare Provider</option>
+          <option value="professional_rescuer">Professional Rescuer</option>
+          <option value="lay">Lay Responder</option>
+        </select>
+      </div>
+      <div class="form-field">
+        <label>State</label>
+        <input type="text" id="cState" placeholder="GA" maxlength="2">
+      </div>
+      <div class="form-field">
+        <label>Issued Date</label>
+        <input type="date" id="cIssuedAt">
+      </div>
+      <div class="form-field">
+        <label>Expiration Date</label>
+        <input type="date" id="cExpiresAt">
+      </div>
+      <div class="form-field">
+        <label>Issuing Body</label>
+        <input type="text" id="cIssuingBody" placeholder="e.g. Georgia LPC Board">
+      </div>
+      <div class="form-field">
+        <label>File (PDF / image, max 25 MB)</label>
+        <input type="file" id="cFile" accept=".pdf,image/*">
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn ghost" onclick="closeCredModal()">Cancel</button>
+      <button class="btn" onclick="submitCred()">Save Credential</button>
+    </div>
   </div>
 </div>
 
@@ -104,6 +282,13 @@
 const API = location.hostname==='localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
 const token = localStorage.getItem('token');
 let currentOrgId = null;
+let currentOrgIsAdmin = false;
+let currentUserEmail = '';
+let allAssignments = [];
+let allCredentials = [];
+let currentMembers = [];
+
+try { const p = JSON.parse(atob(token.split('.')[1])); currentUserEmail = p.email||''; } catch(e){}
 
 function authHeaders(extra) { return Object.assign({ 'Authorization': 'Bearer ' + token }, extra||{}); }
 async function api(path, opts) {
@@ -115,6 +300,14 @@ async function api(path, opts) {
   } finally { clearTimeout(t); }
 }
 const esc = s => String(s==null?'':s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const fmtDate = d => d ? new Date(d).toLocaleDateString('en-US', {month:'short',day:'numeric',year:'numeric'}) : '—';
+function expiryClass(d) {
+  if (!d) return '';
+  const days = Math.ceil((new Date(d) - Date.now()) / 86400000);
+  if (days <= 0) return 'exp-bad';
+  if (days <= 30) return 'exp-warn';
+  return 'exp-ok';
+}
 
 async function init() {
   if (!token) { document.getElementById('needAuth').style.display='block'; return; }
@@ -130,11 +323,27 @@ async function init() {
 
 async function loadOrg(orgId) {
   currentOrgId = orgId;
-  const [data, tracks, suggestions] = await Promise.all([
+  const [data, tracks, suggestions, assignments, credentials] = await Promise.all([
     api('/api/orgs/'+orgId+'/members'),
     api('/api/orgs/'+orgId+'/tracks').catch(()=>[]),
-    api('/api/orgs/'+orgId+'/suggestions').catch(()=>({states:[],tracks:[]}))
+    api('/api/orgs/'+orgId+'/suggestions').catch(()=>({states:[],tracks:[]})),
+    api('/api/orgs/'+orgId+'/assignments').catch(()=>[]),
+    api('/api/orgs/'+orgId+'/credentials').catch(()=>[])
   ]);
+
+  allAssignments = assignments;
+  allCredentials = credentials;
+  currentMembers = data.members || [];
+
+  const myMember = currentMembers.find(m => m.email === currentUserEmail);
+  currentOrgIsAdmin = myMember && ['owner','admin','manager'].includes(myMember.role);
+
+  // Show/hide admin-only UI
+  if (document.getElementById('newTrackBtn')) document.getElementById('newTrackBtn').style.display = currentOrgIsAdmin ? 'inline-block' : 'none';
+  if (document.getElementById('addCredBtn')) document.getElementById('addCredBtn').style.display = currentOrgIsAdmin ? 'inline-block' : 'none';
+  if (document.getElementById('assignActionsHead')) document.getElementById('assignActionsHead').style.display = currentOrgIsAdmin ? '' : 'none';
+  if (document.getElementById('credActionsHead')) document.getElementById('credActionsHead').style.display = currentOrgIsAdmin ? '' : 'none';
+
   const isAgency = data.organization.settings && data.organization.settings.segment === 'dbhdd_agency';
   document.getElementById('segBadge').textContent = isAgency ? 'DBHDD/DCH Agency' : 'Private Practice';
 
@@ -148,39 +357,255 @@ async function loadOrg(orgId) {
   if (r.recoupmentExposure > 0) { banner.style.display='block'; banner.textContent = `⚠ BILLING AT RISK — ${r.recoupmentExposure} member(s) have overdue Standard Training Requirement items. Services billed past the grace period are subject to recoupment.`; }
   else banner.style.display='none';
 
-  // matrix
-  document.querySelector('#matrix tbody').innerHTML = data.members.map(m => `
-    <tr>
+  // matrix — extended with GA agency progress bars
+  document.querySelector('#matrix tbody').innerHTML = data.members.map(m => {
+    const annHrs = m.annualHours || 0;
+    const annTarget = isAgency ? 16 : 0;
+    const annPct = annTarget ? Math.min(100, Math.round((annHrs/annTarget)*100)) : 0;
+    const annBarClass = annPct >= 100 ? 'pb' : annPct >= 60 ? 'pb warn' : 'pb risk';
+    const annualCell = isAgency
+      ? `${annHrs}/16 <span class="pb-wrap"><span class="${annBarClass}" style="width:${annPct}%"></span></span>`
+      : (annHrs || 0);
+    return `<tr>
       <td><strong>${esc(m.name)}</strong><div class="muted">${esc(m.email)}</div></td>
       <td>${esc(m.role)}${m.title?`<div class="muted">${esc(m.title)}</div>`:''}</td>
       <td><span class="pill ${m.status}">${m.status.replace('_',' ')}</span></td>
       <td>${m.completed}/${m.totalAssignments}</td>
       <td>${m.overdue>0?`<span class="risk">${m.overdue}</span>`:'0'}</td>
       <td>${m.credentials}${m.expiredCredentials>0?` <span class="risk">(${m.expiredCredentials} expired)</span>`:''}</td>
-      <td>${isAgency ? (m.annualHours+'/16') : (m.annualHours||0)}</td>
+      <td>${annualCell}</td>
       <td>${m.recoupmentRisk?'<span class="risk">RECOUPMENT</span>':''}${!m.directContactCleared && isAgency?'<span class="muted"> · pre-contact</span>':''}</td>
-    </tr>`).join('') || '<tr><td colspan="8" class="muted">No members yet.</td></tr>';
+    </tr>`;
+  }).join('') || '<tr><td colspan="8" class="muted">No members yet.</td></tr>';
 
-  // next expiration (soonest expiring among at-risk members is approximated via overall)
   document.getElementById('nextExp').textContent = r.atRisk>0 || r.nonCompliant>0 ? 'review at-risk members below' : 'all current';
 
-  // tracks
-  document.querySelector('#tracks tbody').innerHTML = tracks.map(t => `
-    <tr>
+  // tracks — with Edit button for org-owned tracks
+  document.querySelector('#tracks tbody').innerHTML = tracks.map(t => {
+    const isOrgTrack = t.orgId && t.orgId === currentOrgId;
+    const editBtn = currentOrgIsAdmin && isOrgTrack ? `<button class="btn ghost" onclick="editTrack('${t._id}')" style="margin-right:4px;">Edit</button>` : '';
+    return `<tr>
       <td><strong>${esc(t.name)}</strong>${t.manualVersion?`<div class="muted">${esc(t.manualVersion)}</div>`:''}</td>
       <td><span class="seg">${esc((t.segment||'').replace('_',' '))}</span></td>
       <td>${esc((t.appliesToRoles||[]).join(', ')||'—')}</td>
       <td>${(t.items||[]).length}</td>
-      <td><button class="btn ghost" onclick="assignTrack('${t._id}','${esc(t.name).replace(/'/g,'')}')">Assign</button></td>
-    </tr>`).join('') || '<tr><td colspan="5" class="muted">No tracks available.</td></tr>';
+      <td>${editBtn}<button class="btn ghost" onclick="assignTrack('${t._id}','${esc(t.name).replace(/'/g,'')}')">Assign</button></td>
+    </tr>`;
+  }).join('') || '<tr><td colspan="5" class="muted">No tracks available.</td></tr>';
 
   // suggestions
   const sug = suggestions || {};
   document.getElementById('suggestions').innerHTML = (sug.states&&sug.states.length)
     ? sug.states.map(s=>`<div><strong>${esc(s.name)}</strong>: ${esc(s.notes)}</div>`).join('') + `<div style="margin-top:8px;">Suggested tracks: ${esc((sug.tracks||[]).join(', ')||'—')}</div>`
     : 'Set your states of operation in org settings to see suggestions.';
+
+  // show new sections
+  document.getElementById('assignmentsCard').style.display = 'block';
+  document.getElementById('credCard').style.display = 'block';
+  renderAssignments();
+  renderCredentials();
+
+  // populate seat picker in cred modal
+  const seatSel = document.getElementById('cSeatId');
+  if (seatSel) {
+    seatSel.innerHTML = data.members.map(m =>
+      `<option value="${m.seatId}">${esc(m.name||m.email)}</option>`
+    ).join('');
+  }
 }
 
+// ── Assignments ──────────────────────────────────────────────────────────────
+function renderAssignments() {
+  const filter = document.getElementById('assignFilter').value;
+  const rows = filter ? allAssignments.filter(a => a.status === filter) : allAssignments;
+  const memberMap = Object.fromEntries(currentMembers.map(m => [String(m.userId||''), m.name||m.email]));
+  document.getElementById('assignBody').innerHTML = rows.length ? rows.map(a => {
+    const name = memberMap[String(a.userId||'')] || '—';
+    const dueClass = a.status==='overdue' ? 'risk' : '';
+    const waiveBtn = currentOrgIsAdmin && a.status !== 'waived' && a.status !== 'completed'
+      ? `<button class="btn ghost" style="font-size:12px;padding:4px 8px;" onclick="waiveAssignment('${a._id}')">Waive</button>` : '';
+    return `<tr>
+      <td>${esc(name)}</td>
+      <td>${esc(a.courseCode||a.title||'—')}</td>
+      <td><span class="pill ${a.status}">${(a.status||'').replace('_',' ')}</span></td>
+      <td class="${dueClass}">${fmtDate(a.dueDate)}</td>
+      <td>${a.recoupmentRisk?'<span class="risk">YES</span>':'—'}</td>
+      ${currentOrgIsAdmin ? `<td>${waiveBtn}</td>` : ''}
+    </tr>`;
+  }).join('') : `<tr><td colspan="${currentOrgIsAdmin?6:5}" class="muted">No assignments found.</td></tr>`;
+}
+
+async function waiveAssignment(id) {
+  const reason = prompt('Waiver reason (optional):') ?? null;
+  if (reason === null) return; // cancelled
+  try {
+    await api('/api/orgs/'+currentOrgId+'/assignments/'+id, { method:'PATCH', body: JSON.stringify({ waive:true, waivedReason: reason||'' }) });
+    allAssignments = await api('/api/orgs/'+currentOrgId+'/assignments').catch(()=>allAssignments);
+    renderAssignments();
+  } catch(e) { alert('Waive failed: ' + e.message); }
+}
+
+// ── Credential vault ─────────────────────────────────────────────────────────
+function renderCredentials() {
+  const memberMap = Object.fromEntries(currentMembers.map(m => [String(m.seatId||''), m.name||m.email]));
+  document.getElementById('credBody').innerHTML = allCredentials.length ? allCredentials.map(c => {
+    const name = memberMap[String(c.seatId||'')] || '—';
+    const ec = expiryClass(c.expiresAt);
+    const verBadge = c.verifiedAt
+      ? `<span class="tag">✓ Verified</span>`
+      : `<span class="tag unverified">Unverified</span>`;
+    const actions = currentOrgIsAdmin ? `
+      ${!c.verifiedAt ? `<button class="btn ghost" style="font-size:12px;padding:3px 8px;" onclick="verifyCred('${c._id}')">Verify</button>` : ''}
+      <button class="btn ghost" style="font-size:12px;padding:3px 8px;color:var(--red);border-color:var(--red);" onclick="deleteCred('${c._id}')">Delete</button>` : '';
+    return `<tr>
+      <td>${esc(name)}</td>
+      <td>${esc(c.type||'—')}</td>
+      <td>${esc(c.label||'—')}</td>
+      <td>${esc(c.identifier||'—')}</td>
+      <td class="${ec}">${fmtDate(c.expiresAt)}</td>
+      <td>${esc(c.level||'—')}</td>
+      <td>${verBadge}</td>
+      ${currentOrgIsAdmin ? `<td style="white-space:nowrap;">${actions}</td>` : ''}
+    </tr>`;
+  }).join('') : `<tr><td colspan="${currentOrgIsAdmin?8:7}" class="muted">No credentials on file.</td></tr>`;
+}
+
+function openCredModal() { document.getElementById('credModal').classList.add('open'); }
+function closeCredModal() { document.getElementById('credModal').classList.remove('open'); }
+
+async function submitCred() {
+  const fd = new FormData();
+  fd.append('seatId', document.getElementById('cSeatId').value);
+  fd.append('type', document.getElementById('cType').value);
+  fd.append('label', document.getElementById('cLabel').value);
+  fd.append('identifier', document.getElementById('cIdentifier').value);
+  const level = document.getElementById('cLevel').value;
+  if (level) fd.append('level', level);
+  const state = document.getElementById('cState').value.toUpperCase();
+  if (state) fd.append('state', state);
+  const issuedAt = document.getElementById('cIssuedAt').value;
+  if (issuedAt) fd.append('issuedAt', issuedAt);
+  const expiresAt = document.getElementById('cExpiresAt').value;
+  if (expiresAt) fd.append('expiresAt', expiresAt);
+  const issuingBody = document.getElementById('cIssuingBody').value;
+  if (issuingBody) fd.append('issuingBody', issuingBody);
+  const file = document.getElementById('cFile').files[0];
+  if (file) fd.append('file', file);
+
+  try {
+    const ctrl = new AbortController(); const t = setTimeout(()=>ctrl.abort(), 30000);
+    const res = await fetch(API+'/api/orgs/'+currentOrgId+'/credentials', {
+      method:'POST', headers:{ 'Authorization':'Bearer '+token }, body:fd, signal:ctrl.signal
+    });
+    clearTimeout(t);
+    if (!res.ok) throw new Error((await res.json().catch(()=>({}))).error || 'Upload failed');
+    allCredentials = await api('/api/orgs/'+currentOrgId+'/credentials').catch(()=>allCredentials);
+    renderCredentials();
+    closeCredModal();
+    // reset form
+    ['cLabel','cIdentifier','cState','cIssuedAt','cExpiresAt','cIssuingBody','cFile'].forEach(id=>{const el=document.getElementById(id);if(el)el.value='';});
+    document.getElementById('cType').value='license';
+    document.getElementById('cLevel').value='';
+  } catch(e) { alert('Save failed: '+e.message); }
+}
+
+async function verifyCred(id) {
+  try {
+    await api('/api/orgs/'+currentOrgId+'/credentials/'+id, { method:'PATCH', body: JSON.stringify({ verify:true }) });
+    allCredentials = await api('/api/orgs/'+currentOrgId+'/credentials').catch(()=>allCredentials);
+    renderCredentials();
+  } catch(e) { alert('Verify failed: '+e.message); }
+}
+
+async function deleteCred(id) {
+  if (!confirm('Delete this credential? This cannot be undone.')) return;
+  try {
+    await api('/api/orgs/'+currentOrgId+'/credentials/'+id, { method:'DELETE' });
+    allCredentials = await api('/api/orgs/'+currentOrgId+'/credentials').catch(()=>allCredentials);
+    renderCredentials();
+  } catch(e) { alert('Delete failed: '+e.message); }
+}
+
+// ── Track builder ─────────────────────────────────────────────────────────────
+let trackItems = [];
+
+function openTrackModal(prefill) {
+  trackItems = prefill ? (prefill.items||[]).map(i=>({...i})) : [];
+  document.getElementById('trackEditId').value = prefill ? (prefill._id||'') : '';
+  document.getElementById('trackModalTitle').textContent = prefill ? 'Edit Track' : 'New Training Track';
+  document.getElementById('tName').value = prefill ? (prefill.name||'') : '';
+  document.getElementById('tSegment').value = prefill ? (prefill.segment||'private_practice') : 'private_practice';
+  document.getElementById('tRoles').value = prefill ? (prefill.appliesToRoles||[]).join(', ') : '';
+  document.getElementById('tManual').value = prefill ? (prefill.manualVersion||'') : '';
+  document.getElementById('tAnnualHrs').value = prefill ? (prefill.annualHoursTarget||0) : 0;
+  document.getElementById('tStrHrs').value = prefill ? (prefill.strHoursTarget||0) : 0;
+  renderTrackItems();
+  document.getElementById('trackModal').classList.add('open');
+}
+
+function closeTrackModal() { document.getElementById('trackModal').classList.remove('open'); }
+
+function renderTrackItems() {
+  document.getElementById('trackItemsList').innerHTML = trackItems.length
+    ? trackItems.map((item, i) => `
+      <div class="item-row">
+        <input type="text" value="${esc(item.courseCode||item.title||'')}" placeholder="Course code or title" oninput="trackItems[${i}].courseCode=this.value">
+        <input type="number" value="${item.dueDays||30}" min="1" placeholder="Days" oninput="trackItems[${i}].dueDays=+this.value" title="Due in N days">
+        <select oninput="trackItems[${i}].recurrence=this.value" title="Recurrence">
+          <option value="once"${(item.recurrence||'once')==='once'?' selected':''}>Once</option>
+          <option value="annual"${item.recurrence==='annual'?' selected':''}>Annual</option>
+          <option value="biennial"${item.recurrence==='biennial'?' selected':''}>Biennial</option>
+        </select>
+        <button onclick="removeTrackItem(${i})" style="background:none;border:none;cursor:pointer;color:#a3302f;font-size:15px;padding:0;">✕</button>
+      </div>`)
+      .join('')
+    : '<div style="padding:12px;font-size:13px;color:#7a8591;text-align:center;">No items yet. Add items above.</div>';
+}
+
+function addTrackItem() {
+  trackItems.push({ courseCode:'', dueDays:30, recurrence:'once' });
+  renderTrackItems();
+}
+
+function removeTrackItem(i) {
+  trackItems.splice(i, 1);
+  renderTrackItems();
+}
+
+async function editTrack(trackId) {
+  try {
+    const tracks = await api('/api/orgs/'+currentOrgId+'/tracks');
+    const t = tracks.find(tr => tr._id === trackId);
+    if (t) openTrackModal(t);
+  } catch(e) { alert('Could not load track: '+e.message); }
+}
+
+async function submitTrack() {
+  const name = document.getElementById('tName').value.trim();
+  if (!name) { alert('Track name is required.'); return; }
+  const rolesRaw = document.getElementById('tRoles').value;
+  const body = {
+    name,
+    segment: document.getElementById('tSegment').value,
+    appliesToRoles: rolesRaw.split(',').map(s=>s.trim()).filter(Boolean),
+    items: trackItems.map(({courseCode, dueDays, recurrence}) => ({courseCode: courseCode.trim(), dueDays, recurrence})).filter(i=>i.courseCode),
+    manualVersion: document.getElementById('tManual').value.trim() || null,
+    annualHoursTarget: +document.getElementById('tAnnualHrs').value || 0,
+    strHoursTarget: +document.getElementById('tStrHrs').value || 0
+  };
+  const editId = document.getElementById('trackEditId').value;
+  try {
+    if (editId) {
+      await api('/api/orgs/'+currentOrgId+'/tracks/'+editId, { method:'PATCH', body: JSON.stringify(body) });
+    } else {
+      await api('/api/orgs/'+currentOrgId+'/tracks', { method:'POST', body: JSON.stringify(body) });
+    }
+    closeTrackModal();
+    loadOrg(currentOrgId);
+  } catch(e) { alert('Save failed: '+e.message); }
+}
+
+// ── Assign track ──────────────────────────────────────────────────────────────
 async function assignTrack(trackId, name) {
   if (!confirm('Assign "'+name+'" to all matching active members?')) return;
   try {
@@ -190,6 +615,7 @@ async function assignTrack(trackId, name) {
   } catch (e) { alert('Assign failed: ' + e.message); }
 }
 
+// ── Audit binder ──────────────────────────────────────────────────────────────
 document.getElementById('binderBtn').onclick = async () => {
   if (!currentOrgId) return;
   try {

--- a/server/src/routes/organizations.js
+++ b/server/src/routes/organizations.js
@@ -89,9 +89,12 @@ router.put('/:id', async (req, res) => {
       return res.status(403).json({ error: 'Only owners and managers can update the organization' });
     }
 
-    const allowed = ['name', 'type', 'address', 'phone', 'website', 'npiNumber', 'settings', 'billingEmail'];
+    const allowed = ['name', 'type', 'address', 'phone', 'website', 'npiNumber', 'billingEmail'];
     for (const key of allowed) {
       if (req.body[key] !== undefined) org[key] = req.body[key];
+    }
+    if (req.body.settings !== undefined) {
+      org.settings = { ...(org.settings?.toObject?.() ?? org.settings ?? {}), ...req.body.settings };
     }
     await org.save();
     res.json(org);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **§3a-PRE (backend):** `server/src/routes/organizations.js` `PUT /:id` now merges `settings` instead of wholesale-replacing — prevents a partial update from clobbering `segment`, `statesOfOperation`, `timezone`, `alertEmails`. Verified: `org.settings = { ...(org.settings?.toObject?.() ?? org.settings ?? {}), ...req.body.settings }`.
- **`organization.html`:** bilateral nav to Team Compliance / My Compliance; Settings panel (segment, timezone, statesOfOperation, alertEmails → `PATCH /api/orgs/:orgId`, admin-only); member row role selector + suspend/reactivate/offboard/remove controls (`PATCH /api/orgs/:orgId/members/:id`, admin-only). Member list now loads from `/api/orgs/:orgId/members` (provides `seatId` and full role/status fields); admin detection from seat role.
- **`team-compliance.html`:** track builder + editor modal (`POST/PATCH /api/orgs/:orgId/tracks`); assignments drill-down with status filter and waive action (`GET/PATCH /api/orgs/:orgId/assignments`); credential vault with add (multipart file upload), verify, and delete (`/api/orgs/:orgId/credentials`); GA agency annual-hours progress bars (16-hr target, color-coded green/amber/red); all management controls hidden from non-admin members.

## Files changed
- `server/src/routes/organizations.js` — 1 behavioral fix (settings merge)
- `client/public/organization.html` — bilateral nav, Settings panel, member management
- `client/public/team-compliance.html` — track builder, assignments, credential vault, GA counters

## Test plan
- [ ] Solo user with no org → organization.html shows empty CTA, no console errors; team-compliance.html shows "No practice yet", no console errors
- [ ] Admin: Settings button visible; saves segment toggle → team-compliance.html segment badge updates; partial settings PUT preserves other settings fields
- [ ] Admin: member role change → row reflects new role; suspend/reactivate/offboard flows; 403 not reachable from UI
- [ ] Admin: "New Track" button visible; create track with items → appears in track list; Edit button on org-owned tracks; global templates have no Edit button
- [ ] Assignments card loads; status filter works; Waive button captures reason and updates row
- [ ] Credential vault: Add with file upload → appears in table; Verify → badge flips; Delete → removed; CPR level field visible
- [ ] GA agency org: annual hours column shows `N/16` with progress bar; recoupment banner fires when `recoupmentExposure > 0`
- [ ] Non-admin member: no Settings button, no role selects, no Waive/Verify/Delete/New Track buttons

https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR)_