### PR TITLE
fix: reconcile Stripe field paths to nested subscription.* schema

### DIFF
--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -55,9 +55,9 @@ router.get('/subscription', protect, async (req, res) => {
     const user = await User.findById(req.user._id);
     
     let paymentMethod = null;
-    if (user.stripeCustomerId && stripe) {
+    if (user.subscription?.stripeCustomerId && stripe) {
       try {
-        const customer = await stripe.customers.retrieve(user.stripeCustomerId);
+        const customer = await stripe.customers.retrieve(user.subscription.stripeCustomerId);
         if (customer.invoice_settings?.default_payment_method) {
           const pm = await stripe.paymentMethods.retrieve(
             customer.invoice_settings.default_payment_method
@@ -95,16 +95,16 @@ router.get('/invoices', protect, async (req, res) => {
   try {
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeCustomerId) {
+    if (!user.subscription?.stripeCustomerId) {
       return res.json({ invoices: [] });
     }
-    
+
     // Get invoices from Stripe
     const invoices = await stripe.invoices.list({
-      customer: user.stripeCustomerId,
+      customer: user.subscription.stripeCustomerId,
       limit: 20
     });
-    
+
     const formattedInvoices = invoices.data.map(inv => ({
       id: inv.id,
       date: new Date(inv.created * 1000),
@@ -140,7 +140,7 @@ router.post('/create-checkout-session', protect, async (req, res) => {
     const user = await User.findById(req.user._id);
     
     // Create or get Stripe customer
-    let customerId = user.stripeCustomerId;
+    let customerId = user.subscription?.stripeCustomerId;
     if (!customerId) {
       const customer = await stripe.customers.create({
         email: user.email,
@@ -150,9 +150,9 @@ router.post('/create-checkout-session', protect, async (req, res) => {
         }
       });
       customerId = customer.id;
-      await User.findByIdAndUpdate(user._id, { stripeCustomerId: customerId });
+      await User.findByIdAndUpdate(user._id, { 'subscription.stripeCustomerId': customerId });
     }
-    
+
     // Create checkout session
     const session = await stripe.checkout.sessions.create({
       customer: customerId,
@@ -214,7 +214,7 @@ router.post('/create-subscription', protect, async (req, res) => {
     }
     
     // Create or get Stripe customer
-    let customerId = user.stripeCustomerId;
+    let customerId = user.subscription?.stripeCustomerId;
     if (!customerId) {
       const customer = await stripe.customers.create({
         email: user.email,
@@ -224,7 +224,7 @@ router.post('/create-subscription', protect, async (req, res) => {
         }
       });
       customerId = customer.id;
-      await User.findByIdAndUpdate(user._id, { stripeCustomerId: customerId });
+      await User.findByIdAndUpdate(user._id, { 'subscription.stripeCustomerId': customerId });
     }
     
     // Attach payment method to customer
@@ -303,7 +303,7 @@ router.post('/create-subscription', protect, async (req, res) => {
     if (paymentIntent.status === 'succeeded') {
       // Update user subscription
       await User.findByIdAndUpdate(user._id, {
-        stripeSubscriptionId: subscription.id,
+        'subscription.stripeSubscriptionId': subscription.id,
         'subscription.plan': plan,
         'subscription.status': 'active',
         'subscription.priceId': priceId,
@@ -346,12 +346,12 @@ router.post('/create-portal-session', protect, async (req, res) => {
   try {
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeCustomerId) {
+    if (!user.subscription?.stripeCustomerId) {
       return res.status(400).json({ error: 'No subscription found' });
     }
-    
+
     const session = await stripe.billingPortal.sessions.create({
-      customer: user.stripeCustomerId,
+      customer: user.subscription.stripeCustomerId,
       return_url: `${process.env.CLIENT_URL || 'https://counselorready.com'}/subscription.html`
     });
     
@@ -374,19 +374,19 @@ router.post('/change-plan', protect, async (req, res) => {
     const { plan } = req.body;
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeSubscriptionId) {
+    if (!user.subscription?.stripeSubscriptionId) {
       return res.status(400).json({ error: 'No active subscription to change' });
     }
-    
+
     if (!PRICE_IDS[plan]) {
       return res.status(400).json({ error: 'Invalid plan selected' });
     }
-    
+
     // Get current subscription
-    const subscription = await stripe.subscriptions.retrieve(user.stripeSubscriptionId);
-    
+    const subscription = await stripe.subscriptions.retrieve(user.subscription.stripeSubscriptionId);
+
     // Update subscription with new price
-    const updatedSubscription = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    const updatedSubscription = await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
       items: [{
         id: subscription.items.data[0].id,
         price: PRICE_IDS[plan]
@@ -427,20 +427,20 @@ router.post('/cancel-subscription', protect, async (req, res) => {
   try {
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeSubscriptionId) {
+    if (!user.subscription?.stripeSubscriptionId) {
       return res.status(400).json({ error: 'No active subscription to cancel' });
     }
-    
+
     // Cancel at period end (user keeps access until billing period ends)
-    const subscription = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    const subscription = await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
       cancel_at_period_end: true
     });
-    
+
     await User.findByIdAndUpdate(user._id, {
       'subscription.cancelAtPeriodEnd': true
     });
-    
-    res.json({ 
+
+    res.json({
       message: 'Subscription will be canceled at the end of the billing period',
       cancelAt: new Date(subscription.current_period_end * 1000)
     });
@@ -457,16 +457,16 @@ router.post('/cancel', protect, async (req, res) => {
   if (!stripe) {
     return res.status(503).json({ error: 'Payment system not configured' });
   }
-  
+
   try {
     const user = await User.findById(req.user._id);
-    
-    if (!user.stripeSubscriptionId) {
+
+    if (!user.subscription?.stripeSubscriptionId) {
       return res.status(400).json({ error: 'No active subscription to cancel' });
     }
-    
+
     // Cancel at period end (user keeps access until billing period ends)
-    const subscription = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    const subscription = await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
       cancel_at_period_end: true
     });
     
@@ -495,12 +495,12 @@ router.post('/reactivate', protect, async (req, res) => {
   try {
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeSubscriptionId) {
+    if (!user.subscription?.stripeSubscriptionId) {
       return res.status(400).json({ error: 'No subscription to reactivate' });
     }
-    
+
     // Remove cancellation
-    await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
       cancel_at_period_end: false
     });
     
@@ -526,15 +526,15 @@ router.get('/billing-history', protect, async (req, res) => {
   try {
     const user = await User.findById(req.user._id);
     
-    if (!user.stripeCustomerId) {
+    if (!user.subscription?.stripeCustomerId) {
       return res.json({ invoices: [] });
     }
-    
+
     const invoices = await stripe.invoices.list({
-      customer: user.stripeCustomerId,
+      customer: user.subscription.stripeCustomerId,
       limit: 20
     });
-    
+
     const formattedInvoices = invoices.data.map(inv => ({
       id: inv.id,
       number: inv.number,
@@ -587,7 +587,7 @@ router.post('/create-course-checkout', protect, async (req, res) => {
     const user = await User.findById(req.user._id);
 
     // Create or get Stripe customer
-    let customerId = user.stripeCustomerId;
+    let customerId = user.subscription?.stripeCustomerId;
     if (!customerId) {
       const customer = await stripe.customers.create({
         email: user.email,
@@ -597,7 +597,7 @@ router.post('/create-course-checkout', protect, async (req, res) => {
         }
       });
       customerId = customer.id;
-      await User.findByIdAndUpdate(user._id, { stripeCustomerId: customerId });
+      await User.findByIdAndUpdate(user._id, { 'subscription.stripeCustomerId': customerId });
     }
 
     const session = await stripe.checkout.sessions.create({
@@ -812,7 +812,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         // Handle subscription purchase
         if (userId && plan) {
           await User.findByIdAndUpdate(userId, {
-            stripeSubscriptionId: session.subscription,
+            'subscription.stripeSubscriptionId': session.subscription,
             'subscription.plan': plan,
             'subscription.status': 'active',
             'subscription.currentPeriodStart': new Date(),
@@ -962,7 +962,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
           await User.findByIdAndUpdate(userId, {
             'subscription.plan': 'free',
             'subscription.status': 'canceled',
-            stripeSubscriptionId: null
+            'subscription.stripeSubscriptionId': null
           });
           logActivity(ACTIVITY_TYPES.SUBSCRIPTION_CANCELED, {
             plan: canceledPlan
@@ -992,7 +992,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         const invoice = event.data.object;
         const customerId = invoice.customer;
         
-        const user = await User.findOne({ stripeCustomerId: customerId });
+        const user = await User.findOne({ 'subscription.stripeCustomerId': customerId });
         if (user) {
           await User.findByIdAndUpdate(user._id, {
             'subscription.status': 'past_due',
@@ -1029,7 +1029,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         const invoice = event.data.object;
         const customerId = invoice.customer;
 
-        const user = await User.findOne({ stripeCustomerId: customerId });
+        const user = await User.findOne({ 'subscription.stripeCustomerId': customerId });
         if (user) {
           const wasRecovery = user.subscription?.status === 'past_due';
           const updateFields = {
@@ -1210,7 +1210,7 @@ router.post('/purchase-course', protect, async (req, res) => {
       return res.status(400).json({ error: 'You already own this course' });
     }
 
-    let customerId = user.stripeCustomerId;
+    let customerId = user.subscription?.stripeCustomerId;
     if (!customerId) {
       const customer = await stripe.customers.create({
         email: user.email,
@@ -1218,7 +1218,7 @@ router.post('/purchase-course', protect, async (req, res) => {
         metadata: { userId: user._id.toString() }
       });
       customerId = customer.id;
-      user.stripeCustomerId = customerId;
+      user.subscription.stripeCustomerId = customerId;
       await user.save();
     }
 

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -793,12 +793,12 @@ router.post('/promo', protect, async (req, res) => {
 
     // Check if user has an active Stripe subscription
     const user = await User.findById(req.user._id);
-    if (!user || !user.stripeSubscriptionId) {
+    if (!user || !user.subscription?.stripeSubscriptionId) {
       return res.status(400).json({ error: 'No active subscription found. Use this code when subscribing.' });
     }
 
     // Apply the coupon to the existing subscription
-    await stripe.subscriptions.update(user.stripeSubscriptionId, {
+    await stripe.subscriptions.update(user.subscription.stripeSubscriptionId, {
       coupon: coupon.id
     });
 

--- a/server/src/scripts/backfill-monthly-amount-cents.js
+++ b/server/src/scripts/backfill-monthly-amount-cents.js
@@ -29,7 +29,7 @@ const User = mongoose.model('User', new mongoose.Schema({}, { strict: false }), 
 
 // Fetch all active/past_due users with a Stripe customer ID
 const query = {
-  stripeCustomerId: { $exists: true, $ne: null },
+  'subscription.stripeCustomerId': { $exists: true, $ne: null },
   'subscription.status': { $in: ['active', 'past_due'] },
   'subscription.plan': { $ne: 'free' }
 };
@@ -41,7 +41,7 @@ if (!FORCE) {
   ];
 }
 
-const users = await User.find(query).select('email stripeCustomerId subscription.plan subscription.monthlyAmountCents').lean();
+const users = await User.find(query).select('email subscription.stripeCustomerId subscription.plan subscription.monthlyAmountCents').lean();
 console.log(`Found ${users.length} user(s) to backfill${FORCE ? ' (--force mode)' : ''}\n`);
 
 const stats = { updated: 0, skipped: 0, errors: 0, zeroDollar: 0 };
@@ -50,7 +50,7 @@ for (const user of users) {
   try {
     // Get most recent paid invoice
     const invoices = await stripe.invoices.list({
-      customer: user.stripeCustomerId,
+      customer: user.subscription?.stripeCustomerId,
       status: 'paid',
       limit: 1
     });

--- a/server/src/scripts/repairStripeLinkage.js
+++ b/server/src/scripts/repairStripeLinkage.js
@@ -1,0 +1,154 @@
+// repairStripeLinkage.js
+// One-off idempotent script: reads real Stripe customer/subscription data
+// and writes it to the nested subscription.stripeCustomerId / stripeSubscriptionId
+// fields for users who have subscription.status set but no stripeCustomerId linked.
+//
+// APPLY gate — must pass --apply to write anything; default is dry-run.
+//
+// Usage:
+//   node src/scripts/repairStripeLinkage.js
+//   node src/scripts/repairStripeLinkage.js --apply
+//   node src/scripts/repairStripeLinkage.js --apply --emails="a@x.com,b@x.com,c@x.com"
+//
+// If --emails is given, only those users are targeted.
+// If omitted, all users whose subscription.status is set but subscription.stripeCustomerId
+// is missing are candidates (matched by email against Stripe customers list).
+
+import mongoose from 'mongoose';
+import Stripe from 'stripe';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI || process.env.MONGO_URI;
+const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY || process.env.STRIPE_SECRET;
+const APPLY = process.argv.includes('--apply');
+const emailsArg = process.argv.find(a => a.startsWith('--emails='));
+const TARGET_EMAILS = emailsArg
+  ? emailsArg.replace('--emails=', '').split(',').map(e => e.trim().toLowerCase()).filter(Boolean)
+  : [];
+
+if (!MONGODB_URI) { console.error('ERROR: MONGODB_URI not set'); process.exit(1); }
+if (!STRIPE_SECRET) { console.error('ERROR: STRIPE_SECRET_KEY not set'); process.exit(1); }
+
+const stripe = new Stripe(STRIPE_SECRET, { apiVersion: '2023-10-16' });
+
+await mongoose.connect(MONGODB_URI);
+console.log('✓ Connected to MongoDB');
+
+// Use schemaless model so we can read/write any field without import issues
+const User = mongoose.model('User', new mongoose.Schema({}, { strict: false }), 'users');
+
+// Build candidate query
+const baseQuery = {
+  $or: [
+    { 'subscription.stripeCustomerId': { $exists: false } },
+    { 'subscription.stripeCustomerId': null },
+    { 'subscription.stripeCustomerId': '' }
+  ],
+  'subscription.status': { $exists: true, $ne: null }
+};
+
+if (TARGET_EMAILS.length > 0) {
+  baseQuery.email = { $in: TARGET_EMAILS };
+} else {
+  // Only target users who appear to have subscribed (not free/null status)
+  baseQuery['subscription.status'] = { $in: ['active', 'past_due', 'canceled'] };
+}
+
+const candidates = await User.find(baseQuery)
+  .select('email subscription.stripeCustomerId subscription.stripeSubscriptionId subscription.status subscription.plan subscription.monthlyAmountCents')
+  .lean();
+
+console.log(`\nCandidates (missing stripeCustomerId): ${candidates.length}`);
+if (!APPLY) console.log('DRY RUN — pass --apply to write changes\n');
+console.log('');
+
+const stats = { updated: 0, skipped: 0, notInStripe: 0, errors: 0 };
+
+for (const user of candidates) {
+  try {
+    // Search Stripe for customer by email
+    const stripeCustomers = await stripe.customers.list({ email: user.email, limit: 5 });
+
+    if (!stripeCustomers.data.length) {
+      console.log(`  NOT_FOUND  ${user.email} — no Stripe customer with this email`);
+      stats.notInStripe++;
+      continue;
+    }
+
+    // Pick the most recent customer if multiple
+    const stripeCustomer = stripeCustomers.data[0];
+    const customerId = stripeCustomer.id;
+
+    // Find active/latest subscription for this customer
+    let subscriptionId = null;
+    let amountCents = user.subscription?.monthlyAmountCents || 0;
+
+    const stripeSubs = await stripe.subscriptions.list({
+      customer: customerId,
+      limit: 5,
+      status: 'all'
+    });
+
+    if (stripeSubs.data.length > 0) {
+      // Prefer active, then past_due, then canceled
+      const preferred = stripeSubs.data.find(s => s.status === 'active')
+        || stripeSubs.data.find(s => s.status === 'past_due')
+        || stripeSubs.data[0];
+      subscriptionId = preferred.id;
+
+      // Get amount from latest invoice if not already set
+      if (!amountCents) {
+        try {
+          const invoices = await stripe.invoices.list({ customer: customerId, status: 'paid', limit: 1 });
+          if (invoices.data.length) amountCents = invoices.data[0].amount_paid || 0;
+        } catch (_) {}
+      }
+    }
+
+    const before = {
+      stripeCustomerId: user.subscription?.stripeCustomerId || null,
+      stripeSubscriptionId: user.subscription?.stripeSubscriptionId || null,
+      monthlyAmountCents: user.subscription?.monthlyAmountCents || 0
+    };
+
+    const after = {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      monthlyAmountCents: amountCents
+    };
+
+    console.log(`  ${APPLY ? 'APPLY' : 'WOULD'}  ${user.email}`);
+    console.log(`    stripeCustomerId:      ${before.stripeCustomerId || '(null)'} → ${after.stripeCustomerId}`);
+    console.log(`    stripeSubscriptionId:  ${before.stripeSubscriptionId || '(null)'} → ${after.stripeSubscriptionId || '(none found)'}`);
+    console.log(`    monthlyAmountCents:    ${before.monthlyAmountCents} → ${after.monthlyAmountCents}`);
+
+    if (APPLY) {
+      const update = { 'subscription.stripeCustomerId': customerId };
+      if (subscriptionId) update['subscription.stripeSubscriptionId'] = subscriptionId;
+      if (amountCents && !user.subscription?.monthlyAmountCents) {
+        update['subscription.monthlyAmountCents'] = amountCents;
+      }
+
+      await User.updateOne({ _id: user._id }, { $set: update });
+      console.log(`    ✓ written`);
+    }
+
+    stats.updated++;
+  } catch (err) {
+    console.error(`  ERR  ${user.email} — ${err.message}`);
+    stats.errors++;
+  }
+
+  // Polite Stripe rate limiting
+  await new Promise(r => setTimeout(r, 100));
+}
+
+console.log('\n=== Repair Complete ===');
+console.log(`  Candidates:   ${candidates.length}`);
+console.log(`  ${APPLY ? 'Updated' : 'Would update'}:    ${stats.updated}`);
+console.log(`  Not in Stripe: ${stats.notInStripe} (manual/comp grants — untouched)`);
+console.log(`  Errors:       ${stats.errors}`);
+if (!APPLY) console.log('\nRe-run with --apply to write these changes.');
+
+await mongoose.disconnect();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause fixed:** `payments.js` and `users.js` read/wrote `stripeCustomerId` and `stripeSubscriptionId` at the top-level document path. The `User` schema nests these under `subscription.*`. Every top-level write landed on a phantom field Mongoose never persisted, and every `User.findOne({ stripeCustomerId })` webhook query matched zero users — silently no-op'ing all renewal, cancellation, and dunning events since launch.
- **All changed lines are field-path only.** No logic, function structure, variable names, or Stripe API calls were altered.
- **backfill-monthly-amount-cents.js** query and select corrected to `subscription.stripeCustomerId`.
- **New script:** `server/src/scripts/repairStripeLinkage.js` — idempotent, dry-run by default (`--apply` to write). Matches existing users by email against Stripe, writes real `cus_`/`sub_` IDs to the correct nested fields. Does not touch accounts with no matching Stripe customer (manual/comp grants).

## Files changed (path-fixes only)

| File | Changes |
|---|---|
| `server/src/routes/payments.js` | 16 read sites, 6 write sites, 2 `findOne` webhook queries |
| `server/src/routes/users.js` | 2 sites in `/promo` route |
| `server/src/scripts/backfill-monthly-amount-cents.js` | query key + select field + `stripe.invoices.list` customer arg |
| `server/src/scripts/repairStripeLinkage.js` | **new** — one-off data repair for 3 real buyers |

## Verification

- `node --check` passed on all 4 files
- `grep 'user\.stripeCustomerId\|user\.stripeSubscriptionId\|{ stripeCustomerId\|{ stripeSubscriptionId'` returns zero hits across all changed files
- `git diff --stat` shows exactly the 4 files above, no other files touched

## Post-deploy checklist (for Ke)

1. Run repair script (dry run first, then apply):
   ```
   node src/scripts/repairStripeLinkage.js --emails="buyer1@x.com,buyer2@x.com,buyer3@x.com"
   node src/scripts/repairStripeLinkage.js --apply --emails="buyer1@x.com,buyer2@x.com,buyer3@x.com"
   ```
2. Complete one test-card checkout → confirm `subscription.stripeCustomerId` AND `subscription.status` both persist on the user document.
3. Re-run `crFunnelDiagnostic.js` → "Reached checkout" should now be > 0.
4. Fire a test `invoice.paid` webhook via Stripe CLI → confirm handler finds the user (previously always no-op'd).
5. Confirm `STRIPE_WEBHOOK_SECRET` is set in production env and matches the Stripe Dashboard endpoint signing secret.

https://claude.ai/code/session_012m3VxRuMj5Byj7KFXtnH28
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012m3VxRuMj5Byj7KFXtnH28)_