### PR TITLE
Replace credentials.html and certificates.js from files48 upload

### DIFF
--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -591,6 +591,47 @@
     }
 
     // ── Render Certificates ──
+    // ── Download cert with auth ──
+    async function downloadCert(certId, title){
+      try{
+        const r=await fetch(`${API_URL}/api/certificates/${certId}/serve`,{headers:{Authorization:`Bearer ${token}`}});
+        if(!r.ok){
+          const e=await r.json().catch(()=>({}));
+          alert(e.error||'Certificate file not available for download.');
+          return;
+        }
+        const blob=await r.blob();
+        const ext=r.headers.get('content-type')?.includes('pdf')?'pdf':'jpg';
+        const a=document.createElement('a');
+        a.href=URL.createObjectURL(blob);
+        a.download=`${title.replace(/[^a-zA-Z0-9 ]/g,'').replace(/ +/g,'_')}.${ext}`;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},1000);
+      }catch(err){
+        console.error('Download failed:',err);
+        alert('Download failed. Please try again.');
+      }
+    }
+
+    // ── View cert in new tab ──
+    async function viewCert(certId){
+      try{
+        const r=await fetch(`${API_URL}/api/certificates/${certId}/serve`,{headers:{Authorization:`Bearer ${token}`}});
+        if(!r.ok){
+          const e=await r.json().catch(()=>({}));
+          alert(e.error||'Certificate file not available.');
+          return;
+        }
+        const blob=await r.blob();
+        const url=URL.createObjectURL(blob);
+        window.open(url,'_blank');
+      }catch(err){
+        console.error('View failed:',err);
+        alert('Could not open certificate. Please try again.');
+      }
+    }
+
     function renderCertificates(){
       const grid=document.getElementById('certificatesGrid');
       if(!allCertificates.length){
@@ -624,9 +665,13 @@
           </div>
           <p style="font-size:13px;font-weight:500;color:#284157;margin:8px 0 0;line-height:1.4;word-break:break-word">${esc(c.title||'Certificate')}</p>
           <p style="font-size:11px;color:#78716c;margin:4px 0 0">${esc(provider)}${date?' &middot; '+date:''}</p>
+          ${c.certificateNumber?`<p style="font-size:10px;color:#a8a29e;margin:2px 0 0;font-family:monospace">${esc(c.certificateNumber)}</p>`:''}
+          ${c.acepNumber?`<p style="font-size:10px;color:#a8a29e;margin:1px 0 0">ACEP #${esc(c.acepNumber)}</p>`:''}
+          ${c.approvingBody&&c.approvingBody!=='null'?`<p style="font-size:10px;color:#a8a29e;margin:1px 0 0">Approved by: ${esc(c.approvingBody)}</p>`:''}
           <div style="margin-top:10px;display:flex;align-items:center;gap:12px">
-            ${c.certificateNumber?`<a href="/api/certificates/${c._id}/download" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#4A7C59;text-decoration:none"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a>`:''}
-            <a href="/interactive-course.html?cert=${c._id}" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#284157;text-decoration:none"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>View</a>
+            ${c.fileUrl?`<a href="#" onclick="viewCert('${c._id}');return false" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#284157;text-decoration:none;cursor:pointer"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>View</a>`:''}
+            ${c.fileUrl?`<a href="#" onclick="downloadCert('${c._id}','${esc(c.title||'certificate')}');return false" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#4A7C59;text-decoration:none;cursor:pointer"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a>`:''}
+            ${c.verificationCode?`<a href="/verify/${c.verificationCode}" target="_blank" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:500;color:#284157;text-decoration:none"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/></svg>Verify</a>`:''}
           </div>
         </div>`;
       }).join('');
@@ -1061,12 +1106,16 @@
     loadAll();
 
     // Handle hash-based tab switching (e.g. #planning from ce-planner redirect)
-    if (location.hash) {
-      const tab = location.hash.replace('#', '');
-      if (document.getElementById('tab-' + tab)) {
-        switchTab(tab);
+    function handleHash() {
+      if (location.hash) {
+        const tab = location.hash.replace('#', '');
+        if (document.getElementById('tab-' + tab)) {
+          switchTab(tab);
+        }
       }
     }
+    handleHash();
+    window.addEventListener('hashchange', handleHash);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaced `client/public/credentials.html` with uploaded version (55 lines added, 6 removed)
- `server/src/routes/certificates.js` was identical to existing — no change

## Test plan
- [ ] Verify credentials page renders correctly
- [ ] Verify certificate routes still function

https://claude.ai/code/session_0153uQSP96ctNpWiqCwGp1KK

---
_Generated by [Claude Code](https://claude.ai/code/session_0153uQSP96ctNpWiqCwGp1KK)_