### PR TITLE
Add block variety audit script and batch course generation prompts

### DIFF
--- a/docs/CC_Batch_Course_Prompts.md
+++ b/docs/CC_Batch_Course_Prompts.md
@@ -1,0 +1,592 @@
+# CounselorReady — CC Batch Course Generation Prompts
+
+**Purpose:** Copy-paste prompts for Claude Code to generate deployment-ready seed scripts with rich interactive content — not text-heavy walls.
+
+**Problem these solve:** Every existing seed script except TMH601/602 is 90%+ `text` + `multipleChoice`. Courses need videos, images, supplemental resources, varied KC types (matching, cardSort, scenarioTree, flashcardDeck, sequencing, fillInBlank, multiSelect), callouts, keyTakeaways, and reflections.
+
+---
+
+## Prompt 1 — Single Rich Course Seed
+
+> **When to use:** Generating one course at a time with full block variety.
+
+```
+Read these files before writing anything:
+- server/src/models/InteractiveCourse.js (schema — authoritative)
+- client/public/interactive-course.html (viewer — grep for renderBlock switch)
+- SEED_AUTHORING_AND_VIEWER_GUIDE.md (if present)
+- GOLD_STANDARD_SPEC.md (if present)
+
+Generate a COMPLETE, deployment-ready seed script for:
+
+Title: [TITLE]
+Course Code: [CODE]
+CE Hours: [X]
+Category: [ethics | clinical | multicultural | supervision | professional_development]
+Topic: [TOPIC DESCRIPTION — 2-3 sentences of what the course covers]
+
+═══ BLOCK VARIETY REQUIREMENTS (non-negotiable) ═══
+
+Every content section (not intro/conclusion) MUST contain ALL of these:
+1. sectionDivider (with title AND subtitle)
+2. 2-4 text blocks (HTML prose, 500-800 words each)
+3. 1 accordion (3-5 items with clinical depth)
+4. 1 callout (rotate types: ethics, clinical, warning, tip, protocol, donot)
+5. 2-3 knowledge checks using DIFFERENT types per section — rotate through:
+   - multipleChoice (options: [{text, isCorrect}], correctAnswer: index)
+   - multiSelect (options: [{text, isCorrect}] — multiple isCorrect:true)
+   - matching (matchingInstructions, matchingPairs: [{term, definition}])
+   - fillInBlank (blanks: [{prompt, answer, acceptAlternates:[]}])
+6. 1 interactive activity — rotate through sections:
+   - flashcardDeck (cards: [{front, back}] — 6-10 cards)
+   - scenarioTree (nodes: [{id, text, choices:[{text, nextId}]}] — real clinical decisions, 4-6 nodes with isEnd:true on terminal nodes)
+   - cardSort (categories:[], items:[{text, category}] — 8-12 items)
+   - sequencing (steps:[{text, order}], instructions, explanation — 5-8 steps)
+7. 1 reflection (prompt: clinically specific question)
+8. 1 keyTakeaway (title, takeaways:["item1","item2"...] — 3-5 items)
+
+MEDIA REQUIREMENTS (per course, not per section):
+- At least 2 videoEmbed blocks across the course:
+  { type: "videoEmbed", title: "...", videoUrl: "https://www.youtube.com/embed/VIDEO_ID",
+    description: "...", accessibility: { ariaLabel: "Video: ...", role: "complementary" } }
+  Use REAL YouTube embed URLs relevant to the topic. Search YouTube for:
+  "[topic] counseling" OR "[topic] mental health professional" OR "[topic] clinical training"
+  Prefer: APA, SAMHSA, NIMH, university lectures, professional conference recordings.
+  If you cannot find a real URL, use a PLACEHOLDER format:
+  "https://www.youtube.com/embed/PLACEHOLDER_[TOPIC_KEYWORD]"
+  and add a comment: // TODO: Replace with verified YouTube URL
+
+- At least 2 imageText blocks across the course:
+  { type: "imageText", content: "<p>HTML prose...</p>",
+    image: "https://res.cloudinary.com/dzfscjhdx/image/upload/v1/counselorready/[descriptive-name]",
+    imageAlt: "...", imagePosition: "left" or "right", highlight: true/false }
+  For images: use descriptive Cloudinary paths. If the image doesn't exist yet, use:
+  image: "" (empty string — renders text-only, no broken image)
+  and add comment: // TODO: Upload to Cloudinary and add URL
+
+- 1 resources block in the final content section (before conclusion):
+  { type: "resources", title: "Professional Resources",
+    resources: [
+      { name: "...", description: "...", url: "https://..." },
+      ...
+    ],
+    accessibility: { ariaLabel: "...", role: "complementary" } }
+  Include 6-10 REAL URLs: professional orgs, gov sites, research databases.
+  Good sources: APA, ACA, SAMHSA, NIMH, NBCC, state licensing boards,
+  peer-reviewed journal landing pages, NICE guidelines, WHO resources.
+
+═══ COURSE-LEVEL STRUCTURE ═══
+
+const COURSE = {
+  title, slug (kebab-case from title), courseCode: "[CODE]",
+  description: "...", // 2-3 sentences
+  ceHours: [X], ceuHours: [X],
+  category: "[category]",
+  difficulty: "intermediate",
+  targetAudience: "Licensed mental health professionals (LPCs, LCSWs, LMFTs, NCCs)",
+  learningObjectives: ["...", "...", "...", "..."], // 4-6 objectives starting with action verbs
+  presenter: {
+    name: "Kejuiana Johnson",
+    credentials: "MA, LPC, NCC, CPCS, BC-TMH",
+    licenseNumber: "LPC009587", licenseState: "Georgia", licenseType: "LPC"
+  },
+  provider: {
+    name: "GA Integrated Therapeutic Perspectives LLC",
+    shortName: "GAITP LLC", acepNumber: "7760", approvalBody: "NBCC"
+  },
+  approvals: [{ body: "NBCC", number: "#7760",
+    hourBreakdown: [{ label: "core", hours: [X] }] }],
+  isPublished: false, status: "draft",
+  sections: [...],           // content sections
+  assessment: { ... },       // final exam
+  references: [{ ... }],     // APA 7th edition
+  wordCount: COMPUTED         // stripped HTML word count
+};
+
+═══ ASSESSMENT ═══
+
+assessment: {
+  title: "Final Assessment — [CODE]: [SHORT TITLE]",
+  passingScore: 80, maxAttempts: 3, shuffleQuestions: true,
+  questions: [
+    { question: "...", type: "multipleChoice",
+      options: [{text:"A",isCorrect:false},{text:"B",isCorrect:true},
+               {text:"C",isCorrect:false},{text:"D",isCorrect:false}],
+      correctAnswer: 1, explanation: "..." },
+    // 15-20 questions, answer distribution: no single index > 40%
+    // Include 2-3 multiSelect questions in the exam too
+  ]
+}
+
+═══ REFERENCES ═══
+
+references: [
+  { title: "Author, A. A. (Year). Article title. Journal, Vol(Issue), pp-pp.",
+    url: "https://doi.org/..." },
+  // 15-20 APA 7th edition references, real DOIs/URLs when possible
+]
+
+═══ SEED WRAPPER ═══
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const SLUG = '[slug]';
+
+// ... COURSE definition with all sections ...
+
+// ═══ SELF-VALIDATION ═══
+function stripHTML(html) { return (html||'').replace(/<[^>]*>/g,' ').replace(/\s+/g,' ').trim(); }
+function countWords(course) {
+  let total = 0;
+  for (const sec of course.sections || []) {
+    for (const b of sec.contentBlocks || []) {
+      if (b.content) total += stripHTML(b.content).split(/\s+/).filter(Boolean).length;
+      if (b.question) total += stripHTML(b.question).split(/\s+/).filter(Boolean).length;
+      if (b.explanation) total += stripHTML(b.explanation).split(/\s+/).filter(Boolean).length;
+      if (b.accordionItems) b.accordionItems.forEach(a => {
+        total += stripHTML(a.title).split(/\s+/).filter(Boolean).length;
+        total += stripHTML(a.content).split(/\s+/).filter(Boolean).length;
+      });
+      if (b.options) b.options.forEach(o => {
+        const t = typeof o === 'string' ? o : o.text || '';
+        total += stripHTML(t).split(/\s+/).filter(Boolean).length;
+      });
+      if (b.cards || b.flashcards) (b.cards || b.flashcards || []).forEach(c => {
+        total += stripHTML(c.front).split(/\s+/).filter(Boolean).length;
+        total += stripHTML(c.back).split(/\s+/).filter(Boolean).length;
+      });
+      // scenarioTree nodes
+      if (b.nodes) b.nodes.forEach(n => {
+        total += stripHTML(n.text).split(/\s+/).filter(Boolean).length;
+        if (n.choices) n.choices.forEach(ch => total += stripHTML(ch.text).split(/\s+/).filter(Boolean).length);
+      });
+    }
+  }
+  return total;
+}
+
+function validate(course) {
+  const errors = [];
+  const wc = countWords(course);
+  const required = course.ceHours * 6000;
+  if (wc < required) errors.push(`CRITICAL: Word count ${wc} < required ${required}`);
+
+  for (const [i, sec] of (course.sections||[]).entries()) {
+    const blocks = sec.contentBlocks || [];
+    const types = blocks.map(b => b.type);
+    if (!types.includes('sectionDivider')) errors.push(`Section ${i+1}: missing sectionDivider`);
+    const kcTypes = types.filter(t => ['multipleChoice','multiSelect','matching','fillInBlank'].includes(t));
+    if (kcTypes.length < 2) errors.push(`Section ${i+1}: only ${kcTypes.length} KC blocks (need 2-3)`);
+    const actTypes = types.filter(t => ['flashcardDeck','scenarioTree','cardSort','sequencing'].includes(t));
+    if (i > 0 && i < (course.sections.length - 1) && actTypes.length < 1)
+      errors.push(`Section ${i+1}: missing interactive activity`);
+  }
+
+  if (!course.assessment?.questions?.length || course.assessment.questions.length < 15)
+    errors.push(`CRITICAL: Assessment has ${course.assessment?.questions?.length || 0} questions (need 15+)`);
+  if (!course.references?.length || course.references.length < 15)
+    errors.push(`CRITICAL: Only ${course.references?.length || 0} references (need 15+)`);
+
+  return { wc, errors };
+}
+
+async function main() {
+  await mongoose.connect(MONGODB_URI);
+  const db = mongoose.connection.db;
+  const col = db.collection('interactivecourses');
+
+  const { wc, errors } = validate(COURSE);
+  console.log(`Word count: ${wc} / ${COURSE.ceHours * 6000} required`);
+  console.log(`Sections: ${COURSE.sections.length}`);
+  console.log(`Assessment: ${COURSE.assessment?.questions?.length || 0} questions`);
+  console.log(`References: ${COURSE.references?.length || 0}`);
+
+  if (errors.filter(e => e.startsWith('CRITICAL')).length > 0) {
+    console.error('\\n❌ CRITICAL ERRORS — refusing to save:');
+    errors.forEach(e => console.error('  ' + e));
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+  if (errors.length) {
+    console.warn('\\n⚠️  Warnings:');
+    errors.forEach(e => console.warn('  ' + e));
+  }
+
+  COURSE.wordCount = wc;
+  const existing = await col.findOne({ slug: SLUG });
+  if (existing) {
+    await col.updateOne({ slug: SLUG }, { $set: { ...COURSE, updatedAt: new Date() } });
+    console.log('\\n✅ Updated existing course');
+  } else {
+    await col.insertOne({ ...COURSE, createdAt: new Date(), updatedAt: new Date() });
+    console.log('\\n✅ Inserted new course');
+  }
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+main().catch(e => { console.error(e.message); process.exit(1); });
+
+═══ FILENAME ═══
+seed[CODE]-[Title_Words]-[wordcount]words.js
+
+═══ CRITICAL RULES ═══
+1. Options are ALWAYS [{text, isCorrect}] — NEVER flat strings
+2. Type names are camelCase exactly: multipleChoice, multiSelect, flashcardDeck, cardSort, scenarioTree, videoEmbed, imageText, sectionDivider, keyTakeaway, fillInBlank
+3. NEVER: multiple_choice, quiz, knowledgeCheck (wrapper), text_block
+4. No ACEP metadata inside content blocks
+5. No via.placeholder.com URLs
+6. Navy is #284157 — NEVER #34495E
+7. All content embedded as string literals — no fs.readFileSync, no API calls
+8. ES module syntax (import, not require)
+9. Ship as draft (isPublished: false, status: "draft")
+10. Script uses process.env.MONGODB_URI — no hardcoded connection strings
+```
+
+---
+
+## Prompt 2 — Batch of 3-5 Courses (Sequential)
+
+> **When to use:** Generating a themed series or filling catalog gaps. Give CC a list and it writes them one file at a time.
+
+```
+Read these files first:
+- server/src/models/InteractiveCourse.js
+- client/public/interactive-course.html (grep for the renderBlock switch to confirm supported types)
+- SEED_AUTHORING_AND_VIEWER_GUIDE.md
+- GOLD_STANDARD_SPEC.md
+
+I need seed scripts for the following courses. Generate each as a SEPARATE file.
+Follow the block variety requirements below for EVERY course.
+
+═══ COURSE LIST ═══
+
+1. [CODE] | [TITLE] | [X] CE | [category]
+2. [CODE] | [TITLE] | [X] CE | [category]
+3. [CODE] | [TITLE] | [X] CE | [category]
+4. [CODE] | [TITLE] | [X] CE | [category]
+5. [CODE] | [TITLE] | [X] CE | [category]
+
+═══ BLOCK VARIETY MATRIX (per section) ═══
+
+Each content section must have:
+- 1 sectionDivider (title + subtitle)
+- 2-4 text blocks (500-800 words each, HTML)
+- 1 accordion (3-5 items)
+- 1 callout (rotate: ethics, clinical, warning, tip, protocol, donot)
+- 2-3 KC blocks — use DIFFERENT types per section, rotating:
+  • multipleChoice: { question, options:[{text,isCorrect}], correctAnswer:N, explanation }
+  • multiSelect: { question, options:[{text,isCorrect}], explanation } (2+ correct)
+  • matching: { matchingInstructions, matchingPairs:[{term,definition}] }
+  • fillInBlank: { title, blanks:[{prompt,answer,acceptAlternates:[]}] }
+- 1 interactive activity — rotate across sections:
+  • flashcardDeck: { title, cards:[{front,back}] } (6-10 cards)
+  • scenarioTree: { title, description, nodes:[{id,text,choices:[{text,nextId}],isEnd?}] }
+  • cardSort: { instructions, categories:[], items:[{text,category}] } (8-12 items)
+  • sequencing: { instructions, steps:[{text,order:N}], explanation } (5-8 steps)
+- 1 reflection (prompt: specific clinical question)
+- 1 keyTakeaway (title, takeaways:["...", "..."] 3-5 items)
+
+═══ MEDIA PER COURSE ═══
+
+- 2+ videoEmbed blocks (real YouTube embed URLs for clinical/CE content, or PLACEHOLDER with TODO)
+- 2+ imageText blocks (Cloudinary URL or empty string with TODO comment)
+- 1 resources block with 6-10 real professional URLs (APA, ACA, SAMHSA, etc.)
+
+═══ PER-COURSE OUTPUT ═══
+
+For each course, create file: server/src/scripts/seed[CODE]-[Title]-[wordcount]words.js
+
+Include the self-validation function (countWords + validate) in every file.
+Set isPublished: false, status: "draft".
+Include presenter and provider metadata.
+Include 15-20 assessment questions (with 2-3 multiSelect in the exam).
+Include 15-20 APA 7th edition references with real DOIs/URLs.
+
+Generate Course 1 first. After I confirm, generate Course 2. Continue until all done.
+
+═══ CRITICAL RULES ═══
+- Options: ALWAYS [{text, isCorrect}] objects — NEVER flat strings
+- Type names: camelCase exactly (multipleChoice, NOT multiple_choice)
+- Never use: quiz, knowledgeCheck (as wrapper), multiple_choice
+- Navy: #284157 — NEVER #34495E
+- ES module syntax, process.env.MONGODB_URI, process.exit
+- All content as string literals — no API calls or file reads
+- Section blocks ordered: divider → text → activity → text → KC → reflection → keyTakeaway
+- No ACEP metadata inside content blocks
+```
+
+---
+
+## Prompt 3 — Enrich Existing Thin Course
+
+> **When to use:** An existing seed script is text-heavy and needs block variety added without rewriting prose.
+
+```
+Read this seed script: server/src/scripts/[FILENAME]
+
+This course is text-heavy — it needs interactive block variety added WITHOUT
+rewriting or removing existing prose. The prose is authoritative; never shorten it.
+
+For EACH content section, ADD the following blocks interleaved with existing text
+(don't stack them at the end):
+
+1. 1 accordion — derived from a taxonomy, list, or multi-point concept already in the text
+2. 1 callout — extract a critical clinical point, ethical mandate, or warning from the text
+3. 1-2 additional KC blocks beyond what exists. Use types NOT already in the section:
+   - If section has multipleChoice → add matching or fillInBlank or multiSelect
+   - matching: { matchingInstructions, matchingPairs:[{term,definition}] }
+   - fillInBlank: { title, blanks:[{prompt,answer,acceptAlternates:[]}] }
+   - multiSelect: { question, options:[{text,isCorrect}], explanation }
+4. 1 interactive activity derived from the prose:
+   - Categories in the text → cardSort
+   - Clinical terminology → flashcardDeck
+   - Decision points → scenarioTree (only if real clinical decisions exist)
+   - Ordered processes/protocols → sequencing
+5. 1 keyTakeaway (takeaways:["...", "..."] — summarize the section's key points)
+6. 1 reflection (clinically specific prompt)
+
+ALSO add across the whole course:
+- 2 videoEmbed blocks (real YouTube URLs or PLACEHOLDER with TODO)
+- 2 imageText blocks (empty image string + TODO, with meaningful prose)
+- 1 resources block in the last content section
+
+Fix any wrong type names:
+- multiple_choice → multipleChoice
+- quiz → move questions into course.assessment
+- knowledgeCheck (wrapper) → expand into individual multipleChoice blocks
+- Flat string options → [{text, isCorrect}] objects
+
+Show me the enrichment plan section-by-section before writing the updated file.
+Run the self-validation checks at the end.
+```
+
+---
+
+## Prompt 4 — Batch Enrichment (Fix All Thin Courses)
+
+> **When to use:** Auditing and enriching all courses in the DB that lack block variety.
+
+```
+Read server/src/models/InteractiveCourse.js first.
+
+Write a diagnostic script (server/src/scripts/auditBlockVariety.js) that:
+
+1. Connects to MongoDB via process.env.MONGODB_URI
+2. Reads every document in interactivecourses
+3. For each course, counts block types per section:
+   - text, accordion, callout, keyTakeaway, reflection
+   - KC types: multipleChoice, multiSelect, matching, fillInBlank
+   - Activities: flashcardDeck, scenarioTree, cardSort, sequencing
+   - Media: videoEmbed, video, imageText, image, resources
+4. Flags courses as:
+   - 🔴 THIN: any section with 0 interactive activities AND 0 varied KC types (only multipleChoice)
+   - 🟡 PARTIAL: has some variety but missing media (no videoEmbed, no resources)
+   - 🟢 RICH: meets all variety requirements
+5. Also flags wrong type names: multiple_choice, quiz, knowledgeCheck
+6. Outputs a table:
+
+   Course Code | Status | Sections | text% | KC variety | Activities | Media | Wrong Types
+   CR-ETH301   | 🔴 THIN | 6       | 92%   | MC only    | 0          | 0     | —
+   CR-TMH601   | 🟢 RICH | 13      | 45%   | 5 types    | 8          | 4     | —
+
+7. At the end, prints the list of 🔴 THIN courses that need enrichment, sorted by
+   fewest block types first (worst → best).
+
+ES module syntax. Read-only (no writes). Run with: node src/scripts/auditBlockVariety.js
+```
+
+---
+
+## Block Shape Quick Reference (Verified Against Viewer)
+
+These are the EXACT field shapes the CReady Viewer renders. Using anything else = "Unsupported block type" card.
+
+```js
+// ── sectionDivider ──
+{ type: "sectionDivider", title: "...", subtitle: "...", sectionNumber: N }
+
+// ── text ──
+{ type: "text", content: "<p>HTML prose here</p>" }
+
+// ── imageText ──
+{ type: "imageText", content: "<p>HTML prose</p>",
+  image: "https://...", imageAlt: "...", imagePosition: "left"|"right", highlight: true|false }
+
+// ── image ──
+{ type: "image", imageUrl: "https://...", imageAltText: "...", imageCaption: "...",
+  imageSize: "small"|"medium"|"full", imageAlignment: "left"|"center"|"right" }
+
+// ── accordion ──
+{ type: "accordion", accordionItems: [{ title: "...", content: "<p>HTML</p>" }] }
+
+// ── multipleChoice ──
+{ type: "multipleChoice", question: "...",
+  options: [{ text: "...", isCorrect: false }, { text: "...", isCorrect: true }, ...],
+  correctAnswer: 1, // 0-based index of correct option
+  explanation: "..." }
+
+// ── multiSelect ──
+{ type: "multiSelect", question: "... (Select all that apply)",
+  options: [{ text: "...", isCorrect: true }, { text: "...", isCorrect: false }, ...],
+  explanation: "..." }  // 2+ options have isCorrect:true
+
+// ── matching ──
+{ type: "matching", matchingInstructions: "...",
+  matchingPairs: [{ term: "...", definition: "..." }, ...] }
+
+// ── fillInBlank ──
+{ type: "fillInBlank", title: "...",
+  blanks: [{ prompt: "...", answer: "...", acceptAlternates: ["...", "..."] }] }
+
+// ── flashcardDeck ──
+{ type: "flashcardDeck", title: "...",
+  cards: [{ front: "...", back: "..." }, ...],  // 6-10 cards
+  accessibility: { ariaLabel: "...", role: "application" } }
+
+// ── scenarioTree ──
+{ type: "scenarioTree", title: "...", description: "...",
+  nodes: [
+    { id: "start", text: "...", choices: [{ text: "...", nextId: "node2" }, ...] },
+    { id: "node2", text: "...", choices: [...] },
+    { id: "end1", text: "...", isEnd: true }
+  ],
+  accessibility: { ariaLabel: "...", role: "application" } }
+
+// ── cardSort ──
+{ type: "cardSort", instructions: "...",
+  categories: ["Cat A", "Cat B", "Cat C"],
+  items: [{ text: "...", category: "Cat A" }, ...],  // 8-12 items
+  accessibility: { ariaLabel: "...", role: "application" } }
+
+// ── sequencing ──
+{ type: "sequencing", instructions: "...",
+  steps: [{ text: "Step description", order: 1 }, { text: "...", order: 2 }, ...],  // 5-8 steps
+  explanation: "Correct order explanation" }
+
+// ── timeline ──
+{ type: "timeline", title: "...",
+  events: [{ year: "1990", text: "<p>HTML description</p>" }, ...] }
+
+// ── hotspot ──  (needs a real image URL)
+{ type: "hotspot", instructions: "...",
+  hotspotImage: "https://...", imageDescription: "...",
+  hotspots: [{ label: "...", x: 25, y: 30, description: "..." }, ...] }
+
+// ── videoEmbed / video ──
+{ type: "videoEmbed", title: "...",
+  videoUrl: "https://www.youtube.com/embed/VIDEO_ID",
+  description: "...",
+  accessibility: { ariaLabel: "Video: ...", role: "complementary" } }
+
+// ── resources ──
+{ type: "resources", title: "Professional Resources",
+  resources: [{ name: "...", description: "...", url: "https://..." }, ...],
+  accessibility: { ariaLabel: "...", role: "complementary" } }
+
+// ── reflection ──
+{ type: "reflection", prompt: "Clinically specific reflection question..." }
+
+// ── callout ──
+{ type: "callout", title: "...", calloutType: "info"|"warning"|"ethics"|"clinical"|"tip"|"key"|"donot"|"protocol",
+  content: "<p>HTML body</p>",
+  calloutItems: ["bullet 1", "bullet 2"] }  // optional list items
+
+// ── keyTakeaway ──
+{ type: "keyTakeaway", title: "Key Takeaways",
+  takeaways: ["Point 1", "Point 2", "Point 3"] }
+```
+
+---
+
+## Section Rhythm Template
+
+Each content section should follow this rhythm (not rigid, but the general flow):
+
+```
+sectionDivider
+text (intro prose ~500 words)
+callout (highlight a critical point from the intro)
+text (deeper clinical content ~600 words)
+accordion (expand on a framework/taxonomy from the text)
+imageText (visual + prose — or text-only if no image yet)
+multipleChoice or multiSelect (test comprehension of prose above)
+text (case material, research, clinical application ~500 words)
+flashcardDeck | cardSort | scenarioTree | sequencing (rotate per section)
+matching or fillInBlank (second KC type, different from above)
+reflection
+keyTakeaway
+```
+
+---
+
+## Pre-Built Course Topics for Batch Generation
+
+Ready-to-paste course lists for Prompt 2:
+
+### Batch A — Ethics & Law (10 CE)
+```
+1. CR-ETH-401 | Dual Relationships and Boundary Crossings in Rural Practice | 3 CE | ethics
+2. CR-ETH-402 | Informed Consent in the Digital Age | 2 CE | ethics
+3. CR-ETH-403 | Ethical Practice with LGBTQ+ Clients | 3 CE | ethics
+4. CR-ETH-404 | Documentation and Record-Keeping for Legal Protection | 2 CE | ethics
+```
+
+### Batch B — Clinical Skills (10 CE)
+```
+1. CR-CLI-501 | Attachment Theory in Adult Psychotherapy | 3 CE | clinical
+2. CR-CLI-502 | Somatic Approaches to Trauma Processing | 2 CE | clinical
+3. CR-CLI-503 | Working with Grief and Complicated Bereavement | 3 CE | clinical
+4. CR-CLI-504 | Motivational Interviewing for Substance Use Disorders | 2 CE | clinical
+```
+
+### Batch C — Specialty Populations (8 CE)
+```
+1. CR-POP-601 | Counseling Military Veterans and First Responders | 3 CE | clinical
+2. CR-POP-602 | Adolescent Mental Health in the Social Media Era | 2 CE | clinical
+3. CR-POP-603 | Perinatal Mental Health for Non-Specialists | 3 CE | clinical
+```
+
+### Batch D — Supervision & Professional Development (6 CE)
+```
+1. CR-SUP-701 | Clinical Supervision Models and Best Practices | 3 CE | supervision
+2. CR-SUP-702 | Developing Your Private Practice Business Plan | 3 CE | professional_development
+```
+
+---
+
+## Validation Checklist (Run After Every Seed)
+
+Before committing any seed script, verify:
+
+```bash
+# 1. Check for wrong type names
+grep -c "multiple_choice\|knowledgeCheck\|quiz" server/src/scripts/seed[NEW].js
+# Should return 0
+
+# 2. Check for flat string options
+grep -c "options: \[\"" server/src/scripts/seed[NEW].js
+# Should return 0
+
+# 3. Count block type variety
+grep "type:" server/src/scripts/seed[NEW].js | sed 's/.*type: *"\([^"]*\)".*/\1/' | sort | uniq -c | sort -rn
+# Should show 8+ different types
+
+# 4. Check media blocks exist
+grep -c "videoEmbed\|imageText\|resources" server/src/scripts/seed[NEW].js
+# Should be 5+
+
+# 5. Run the script in dry mode (will validate before saving)
+node server/src/scripts/seed[NEW].js
+# Should print word count, section count, assessment count, reference count
+# Should NOT show CRITICAL errors
+```
+
+---
+
+*CounselorReady · GAITP LLC · NBCC ACEP #7760 · counselorready.com*

--- a/server/src/scripts/auditBlockVariety.js
+++ b/server/src/scripts/auditBlockVariety.js
@@ -1,0 +1,189 @@
+// auditBlockVariety.js — Read-only diagnostic: block type variety across all courses
+// Run: node src/scripts/auditBlockVariety.js (from server/)
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const KC_TYPES = new Set(['multipleChoice', 'multiSelect', 'matching', 'fillInBlank']);
+const ACTIVITY_TYPES = new Set(['flashcardDeck', 'scenarioTree', 'cardSort', 'sequencing', 'timeline', 'hotspot']);
+const MEDIA_TYPES = new Set(['videoEmbed', 'video', 'imageText', 'image', 'resources']);
+const WRONG_TYPES = new Set(['multiple_choice', 'quiz', 'knowledgeCheck', 'text_block']);
+
+async function main() {
+  await mongoose.connect(MONGODB_URI);
+  const db = mongoose.connection.db;
+  const courses = await db.collection('interactivecourses').find({}).toArray();
+
+  console.log(`\n═══ CounselorReady Block Variety Audit ═══`);
+  console.log(`Courses found: ${courses.length}\n`);
+
+  const results = [];
+
+  for (const course of courses) {
+    const sections = course.sections || [];
+    const allBlocks = sections.flatMap(s => s.contentBlocks || []);
+    const totalBlocks = allBlocks.length;
+
+    // Count by type
+    const typeCounts = {};
+    const wrongFound = [];
+    let textCount = 0;
+    const kcVariety = new Set();
+    const activityVariety = new Set();
+    const mediaFound = new Set();
+
+    for (const block of allBlocks) {
+      const t = block.type || 'unknown';
+      typeCounts[t] = (typeCounts[t] || 0) + 1;
+
+      if (t === 'text') textCount++;
+      if (KC_TYPES.has(t)) kcVariety.add(t);
+      if (ACTIVITY_TYPES.has(t)) activityVariety.add(t);
+      if (MEDIA_TYPES.has(t)) mediaFound.add(t);
+      if (WRONG_TYPES.has(t)) wrongFound.push(t);
+
+      // Check for flat string options (common error)
+      if (block.options?.length && typeof block.options[0] === 'string') {
+        wrongFound.push('flat_options');
+      }
+    }
+
+    // Assessment check
+    const assessQs = course.assessment?.questions?.length || 0;
+    const refs = course.references?.length || 0;
+
+    // Per-section detail
+    const sectionIssues = [];
+    for (const [i, sec] of sections.entries()) {
+      const blocks = sec.contentBlocks || [];
+      const types = blocks.map(b => b.type);
+      const secKC = types.filter(t => KC_TYPES.has(t));
+      const secAct = types.filter(t => ACTIVITY_TYPES.has(t));
+      const secMedia = types.filter(t => MEDIA_TYPES.has(t));
+      const hasDivider = types.includes('sectionDivider');
+      const hasReflection = types.includes('reflection');
+      const hasAccordion = types.includes('accordion');
+      const hasCallout = types.includes('callout');
+      const hasKeyTakeaway = types.includes('keyTakeaway');
+
+      const missing = [];
+      if (!hasDivider) missing.push('sectionDivider');
+      if (secKC.length < 2) missing.push(`KC(${secKC.length}/2)`);
+      if (secAct.length < 1 && i > 0 && i < sections.length - 1) missing.push('activity');
+      if (!hasReflection) missing.push('reflection');
+      if (!hasAccordion && i > 0 && i < sections.length - 1) missing.push('accordion');
+      if (!hasCallout && i > 0 && i < sections.length - 1) missing.push('callout');
+      if (!hasKeyTakeaway) missing.push('keyTakeaway');
+
+      if (missing.length) {
+        sectionIssues.push({ section: i + 1, title: sec.title || `Section ${i + 1}`, missing });
+      }
+    }
+
+    // Status determination
+    const textPct = totalBlocks > 0 ? Math.round((textCount / totalBlocks) * 100) : 0;
+    const uniqueWrong = [...new Set(wrongFound)];
+    let status;
+    if (kcVariety.size >= 3 && activityVariety.size >= 2 && mediaFound.size >= 2) {
+      status = '🟢 RICH';
+    } else if (kcVariety.size >= 2 || activityVariety.size >= 1) {
+      status = '🟡 PARTIAL';
+    } else {
+      status = '🔴 THIN';
+    }
+
+    results.push({
+      code: course.courseCode || course.slug || '(no code)',
+      title: (course.title || '').substring(0, 45),
+      ceHours: course.ceHours || course.ceuHours || '?',
+      status,
+      sections: sections.length,
+      totalBlocks,
+      textPct,
+      kcVariety: [...kcVariety].join(', ') || 'none',
+      kcCount: kcVariety.size,
+      activityVariety: [...activityVariety].join(', ') || 'none',
+      actCount: activityVariety.size,
+      media: [...mediaFound].join(', ') || 'none',
+      mediaCount: mediaFound.size,
+      wrongTypes: uniqueWrong.join(', ') || '—',
+      assessQs,
+      refs,
+      sectionIssues,
+      isPublished: course.isPublished || false,
+      slug: course.slug
+    });
+  }
+
+  // Sort: THIN first, then PARTIAL, then RICH
+  const order = { '🔴 THIN': 0, '🟡 PARTIAL': 1, '🟢 RICH': 2 };
+  results.sort((a, b) => (order[a.status] ?? 3) - (order[b.status] ?? 3));
+
+  // Print summary table
+  console.log('Code'.padEnd(16) + 'Status'.padEnd(12) + 'CE'.padEnd(4) + 'Sec'.padEnd(5) +
+    'Blks'.padEnd(6) + 'Txt%'.padEnd(6) + 'KC Types'.padEnd(10) + 'Activities'.padEnd(12) +
+    'Media'.padEnd(8) + 'Exam'.padEnd(6) + 'Refs'.padEnd(6) + 'Wrong Types');
+  console.log('─'.repeat(105));
+
+  for (const r of results) {
+    console.log(
+      r.code.padEnd(16) +
+      r.status.padEnd(12) +
+      String(r.ceHours).padEnd(4) +
+      String(r.sections).padEnd(5) +
+      String(r.totalBlocks).padEnd(6) +
+      (r.textPct + '%').padEnd(6) +
+      String(r.kcCount).padEnd(10) +
+      String(r.actCount).padEnd(12) +
+      String(r.mediaCount).padEnd(8) +
+      String(r.assessQs).padEnd(6) +
+      String(r.refs).padEnd(6) +
+      r.wrongTypes
+    );
+  }
+
+  // Print THIN courses needing enrichment
+  const thin = results.filter(r => r.status === '🔴 THIN');
+  const partial = results.filter(r => r.status === '🟡 PARTIAL');
+
+  if (thin.length) {
+    console.log(`\n\n═══ 🔴 COURSES NEEDING FULL ENRICHMENT (${thin.length}) ═══\n`);
+    for (const r of thin) {
+      console.log(`  ${r.code} — ${r.title} (${r.ceHours}CE, ${r.totalBlocks} blocks, ${r.textPct}% text)`);
+      console.log(`    KC: ${r.kcVariety} | Activities: ${r.activityVariety} | Media: ${r.media}`);
+      if (r.wrongTypes !== '—') console.log(`    ⚠️  Wrong types: ${r.wrongTypes}`);
+      if (r.sectionIssues.length) {
+        for (const si of r.sectionIssues.slice(0, 3)) {
+          console.log(`    Section ${si.section}: missing ${si.missing.join(', ')}`);
+        }
+        if (r.sectionIssues.length > 3) console.log(`    ... and ${r.sectionIssues.length - 3} more sections with issues`);
+      }
+      console.log();
+    }
+  }
+
+  if (partial.length) {
+    console.log(`\n═══ 🟡 COURSES NEEDING MEDIA/VARIETY BOOST (${partial.length}) ═══\n`);
+    for (const r of partial) {
+      console.log(`  ${r.code} — ${r.title} (${r.ceHours}CE)`);
+      console.log(`    Has: KC(${r.kcVariety}), Act(${r.activityVariety}), Media(${r.media})`);
+      if (r.wrongTypes !== '—') console.log(`    ⚠️  Wrong types: ${r.wrongTypes}`);
+      console.log();
+    }
+  }
+
+  const rich = results.filter(r => r.status === '🟢 RICH');
+  console.log(`\n═══ SUMMARY ═══`);
+  console.log(`  🔴 THIN:    ${thin.length} courses need full enrichment`);
+  console.log(`  🟡 PARTIAL: ${partial.length} courses need media/variety boost`);
+  console.log(`  🟢 RICH:    ${rich.length} courses meet variety requirements`);
+  console.log(`  Total:      ${results.length} courses\n`);
+
+  await mongoose.disconnect();
+}
+
+main().catch(e => { console.error(e.message); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds `server/src/scripts/auditBlockVariety.js` — read-only diagnostic script that connects to MongoDB and categorises every course as 🟢 RICH / 🟡 PARTIAL / 🔴 THIN based on KC variety, interactive activity count, and media block count. Also flags wrong type names (`multiple_choice`, `quiz`, `knowledgeCheck`) and flat-string options arrays.
- Adds `docs/CC_Batch_Course_Prompts.md` — copy-paste Claude Code prompts for generating single courses, batches of 3–5 courses, enriching thin existing courses, and running a batch enrichment audit. Includes verified block shape quick-reference and section rhythm template.

## Test plan

- [ ] Run `node src/scripts/auditBlockVariety.js` from `server/` with `MONGODB_URI` set — should print summary table and THIN/PARTIAL/RICH lists without writing any data
- [ ] Confirm no existing files were modified (`git diff --stat main` shows exactly 2 new files)

https://claude.ai/code/session_011dFHqWsQTC1c74UdfNnuuY

---
_Generated by [Claude Code](https://claude.ai/code/session_011dFHqWsQTC1c74UdfNnuuY)_