### PR TITLE
Add Psychotropic Medication Tracker

### DIFF
--- a/client/public/med-tracker.html
+++ b/client/public/med-tracker.html
@@ -1,0 +1,1051 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Psychotropic Med Tracker — CounselorReady</title>
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <style>
+    :root {
+      --burgundy: #8B2542;
+      --burgundy-dark: #6B1D34;
+      --burgundy-light: #a83056;
+      --navy: #284157;
+      --stone-50: #fafaf9;
+      --stone-100: #f5f5f4;
+      --stone-200: #e7e5e4;
+      --stone-300: #d6d3d1;
+      --stone-500: #78716c;
+      --stone-700: #44403c;
+      --stone-900: #1c1917;
+      --green-100: #dcfce7;
+      --green-700: #15803d;
+      --yellow-100: #fef9c3;
+      --yellow-700: #a16207;
+      --orange-100: #ffedd5;
+      --orange-700: #c2410c;
+      --red-100: #fee2e2;
+      --red-700: #b91c1c;
+      --blue-100: #dbeafe;
+      --blue-700: #1d4ed8;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--stone-100);
+      color: var(--stone-900);
+      min-height: 100vh;
+    }
+
+    /* ── Nav ── */
+    .nav {
+      background: linear-gradient(135deg, #8B2542, #6B1D34);
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    }
+    .nav-logo { color: #fff; font-size: 18px; font-weight: 700; text-decoration: none; }
+    .nav-back { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 14px; }
+    .nav-back:hover { color: #fff; }
+
+    /* ── Layout ── */
+    .container { max-width: 1200px; margin: 0 auto; padding: 24px 16px; }
+    .page-header { margin-bottom: 24px; }
+    .page-title { font-size: 26px; font-weight: 700; color: var(--navy); }
+    .page-subtitle { font-size: 14px; color: var(--stone-500); margin-top: 4px; }
+    .disclaimer {
+      background: var(--blue-100);
+      border-left: 4px solid var(--blue-700);
+      color: var(--blue-700);
+      padding: 10px 14px;
+      border-radius: 4px;
+      font-size: 13px;
+      margin-bottom: 20px;
+    }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+      transition: background 0.15s;
+    }
+    .btn-primary { background: var(--burgundy); color: #fff; }
+    .btn-primary:hover { background: var(--burgundy-dark); }
+    .btn-secondary { background: var(--stone-200); color: var(--stone-700); }
+    .btn-secondary:hover { background: var(--stone-300); }
+    .btn-danger { background: var(--red-100); color: var(--red-700); }
+    .btn-danger:hover { background: #fecaca; }
+    .btn-sm { padding: 5px 10px; font-size: 12px; }
+
+    /* ── Cards ── */
+    .card {
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid var(--stone-200);
+      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+      margin-bottom: 16px;
+    }
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--stone-200);
+    }
+    .card-title { font-size: 15px; font-weight: 600; color: var(--stone-900); }
+    .card-body { padding: 18px; }
+
+    /* ── Grid ── */
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+    @media (max-width: 768px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+
+    /* ── Client list ── */
+    .client-list { display: flex; flex-direction: column; gap: 10px; }
+    .client-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 16px;
+      background: #fff;
+      border: 1px solid var(--stone-200);
+      border-radius: 8px;
+      cursor: pointer;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .client-row:hover { border-color: var(--burgundy); box-shadow: 0 0 0 2px rgba(139,37,66,0.08); }
+    .client-row.active { border-color: var(--burgundy); background: #fdf8f9; }
+    .client-code { font-weight: 700; font-size: 15px; color: var(--navy); }
+    .client-meta { font-size: 12px; color: var(--stone-500); margin-top: 2px; }
+
+    /* ── Load flag badges ── */
+    .badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 99px;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .badge-adequate     { background: var(--green-100);  color: var(--green-700); }
+    .badge-under        { background: var(--yellow-100); color: var(--yellow-700); }
+    .badge-over         { background: var(--orange-100); color: var(--orange-700); }
+    .badge-review       { background: var(--red-100);    color: var(--red-700); }
+    .badge-unset        { background: var(--stone-100);  color: var(--stone-500); }
+    .badge-within       { background: var(--green-100);  color: var(--green-700); }
+    .badge-low          { background: var(--yellow-100); color: var(--yellow-700); }
+    .badge-high         { background: var(--orange-100); color: var(--orange-700); }
+    .badge-critical     { background: var(--red-100);    color: var(--red-700); }
+    .badge-severe       { background: var(--red-100);    color: var(--red-700); }
+    .badge-contraindicated { background: #450a0a; color: #fff; }
+    .badge-moderate     { background: var(--orange-100); color: var(--orange-700); }
+    .badge-mild         { background: var(--yellow-100); color: var(--yellow-700); }
+
+    /* ── Alert banner ── */
+    .alert-banner {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      border-radius: 8px;
+      margin-bottom: 10px;
+      font-size: 13px;
+    }
+    .alert-banner.red   { background: var(--red-100);    border-left: 4px solid var(--red-700);    color: var(--red-700); }
+    .alert-banner.orange { background: var(--orange-100); border-left: 4px solid var(--orange-700); color: var(--orange-700); }
+    .alert-banner.yellow { background: var(--yellow-100); border-left: 4px solid var(--yellow-700); color: var(--yellow-700); }
+
+    /* ── Forms ── */
+    .form-group { margin-bottom: 14px; }
+    label { display: block; font-size: 12px; font-weight: 600; color: var(--stone-700); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.3px; }
+    input, select, textarea {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--stone-300);
+      border-radius: 6px;
+      font-size: 14px;
+      color: var(--stone-900);
+      background: #fff;
+      transition: border-color 0.15s;
+    }
+    input:focus, select:focus, textarea:focus {
+      outline: none;
+      border-color: var(--burgundy);
+      box-shadow: 0 0 0 2px rgba(139,37,66,0.1);
+    }
+    textarea { resize: vertical; min-height: 80px; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 13px; margin-bottom: 8px; }
+    .checkbox-row input[type=checkbox] { width: auto; }
+
+    /* ── Stat boxes ── */
+    .stat-box {
+      background: var(--stone-50);
+      border: 1px solid var(--stone-200);
+      border-radius: 8px;
+      padding: 12px 14px;
+      text-align: center;
+    }
+    .stat-value { font-size: 22px; font-weight: 700; color: var(--navy); }
+    .stat-label { font-size: 11px; color: var(--stone-500); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
+
+    /* ── Sections ── */
+    .section-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--stone-500);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 10px;
+      margin-top: 20px;
+    }
+    .med-row {
+      border: 1px solid var(--stone-200);
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin-bottom: 8px;
+      background: #fff;
+    }
+    .med-row-header { display: flex; align-items: center; justify-content: space-between; }
+    .med-name { font-weight: 700; font-size: 15px; }
+    .med-detail { font-size: 12px; color: var(--stone-500); margin-top: 4px; }
+
+    /* ── Efficacy bar ── */
+    .efficacy-bar-wrap { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+    .efficacy-bar-track { flex: 1; background: var(--stone-200); border-radius: 99px; height: 8px; overflow: hidden; }
+    .efficacy-bar-fill { height: 100%; border-radius: 99px; transition: width 0.3s; }
+    .efficacy-label { font-size: 11px; color: var(--stone-500); min-width: 32px; text-align: right; }
+
+    /* ── Modal overlay ── */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 200;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+    .modal-overlay.open { display: flex; }
+    .modal {
+      background: #fff;
+      border-radius: 12px;
+      max-width: 560px;
+      width: 100%;
+      max-height: 90vh;
+      overflow-y: auto;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.25);
+    }
+    .modal-header {
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--stone-200);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .modal-title { font-size: 16px; font-weight: 700; }
+    .modal-close { background: none; border: none; font-size: 20px; cursor: pointer; color: var(--stone-500); line-height: 1; }
+    .modal-body { padding: 20px; }
+    .modal-footer { padding: 14px 20px; border-top: 1px solid var(--stone-200); display: flex; gap: 10px; justify-content: flex-end; }
+
+    /* ── Empty state ── */
+    .empty-state { text-align: center; padding: 48px 24px; color: var(--stone-500); }
+    .empty-icon { font-size: 40px; margin-bottom: 12px; }
+    .empty-text { font-size: 15px; }
+
+    /* ── Toast ── */
+    #toast {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      background: var(--stone-900);
+      color: #fff;
+      padding: 10px 18px;
+      border-radius: 8px;
+      font-size: 14px;
+      z-index: 999;
+      opacity: 0;
+      transform: translateY(10px);
+      transition: opacity 0.2s, transform 0.2s;
+      pointer-events: none;
+    }
+    #toast.show { opacity: 1; transform: translateY(0); }
+
+    /* ── Layout panels ── */
+    .layout { display: grid; grid-template-columns: 300px 1fr; gap: 20px; }
+    @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+    .panel-left { }
+    .panel-right { }
+    .hidden { display: none !important; }
+
+    /* ── Observation history ── */
+    .obs-entry {
+      border-left: 3px solid var(--stone-300);
+      padding: 8px 12px;
+      margin-bottom: 8px;
+      font-size: 13px;
+    }
+    .obs-date { font-size: 11px; color: var(--stone-500); margin-bottom: 4px; }
+    .obs-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+    .obs-chip {
+      background: var(--stone-100);
+      border: 1px solid var(--stone-200);
+      border-radius: 4px;
+      padding: 2px 7px;
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/dashboard.html" class="nav-back">← Dashboard</a>
+  <a href="/" class="nav-logo">CounselorReady</a>
+  <span></span>
+</nav>
+
+<div class="container">
+  <div class="page-header">
+    <div class="page-title">Psychotropic Medication Tracker</div>
+    <div class="page-subtitle">Anonymous client records — identified by code only. No PII stored.</div>
+  </div>
+
+  <div class="disclaimer">
+    <strong>Clinical Observation Tool Only.</strong> This tracker supports clinical documentation and case management. Dosage flags are observation prompts, not clinical recommendations. All medication decisions remain with the prescribing provider.
+  </div>
+
+  <!-- Auth check message -->
+  <div id="auth-error" class="hidden">
+    <div class="empty-state">
+      <div class="empty-icon">🔒</div>
+      <div class="empty-text">Please <a href="/login.html">sign in</a> to access the Med Tracker.</div>
+    </div>
+  </div>
+
+  <!-- Main content -->
+  <div id="main-content" class="hidden">
+    <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:16px;">
+      <div id="client-count-label" style="font-size:14px; color:var(--stone-500);"></div>
+      <button class="btn btn-primary" onclick="openNewClientModal()">+ New Client Record</button>
+    </div>
+
+    <div class="layout">
+      <!-- Left: client list -->
+      <div class="panel-left">
+        <div id="client-list" class="client-list">
+          <div class="empty-state" style="padding:32px 12px;">
+            <div class="empty-icon">💊</div>
+            <div class="empty-text" style="font-size:13px;">No client records yet.</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right: client detail -->
+      <div class="panel-right">
+        <div id="detail-empty" class="empty-state" style="padding:80px 24px;">
+          <div class="empty-icon">👤</div>
+          <div class="empty-text">Select a client to view their medication record.</div>
+        </div>
+        <div id="detail-panel" class="hidden"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ── Modals ── -->
+
+<!-- New client modal -->
+<div class="modal-overlay" id="modal-new-client">
+  <div class="modal">
+    <div class="modal-header">
+      <div class="modal-title">New Client Record</div>
+      <button class="modal-close" onclick="closeModal('modal-new-client')">×</button>
+    </div>
+    <div class="modal-body">
+      <div class="disclaimer" style="margin-bottom:16px;">
+        Use an anonymous code (e.g. initials + number). Do NOT enter names, DOB, or identifying information.
+      </div>
+      <div class="form-group">
+        <label>Client Code *</label>
+        <input type="text" id="nc-code" placeholder="e.g. AA001" maxlength="20" style="text-transform:uppercase;" />
+      </div>
+      <div class="grid-2">
+        <div class="form-group">
+          <label>Weight (kg)</label>
+          <input type="number" id="nc-weight" placeholder="e.g. 72" min="20" max="300" step="0.1" />
+        </div>
+        <div class="form-group">
+          <label>Height (cm)</label>
+          <input type="number" id="nc-height" placeholder="e.g. 170" min="100" max="250" step="0.5" />
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Diagnosis Category (DSM-5)</label>
+        <select id="nc-dx">
+          <option value="">— Select —</option>
+          <option value="schizophrenia_spectrum">Schizophrenia Spectrum</option>
+          <option value="bipolar_related">Bipolar & Related Disorders</option>
+          <option value="depressive_disorders">Depressive Disorders</option>
+          <option value="anxiety_disorders">Anxiety Disorders</option>
+          <option value="trauma_related">Trauma & Stressor-Related</option>
+          <option value="ocd_related">OCD & Related Disorders</option>
+          <option value="adhd">ADHD / Neurodevelopmental</option>
+          <option value="personality_disorders">Personality Disorders</option>
+          <option value="neurodevelopmental">Neurodevelopmental</option>
+          <option value="substance_related">Substance-Related</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Case Notes (optional)</label>
+        <textarea id="nc-notes" placeholder="General case management notes..."></textarea>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal('modal-new-client')">Cancel</button>
+      <button class="btn btn-primary" onclick="saveNewClient()">Create Record</button>
+    </div>
+  </div>
+</div>
+
+<!-- Add medication modal -->
+<div class="modal-overlay" id="modal-add-med">
+  <div class="modal">
+    <div class="modal-header">
+      <div class="modal-title">Add Medication</div>
+      <button class="modal-close" onclick="closeModal('modal-add-med')">×</button>
+    </div>
+    <div class="modal-body">
+      <div class="grid-2">
+        <div class="form-group">
+          <label>Brand Name *</label>
+          <input type="text" id="am-name" placeholder="e.g. Risperdal" />
+        </div>
+        <div class="form-group">
+          <label>Generic Name</label>
+          <input type="text" id="am-generic" placeholder="e.g. risperidone" />
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Medication Class *</label>
+        <select id="am-class">
+          <option value="">— Select —</option>
+          <optgroup label="Antipsychotics">
+            <option value="antipsychotic_typical">Antipsychotic — Typical (1st Gen)</option>
+            <option value="antipsychotic_atypical">Antipsychotic — Atypical (2nd Gen)</option>
+          </optgroup>
+          <optgroup label="Antidepressants">
+            <option value="antidepressant_ssri">Antidepressant — SSRI</option>
+            <option value="antidepressant_snri">Antidepressant — SNRI</option>
+            <option value="antidepressant_maoi">Antidepressant — MAOI</option>
+            <option value="antidepressant_tca">Antidepressant — TCA</option>
+            <option value="antidepressant_other">Antidepressant — Other</option>
+          </optgroup>
+          <option value="mood_stabilizer">Mood Stabilizer</option>
+          <optgroup label="Anxiolytics">
+            <option value="anxiolytic_benzodiazepine">Anxiolytic — Benzodiazepine</option>
+            <option value="anxiolytic_other">Anxiolytic — Other</option>
+          </optgroup>
+          <option value="stimulant">Stimulant (ADHD)</option>
+          <option value="non_stimulant_adhd">Non-Stimulant (ADHD)</option>
+          <option value="hypnotic">Hypnotic / Sleep Aid</option>
+          <option value="anticholinergic">Anticholinergic</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div class="grid-3">
+        <div class="form-group">
+          <label>Dose (mg) *</label>
+          <input type="number" id="am-dose" placeholder="e.g. 50" min="0.1" step="0.1" />
+        </div>
+        <div class="form-group">
+          <label>Frequency *</label>
+          <select id="am-frequency">
+            <option value="once_daily">Once daily</option>
+            <option value="twice_daily">Twice daily</option>
+            <option value="three_times_daily">3× daily</option>
+            <option value="four_times_daily">4× daily</option>
+            <option value="every_other_day">Every other day</option>
+            <option value="weekly">Weekly</option>
+            <option value="as_needed">As needed (PRN)</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Route</label>
+          <select id="am-route">
+            <option value="oral">Oral</option>
+            <option value="sublingual">Sublingual</option>
+            <option value="injectable_im">Injectable IM</option>
+            <option value="injectable_iv">Injectable IV</option>
+            <option value="patch">Patch</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+      </div>
+      <div class="grid-2">
+        <div class="form-group">
+          <label>Start Date</label>
+          <input type="date" id="am-start" />
+        </div>
+        <div class="form-group">
+          <label>Prescriber Type</label>
+          <select id="am-prescriber">
+            <option value="">— Unknown —</option>
+            <option value="psychiatrist">Psychiatrist</option>
+            <option value="pcp">Primary Care (PCP)</option>
+            <option value="np">Nurse Practitioner</option>
+            <option value="pa">Physician's Assistant</option>
+            <option value="neurologist">Neurologist</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Target Symptoms (comma-separated)</label>
+        <input type="text" id="am-targets" placeholder="e.g. hallucinations, agitation, insomnia" />
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal('modal-add-med')">Cancel</button>
+      <button class="btn btn-primary" onclick="saveMedication()">Add Medication</button>
+    </div>
+  </div>
+</div>
+
+<!-- Add observation modal -->
+<div class="modal-overlay" id="modal-add-obs">
+  <div class="modal">
+    <div class="modal-header">
+      <div class="modal-title">Add Observation</div>
+      <button class="modal-close" onclick="closeModal('modal-add-obs')">×</button>
+    </div>
+    <div class="modal-body">
+      <input type="hidden" id="obs-med-id" />
+
+      <div class="grid-2">
+        <div class="form-group">
+          <label>Efficacy (1–5)</label>
+          <input type="range" id="obs-efficacy" min="1" max="5" step="1" value="3" oninput="document.getElementById('obs-efficacy-val').textContent=this.value" />
+          <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--stone-500);margin-top:2px;">
+            <span>Not working</span><span id="obs-efficacy-val">3</span><span>Excellent</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label>Sedation Level (0–5)</label>
+          <input type="range" id="obs-sedation" min="0" max="5" step="1" value="0" oninput="document.getElementById('obs-sed-val').textContent=this.value" />
+          <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--stone-500);margin-top:2px;">
+            <span>None</span><span id="obs-sed-val">0</span><span>Severely sedated</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>Functional Impairment (0–5)</label>
+        <input type="range" id="obs-impairment" min="0" max="5" step="1" value="0" oninput="document.getElementById('obs-imp-val').textContent=this.value" />
+        <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--stone-500);margin-top:2px;">
+          <span>None</span><span id="obs-imp-val">0</span><span>Severe</span>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>Symptom Trend</label>
+        <select id="obs-trend">
+          <option value="unknown">Unknown / First observation</option>
+          <option value="improving">Improving</option>
+          <option value="stable">Stable</option>
+          <option value="worsening">Worsening</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>PRN Use Since Last Observation (count)</label>
+        <input type="number" id="obs-prn" min="0" max="99" value="0" placeholder="0" />
+      </div>
+
+      <div class="section-title">Negative Symptoms</div>
+      <div class="grid-2">
+        <div class="checkbox-row"><input type="checkbox" id="obs-flat-affect" /><label for="obs-flat-affect" style="text-transform:none;letter-spacing:0;font-size:13px;">Flat / Blunted Affect</label></div>
+        <div class="checkbox-row"><input type="checkbox" id="obs-avolition" /><label for="obs-avolition" style="text-transform:none;letter-spacing:0;font-size:13px;">Avolition</label></div>
+        <div class="checkbox-row"><input type="checkbox" id="obs-anhedonia" /><label for="obs-anhedonia" style="text-transform:none;letter-spacing:0;font-size:13px;">Anhedonia</label></div>
+        <div class="checkbox-row"><input type="checkbox" id="obs-withdrawal" /><label for="obs-withdrawal" style="text-transform:none;letter-spacing:0;font-size:13px;">Social Withdrawal</label></div>
+        <div class="checkbox-row"><input type="checkbox" id="obs-alogia" /><label for="obs-alogia" style="text-transform:none;letter-spacing:0;font-size:13px;">Alogia (poverty of speech)</label></div>
+        <div class="checkbox-row"><input type="checkbox" id="obs-cog-slow" /><label for="obs-cog-slow" style="text-transform:none;letter-spacing:0;font-size:13px;">Cognitive Slowing</label></div>
+      </div>
+
+      <div class="section-title">Side Effects</div>
+      <div class="grid-2">
+        <div class="form-group">
+          <label>Weight Change</label>
+          <select id="obs-weight-change">
+            <option value="none">None</option>
+            <option value="gain">Gain</option>
+            <option value="loss">Loss</option>
+          </select>
+        </div>
+        <div style="padding-top:20px;">
+          <div class="checkbox-row"><input type="checkbox" id="obs-sleep" /><label for="obs-sleep" style="text-transform:none;letter-spacing:0;font-size:13px;">Sleep Disturbance</label></div>
+          <div class="checkbox-row"><input type="checkbox" id="obs-movement" /><label for="obs-movement" style="text-transform:none;letter-spacing:0;font-size:13px;">Movement Disorder (EPS/TD)</label></div>
+          <div class="checkbox-row"><input type="checkbox" id="obs-mood-instab" /><label for="obs-mood-instab" style="text-transform:none;letter-spacing:0;font-size:13px;">Mood Instability</label></div>
+          <div class="checkbox-row"><input type="checkbox" id="obs-appetite" /><label for="obs-appetite" style="text-transform:none;letter-spacing:0;font-size:13px;">Appetite Change</label></div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>Clinician Notes</label>
+        <textarea id="obs-notes" placeholder="Observations, context, plan..."></textarea>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal('modal-add-obs')">Cancel</button>
+      <button class="btn btn-primary" onclick="saveObservation()">Save Observation</button>
+    </div>
+  </div>
+</div>
+
+<div id="toast"></div>
+
+<script>
+  const API = '/api/med-tracker';
+  let token = null;
+  let allRecords = [];
+  let activeRecord = null;
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+  async function init() {
+    token = localStorage.getItem('token');
+    if (!token) {
+      try {
+        const r = await fetchWithTimeout('/api/auth/me', { credentials: 'include' });
+        if (!r.ok) throw new Error('not authed');
+        const d = await r.json();
+        token = d.token || null;
+      } catch (_) {
+        document.getElementById('auth-error').classList.remove('hidden');
+        return;
+      }
+    }
+    document.getElementById('main-content').classList.remove('hidden');
+    await loadClients();
+  }
+
+  function fetchWithTimeout(url, opts = {}, ms = 15000) {
+    const ctrl = new AbortController();
+    const id = setTimeout(() => ctrl.abort(), ms);
+    return fetch(url, { ...opts, signal: ctrl.signal }).finally(() => clearTimeout(id));
+  }
+
+  function apiHeaders() {
+    const h = { 'Content-Type': 'application/json' };
+    if (token) h['Authorization'] = 'Bearer ' + token;
+    return h;
+  }
+
+  // ── Load client list ────────────────────────────────────────────────────────
+  async function loadClients() {
+    try {
+      const r = await fetchWithTimeout(API, { headers: apiHeaders() });
+      if (r.status === 401) {
+        document.getElementById('auth-error').classList.remove('hidden');
+        document.getElementById('main-content').classList.add('hidden');
+        return;
+      }
+      const d = await r.json();
+      allRecords = d.data || [];
+      renderClientList();
+    } catch (err) {
+      toast('Failed to load records: ' + err.message);
+    }
+  }
+
+  function renderClientList() {
+    const el = document.getElementById('client-list');
+    const label = document.getElementById('client-count-label');
+    label.textContent = allRecords.length + ' client record' + (allRecords.length !== 1 ? 's' : '');
+
+    if (!allRecords.length) {
+      el.innerHTML = '<div class="empty-state" style="padding:32px 12px;"><div class="empty-icon">💊</div><div class="empty-text" style="font-size:13px;">No client records yet.</div></div>';
+      return;
+    }
+
+    el.innerHTML = allRecords.map(r => {
+      const activeMeds = (r.medications || []).filter(m => m.isActive).length;
+      const alerts = (r.contraindicationAlerts || []).filter(a => !a.acknowledged).length;
+      const flagClass = loadFlagBadgeClass(r.medicationLoadFlag);
+      const isActive = activeRecord && activeRecord._id === r._id ? ' active' : '';
+      return `<div class="client-row${isActive}" onclick="selectClient('${r._id}')">
+        <div>
+          <div class="client-code">${r.clientCode}</div>
+          <div class="client-meta">${activeMeds} active med${activeMeds !== 1 ? 's' : ''} · ${r.diagnosisCategory ? fmtEnum(r.diagnosisCategory) : 'Dx not set'}${alerts ? ` · ⚠️ ${alerts} alert${alerts !== 1 ? 's' : ''}` : ''}</div>
+        </div>
+        <span class="badge ${flagClass}">${fmtLoad(r.medicationLoadFlag)}</span>
+      </div>`;
+    }).join('');
+  }
+
+  // ── Select client ───────────────────────────────────────────────────────────
+  async function selectClient(id) {
+    try {
+      const r = await fetchWithTimeout(`${API}/${id}`, { headers: apiHeaders() });
+      const d = await r.json();
+      activeRecord = d.data;
+      renderDetail();
+      renderClientList();
+    } catch (err) {
+      toast('Failed to load client: ' + err.message);
+    }
+  }
+
+  function renderDetail() {
+    const el = document.getElementById('detail-panel');
+    document.getElementById('detail-empty').classList.add('hidden');
+    el.classList.remove('hidden');
+
+    const rec = activeRecord;
+    const activeMeds = (rec.medications || []).filter(m => m.isActive);
+    const unackAlerts = (rec.contraindicationAlerts || []).filter(a => !a.acknowledged);
+
+    // Bio stats
+    const bmi = rec.bmi ? `<div class="stat-box"><div class="stat-value">${rec.bmi}</div><div class="stat-label">BMI</div></div>` : '';
+    const wt = rec.weightKg ? `<div class="stat-box"><div class="stat-value">${rec.weightKg} kg</div><div class="stat-label">Weight</div></div>` : '';
+    const ht = rec.heightCm ? `<div class="stat-box"><div class="stat-value">${rec.heightCm} cm</div><div class="stat-label">Height</div></div>` : '';
+
+    // Alerts
+    const alertsHTML = unackAlerts.map((a, i) => {
+      const severity = a.severity === 'contraindicated' ? 'red' : a.severity === 'severe' ? 'red' : a.severity === 'moderate' ? 'orange' : 'yellow';
+      return `<div class="alert-banner ${severity}">
+        <span>⚠️</span>
+        <div>
+          <strong>${fmtEnum(a.med1)} + ${fmtEnum(a.med2)}</strong>
+          <span class="badge badge-${a.severity}" style="margin-left:6px;">${a.severity}</span><br/>
+          <span>${a.reason}</span>
+          <div style="margin-top:6px;">
+            <button class="btn btn-sm btn-secondary" onclick="acknowledgeAlert(${i})">Acknowledge</button>
+          </div>
+        </div>
+      </div>`;
+    }).join('');
+
+    // Medications
+    const medsHTML = activeMeds.length ? activeMeds.map(m => {
+      const obs = (m.observations || []).sort((a, b) => new Date(b.date) - new Date(a.date));
+      const latest = obs[0];
+      const efficacyPct = latest ? ((latest.efficacyScore - 1) / 4 * 100) : 0;
+      const efficacyColor = efficacyPct >= 60 ? '#16a34a' : efficacyPct >= 40 ? '#ca8a04' : '#dc2626';
+      const doseBadge = dosageStatusBadge(m.dosageStatus);
+      const negCount = latest ? Object.values(latest.negativeSymptoms || {}).filter(Boolean).length : 0;
+      const sedAlert = latest && latest.sedationScore >= 4 ? '<span style="color:var(--red-700);font-weight:700;"> ⚠ High sedation</span>' : '';
+
+      return `<div class="med-row">
+        <div class="med-row-header">
+          <div>
+            <div class="med-name">${m.name}${m.genericName ? ` <span style="font-weight:400;font-size:13px;color:var(--stone-500);">(${m.genericName})</span>` : ''}</div>
+            <div class="med-detail">${m.doseAmountMg}mg · ${fmtEnum(m.frequency)} · ${fmtEnum(m.route || 'oral')} · ${fmtEnum(m.medicationClass)}</div>
+            ${m.mgPerKg ? `<div class="med-detail">Daily: ${m.dailyDoseMg}mg · <strong>${m.mgPerKg} mg/kg</strong> ${doseBadge}${sedAlert}</div>` : ''}
+            ${m.targetSymptoms && m.targetSymptoms.length ? `<div class="med-detail">Targets: ${m.targetSymptoms.join(', ')}</div>` : ''}
+          </div>
+          <button class="btn btn-sm btn-primary" onclick="openObsModal('${m._id}')">+ Observation</button>
+        </div>
+        ${latest ? `
+          <div class="efficacy-bar-wrap" style="margin-top:10px;">
+            <span style="font-size:11px;color:var(--stone-500);min-width:60px;">Efficacy</span>
+            <div class="efficacy-bar-track">
+              <div class="efficacy-bar-fill" style="width:${efficacyPct}%;background:${efficacyColor};"></div>
+            </div>
+            <span class="efficacy-label">${latest.efficacyScore}/5</span>
+          </div>
+          <div style="margin-top:8px;font-size:12px;color:var(--stone-500);">
+            Trend: <strong>${fmtEnum(latest.symptomTrend)}</strong> ·
+            Sedation: <strong>${latest.sedationScore}/5</strong> ·
+            ${negCount > 0 ? `<span style="color:var(--orange-700);">${negCount} negative symptom${negCount !== 1 ? 's' : ''}</span>` : 'No negative symptoms noted'} ·
+            PRN uses: ${latest.prnUseCount}
+          </div>
+        ` : '<div style="margin-top:8px;font-size:12px;color:var(--stone-500);">No observations yet.</div>'}
+        ${obs.length > 1 ? `<details style="margin-top:10px;"><summary style="font-size:12px;cursor:pointer;color:var(--stone-500);">View ${obs.length - 1} prior observation${obs.length - 1 !== 1 ? 's' : ''}</summary>${obs.slice(1).map(o => renderObsEntry(o)).join('')}</details>` : ''}
+      </div>`;
+    }).join('') : '<div style="color:var(--stone-500);font-size:13px;padding:12px 0;">No active medications. Add one below.</div>';
+
+    el.innerHTML = `
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">Client: ${rec.clientCode}</div>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <span class="badge ${loadFlagBadgeClass(rec.medicationLoadFlag)}">${fmtLoad(rec.medicationLoadFlag)}</span>
+            <button class="btn btn-sm btn-secondary" onclick="openNewClientModal(true)">Edit Biometrics</button>
+          </div>
+        </div>
+        <div class="card-body">
+          ${rec.diagnosisCategory ? `<div style="font-size:13px;color:var(--stone-500);margin-bottom:12px;">Category: <strong>${fmtEnum(rec.diagnosisCategory)}</strong></div>` : ''}
+          ${(wt || ht || bmi) ? `<div class="grid-3" style="margin-bottom:16px;">${wt}${ht}${bmi}</div>` : ''}
+          ${alertsHTML ? `<div style="margin-bottom:16px;">${alertsHTML}</div>` : ''}
+          <div class="section-title">Active Medications</div>
+          ${medsHTML}
+          <button class="btn btn-primary" style="margin-top:12px;" onclick="openAddMedModal()">+ Add Medication</button>
+          ${rec.notes ? `<div class="section-title">Case Notes</div><div style="font-size:13px;color:var(--stone-700);background:var(--stone-50);padding:10px;border-radius:6px;">${rec.notes}</div>` : ''}
+        </div>
+      </div>`;
+  }
+
+  function renderObsEntry(o) {
+    const negatives = Object.entries(o.negativeSymptoms || {})
+      .filter(([, v]) => v).map(([k]) => fmtEnum(k));
+    return `<div class="obs-entry">
+      <div class="obs-date">${new Date(o.date).toLocaleDateString()}</div>
+      <div>Efficacy: ${o.efficacyScore ?? '—'}/5 · Sedation: ${o.sedationScore ?? '—'}/5 · Trend: ${fmtEnum(o.symptomTrend)}</div>
+      ${negatives.length ? `<div class="obs-chips">${negatives.map(n => `<span class="obs-chip">${n}</span>`).join('')}</div>` : ''}
+      ${o.notes ? `<div style="margin-top:4px;font-size:12px;color:var(--stone-500);">${o.notes}</div>` : ''}
+    </div>`;
+  }
+
+  // ── Modals ──────────────────────────────────────────────────────────────────
+  function openModal(id) { document.getElementById(id).classList.add('open'); }
+  function closeModal(id) { document.getElementById(id).classList.remove('open'); }
+
+  function openNewClientModal(editMode = false) {
+    if (editMode && activeRecord) {
+      document.getElementById('nc-code').value = activeRecord.clientCode;
+      document.getElementById('nc-code').disabled = true;
+      document.getElementById('nc-weight').value = activeRecord.weightKg || '';
+      document.getElementById('nc-height').value = activeRecord.heightCm || '';
+      document.getElementById('nc-dx').value = activeRecord.diagnosisCategory || '';
+      document.getElementById('nc-notes').value = activeRecord.notes || '';
+    } else {
+      document.getElementById('nc-code').value = '';
+      document.getElementById('nc-code').disabled = false;
+      document.getElementById('nc-weight').value = '';
+      document.getElementById('nc-height').value = '';
+      document.getElementById('nc-dx').value = '';
+      document.getElementById('nc-notes').value = '';
+    }
+    openModal('modal-new-client');
+  }
+
+  async function saveNewClient() {
+    const code = document.getElementById('nc-code').value.trim().toUpperCase();
+    const weight = parseFloat(document.getElementById('nc-weight').value) || undefined;
+    const height = parseFloat(document.getElementById('nc-height').value) || undefined;
+    const dx = document.getElementById('nc-dx').value || undefined;
+    const notes = document.getElementById('nc-notes').value || undefined;
+
+    if (!code) { toast('Client code is required'); return; }
+
+    const isEdit = activeRecord && document.getElementById('nc-code').disabled;
+
+    try {
+      let r;
+      if (isEdit) {
+        r = await fetchWithTimeout(`${API}/${activeRecord._id}`, {
+          method: 'PATCH',
+          headers: apiHeaders(),
+          body: JSON.stringify({ weightKg: weight, heightCm: height, diagnosisCategory: dx, notes }),
+        });
+      } else {
+        r = await fetchWithTimeout(API, {
+          method: 'POST',
+          headers: apiHeaders(),
+          body: JSON.stringify({ clientCode: code, weightKg: weight, heightCm: height, diagnosisCategory: dx, notes }),
+        });
+        if (r.status === 409) { toast('Client code already exists'); return; }
+      }
+      const d = await r.json();
+      if (!d.success) { toast(d.error); return; }
+      closeModal('modal-new-client');
+      await loadClients();
+      if (isEdit) {
+        activeRecord = d.data;
+        renderDetail();
+      } else {
+        await selectClient(d.data._id);
+      }
+      toast(isEdit ? 'Record updated' : 'Client record created');
+    } catch (err) {
+      toast('Error: ' + err.message);
+    }
+  }
+
+  function openAddMedModal() {
+    ['am-name','am-generic','am-targets'].forEach(id => document.getElementById(id).value = '');
+    document.getElementById('am-class').value = '';
+    document.getElementById('am-dose').value = '';
+    document.getElementById('am-frequency').value = 'once_daily';
+    document.getElementById('am-route').value = 'oral';
+    document.getElementById('am-prescriber').value = '';
+    document.getElementById('am-start').value = '';
+    openModal('modal-add-med');
+  }
+
+  async function saveMedication() {
+    if (!activeRecord) return;
+    const name = document.getElementById('am-name').value.trim();
+    const medicationClass = document.getElementById('am-class').value;
+    const doseAmountMg = parseFloat(document.getElementById('am-dose').value);
+    const frequency = document.getElementById('am-frequency').value;
+
+    if (!name || !medicationClass || !doseAmountMg || !frequency) {
+      toast('Please fill all required fields'); return;
+    }
+
+    const targets = document.getElementById('am-targets').value.split(',').map(s => s.trim()).filter(Boolean);
+    const payload = {
+      name,
+      genericName: document.getElementById('am-generic').value.trim() || undefined,
+      medicationClass,
+      doseAmountMg,
+      frequency,
+      route: document.getElementById('am-route').value,
+      prescriberType: document.getElementById('am-prescriber').value || undefined,
+      startDate: document.getElementById('am-start').value || undefined,
+      targetSymptoms: targets,
+    };
+
+    try {
+      const r = await fetchWithTimeout(`${API}/${activeRecord._id}/medications`, {
+        method: 'POST',
+        headers: apiHeaders(),
+        body: JSON.stringify(payload),
+      });
+      const d = await r.json();
+      if (!d.success) { toast(d.error); return; }
+      activeRecord = d.data;
+      closeModal('modal-add-med');
+      renderDetail();
+      renderClientList();
+      toast('Medication added');
+    } catch (err) {
+      toast('Error: ' + err.message);
+    }
+  }
+
+  function openObsModal(medId) {
+    document.getElementById('obs-med-id').value = medId;
+    document.getElementById('obs-efficacy').value = 3;
+    document.getElementById('obs-efficacy-val').textContent = '3';
+    document.getElementById('obs-sedation').value = 0;
+    document.getElementById('obs-sed-val').textContent = '0';
+    document.getElementById('obs-impairment').value = 0;
+    document.getElementById('obs-imp-val').textContent = '0';
+    document.getElementById('obs-trend').value = 'unknown';
+    document.getElementById('obs-prn').value = 0;
+    document.getElementById('obs-notes').value = '';
+    ['obs-flat-affect','obs-avolition','obs-anhedonia','obs-withdrawal','obs-alogia','obs-cog-slow',
+     'obs-sleep','obs-movement','obs-mood-instab','obs-appetite'].forEach(id => {
+      document.getElementById(id).checked = false;
+    });
+    document.getElementById('obs-weight-change').value = 'none';
+    openModal('modal-add-obs');
+  }
+
+  async function saveObservation() {
+    if (!activeRecord) return;
+    const medId = document.getElementById('obs-med-id').value;
+    const payload = {
+      efficacyScore: parseInt(document.getElementById('obs-efficacy').value),
+      sedationScore: parseInt(document.getElementById('obs-sedation').value),
+      functionalImpairmentScore: parseInt(document.getElementById('obs-impairment').value),
+      symptomTrend: document.getElementById('obs-trend').value,
+      prnUseCount: parseInt(document.getElementById('obs-prn').value) || 0,
+      notes: document.getElementById('obs-notes').value || undefined,
+      negativeSymptoms: {
+        flatAffect: document.getElementById('obs-flat-affect').checked,
+        avolition: document.getElementById('obs-avolition').checked,
+        anhedonia: document.getElementById('obs-anhedonia').checked,
+        socialWithdrawal: document.getElementById('obs-withdrawal').checked,
+        alogia: document.getElementById('obs-alogia').checked,
+        cognitiveSlowing: document.getElementById('obs-cog-slow').checked,
+      },
+      sideEffects: {
+        weightChange: document.getElementById('obs-weight-change').value,
+        sleepDisturbance: document.getElementById('obs-sleep').checked,
+        movementDisorder: document.getElementById('obs-movement').checked,
+        moodInstability: document.getElementById('obs-mood-instab').checked,
+        appetiteChange: document.getElementById('obs-appetite').checked,
+      },
+    };
+
+    try {
+      const r = await fetchWithTimeout(`${API}/${activeRecord._id}/medications/${medId}/observations`, {
+        method: 'POST',
+        headers: apiHeaders(),
+        body: JSON.stringify(payload),
+      });
+      const d = await r.json();
+      if (!d.success) { toast(d.error); return; }
+      activeRecord = d.data;
+      closeModal('modal-add-obs');
+      renderDetail();
+      renderClientList();
+      toast('Observation saved');
+    } catch (err) {
+      toast('Error: ' + err.message);
+    }
+  }
+
+  async function acknowledgeAlert(idx) {
+    try {
+      const r = await fetchWithTimeout(`${API}/${activeRecord._id}/alerts/${idx}/acknowledge`, {
+        method: 'PATCH',
+        headers: apiHeaders(),
+      });
+      const d = await r.json();
+      if (!d.success) { toast(d.error); return; }
+      activeRecord = d.data;
+      renderDetail();
+      renderClientList();
+      toast('Alert acknowledged');
+    } catch (err) {
+      toast('Error: ' + err.message);
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+  function loadFlagBadgeClass(flag) {
+    return { adequate: 'badge-adequate', possibly_under: 'badge-under', possibly_over: 'badge-over', review_needed: 'badge-review', unset: 'badge-unset' }[flag] || 'badge-unset';
+  }
+
+  function fmtLoad(flag) {
+    return { adequate: 'Adequate', possibly_under: 'Possibly Under', possibly_over: 'Possibly Over', review_needed: 'Review Needed', unset: 'Unassessed' }[flag] || 'Unassessed';
+  }
+
+  function dosageStatusBadge(status) {
+    if (!status || status === 'unset') return '';
+    const map = { within_range: 'badge-within', low: 'badge-low', high: 'badge-high', critical_low: 'badge-critical', critical_high: 'badge-critical' };
+    const label = { within_range: 'In Range', low: 'Low', high: 'High', critical_low: 'Critical Low', critical_high: 'Critical High' };
+    return `<span class="badge ${map[status] || 'badge-unset'}">${label[status] || status}</span>`;
+  }
+
+  function fmtEnum(s) {
+    if (!s) return '';
+    return s.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  function toast(msg, duration = 3000) {
+    const el = document.getElementById('toast');
+    el.textContent = msg;
+    el.classList.add('show');
+    setTimeout(() => el.classList.remove('show'), duration);
+  }
+
+  // Close modals on overlay click
+  document.querySelectorAll('.modal-overlay').forEach(overlay => {
+    overlay.addEventListener('click', e => {
+      if (e.target === overlay) overlay.classList.remove('open');
+    });
+  });
+
+  init();
+</script>
+</body>
+</html>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -100,6 +100,7 @@ import uploadsRoutes from './routes/uploads.js';
 import videoAuditRoutes from './routes/videoAudit.js';
 import orgRoutes from './routes/orgRoutes.js';
 import complianceRoutes from './routes/complianceRoutes.js';
+import medTrackerRoutes from './routes/medTracker.js';
 import { runVideoLinkAudit } from './jobs/videoLinkAuditJob.js';
 
 // ═══════════════════════════════════════════════════════════════
@@ -301,6 +302,7 @@ app.use('/api/uploads', uploadsRoutes);
 app.use('/api/admin/video-audit', videoAuditRoutes);
 app.use('/api/orgs', orgRoutes);
 app.use('/api', complianceRoutes);
+app.use('/api/med-tracker', medTrackerRoutes);
 
 app.use('/templates', express.static(path.join(__dirname, 'templates')));
 

--- a/server/src/models/MedTracker.js
+++ b/server/src/models/MedTracker.js
@@ -1,0 +1,294 @@
+/**
+ * MedTracker.js — Psychotropic Medication Tracking Model
+ * Tracks client medications by anonymous ID (no PII stored).
+ * Supports dosage/weight ratio analysis, efficacy tracking,
+ * negative symptom monitoring, and contraindication flags.
+ */
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+// ── Observation entry (timestamped clinician rating) ──────────────────────────
+const ObservationSchema = new Schema({
+  date:           { type: Date, default: Date.now },
+  clinicianId:    { type: Schema.Types.ObjectId, ref: 'User', required: true },
+
+  // Efficacy (1 = not working, 5 = excellent)
+  efficacyScore:  { type: Number, min: 1, max: 5 },
+
+  // Sedation / over-medication signal (0 = none, 5 = severely sedated)
+  sedationScore:  { type: Number, min: 0, max: 5 },
+
+  // Functional impairment (0 = none, 5 = severe)
+  functionalImpairmentScore: { type: Number, min: 0, max: 5 },
+
+  // Negative symptoms checklist
+  negativeSymptoms: {
+    flatAffect:       { type: Boolean, default: false },
+    avolition:        { type: Boolean, default: false },
+    anhedonia:        { type: Boolean, default: false },
+    socialWithdrawal: { type: Boolean, default: false },
+    alogia:           { type: Boolean, default: false },
+    cognitiveSlowing: { type: Boolean, default: false },
+  },
+
+  // Side effects observed
+  sideEffects: {
+    weightChange:     { type: String, enum: ['none', 'gain', 'loss'], default: 'none' },
+    sleepDisturbance: { type: Boolean, default: false },
+    movementDisorder: { type: Boolean, default: false }, // EPS, tardive dyskinesia flag
+    moodInstability:  { type: Boolean, default: false },
+    appetiteChange:   { type: Boolean, default: false },
+  },
+
+  // PRN usage since last observation (frequent = under-controlled signal)
+  prnUseCount:    { type: Number, default: 0 },
+
+  // Symptom trend relative to previous observation
+  symptomTrend: {
+    type: String,
+    enum: ['improving', 'stable', 'worsening', 'unknown'],
+    default: 'unknown'
+  },
+
+  notes: { type: String, maxlength: 2000 },
+}, { _id: true });
+
+// ── Per-medication record ─────────────────────────────────────────────────────
+const MedicationSchema = new Schema({
+  name:           { type: String, required: true, trim: true },
+  genericName:    { type: String, trim: true },
+
+  // Classification
+  medicationClass: {
+    type: String,
+    enum: [
+      'antipsychotic_typical',
+      'antipsychotic_atypical',
+      'antidepressant_ssri',
+      'antidepressant_snri',
+      'antidepressant_maoi',
+      'antidepressant_tca',
+      'antidepressant_other',
+      'mood_stabilizer',
+      'anxiolytic_benzodiazepine',
+      'anxiolytic_other',
+      'stimulant',
+      'non_stimulant_adhd',
+      'hypnotic',
+      'anticholinergic',
+      'other'
+    ],
+    required: true
+  },
+
+  // Dosing
+  doseAmountMg:   { type: Number, required: true },       // mg per administration
+  frequency:      {
+    type: String,
+    enum: ['once_daily', 'twice_daily', 'three_times_daily', 'four_times_daily',
+           'every_other_day', 'weekly', 'as_needed', 'other'],
+    required: true
+  },
+  route:          {
+    type: String,
+    enum: ['oral', 'sublingual', 'injectable_im', 'injectable_iv', 'patch', 'other'],
+    default: 'oral'
+  },
+
+  // Calculated fields (set at record-save time from client biometrics)
+  dailyDoseMg:    { type: Number },   // doseAmountMg × doses_per_day
+  mgPerKg:        { type: Number },   // dailyDoseMg / weightKg
+  dosageStatus: {
+    type: String,
+    enum: ['within_range', 'low', 'high', 'critical_low', 'critical_high', 'unset'],
+    default: 'unset'
+  },
+
+  // Prescriber (free text — no PII linkage required)
+  prescriberType: {
+    type: String,
+    enum: ['psychiatrist', 'pcp', 'np', 'pa', 'neurologist', 'other'],
+  },
+
+  // Dates
+  startDate:      { type: Date },
+  endDate:        { type: Date },   // null = still active
+  isActive:       { type: Boolean, default: true },
+
+  // Target symptoms this med addresses
+  targetSymptoms: [{ type: String, trim: true }],
+
+  // Observations over time
+  observations:   [ObservationSchema],
+}, { _id: true });
+
+// ── Root client record ────────────────────────────────────────────────────────
+const MedTrackerSchema = new Schema({
+  // Anonymous client identifier — NO name, DOB, SSN, or contact info stored
+  clientCode:     { type: String, required: true, trim: true, uppercase: true },
+
+  // Clinician who owns this record
+  clinicianId:    { type: Schema.Types.ObjectId, ref: 'User', required: true },
+
+  // Biometrics — used for mg/kg dosage ratio calculation
+  weightKg:       { type: Number },   // kilograms
+  heightCm:       { type: Number },   // centimeters
+  bmi:            { type: Number },   // auto-calculated on save
+
+  // Diagnosis context (DSM-5 category, not full diagnosis)
+  diagnosisCategory: {
+    type: String,
+    enum: [
+      'schizophrenia_spectrum',
+      'bipolar_related',
+      'depressive_disorders',
+      'anxiety_disorders',
+      'trauma_related',
+      'ocd_related',
+      'adhd',
+      'personality_disorders',
+      'neurodevelopmental',
+      'substance_related',
+      'other'
+    ]
+  },
+
+  // Active medications
+  medications:    [MedicationSchema],
+
+  // Contraindication flags (auto-checked on save against known interaction pairs)
+  contraindicationAlerts: [{
+    med1:     { type: String },
+    med2:     { type: String },
+    severity: { type: String, enum: ['mild', 'moderate', 'severe', 'contraindicated'] },
+    reason:   { type: String },
+    flaggedAt: { type: Date, default: Date.now },
+    acknowledged: { type: Boolean, default: false },
+    acknowledgedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    acknowledgedAt: { type: Date },
+  }],
+
+  // Overall medication load assessment (computed)
+  medicationLoadFlag: {
+    type: String,
+    enum: ['adequate', 'possibly_under', 'possibly_over', 'review_needed', 'unset'],
+    default: 'unset'
+  },
+
+  notes:          { type: String, maxlength: 5000 },
+  isArchived:     { type: Boolean, default: false },
+}, {
+  timestamps: true,
+  collection: 'medtrackerrecords'
+});
+
+// ── Indexes ───────────────────────────────────────────────────────────────────
+MedTrackerSchema.index({ clinicianId: 1, clientCode: 1 }, { unique: true });
+MedTrackerSchema.index({ clinicianId: 1, isArchived: 1 });
+
+// ── Pre-save: compute BMI and mg/kg ratios ────────────────────────────────────
+MedTrackerSchema.pre('save', function(next) {
+  // BMI = weight(kg) / (height(m))^2
+  if (this.weightKg && this.heightCm) {
+    const heightM = this.heightCm / 100;
+    this.bmi = Math.round((this.weightKg / (heightM * heightM)) * 10) / 10;
+  }
+
+  // Compute mg/kg for each active med and flag dosage status
+  if (this.weightKg) {
+    for (const med of this.medications) {
+      const dosesPerDay = {
+        once_daily: 1, twice_daily: 2, three_times_daily: 3,
+        four_times_daily: 4, every_other_day: 0.5, weekly: 1/7,
+        as_needed: 1, other: 1
+      }[med.frequency] ?? 1;
+
+      med.dailyDoseMg = med.doseAmountMg * dosesPerDay;
+      med.mgPerKg = Math.round((med.dailyDoseMg / this.weightKg) * 1000) / 1000;
+
+      // Simple high-level dosage flag based on mg/kg thresholds by class
+      med.dosageStatus = computeDosageStatus(med);
+    }
+  }
+
+  // Compute overall medication load
+  this.medicationLoadFlag = computeMedLoad(this);
+
+  next();
+});
+
+// ── Helper: dosage status by medication class ─────────────────────────────────
+function computeDosageStatus(med) {
+  if (!med.mgPerKg) return 'unset';
+
+  // Thresholds (mg/kg/day) — conservative clinical ranges for flagging only.
+  // These are NOT clinical decision support; they are observation prompts.
+  const thresholds = {
+    antipsychotic_typical:      { low: 0.05, high: 1.0, critHigh: 2.0 },
+    antipsychotic_atypical:     { low: 0.03, high: 0.6, critHigh: 1.2 },
+    antidepressant_ssri:        { low: 0.1,  high: 1.5, critHigh: 3.0 },
+    antidepressant_snri:        { low: 0.1,  high: 2.0, critHigh: 4.0 },
+    antidepressant_maoi:        { low: 0.1,  high: 1.0, critHigh: 1.5 },
+    antidepressant_tca:         { low: 0.5,  high: 3.0, critHigh: 5.0 },
+    antidepressant_other:       { low: 0.1,  high: 2.0, critHigh: 4.0 },
+    mood_stabilizer:            { low: 5.0,  high: 30,  critHigh: 40  },
+    anxiolytic_benzodiazepine:  { low: 0.02, high: 0.3, critHigh: 0.6 },
+    anxiolytic_other:           { low: 0.1,  high: 1.0, critHigh: 2.0 },
+    stimulant:                  { low: 0.1,  high: 1.0, critHigh: 2.0 },
+    non_stimulant_adhd:         { low: 0.5,  high: 1.8, critHigh: 2.5 },
+    hypnotic:                   { low: 0.03, high: 0.2, critHigh: 0.4 },
+  };
+
+  const t = thresholds[med.medicationClass];
+  if (!t) return 'unset';
+
+  if (med.mgPerKg >= t.critHigh)  return 'critical_high';
+  if (med.mgPerKg >= t.high)      return 'high';
+  if (med.mgPerKg < t.low)        return 'low';
+  return 'within_range';
+}
+
+// ── Helper: overall medication load ──────────────────────────────────────────
+function computeMedLoad(record) {
+  const active = record.medications.filter(m => m.isActive);
+  if (!active.length) return 'unset';
+
+  const highCount     = active.filter(m => ['high', 'critical_high'].includes(m.dosageStatus)).length;
+  const lowCount      = active.filter(m => ['low', 'critical_low'].includes(m.dosageStatus)).length;
+  const critHighCount = active.filter(m => m.dosageStatus === 'critical_high').length;
+  const hasUnack      = record.contraindicationAlerts?.some(a => !a.acknowledged);
+
+  if (critHighCount > 0 || hasUnack) return 'review_needed';
+  if (highCount > lowCount && highCount > 0) return 'possibly_over';
+  if (lowCount > 0 && highCount === 0) return 'possibly_under';
+  return 'adequate';
+}
+
+// ── Known interaction pairs ───────────────────────────────────────────────────
+// Abbreviated set of clinically significant psychotropic interactions.
+// Keys are normalized lowercase generic names.
+export const KNOWN_INTERACTIONS = [
+  { drugs: ['fluoxetine', 'maoi'], severity: 'contraindicated', reason: 'Risk of serotonin syndrome' },
+  { drugs: ['sertraline', 'maoi'], severity: 'contraindicated', reason: 'Risk of serotonin syndrome' },
+  { drugs: ['venlafaxine', 'maoi'], severity: 'contraindicated', reason: 'Risk of serotonin syndrome' },
+  { drugs: ['tramadol', 'ssri'], severity: 'severe', reason: 'Increased serotonin syndrome risk' },
+  { drugs: ['lithium', 'nsaid'], severity: 'moderate', reason: 'NSAIDs may increase lithium levels' },
+  { drugs: ['lithium', 'haloperidol'], severity: 'moderate', reason: 'Risk of neurotoxicity' },
+  { drugs: ['clozapine', 'benzodiazepine'], severity: 'severe', reason: 'Risk of respiratory depression' },
+  { drugs: ['clozapine', 'valproate'], severity: 'moderate', reason: 'Increased seizure risk' },
+  { drugs: ['carbamazepine', 'clozapine'], severity: 'contraindicated', reason: 'Increased agranulocytosis risk' },
+  { drugs: ['haloperidol', 'lithium'], severity: 'moderate', reason: 'Monitor for neurotoxicity' },
+  { drugs: ['aripiprazole', 'carbamazepine'], severity: 'moderate', reason: 'Carbamazepine reduces aripiprazole levels' },
+  { drugs: ['quetiapine', 'carbamazepine'], severity: 'moderate', reason: 'Reduced quetiapine efficacy' },
+  { drugs: ['alprazolam', 'opioid'], severity: 'severe', reason: 'Combined CNS depression risk' },
+  { drugs: ['diazepam', 'opioid'], severity: 'severe', reason: 'Combined CNS depression risk' },
+  { drugs: ['bupropion', 'maoi'], severity: 'contraindicated', reason: 'Risk of hypertensive crisis' },
+  { drugs: ['amphetamine', 'maoi'], severity: 'contraindicated', reason: 'Risk of hypertensive crisis' },
+  { drugs: ['methylphenidate', 'maoi'], severity: 'contraindicated', reason: 'Risk of hypertensive crisis' },
+  { drugs: ['valproate', 'lamotrigine'], severity: 'moderate', reason: 'Valproate doubles lamotrigine levels' },
+  { drugs: ['clonidine', 'stimulant'], severity: 'mild', reason: 'Monitor blood pressure interaction' },
+  { drugs: ['trazodone', 'ssri'], severity: 'moderate', reason: 'Additive serotonergic effect' },
+];
+
+export default mongoose.model('MedTrackerRecord', MedTrackerSchema);

--- a/server/src/routeManifest.js
+++ b/server/src/routeManifest.js
@@ -83,6 +83,7 @@ import orgRoutes from './routes/orgRoutes.js';
 import complianceRoutes from './routes/complianceRoutes.js';
 import liveSessionRoutes from './routes/liveSessions.js';
 import webhooksWherebyRoutes from './routes/webhooksWhereby.js';
+import medTrackerRoutes from './routes/medTracker.js';
 
 /**
  * Route Manifest — declared route registrations.
@@ -167,6 +168,7 @@ export const ROUTE_MANIFEST = [
   ['/api',                       complianceRoutes,          'Practice Compliance — Credentials/Policies/Supervision/Audit Binder'],
   ['/api/live-sessions',         liveSessionRoutes,         'Live Sessions (Whereby)'],
   ['/api/webhooks/whereby',      webhooksWherebyRoutes,     'Whereby attendance + recording webhook'],
+  ['/api/med-tracker',           medTrackerRoutes,          'Psychotropic Med Tracker'],
 ];
 
 /**

--- a/server/src/routes/medTracker.js
+++ b/server/src/routes/medTracker.js
@@ -1,0 +1,300 @@
+/**
+ * medTracker.js — Psychotropic Medication Tracker API
+ * All clients are referenced by anonymous clientCode only — no PII stored.
+ */
+import express from 'express';
+import MedTrackerRecord, { KNOWN_INTERACTIONS } from '../models/MedTracker.js';
+import { protect } from '../middleware/auth.js';
+
+const router = express.Router();
+
+// All routes require authentication
+router.use(protect);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Checks a list of medication names/genericNames against KNOWN_INTERACTIONS.
+ * Returns array of triggered alerts (deduplicated).
+ */
+function checkInteractions(medications) {
+  const alerts = [];
+  const names = medications
+    .filter(m => m.isActive !== false)
+    .flatMap(m => [m.name, m.genericName].filter(Boolean).map(n => n.toLowerCase().trim()));
+
+  for (const interaction of KNOWN_INTERACTIONS) {
+    const [drugA, drugB] = interaction.drugs;
+    const aMatch = names.some(n => n.includes(drugA));
+    const bMatch = names.some(n => n.includes(drugB));
+    if (aMatch && bMatch) {
+      const alreadyAdded = alerts.some(
+        a => a.med1 === drugA && a.med2 === drugB
+      );
+      if (!alreadyAdded) {
+        alerts.push({
+          med1: drugA,
+          med2: drugB,
+          severity: interaction.severity,
+          reason: interaction.reason,
+        });
+      }
+    }
+  }
+
+  return alerts;
+}
+
+// ── GET /api/med-tracker — list all records for authenticated clinician ────────
+router.get('/', async (req, res) => {
+  try {
+    const records = await MedTrackerRecord.find({
+      clinicianId: req.user._id,
+      isArchived: false,
+    })
+      .select('-medications.observations') // omit observation history from list view
+      .sort({ updatedAt: -1 });
+    res.json({ success: true, data: records });
+  } catch (err) {
+    console.error('[MedTracker] GET /', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── GET /api/med-tracker/:id — single full record ─────────────────────────────
+router.get('/:id', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+    res.json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] GET /:id', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── POST /api/med-tracker — create new client record ─────────────────────────
+router.post('/', async (req, res) => {
+  try {
+    const { clientCode, weightKg, heightCm, diagnosisCategory, notes } = req.body;
+
+    if (!clientCode) {
+      return res.status(400).json({ success: false, error: 'clientCode is required' });
+    }
+
+    const existing = await MedTrackerRecord.findOne({
+      clinicianId: req.user._id,
+      clientCode: clientCode.toUpperCase().trim(),
+    });
+    if (existing) {
+      return res.status(409).json({ success: false, error: 'Client code already exists for this clinician', id: existing._id });
+    }
+
+    const record = new MedTrackerRecord({
+      clientCode,
+      clinicianId: req.user._id,
+      weightKg,
+      heightCm,
+      diagnosisCategory,
+      notes,
+    });
+    await record.save();
+    res.status(201).json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] POST /', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── PATCH /api/med-tracker/:id — update biometrics or notes ──────────────────
+router.patch('/:id', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const allowed = ['weightKg', 'heightCm', 'diagnosisCategory', 'notes', 'isArchived'];
+    for (const field of allowed) {
+      if (req.body[field] !== undefined) record[field] = req.body[field];
+    }
+    await record.save();
+    res.json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] PATCH /:id', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── POST /api/med-tracker/:id/medications — add a medication ─────────────────
+router.post('/:id/medications', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const med = req.body;
+    if (!med.name || !med.medicationClass || !med.doseAmountMg || !med.frequency) {
+      return res.status(400).json({ success: false, error: 'name, medicationClass, doseAmountMg, and frequency are required' });
+    }
+
+    record.medications.push(med);
+
+    // Re-check interactions with the new medication included
+    const newAlerts = checkInteractions(record.medications);
+    // Merge new alerts (avoid duplicates by med1+med2 pair)
+    for (const alert of newAlerts) {
+      const alreadyExists = record.contraindicationAlerts.some(
+        a => a.med1 === alert.med1 && a.med2 === alert.med2
+      );
+      if (!alreadyExists) record.contraindicationAlerts.push(alert);
+    }
+
+    await record.save();
+    res.status(201).json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] POST /:id/medications', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── PATCH /api/med-tracker/:id/medications/:medId — update a medication ──────
+router.patch('/:id/medications/:medId', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const med = record.medications.id(req.params.medId);
+    if (!med) return res.status(404).json({ success: false, error: 'Medication not found' });
+
+    const updatable = [
+      'name', 'genericName', 'medicationClass', 'doseAmountMg', 'frequency',
+      'route', 'prescriberType', 'startDate', 'endDate', 'isActive', 'targetSymptoms'
+    ];
+    for (const field of updatable) {
+      if (req.body[field] !== undefined) med[field] = req.body[field];
+    }
+
+    // Re-check interactions after update
+    const newAlerts = checkInteractions(record.medications);
+    record.contraindicationAlerts = [];
+    for (const alert of newAlerts) {
+      record.contraindicationAlerts.push(alert);
+    }
+
+    await record.save();
+    res.json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] PATCH /:id/medications/:medId', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── POST /api/med-tracker/:id/medications/:medId/observations — add observation
+router.post('/:id/medications/:medId/observations', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const med = record.medications.id(req.params.medId);
+    if (!med) return res.status(404).json({ success: false, error: 'Medication not found' });
+
+    med.observations.push({
+      ...req.body,
+      clinicianId: req.user._id,
+    });
+
+    await record.save();
+    res.status(201).json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] POST observations', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── PATCH /api/med-tracker/:id/alerts/:alertIndex/acknowledge ────────────────
+router.patch('/:id/alerts/:alertIndex/acknowledge', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const idx = parseInt(req.params.alertIndex, 10);
+    if (isNaN(idx) || idx < 0 || idx >= record.contraindicationAlerts.length) {
+      return res.status(400).json({ success: false, error: 'Invalid alert index' });
+    }
+
+    record.contraindicationAlerts[idx].acknowledged = true;
+    record.contraindicationAlerts[idx].acknowledgedBy = req.user._id;
+    record.contraindicationAlerts[idx].acknowledgedAt = new Date();
+
+    await record.save();
+    res.json({ success: true, data: record });
+  } catch (err) {
+    console.error('[MedTracker] PATCH acknowledge', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ── GET /api/med-tracker/:id/summary — computed load summary ─────────────────
+router.get('/:id/summary', async (req, res) => {
+  try {
+    const record = await MedTrackerRecord.findOne({
+      _id: req.params.id,
+      clinicianId: req.user._id,
+    });
+    if (!record) return res.status(404).json({ success: false, error: 'Record not found' });
+
+    const activeMeds = record.medications.filter(m => m.isActive);
+    const unacknowledgedAlerts = record.contraindicationAlerts.filter(a => !a.acknowledged);
+
+    const latestObservations = activeMeds.map(med => {
+      const obs = med.observations.sort((a, b) => new Date(b.date) - new Date(a.date));
+      return {
+        medId: med._id,
+        medName: med.name,
+        dosageStatus: med.dosageStatus,
+        mgPerKg: med.mgPerKg,
+        dailyDoseMg: med.dailyDoseMg,
+        latestEfficacy: obs[0]?.efficacyScore ?? null,
+        latestSedation: obs[0]?.sedationScore ?? null,
+        latestTrend: obs[0]?.symptomTrend ?? 'unknown',
+        negativeSymptomCount: obs[0] ? Object.values(obs[0].negativeSymptoms).filter(Boolean).length : 0,
+        observationCount: obs.length,
+      };
+    });
+
+    res.json({
+      success: true,
+      data: {
+        clientCode: record.clientCode,
+        bmi: record.bmi,
+        weightKg: record.weightKg,
+        heightCm: record.heightCm,
+        medicationLoadFlag: record.medicationLoadFlag,
+        unacknowledgedAlertCount: unacknowledgedAlerts.length,
+        alerts: unacknowledgedAlerts,
+        medications: latestObservations,
+      }
+    });
+  } catch (err) {
+    console.error('[MedTracker] GET summary', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- **New model** `server/src/models/MedTracker.js` — anonymous client records (code-only, no PII), per-medication subdocuments with timestamped observations, mg/kg dosage ratio auto-computed from weight/height on save, negative symptom tracking, side-effect log, 20-pair contraindication alert engine, and overall medication load flag (adequate / possibly_under / possibly_over / review_needed)
- **New route** `server/src/routes/medTracker.js` — full REST API at `/api/med-tracker`: CRUD client records, add/update medications, log observations, acknowledge interaction alerts, computed summary endpoint
- **New frontend** `client/public/med-tracker.html` — static single-page UI consistent with platform architecture: client list panel, detail panel with efficacy bar, sedation/impairment sliders, negative symptom checklist, contraindication alert banners with acknowledge flow
- **Wired** into `server/src/index.js` and `server/src/routeManifest.js` at `/api/med-tracker`

## Clinical scope

This is a **clinician observation tool**, not a clinical decision engine. Dosage flags (within_range / low / high / critical_high) are conversation prompts based on conservative mg/kg thresholds by medication class — they surface for the clinician to review with the prescriber, not to replace prescriber judgment. All clients are identified by anonymous code only; no name, DOB, or contact info is stored.

## Test plan

- [ ] Create a new client record with a code, weight, height, and diagnosis category
- [ ] Add two medications that have a known interaction (e.g. fluoxetine + MAOI) — confirm alert banner appears
- [ ] Acknowledge the interaction alert — confirm banner clears and load flag recalculates
- [ ] Add an observation with high sedation score — confirm "High sedation" warning appears on med row
- [ ] Verify mg/kg and BMI display correctly after saving weight/height
- [ ] Confirm route integrity check passes on server boot (no untracked route warnings)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg96C7xV9kX6kaxyxLseyf)_