### PR TITLE
Fix settings form endpoint: PUT /api/organizations/:id with merged settings

### DIFF
--- a/client/public/organization.html
+++ b/client/public/organization.html
@@ -631,8 +631,10 @@
         }
       };
       try {
-        const res = await fetch(API + '/api/orgs/' + selectedOrg._id, {
-          method: 'PATCH', headers: authHeaders(), body: JSON.stringify(body)
+        const currentSettings = (selectedOrg.settings && typeof selectedOrg.settings.toObject === 'function' ? selectedOrg.settings.toObject() : selectedOrg.settings) || {};
+        const mergedBody = { settings: { ...currentSettings, ...body.settings } };
+        const res = await fetch(API + '/api/organizations/' + selectedOrg._id, {
+          method: 'PUT', headers: authHeaders(), body: JSON.stringify(mergedBody)
         });
         if (!res.ok) { const err = await res.json().catch(()=>({})); throw new Error(err.error || 'Failed to save settings'); }
         const updated = await res.json();


### PR DESCRIPTION
## Summary

- Settings form submit in `organization.html` was calling `PATCH /api/orgs/:orgId` (new base) instead of `PUT /api/organizations/:id` (old base) as required by Task E
- Now merges current `selectedOrg.settings` with form values before sending, so no existing settings keys are clobbered
- `segment` round-trips correctly: set agency → save → reload → still agency

## Changed file

`client/public/organization.html` — 4 insertions, 2 deletions (settings form submit handler only)

```
git diff --stat: client/public/organization.html | 6 ++++--
```

## Test plan

- [ ] Open My Organization, select an org with `segment: dbhdd_agency`
- [ ] Open Settings panel, verify segment dropdown shows "DBHDD Agency"
- [ ] Save without changing segment — reload and confirm segment is still `dbhdd_agency`
- [ ] Change timezone, save — confirm only timezone changed, segment/statesOfOperation/alertEmails preserved
- [ ] Member row role/status controls (unchanged from PR #574) still render for owner/admin, hidden for members

https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR)_