### PR TITLE
Add shared nav to team-compliance and my-compliance pages

### DIFF
--- a/client/public/my-compliance.html
+++ b/client/public/my-compliance.html
@@ -34,6 +34,8 @@
 </style>
 </head>
 <body>
+  <div id="cr-header"></div>
+  <script src="/shared/nav-footer.js"></script>
 <header class="app"><h1>My Compliance</h1></header>
 <div style="max-width:920px;margin:0 auto;padding:14px 24px 0;display:flex;gap:10px;flex-wrap:wrap;">
   <a href="/organization.html" style="font-size:13px;color:var(--burgundy-dark);text-decoration:none;padding:5px 14px;border:1px solid var(--burgundy-dark);border-radius:8px;background:#fff;font-weight:600;">← Organization</a>

--- a/client/public/team-compliance.html
+++ b/client/public/team-compliance.html
@@ -69,6 +69,8 @@
 </style>
 </head>
 <body>
+  <div id="cr-header"></div>
+  <script src="/shared/nav-footer.js"></script>
 <header class="app">
   <h1>Practice Compliance</h1>
   <div class="row">


### PR DESCRIPTION
## Summary

Both `team-compliance.html` and `my-compliance.html` were missing the global site navigation, leaving users with no way to get back to Dashboard, Courses, etc. once they landed there.

Adds the identical `<div id="cr-header"></div>` + `<script src="/shared/nav-footer.js"></script>` pattern used by `organization.html`, inserted immediately after `<body>` in both files.

Existing in-page cross-links (← Organization, bilateral nav) are untouched.

## Diff stat

```
client/public/my-compliance.html   | 2 ++
client/public/team-compliance.html | 2 ++
2 files changed, 4 insertions(+)
```

## Test plan

- [ ] Open `/team-compliance.html` — shared top nav renders (Dashboard, Courses, etc.)
- [ ] Open `/my-compliance.html` — shared top nav renders
- [ ] Existing `← Organization` and bilateral cross-links still present on both pages
- [ ] `organization.html` nav unaffected

https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHUqkZtScwCE8GKd8vKwcR)_