### PR TITLE
Add 40-course production queue and streamlined batch generation spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,19 +417,9 @@ EVERY session, without exception:
 
 ---
 
-## Batch Course Generation (Autonomous Pipeline)
-
-When the user says anything like "generate courses", "batch courses", "new course batch",
-"write me [N] courses on [topic]", or gives a topic + CE hours + count:
-
-1. **Read `docs/BATCH_COURSE_GEN.md`** — this is the full autonomous pipeline spec
-2. **Ask exactly 3 questions** (skip any already answered):
-   - Subject area or topic?
-   - CE hours per course?
-   - How many courses?
-3. **Generate all courses without stopping for confirmation between them**
-4. Each seed file goes in `server/src/scripts/`, includes self-validation, refuses to save on CRITICAL errors
-5. Print summary table when done
-
-Do NOT ask for approval between courses. Do NOT stop to show outlines. Generate → validate → next.
-The user wants hands-off batch production, not a review cycle.
+## Batch Course Generation
+When Ke says "generate courses", "next batch", "run week N", "next 10", or gives a topic + CE hours + count:
+1. Read `docs/BATCH_COURSE_GENERATION.md` — follow end-to-end
+2. Read `docs/COURSE_PRODUCTION_QUEUE.md` — find next pending week
+3. Generate all 10 courses autonomously. No pausing. No confirmation between courses.
+4. Update queue status. Commit to feature branch.

--- a/docs/BATCH_COURSE_GENERATION.md
+++ b/docs/BATCH_COURSE_GENERATION.md
@@ -1,0 +1,262 @@
+# CC Task: Batch Course Generation (Autonomous)
+
+**Location:** `docs/BATCH_COURSE_GENERATION.md`
+**Queue:** `docs/COURSE_PRODUCTION_QUEUE.md`
+
+---
+
+## Trigger
+
+Any phrasing like "generate courses", "next batch", "run week X", "next 10", "go".
+
+---
+
+## Step 1 — Determine What to Generate
+
+**Option A — Queue mode (default):**
+Read `docs/COURSE_PRODUCTION_QUEUE.md`. Find the first week with `[ ]` courses. Generate ALL courses in that week (10 courses). No confirmation needed.
+
+**Option B — Custom request:**
+If Ke specifies a topic, CE hours, and count instead of "next batch", generate those. Ask for any of the three that are missing — in one message, not three.
+
+**Option C — "run week N":**
+Jump to week N in the queue regardless of earlier weeks' status.
+
+After determining the course list, proceed to Step 2. Do NOT ask for confirmation.
+
+---
+
+## Step 2 — Read Required Files (silent)
+
+```bash
+cat server/src/models/InteractiveCourse.js
+grep -A2 "case '" client/public/interactive-course.html | head -60
+cat docs/SEED_AUTHORING_AND_VIEWER_GUIDE.md 2>/dev/null || true
+```
+
+---
+
+## Step 3 — Generate All Seed Scripts (no pausing between courses)
+
+For each course in the batch, create a complete seed script in `server/src/scripts/`.
+
+### File naming
+```
+seed[CODE]-[Title_Slug]-[wordcount]words.js
+```
+
+### Course metadata (same for all courses)
+```js
+presenter: {
+  name: "Kejuiana Johnson",
+  credentials: "MA, LPC, NCC, CPCS, BC-TMH",
+  licenseNumber: "LPC009587", licenseState: "Georgia", licenseType: "LPC"
+},
+provider: {
+  name: "GA Integrated Therapeutic Perspectives LLC",
+  shortName: "GAITP LLC", acepNumber: "7760", approvalBody: "NBCC"
+},
+approvals: [{ body: "NBCC", number: "#7760",
+  hourBreakdown: [{ label: "core", hours: X }] }],
+isPublished: false, status: "draft",
+difficulty: "intermediate",
+targetAudience: "Licensed mental health professionals (LPCs, LCSWs, LMFTs, NCCs)",
+```
+
+### Section count
+`ceHours + 1` sections (1 intro + 1 per CE hour)
+
+### Per-section block requirements (MANDATORY)
+
+Every content section gets ALL of:
+
+| Block | Count | Rotation Rule |
+|-------|-------|--------------|
+| `sectionDivider` | 1 | title + subtitle + sectionNumber |
+| `text` | 2-4 | HTML prose, 500-800 words each |
+| `accordion` | 1 | 3-5 items derived from prose |
+| `callout` | 1 | Rotate type: ethics → clinical → warning → tip → protocol → donot |
+| KC blocks | 2-3 | **Different types per section.** Rotate: multipleChoice → multiSelect → matching → fillInBlank |
+| Interactive activity | 1 | **Different per section.** Rotate: flashcardDeck → scenarioTree → cardSort → sequencing |
+| `reflection` | 1 | Clinically specific prompt |
+| `keyTakeaway` | 1 | 3-5 bullet points |
+
+### Media (per course)
+
+| Block | Count | Notes |
+|-------|-------|-------|
+| `videoEmbed` | 2+ | Real YouTube embed URLs or `PLACEHOLDER_[keyword]` with TODO |
+| `imageText` | 2+ | `image: ""` with TODO comment (renders text-only) |
+| `resources` | 1 | Final content section. 6-10 real URLs (APA, ACA, SAMHSA, NIMH, etc.) |
+
+### Block shapes reference
+
+```js
+{ type: "sectionDivider", title: "...", subtitle: "...", sectionNumber: N }
+{ type: "text", content: "<p>HTML</p>" }
+{ type: "imageText", content: "<p>HTML</p>", image: "", imageAlt: "...", imagePosition: "left"|"right" }
+{ type: "accordion", accordionItems: [{ title: "...", content: "<p>HTML</p>" }] }
+{ type: "multipleChoice", question: "...", options: [{ text: "...", isCorrect: false },...], correctAnswer: N, explanation: "..." }
+{ type: "multiSelect", question: "...", options: [{ text: "...", isCorrect: true|false },...], explanation: "..." }
+{ type: "matching", matchingInstructions: "...", matchingPairs: [{ term: "...", definition: "..." }] }
+{ type: "fillInBlank", title: "...", blanks: [{ prompt: "...", answer: "...", acceptAlternates: [] }] }
+{ type: "flashcardDeck", title: "...", cards: [{ front: "...", back: "..." }], accessibility: { ariaLabel: "...", role: "application" } }
+{ type: "scenarioTree", title: "...", description: "...", nodes: [{ id: "start", text: "...", choices: [{ text: "...", nextId: "..." }] }, { id: "...", text: "...", isEnd: true }], accessibility: { ariaLabel: "...", role: "application" } }
+{ type: "cardSort", instructions: "...", categories: [...], items: [{ text: "...", category: "..." }], accessibility: { ariaLabel: "...", role: "application" } }
+{ type: "sequencing", instructions: "...", steps: [{ text: "...", order: N }], explanation: "..." }
+{ type: "videoEmbed", title: "...", videoUrl: "https://www.youtube.com/embed/...", description: "...", accessibility: { ariaLabel: "...", role: "complementary" } }
+{ type: "resources", title: "...", resources: [{ name: "...", description: "...", url: "..." }], accessibility: { ariaLabel: "...", role: "complementary" } }
+{ type: "reflection", prompt: "..." }
+{ type: "callout", title: "...", calloutType: "ethics"|"clinical"|"warning"|"tip"|"protocol"|"donot", content: "<p>HTML</p>" }
+{ type: "keyTakeaway", title: "Key Takeaways", takeaways: ["...", "..."] }
+```
+
+### Section rhythm
+```
+sectionDivider → text → callout → text → accordion → imageText(if slot) →
+KC-type-A → text → interactive-activity → KC-type-B → reflection → keyTakeaway
+```
+
+### Assessment
+```js
+assessment: {
+  title: "Final Assessment — [CODE]: [SHORT TITLE]",
+  passingScore: 80, maxAttempts: 3, shuffleQuestions: true,
+  questions: [ /* 15-20 Qs, mix MC + multiSelect, no index >40% */ ]
+}
+```
+
+### References
+```js
+references: [ /* 15-20 APA 7th, real DOIs/URLs */ ]
+```
+
+### Self-validation + seed wrapper (include in EVERY file)
+
+```js
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+const SLUG = '[slug]';
+
+// ... COURSE definition ...
+
+function stripHTML(h){return(h||'').replace(/<[^>]*>/g,' ').replace(/\s+/g,' ').trim();}
+function countWords(c){let t=0;for(const s of c.sections||[])for(const b of s.contentBlocks||[]){
+  if(b.content)t+=stripHTML(b.content).split(/\s+/).filter(Boolean).length;
+  if(b.question)t+=stripHTML(b.question).split(/\s+/).filter(Boolean).length;
+  if(b.explanation)t+=stripHTML(b.explanation).split(/\s+/).filter(Boolean).length;
+  if(b.accordionItems)b.accordionItems.forEach(a=>{t+=stripHTML(a.title).split(/\s+/).filter(Boolean).length;t+=stripHTML(a.content).split(/\s+/).filter(Boolean).length;});
+  if(b.options)b.options.forEach(o=>t+=stripHTML(typeof o==='string'?o:o.text||'').split(/\s+/).filter(Boolean).length);
+  if(b.cards||b.flashcards)(b.cards||b.flashcards||[]).forEach(c=>{t+=stripHTML(c.front).split(/\s+/).filter(Boolean).length;t+=stripHTML(c.back).split(/\s+/).filter(Boolean).length;});
+  if(b.nodes)b.nodes.forEach(n=>{t+=stripHTML(n.text).split(/\s+/).filter(Boolean).length;if(n.choices)n.choices.forEach(ch=>t+=stripHTML(ch.text).split(/\s+/).filter(Boolean).length);});
+  if(b.matchingPairs)b.matchingPairs.forEach(p=>{t+=stripHTML(p.term).split(/\s+/).filter(Boolean).length;t+=stripHTML(p.definition).split(/\s+/).filter(Boolean).length;});
+  if(b.steps)b.steps.forEach(s=>t+=stripHTML(s.text).split(/\s+/).filter(Boolean).length);
+  if(b.takeaways)b.takeaways.forEach(tk=>t+=stripHTML(tk).split(/\s+/).filter(Boolean).length);
+  if(b.blanks)b.blanks.forEach(bl=>{t+=stripHTML(bl.prompt).split(/\s+/).filter(Boolean).length;t+=stripHTML(bl.answer).split(/\s+/).filter(Boolean).length;});
+  if(b.resources)b.resources.forEach(r=>{t+=stripHTML(r.name||'').split(/\s+/).filter(Boolean).length;t+=stripHTML(r.description||'').split(/\s+/).filter(Boolean).length;});
+}return t;}
+
+function validate(c){const e=[];const wc=countWords(c);if(wc<c.ceHours*6000)e.push('CRITICAL:words');
+for(const[i,s]of(c.sections||[]).entries()){const t=(s.contentBlocks||[]).map(b=>b.type);
+if(!t.includes('sectionDivider'))e.push(`S${i+1}:divider`);
+if(t.filter(x=>['multipleChoice','multiSelect','matching','fillInBlank'].includes(x)).length<2)e.push(`S${i+1}:KC<2`);
+if(t.filter(x=>['flashcardDeck','scenarioTree','cardSort','sequencing'].includes(x)).length<1&&i>0&&i<c.sections.length-1)e.push(`S${i+1}:activity`);
+for(const b of s.contentBlocks||[])if(b.options?.length&&typeof b.options[0]==='string')e.push('CRITICAL:flat_options');}
+if((c.assessment?.questions?.length||0)<15)e.push('CRITICAL:exam<15');
+if((c.references?.length||0)<15)e.push('CRITICAL:refs<15');return{wc,e};}
+
+async function main(){
+  await mongoose.connect(MONGODB_URI);const db=mongoose.connection.db;const col=db.collection('interactivecourses');
+  const{wc,e}=validate(COURSE);COURSE.wordCount=wc;
+  console.log(`${COURSE.courseCode}|${wc}w/${COURSE.ceHours*6000}req|${COURSE.sections.length}sec|${COURSE.assessment?.questions?.length}exam|${COURSE.references?.length}refs`);
+  const crit=e.filter(x=>x.startsWith('CRITICAL'));
+  if(crit.length){console.error('❌',crit.join('; '));await mongoose.disconnect();process.exit(1);}
+  if(e.length)e.forEach(x=>console.warn('⚠️',x));
+  const ex=await col.findOne({slug:SLUG});
+  if(ex){await col.updateOne({slug:SLUG},{$set:{...COURSE,updatedAt:new Date()}});console.log('✅ Updated');}
+  else{await col.insertOne({...COURSE,createdAt:new Date(),updatedAt:new Date()});console.log('✅ Inserted');}
+  await mongoose.disconnect();
+}
+main().catch(e=>{console.error(e);process.exit(1);});
+```
+
+---
+
+## Step 4 — Validate Each (automatic, inline)
+
+After writing each seed file, run:
+```bash
+grep -c "multiple_choice\|knowledgeCheck\|quiz" server/src/scripts/seed[FILE].js  # must be 0
+grep -c 'options: \["' server/src/scripts/seed[FILE].js                           # must be 0
+grep 'type:' server/src/scripts/seed[FILE].js | sed 's/.*type: *"\([^"]*\)".*/\1/' | sort -u | wc -l  # must be 8+
+```
+Fix any failures inline. Do NOT pause.
+
+---
+
+## Step 5 — Commit Batch
+
+```bash
+git checkout -b batch/week-N-[date]
+git add server/src/scripts/seed*.js
+git commit -m "feat: week N batch — 10 courses ([total]CE)
+
+[list all 10 codes + titles]
+
+All draft. Rich block variety. Self-validation passed."
+```
+
+---
+
+## Step 6 — Update Queue
+
+Edit `docs/COURSE_PRODUCTION_QUEUE.md`: change `[ ]` → `[G]` for all generated courses.
+
+```bash
+git add docs/COURSE_PRODUCTION_QUEUE.md
+git commit -m "docs: mark week N as generated"
+```
+
+---
+
+## Step 7 — Print Summary
+
+```
+═══ Week N Complete ═══
+#   Code         Title                                              CE  Words   Types  Status
+1   CR-XXX-NNN   Title Here                                         2   12840   12     ✅
+2   CR-XXX-NNN   Another Title                                      3   19200   11     ✅
+...
+Branch: batch/week-N-20260618
+Next: Ke merges → manual Render deploy → run each seed script on Render shell
+```
+
+---
+
+## Hard Rules
+
+1. `[{text, isCorrect}]` — NEVER flat strings
+2. Exact camelCase types — never `multiple_choice`, `quiz`, `knowledgeCheck`
+3. Navy `#284157` — never `#34495E`
+4. ES modules, `process.env.MONGODB_URI`, all content as string literals
+5. Draft only (`isPublished: false`)
+6. 6,000 words per CE hour minimum — script refuses to save if under
+7. No ACEP metadata in content blocks
+8. Prose must be clinically grounded — no fabricated claims
+9. After the batch, update the queue file
+
+---
+
+## CLAUDE.md Addition
+
+```markdown
+## Batch Course Generation
+When Ke says "generate courses", "next batch", "run week N", or "next 10":
+1. Read `docs/BATCH_COURSE_GENERATION.md` — follow end-to-end
+2. Read `docs/COURSE_PRODUCTION_QUEUE.md` — find next pending week
+3. Generate all 10 courses autonomously. No pausing. No confirmation between courses.
+4. Update queue status. Commit to feature branch.
+```

--- a/docs/COURSE_PRODUCTION_QUEUE.md
+++ b/docs/COURSE_PRODUCTION_QUEUE.md
@@ -1,0 +1,134 @@
+# CounselorReady — 40-Course Production Queue
+
+**Schedule:** 10 courses/week × 4 weeks = 40 courses (86 CE hours)
+**Status key:** `[ ]` = pending · `[G]` = generated · `[M]` = merged · `[L]` = live
+
+---
+
+## How CC Uses This File
+
+CC reads this file when Ke says anything like:
+- "run the next batch"
+- "generate this week's courses"
+- "next 10"
+
+CC finds the first week with `[ ]` courses, generates all 10, updates status to `[G]`.
+
+**Ke does NOT need to specify topics.** Everything is pre-planned below. Ke just says "go" and CC runs the next batch.
+
+To customize: edit this file before triggering. Swap titles, change CE hours, replace topics. CC reads whatever is here.
+
+---
+
+## Week 1 — Ethics, Crisis & Trauma (22 CE)
+
+> Fills biggest catalog gaps: Crisis & Safety (2→10CE), Trauma (4→14CE), Ethics (9→17CE)
+
+| # | Status | Code | Title | CE | Category |
+|---|--------|------|-------|---:|----------|
+| 1 | [ ] | CR-ETH-501 | Navigating Dual Relationships in Rural and Small Community Practice | 3 | ethics |
+| 2 | [ ] | CR-ETH-502 | Ethical Use of Technology in Clinical Practice | 2 | ethics |
+| 3 | [ ] | CR-ETH-503 | Mandated Reporting: Gray Areas and Clinical Decision-Making | 3 | ethics |
+| 4 | [ ] | CR-CRS-301 | Suicide Safety Planning: From Assessment to Lethal Means Counseling | 3 | clinical |
+| 5 | [ ] | CR-CRS-302 | Crisis De-Escalation Techniques for Outpatient Clinicians | 2 | clinical |
+| 6 | [ ] | CR-CRS-303 | Threat Assessment in Clinical Settings: Duty to Warn and Protect | 3 | ethics |
+| 7 | [ ] | CR-TRM-501 | Complex PTSD: Diagnosis, Case Conceptualization, and Treatment | 3 | clinical |
+| 8 | [ ] | CR-TRM-502 | Vicarious Trauma and Compassion Fatigue in Clinical Practice | 2 | clinical |
+| 9 | [ ] | CR-TRM-503 | Trauma-Informed Assessment: Beyond the ACE Score | 2 | clinical |
+| 10 | [ ] | CR-TRM-504 | EMDR Fundamentals for the Curious Clinician | 2 | clinical |
+
+**Week 1 total: 25 CE**
+
+---
+
+## Week 2 — Clinical Skills & Therapy Models (22 CE)
+
+> Fills Therapy Models (6→16CE), adds new clinical depth
+
+| # | Status | Code | Title | CE | Category |
+|---|--------|------|-------|---:|----------|
+| 11 | [ ] | CR-CLI-601 | Attachment Theory in Adult Psychotherapy: Assessment and Intervention | 3 | clinical |
+| 12 | [ ] | CR-CLI-602 | Acceptance and Commitment Therapy: Core Processes for Clinicians | 2 | clinical |
+| 13 | [ ] | CR-CLI-603 | Internal Family Systems: An Introduction for Licensed Counselors | 3 | clinical |
+| 14 | [ ] | CR-CLI-604 | Solution-Focused Brief Therapy in Community Mental Health | 2 | clinical |
+| 15 | [ ] | CR-CLI-605 | Cognitive Processing Therapy for PTSD: A Practical Guide | 2 | clinical |
+| 16 | [ ] | CR-CLI-606 | Psychopharmacology for Non-Prescribers: What Counselors Need to Know | 3 | clinical |
+| 17 | [ ] | CR-CLI-607 | Group Therapy: Design, Facilitation, and Common Pitfalls | 2 | clinical |
+| 18 | [ ] | CR-CLI-608 | Clinical Assessment and Diagnosis: Structured Interviewing Skills | 2 | clinical |
+| 19 | [ ] | CR-ADD-701 | Co-Occurring Disorders: Integrated Treatment for Substance Use and Mental Health | 3 | clinical |
+| 20 | [ ] | CR-ADD-702 | Harm Reduction in Clinical Practice: Evidence and Application | 2 | clinical |
+
+**Week 2 total: 24 CE**
+
+---
+
+## Week 3 — Specialty Populations & Multicultural (20 CE)
+
+> Fills Specialty (5→15CE), Multicultural (10→16CE)
+
+| # | Status | Code | Title | CE | Category |
+|---|--------|------|-------|---:|----------|
+| 21 | [ ] | CR-POP-701 | Counseling Military Veterans and First Responders | 3 | clinical |
+| 22 | [ ] | CR-POP-702 | Adolescent Mental Health in the Social Media Era | 2 | clinical |
+| 23 | [ ] | CR-POP-703 | Perinatal Mood and Anxiety Disorders for Non-Specialists | 3 | clinical |
+| 24 | [ ] | CR-POP-704 | Counseling Older Adults: Cognitive Decline, Grief, and Late-Life Transitions | 2 | clinical |
+| 25 | [ ] | CR-POP-705 | Working with Justice-Involved Clients: Ethics, Assessment, and Reentry | 2 | clinical |
+| 26 | [ ] | CR-MC-301 | LGBTQ+ Affirming Therapy: Beyond the Basics | 3 | multicultural |
+| 27 | [ ] | CR-MC-302 | Working with Immigrant and Refugee Populations | 2 | multicultural |
+| 28 | [ ] | CR-MC-303 | Intersectionality in Clinical Practice: Race, Gender, Class, and Disability | 2 | multicultural |
+| 29 | [ ] | CR-DIS-401 | Disability-Affirming Counseling: Physical, Sensory, and Intellectual Disabilities | 2 | multicultural |
+| 30 | [ ] | CR-REL-401 | Spirituality and Religion in Counseling: Ethical Integration | 2 | clinical |
+
+**Week 3 total: 23 CE**
+
+---
+
+## Week 4 — Professional Development, Supervision & Wellness (17 CE)
+
+> Fills Professional Dev (3→11CE), Wellness (4→10CE), adds Supervision category
+
+| # | Status | Code | Title | CE | Category |
+|---|--------|------|-------|---:|----------|
+| 31 | [ ] | CR-SUP-801 | Clinical Supervision Models and Best Practices | 3 | supervision |
+| 32 | [ ] | CR-SUP-802 | Supervising Diverse Supervisees: Power, Culture, and the Alliance | 2 | supervision |
+| 33 | [ ] | CR-PD-901 | Building a Sustainable Private Practice | 2 | professional_development |
+| 34 | [ ] | CR-PD-902 | Documentation That Protects: Clinical Notes, Treatment Plans, and Risk Management | 2 | professional_development |
+| 35 | [ ] | CR-PD-903 | Insurance Paneling, Credentialing, and Managed Care Navigation | 2 | professional_development |
+| 36 | [ ] | CR-PD-904 | Continuing Competence: Self-Assessment and Professional Growth Planning | 2 | professional_development |
+| 37 | [ ] | CR-WEL-501 | Clinician Self-Care: Evidence-Based Strategies for Preventing Burnout | 2 | clinical |
+| 38 | [ ] | CR-WEL-502 | Mindfulness for the Therapist: Personal Practice and Clinical Application | 2 | clinical |
+| 39 | [ ] | CR-POP-706 | Counseling Couples: Gottman-Informed Approaches for Individual Therapists | 2 | clinical |
+| 40 | [ ] | CR-FILM-201 | Shrinking the Screen: What Ted Lasso Teaches About Therapeutic Alliance | 2 | clinical |
+
+**Week 4 total: 23 CE**
+
+---
+
+## Catalog Impact After All 40
+
+| Topic Area | Before | Added | After |
+|------------|-------:|------:|------:|
+| Ethics & Law | 9 | 11 | 20 |
+| Crisis & Safety | 2 | 8 | 10 |
+| Trauma | 4 | 9 | 13 |
+| Therapy Models | 6 | 10 | 16 |
+| Clinical (general) | — | 14 | 14 |
+| Addiction | 6 | 5 | 11 |
+| Multicultural | 10 | 9 | 19 |
+| Specialty Populations | 5 | 14 | 19 |
+| Supervision | 0 | 5 | 5 |
+| Professional Dev | 3 | 8 | 11 |
+| Wellness | 4 | 4 | 8 |
+| Pop Culture CE | 2 | 2 | 4 |
+| **TOTAL** | **~51** | **~95** | **~146** |
+
+---
+
+## Customization
+
+Swap any row before triggering CC. Just keep the table format:
+```
+| # | [ ] | CODE | Title | CE | category |
+```
+
+CC reads the status column. `[ ]` = generate it. Anything else = skip it.


### PR DESCRIPTION
## Summary

- **`docs/BATCH_COURSE_GENERATION.md`** — tighter autonomous pipeline spec replacing the earlier `BATCH_COURSE_GEN.md`. Adds queue-mode trigger (reads the queue file to determine what to generate), section rhythm table, minified self-validation function, commit/update-queue/summary steps, and hard rules.
- **`docs/COURSE_PRODUCTION_QUEUE.md`** — pre-planned 40-course / 4-week production schedule (86 CE hours) covering ethics, crisis, trauma, therapy models, specialty populations, multicultural, supervision, and professional development. CC reads the `[ ]` status column to know what to generate next — no topic specification needed from Ke.
- **`CLAUDE.md`** — batch generation trigger section condensed to a 4-line pointer to the two new docs. CC now reads the queue to determine what to generate.

## Test plan

- [ ] `docs/BATCH_COURSE_GENERATION.md` present and matches uploaded spec
- [ ] `docs/COURSE_PRODUCTION_QUEUE.md` present with all 40 courses in `[ ]` state
- [ ] `CLAUDE.md` batch section points to `BATCH_COURSE_GENERATION.md` and `COURSE_PRODUCTION_QUEUE.md`
- [ ] `git diff --stat main` shows exactly 3 files changed, no other files touched

https://claude.ai/code/session_011dFHqWsQTC1c74UdfNnuuY

---
_Generated by [Claude Code](https://claude.ai/code/session_011dFHqWsQTC1c74UdfNnuuY)_