### PR TITLE
feat: partner feature gating — backend + frontend (Prompts 1–4)

### DIFF
--- a/client/public/certificates.html
+++ b/client/public/certificates.html
@@ -10,6 +10,50 @@
 </head>
 <body>
   <script src="/shared/nav-footer.js"></script>
-  <script>window.location.replace('/credentials.html#certifications');</script>
+  <script>
+    (async function() {
+      const token = localStorage.getItem('token');
+      if (token) {
+        // Partner feature gate
+        try {
+          const flagsRes = await fetch('/api/auth/features', {
+            headers: { 'Authorization': `Bearer ${token}` }
+          });
+          if (flagsRes.ok) {
+            const { features } = await flagsRes.json();
+            if (features && features.isPartnerUser && !features.certTracking) {
+              document.querySelector('body').innerHTML = `
+                <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+                  <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+                  <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+                  <p style="color:#4A7C59;margin-bottom:24px;">
+                    This feature requires the Certificate Tracking add-on.
+                    Contact your organization administrator to enable it.
+                  </p>
+                  <a href="/partner-billing.html#addons"
+                     style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                    View Add-ons
+                  </a>
+                </div>
+              `;
+              return;
+            }
+            if (features && features.isPartnerUser && features.certTracking) {
+              const badge = document.createElement('div');
+              badge.id = 'cr-powered-badge';
+              badge.innerHTML = `
+                <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+                  <span style="font-weight:700;">Powered by</span>
+                  <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+                </div>
+              `;
+              document.body.appendChild(badge);
+            }
+          }
+        } catch (e) { /* fail-open */ }
+      }
+      window.location.replace('/credentials.html#certifications');
+    })();
+  </script>
 </body>
 </html>

--- a/client/public/credentials.html
+++ b/client/public/credentials.html
@@ -389,6 +389,46 @@
     const token = localStorage.getItem('token');
     if (!token) window.location.href = '/login.html';
 
+    // Partner feature gate
+    (async function() {
+      try {
+        const flagsRes = await fetch('/api/auth/features', {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (flagsRes.ok) {
+          const { features } = await flagsRes.json();
+          if (features && features.isPartnerUser && !features.credentialManagement) {
+            document.querySelector('main') && (document.querySelector('main').innerHTML = `
+              <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+                <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+                <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+                <p style="color:#4A7C59;margin-bottom:24px;">
+                  This feature requires the Credential Management add-on.
+                  Contact your organization administrator to enable it.
+                </p>
+                <a href="/partner-billing.html#addons"
+                   style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                  View Add-ons
+                </a>
+              </div>
+            `);
+            return;
+          }
+          if (features && features.isPartnerUser && features.credentialManagement) {
+            const badge = document.createElement('div');
+            badge.id = 'cr-powered-badge';
+            badge.innerHTML = `
+              <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+                <span style="font-weight:700;">Powered by</span>
+                <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+              </div>
+            `;
+            document.body.appendChild(badge);
+          }
+        }
+      } catch (e) { /* fail-open */ }
+    })();
+
     let allCredentials = [];
     let allCertificates = [];
 

--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -107,6 +107,14 @@
   <script>
     const API=location.hostname==='localhost'?'http://localhost:5000':'https://api.counselorready.com';
     const T=localStorage.getItem('token');if(!T)location.href='/login.html';
+    // Hide Clinical Tools card for partner users without clinicalTools feature
+    setTimeout(function() {
+      if (window.crFeatureFlags && window.crFeatureFlags.isPartnerUser && !window.crFeatureFlags.clinicalTools) {
+        document.querySelectorAll('a[href="/tools/index.html"]').forEach(function(el) {
+          el.style.display = 'none';
+        });
+      }
+    }, 800);
     // Welcome message (user data loaded by shared nav-footer.js)
     setTimeout(()=>{try{const u=JSON.parse(localStorage.getItem('user')||'{}');const f=u.profile?.firstName||u.firstName||'';if(f){const el=document.getElementById('welcomeMsg');if(el)el.textContent='Welcome back, '+f+'!';}}catch(e){}},600);
     async function loadStats(){try{

--- a/client/public/my-compliance.html
+++ b/client/public/my-compliance.html
@@ -63,6 +63,45 @@ const fmt = d => d ? new Date(d).toLocaleDateString() : '';
 async function init() {
   const root = document.getElementById('root');
   if (!token) { root.innerHTML = '<div class="card"><h2>Sign in required</h2><p class="muted"><a href="/signin.html">Sign in</a> to view your assigned training.</p></div>'; return; }
+
+  // Partner feature gate
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.complianceTracking) {
+        document.querySelector('main') && (document.querySelector('main').innerHTML = `
+          <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+            <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+            <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+            <p style="color:#4A7C59;margin-bottom:24px;">
+              This feature requires the Compliance Tracking add-on.
+              Contact your organization administrator to enable it.
+            </p>
+            <a href="/partner-billing.html#addons"
+               style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+              View Add-ons
+            </a>
+          </div>
+        `);
+        return;
+      }
+      if (features && features.isPartnerUser && features.complianceTracking) {
+        const badge = document.createElement('div');
+        badge.id = 'cr-powered-badge';
+        badge.innerHTML = `
+          <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+            <span style="font-weight:700;">Powered by</span>
+            <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+          </div>
+        `;
+        document.body.appendChild(badge);
+      }
+    }
+  } catch (e) { /* fail-open */ }
+
   let data;
   try { data = await api('/api/me/compliance'); } catch (e) { root.innerHTML = '<div class="card"><p class="muted">Could not load your compliance data.</p></div>'; return; }
   if (!data.orgs || !data.orgs.length) { root.innerHTML = '<div class="card"><h2>No assigned training</h2><p class="muted">You have no practice-assigned training. Your personal CE history is unaffected and remains in your dashboard.</p></div>'; return; }

--- a/client/public/partner-marketplace.html
+++ b/client/public/partner-marketplace.html
@@ -66,29 +66,10 @@
 
     <div id="content" class="hidden space-y-5">
 
-      <!-- Option 1: import CR catalog -->
-      <div class="bg-white rounded-2xl border border-gray-200 p-6">
-        <div class="flex items-start gap-4">
-          <div class="w-11 h-11 rounded-xl flex items-center justify-center flex-none bg-burgundy-50">
-            <i class="fas fa-layer-group text-burgundy-800"></i>
-          </div>
-          <div class="flex-1">
-            <div class="flex items-start justify-between gap-3">
-              <div>
-                <h2 class="text-base font-semibold text-stone-900">Add CounselorReady courses to your library</h2>
-                <p class="text-sm text-stone-500 mt-0.5">Instantly offer our full published catalog under your brand. You keep <span id="importCut" class="font-semibold text-hunter-700">15%</span> of every sale you drive; nothing to build or maintain.</p>
-              </div>
-              <label class="switch mt-1">
-                <input type="checkbox" id="importToggle" onchange="onToggle()">
-                <span class="slider"></span>
-              </label>
-            </div>
-            <div class="mt-3 inline-flex items-center gap-2 text-xs text-stone-600 bg-stone-50 rounded-lg px-3 py-1.5">
-              <i class="fas fa-book-open text-stone-400"></i>
-              <span id="platformCount">—</span> CounselorReady courses available
-            </div>
-          </div>
-        </div>
+      <!-- Option 1: import CR catalog — discontinued -->
+      <div class="bg-stone-100 border border-stone-300 rounded-lg p-4 opacity-60">
+        <p class="font-medium text-stone-600">Import Platform Courses</p>
+        <p class="text-sm text-stone-500 mt-1">This program has been discontinued. You can list your own courses in the CounselorReady marketplace instead.</p>
       </div>
 
       <!-- Option 2: list in CR marketplace -->
@@ -182,7 +163,6 @@
         const distPct = d.distributorPercent ?? 15;
         const ownPct = d.ownerPercent ?? 85;
 
-        document.getElementById('importToggle').checked = !!d.syndication.importPlatformCourses;
         document.getElementById('listToggle').checked = !!d.syndication.listInMarketplace;
         document.getElementById('platformCount').textContent = d.opportunities?.platformCoursesAvailable ?? 0;
         document.getElementById('myCount').textContent = d.opportunities?.myPublishedCourses ?? 0;
@@ -239,9 +219,8 @@
     async function save() {
       const btn = document.getElementById('saveBtn');
       const msg = document.getElementById('saveMsg');
-      const wantImport = document.getElementById('importToggle').checked;
       const wantList = document.getElementById('listToggle').checked;
-      const willBeOn = wantImport || wantList;
+      const willBeOn = wantList;
       const agreed = document.getElementById('agreeCheck').checked;
 
       // Enabling requires accepting the current agreement version (unless already on file).
@@ -253,7 +232,7 @@
 
       btn.disabled = true; btn.textContent = 'Saving...';
       try {
-        const body = { importPlatformCourses: wantImport, listInMarketplace: wantList };
+        const body = { listInMarketplace: wantList };
         // Send the accepted version when the user has checked the box and we don't already have a
         // current-version acceptance on file (a fresh acceptance / re-acceptance).
         if (agreed && !AGREEMENT.accepted) body.acceptedVersion = AGREEMENT.currentVersion;

--- a/client/public/shared/nav-footer.js
+++ b/client/public/shared/nav-footer.js
@@ -247,6 +247,41 @@
   const API = location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
   const T = localStorage.getItem('token');
 
+  // Fetch feature flags for partner gating
+  let featureFlags = null;
+  if (T) {
+    fetch(`${API}/api/auth/features`, { headers: { Authorization: `Bearer ${T}` } })
+      .then(r => { if (r.ok) return r.json(); })
+      .then(d => {
+        if (d && d.features) {
+          featureFlags = d.features;
+          window.crFeatureFlags = featureFlags;
+          // Hide nav links based on partner feature flags
+          if (featureFlags.isPartnerUser) {
+            if (!featureFlags.certTracking) {
+              document.querySelectorAll('a[href="/credentials.html#certifications"]').forEach(el => el.style.display = 'none');
+            }
+            if (!featureFlags.credentialManagement) {
+              document.querySelectorAll('a[href="/credentials.html"]').forEach(el => el.style.display = 'none');
+            }
+            if (!featureFlags.complianceTracking) {
+              document.querySelectorAll('a[href="/my-compliance.html"], a[href="/team-compliance.html"]').forEach(el => el.style.display = 'none');
+              const tcb = document.getElementById('teamCompBadge');
+              if (tcb) tcb.style.display = 'none';
+              const tcm = document.getElementById('teamCompMob');
+              if (tcm) tcm.style.display = 'none';
+              const tcl = document.getElementById('menuTeamCompLink');
+              if (tcl) tcl.style.display = 'none';
+            }
+            if (!featureFlags.clinicalTools) {
+              document.querySelectorAll('a[href^="/tools/"]').forEach(el => el.style.display = 'none');
+            }
+          }
+        }
+      })
+      .catch(() => {});
+  }
+
   if (T) {
     fetch(`${API}/api/auth/me`, { headers: { Authorization: `Bearer ${T}` } })
       .then(r => {

--- a/client/public/team-compliance.html
+++ b/client/public/team-compliance.html
@@ -287,6 +287,48 @@
 <script>
 const API = location.hostname==='localhost' ? 'http://localhost:5000' : 'https://api.counselorready.com';
 const token = localStorage.getItem('token');
+
+// Partner feature gate
+(async function() {
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.complianceTracking) {
+        document.querySelector('main') && (document.querySelector('main').innerHTML = `
+          <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+            <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+            <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+            <p style="color:#4A7C59;margin-bottom:24px;">
+              This feature requires the Compliance Tracking add-on.
+              Contact your organization administrator to enable it.
+            </p>
+            <a href="/partner-billing.html#addons"
+               style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+              View Add-ons
+            </a>
+          </div>
+        `);
+        return;
+      }
+      if (features && features.isPartnerUser && features.complianceTracking) {
+        const badge = document.createElement('div');
+        badge.id = 'cr-powered-badge';
+        badge.innerHTML = `
+          <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+            <span style="font-weight:700;">Powered by</span>
+            <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+          </div>
+        `;
+        document.body.appendChild(badge);
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+
 let currentOrgId = null;
 let currentOrgIsAdmin = false;
 let currentUserEmail = '';

--- a/client/public/tools/consent-generator.html
+++ b/client/public/tools/consent-generator.html
@@ -71,6 +71,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 
 <div class="hdr">
   <div class="hdr-top">

--- a/client/public/tools/diagnostic-helper.html
+++ b/client/public/tools/diagnostic-helper.html
@@ -78,6 +78,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top"><span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span><span class="badge" style="background:rgba(212,168,85,.15);color:var(--gold)">CLINICAL THINKING AID</span></div>
 <div class="hdr-title"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#D4A855" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>Diagnostic Impressions Helper</div>

--- a/client/public/tools/hold-guide.html
+++ b/client/public/tools/hold-guide.html
@@ -774,6 +774,53 @@ textarea.wiz-input { resize: vertical; line-height: 1.6; min-height: 80px; }
 <script src="/js/cr-gtag.js"></script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 
 <header class="site-header">
   <div class="header-top">

--- a/client/public/tools/index.html
+++ b/client/public/tools/index.html
@@ -84,6 +84,53 @@ body{font-family:'Lato','Segoe UI',sans-serif;background:var(--stone);color:#2A2
 <script src="/js/cr-gtag.js"></script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 
 <div class="hero">
   <div class="hero-logo">

--- a/client/public/tools/note-writer.html
+++ b/client/public/tools/note-writer.html
@@ -142,6 +142,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 
 <div class="hdr">
   <div class="hdr-top">

--- a/client/public/tools/safety-plan.html
+++ b/client/public/tools/safety-plan.html
@@ -60,6 +60,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top"><span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span><span style="background:var(--green);color:#fff;font-size:10px;font-weight:700;padding:3px 10px;border-radius:4px;letter-spacing:.8px">FREE TOOL</span></div>
 <div class="hdr-title"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#D4A855" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>Crisis Safety Plan Builder</div>

--- a/client/public/tools/sliding-scale.html
+++ b/client/public/tools/sliding-scale.html
@@ -59,6 +59,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top"><span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span><span style="background:var(--green);color:#fff;font-size:10px;font-weight:700;padding:3px 10px;border-radius:4px;letter-spacing:.8px">FREE TOOL</span></div>
 <div class="hdr-title"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#D4A855" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>Sliding Scale Fee Calculator</div>

--- a/client/public/tools/startup-checklist.html
+++ b/client/public/tools/startup-checklist.html
@@ -59,6 +59,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script src="/js/cr-gtag.js"></script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top"><span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span><span style="background:var(--green);color:#fff;font-size:10px;font-weight:700;padding:3px 10px;border-radius:4px;letter-spacing:.8px">FREE TOOL</span></div>
 <div class="hdr-title"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#D4A855" stroke-width="2"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Private Practice Startup Checklist</div>

--- a/client/public/tools/superbill.html
+++ b/client/public/tools/superbill.html
@@ -62,6 +62,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top"><span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span><span style="background:var(--green);color:#fff;font-size:10px;font-weight:700;padding:3px 10px;border-radius:4px;letter-spacing:.8px">FREE TOOL</span></div>
 <div class="hdr-title"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#D4A855" stroke-width="2"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>Superbill Generator</div>

--- a/client/public/tools/treatment-plan.html
+++ b/client/public/tools/treatment-plan.html
@@ -79,6 +79,53 @@ body{font-family:'Lato',sans-serif;background:var(--stone);color:#2A2A2A;line-he
 <script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!="posthog"&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init("phc_rRGb8TPVl8lDYnD4M2HMGGuBBkL9whGzghD5FEX20Vb",{api_host:"https://us.i.posthog.com",autocapture:false});</script>
 </head>
 <body>
+<script>
+(async function() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const flagsRes = await fetch('/api/auth/features', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (flagsRes.ok) {
+      const { features } = await flagsRes.json();
+      if (features && features.isPartnerUser && !features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const main = document.querySelector('main');
+          if (main) main.innerHTML = `
+            <div style="max-width:480px;margin:80px auto;text-align:center;padding:40px;">
+              <div style="font-size:48px;margin-bottom:16px;">🔒</div>
+              <h2 style="font-size:24px;color:#6B1D34;margin-bottom:12px;">Feature Not Available</h2>
+              <p style="color:#4A7C59;margin-bottom:24px;">
+                This feature requires the Clinical Tools Suite add-on.
+                Contact your organization administrator to enable it.
+              </p>
+              <a href="/partner-billing.html#addons"
+                 style="display:inline-block;padding:12px 24px;background:#6B1D34;color:white;border-radius:8px;text-decoration:none;">
+                View Add-ons
+              </a>
+            </div>
+          `;
+        });
+        return;
+      }
+      if (features && features.isPartnerUser && features.clinicalTools) {
+        document.addEventListener('DOMContentLoaded', function() {
+          const badge = document.createElement('div');
+          badge.id = 'cr-powered-badge';
+          badge.innerHTML = `
+            <div style="position:fixed;bottom:16px;right:16px;background:white;border:1px solid #E5E5E5;border-radius:8px;padding:8px 14px;box-shadow:0 2px 8px rgba(0,0,0,0.1);z-index:9999;display:flex;align-items:center;gap:6px;font-family:Lato,sans-serif;font-size:12px;color:#6B1D34;">
+              <span style="font-weight:700;">Powered by</span>
+              <span><span style="color:#6B1D34;font-weight:700;">Counselor</span><span style="color:#4A7C59;font-weight:700;">Ready</span>™</span>
+            </div>
+          `;
+          document.body.appendChild(badge);
+        });
+      }
+    }
+  } catch (e) { /* fail-open */ }
+})();
+</script>
 <div class="hdr">
 <div class="hdr-top">
 <span class="logo"><span style="color:#D0768A">Counselor</span><span style="color:#5A9469">Ready</span></span>

--- a/server/src/middleware/partnerFeatureGate.js
+++ b/server/src/middleware/partnerFeatureGate.js
@@ -1,0 +1,78 @@
+/**
+ * Partner feature gating middleware.
+ * Blocks access to CR-proprietary features for partner users
+ * unless the partner org has paid for the specific add-on.
+ * Admin users bypass all gates automatically.
+ */
+import Partner from '../models/Partner.js';
+
+// Cache partner addons for 5 minutes to avoid hammering DB
+const addonCache = new Map();
+const CACHE_TTL = 5 * 60 * 1000;
+
+async function getPartnerAddons(partnerId) {
+  const key = String(partnerId);
+  const cached = addonCache.get(key);
+  if (cached && Date.now() - cached.ts < CACHE_TTL) return cached.data;
+
+  const partner = await Partner.findById(partnerId).select('premiumAddons').lean();
+  const data = partner?.premiumAddons || {};
+  addonCache.set(key, { data, ts: Date.now() });
+  return data;
+}
+
+/**
+ * Middleware factory. Usage: requireAddon('certTracking')
+ * - Admin users: always pass through
+ * - Non-partner users (direct CR subscribers): always pass through
+ * - Partner users: blocked unless addon is enabled
+ */
+export function requireAddon(addonKey) {
+  return async (req, res, next) => {
+    // Admins bypass
+    if (req.user?.role === 'admin') return next();
+    // Non-partner users (direct CR subscribers) bypass
+    if (!req.user?.partnerId) return next();
+
+    try {
+      const addons = await getPartnerAddons(req.user.partnerId);
+      if (addons[addonKey]?.enabled) return next();
+
+      return res.status(403).json({
+        error: 'Feature not available',
+        code: 'ADDON_REQUIRED',
+        addon: addonKey,
+        message: 'This feature requires a premium add-on. Contact your organization administrator.',
+        upgradeUrl: '/partner-billing.html#addons'
+      });
+    } catch (err) {
+      console.error('partnerFeatureGate error:', err.message);
+      return next(); // fail-open so we don't break direct subscribers
+    }
+  };
+}
+
+export async function getPartnerFeatureFlags(partnerId) {
+  if (!partnerId) {
+    return {
+      certTracking: true,
+      credentialManagement: true,
+      complianceTracking: true,
+      clinicalTools: true,
+      isPartnerUser: false
+    };
+  }
+
+  const addons = await getPartnerAddons(partnerId);
+  return {
+    certTracking: !!addons.certTracking?.enabled,
+    credentialManagement: !!addons.credentialManagement?.enabled,
+    complianceTracking: !!addons.complianceTracking?.enabled,
+    clinicalTools: !!addons.clinicalTools?.enabled,
+    isPartnerUser: true
+  };
+}
+
+export function bustAddonCache(partnerId) {
+  addonCache.delete(String(partnerId));
+}

--- a/server/src/models/Partner.js
+++ b/server/src/models/Partner.js
@@ -110,6 +110,7 @@ const partnerSchema = new mongoose.Schema({
   syndication: {
     // Partner opts to add CounselorReady's published catalog to their branded library.
     // On those sales the partner (distributor) keeps `distributorRate`, CR keeps the rest.
+    // DEPRECATED — import program removed June 2026. Field retained for historical data only.
     importPlatformCourses: { type: Boolean, default: false },
     // Partner opts to list their own published courses in the CounselorReady marketplace.
     // On those sales CounselorReady (distributor) keeps `distributorRate`, the partner keeps the rest.
@@ -134,6 +135,30 @@ const partnerSchema = new mongoose.Schema({
         listInMarketplace: { type: Boolean }
       }
     }]
+  },
+
+  // Premium feature add-ons (paid separately, always branded "Powered by CounselorReady™")
+  premiumAddons: {
+    certTracking: {
+      enabled: { type: Boolean, default: false },
+      enabledAt: { type: Date },
+      stripeItemId: { type: String }
+    },
+    credentialManagement: {
+      enabled: { type: Boolean, default: false },
+      enabledAt: { type: Date },
+      stripeItemId: { type: String }
+    },
+    complianceTracking: {
+      enabled: { type: Boolean, default: false },
+      enabledAt: { type: Date },
+      stripeItemId: { type: String }
+    },
+    clinicalTools: {
+      enabled: { type: Boolean, default: false },
+      enabledAt: { type: Date },
+      stripeItemId: { type: String }
+    }
   },
 
   // Admin who created this partner

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -694,4 +694,15 @@ router.put('/update-notifications', protect, async (req, res) => {
   }
 });
 
+// Feature flags for frontend (nav gating, page access)
+router.get('/features', protect, async (req, res) => {
+  try {
+    const { getPartnerFeatureFlags } = await import('../middleware/partnerFeatureGate.js');
+    const features = await getPartnerFeatureFlags(req.user.partnerId || null);
+    res.json({ features });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load feature flags' });
+  }
+});
+
 export default router;

--- a/server/src/routes/certificates.js
+++ b/server/src/routes/certificates.js
@@ -10,6 +10,7 @@ import multer from 'multer';
 import { v2 as cloudinary } from 'cloudinary';
 import Certificate from '../models/Certificate.js';
 import { protect } from '../middleware/auth.js';
+import { requireAddon } from '../middleware/partnerFeatureGate.js';
 import { generateCertificate, generateCertificateNumber } from '../utils/certificate.js';
 import User from '../models/User.js';
 import Course from '../models/Course.js';
@@ -47,7 +48,7 @@ cloudinary.config({
 
 // ✅ FIXED: Certificate serving using Cloudinary private download API
 // Bypasses "Restrict unsigned delivery" / "Strict transformations" settings
-router.get('/:id/serve', protect, async (req, res) => {
+router.get('/:id/serve', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const { id } = req.params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
@@ -259,7 +260,7 @@ function sendFile(res, fileBuffer, certificate, ext) {
 }
 
 // GET /api/certificates/my - Get current user's certificates (used by dashboard)
-router.get('/my', protect, async (req, res) => {
+router.get('/my', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const certificates = await Certificate.find({ userId: req.user._id, isRevoked: { $ne: true } })
       .sort({ completionDate: -1 })
@@ -296,7 +297,7 @@ router.get('/my', protect, async (req, res) => {
 });
 
 // GET /api/certificates - Get all certificates for authenticated user
-router.get('/', protect, async (req, res) => {
+router.get('/', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const certificates = await Certificate.find({ userId: req.user._id })
       .sort({ createdAt: -1 })
@@ -334,7 +335,7 @@ router.get('/', protect, async (req, res) => {
 });
 
 // POST /api/certificates/upload - Upload new certificate
-router.post('/upload', protect, upload.single('certificate'), async (req, res) => {
+router.post('/upload', protect, requireAddon('certTracking'), upload.single('certificate'), async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No file uploaded' });
@@ -431,7 +432,7 @@ router.post('/upload', protect, upload.single('certificate'), async (req, res) =
 });
 
 // POST /api/certificates/generate/:courseId - Generate certificate for completed course
-router.post('/generate/:courseId', protect, async (req, res) => {
+router.post('/generate/:courseId', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const { courseId } = req.params;
     if (!mongoose.Types.ObjectId.isValid(courseId)) {
@@ -577,7 +578,7 @@ router.post('/generate/:courseId', protect, async (req, res) => {
 });
 
 // DELETE /api/certificates/:id - Delete certificate
-router.delete('/:id', protect, async (req, res) => {
+router.delete('/:id', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const { id } = req.params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
@@ -615,7 +616,7 @@ router.delete('/:id', protect, async (req, res) => {
 });
 
 // GET /api/certificates/download-all - Download all certificates as ZIP
-router.get('/download-all', protect, async (req, res) => {
+router.get('/download-all', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const certificates = await Certificate.find({ userId: req.user._id, isRevoked: { $ne: true } });
     if (!certificates.length) {
@@ -677,7 +678,7 @@ router.get('/download-all', protect, async (req, res) => {
 });
 
 // GET /api/certificates/transcript - Generate CE transcript PDF
-router.get('/transcript', protect, async (req, res) => {
+router.get('/transcript', protect, requireAddon('certTracking'), async (req, res) => {
   try {
     const userId = req.user._id;
     const { credential, startDate, endDate } = req.query;

--- a/server/src/routes/complianceRoutes.js
+++ b/server/src/routes/complianceRoutes.js
@@ -21,6 +21,7 @@ import Attestation from '../models/Attestation.js';
 import OrgSupervisionLog from '../models/OrgSupervisionLog.js';
 import Assignment from '../models/Assignment.js';
 import { protect } from '../middleware/auth.js';
+import { requireAddon } from '../middleware/partnerFeatureGate.js';
 import { requireOrgRole, ORG_ADMIN_ROLES } from '../middleware/requireOrgRole.js';
 import { uploadFile } from '../utils/r2Storage.js';
 import { generateAuditBinder } from '../services/auditBinderService.js';
@@ -40,7 +41,7 @@ function seatForUser(org, userId) {
 }
 
 // ════════════════════════ CREDENTIAL VAULT ════════════════════════
-router.get('/orgs/:orgId/credentials', protect, requireOrgRole(), async (req, res) => {
+router.get('/orgs/:orgId/credentials', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const filter = { orgId: req.org._id };
     if (!ORG_ADMIN_ROLES.includes(req.orgRole) && req.user.role !== 'admin') {
@@ -55,7 +56,7 @@ router.get('/orgs/:orgId/credentials', protect, requireOrgRole(), async (req, re
   }
 });
 
-router.post('/orgs/:orgId/credentials', protect, requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
+router.post('/orgs/:orgId/credentials', protect, requireAddon('complianceTracking'), requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
   try {
     const b = req.body || {};
     let fileUrl = b.fileUrl;
@@ -94,7 +95,7 @@ router.post('/orgs/:orgId/credentials', protect, requireOrgRole(...ORG_ADMIN_ROL
   }
 });
 
-router.patch('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+router.patch('/orgs/:orgId/credentials/:credId', protect, requireAddon('complianceTracking'), requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
   try {
     const cred = await OrgCredential.findOne({ _id: req.params.credId, orgId: req.org._id });
     if (!cred) return res.status(404).json({ error: 'Credential not found' });
@@ -111,7 +112,7 @@ router.patch('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG_
   }
 });
 
-router.delete('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+router.delete('/orgs/:orgId/credentials/:credId', protect, requireAddon('complianceTracking'), requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
   try {
     const out = await OrgCredential.deleteOne({ _id: req.params.credId, orgId: req.org._id });
     if (!out.deletedCount) return res.status(404).json({ error: 'Credential not found' });
@@ -122,7 +123,7 @@ router.delete('/orgs/:orgId/credentials/:credId', protect, requireOrgRole(...ORG
 });
 
 // ════════════════════════ POLICY DOCS + ATTESTATION ════════════════════════
-router.get('/orgs/:orgId/policies', protect, requireOrgRole(), async (req, res) => {
+router.get('/orgs/:orgId/policies', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const policies = await PolicyDoc.find({ orgId: req.org._id, active: true }).sort({ createdAt: -1 }).lean();
     // Annotate whether the requesting member has attested to the current version.
@@ -134,7 +135,7 @@ router.get('/orgs/:orgId/policies', protect, requireOrgRole(), async (req, res) 
   }
 });
 
-router.post('/orgs/:orgId/policies', protect, requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
+router.post('/orgs/:orgId/policies', protect, requireAddon('complianceTracking'), requireOrgRole(...ORG_ADMIN_ROLES), upload.single('file'), async (req, res) => {
   try {
     const b = req.body || {};
     if (!b.title) return res.status(400).json({ error: 'Policy title is required' });
@@ -161,7 +162,7 @@ router.post('/orgs/:orgId/policies', protect, requireOrgRole(...ORG_ADMIN_ROLES)
   }
 });
 
-router.post('/orgs/:orgId/policies/:policyId/attest', protect, requireOrgRole(), async (req, res) => {
+router.post('/orgs/:orgId/policies/:policyId/attest', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const policy = await PolicyDoc.findOne({ _id: req.params.policyId, orgId: req.org._id });
     if (!policy) return res.status(404).json({ error: 'Policy not found' });
@@ -190,7 +191,7 @@ router.post('/orgs/:orgId/policies/:policyId/attest', protect, requireOrgRole(),
 });
 
 // ════════════════════════ SUPERVISION (dual sign-off) ════════════════════════
-router.get('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, res) => {
+router.get('/orgs/:orgId/supervision', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const filter = { orgId: req.org._id };
     if (!ORG_ADMIN_ROLES.includes(req.orgRole) && req.user.role !== 'admin') {
@@ -206,7 +207,7 @@ router.get('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, re
   }
 });
 
-router.post('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, res) => {
+router.post('/orgs/:orgId/supervision', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const b = req.body || {};
     const superviseeSeat = b.superviseeSeatId ? req.org.seats.id(b.superviseeSeatId) : seatForUser(req.org, req.user._id);
@@ -231,7 +232,7 @@ router.post('/orgs/:orgId/supervision', protect, requireOrgRole(), async (req, r
   }
 });
 
-router.patch('/orgs/:orgId/supervision/:id/sign', protect, requireOrgRole(), async (req, res) => {
+router.patch('/orgs/:orgId/supervision/:id/sign', protect, requireAddon('complianceTracking'), requireOrgRole(), async (req, res) => {
   try {
     const log = await OrgSupervisionLog.findOne({ _id: req.params.id, orgId: req.org._id });
     if (!log) return res.status(404).json({ error: 'Supervision log not found' });
@@ -248,7 +249,7 @@ router.patch('/orgs/:orgId/supervision/:id/sign', protect, requireOrgRole(), asy
 });
 
 // ════════════════════════ AUDIT BINDER (ZIP) ════════════════════════
-router.get('/orgs/:orgId/audit-binder', protect, requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
+router.get('/orgs/:orgId/audit-binder', protect, requireAddon('complianceTracking'), requireOrgRole(...ORG_ADMIN_ROLES), async (req, res) => {
   try {
     const { buffer, filename } = await generateAuditBinder(req.org);
     res.setHeader('Content-Type', 'application/zip');
@@ -261,7 +262,7 @@ router.get('/orgs/:orgId/audit-binder', protect, requireOrgRole(...ORG_ADMIN_ROL
 });
 
 // ════════════════════════ MEMBER SELF-VIEW (across orgs) ════════════════════════
-router.get('/me/compliance', protect, async (req, res) => {
+router.get('/me/compliance', protect, requireAddon('complianceTracking'), async (req, res) => {
   try {
     const orgs = await Organization.find({ 'seats.userId': req.user._id, 'seats.status': 'active' })
       .select('name settings seats').lean();

--- a/server/src/routes/credentials.js
+++ b/server/src/routes/credentials.js
@@ -12,6 +12,7 @@ import UserCredential from '../models/UserCredential.js';
 import CredentialTemplate from '../models/CredentialTemplate.js';
 import Certificate from '../models/Certificate.js';
 import { protect, requireSubscription } from '../middleware/auth.js';
+import { requireAddon } from '../middleware/partnerFeatureGate.js';
 import { syncCredentialToCalendar, removeEventFromCalendar } from '../services/googleCalendarService.js';
 import User from '../models/User.js';
 
@@ -83,7 +84,7 @@ function determineCredentialType(credentialType, code) {
 // @route   GET /api/credentials
 // @desc    Get user's credentials
 // @access  Private
-router.get('/', protect, async (req, res) => {
+router.get('/', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const credentials = await UserCredential.find({ userId: req.user._id })
       .sort({ expirationDate: 1 });
@@ -121,7 +122,7 @@ router.get('/', protect, async (req, res) => {
 // @route   POST /api/credentials
 // @desc    Add a credential
 // @access  Private (Pro required for more than 1)
-router.post('/', protect, async (req, res) => {
+router.post('/', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const {
       templateId,
@@ -223,7 +224,7 @@ router.post('/', protect, async (req, res) => {
 // @route   GET /api/credentials/consult-status
 // @desc    Get consultation status for current user
 // @access  Private
-router.get('/consult-status', protect, async (req, res) => {
+router.get('/consult-status', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const canBook = req.user.canBookConsultation();
     const history = req.user.consultations || [];
@@ -250,7 +251,7 @@ router.get('/consult-status', protect, async (req, res) => {
 // @route   POST /api/credentials/sync
 // @desc    Recalculate CE hours from linked certificates AND platform certificates
 // @access  Private
-router.post('/sync', protect, async (req, res) => {
+router.post('/sync', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const userId = req.user._id;
     
@@ -414,7 +415,7 @@ router.post('/sync', protect, async (req, res) => {
 // @route   POST /api/credentials/recalculate
 // @desc    Force recalculate all credential progress from ceuLogs (data repair)
 // @access  Private
-router.post('/recalculate', protect, async (req, res) => {
+router.post('/recalculate', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const userId = req.user._id;
     
@@ -463,7 +464,7 @@ router.post('/recalculate', protect, async (req, res) => {
 // @route   GET /api/credentials/board-alerts
 // @desc    Board rules for user's credentials with change highlighting
 // @access  Private
-router.get('/board-alerts', protect, async (req, res) => {
+router.get('/board-alerts', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     // Real state licensing board URLs for counseling professions
     const boardUrls = {
@@ -639,7 +640,7 @@ router.get('/templates/state/:state', async (req, res) => {
 // @route   GET /api/credentials/dashboard
 // @desc    Get credential dashboard summary
 // @access  Private
-router.get('/user/dashboard', protect, async (req, res) => {
+router.get('/user/dashboard', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const credentials = await UserCredential.find({ userId: req.user._id })
       .sort({ expirationDate: 1 });
@@ -702,7 +703,7 @@ router.get('/user/dashboard', protect, async (req, res) => {
 // @route   POST /api/credentials/book-consult
 // @desc    Book a VIP consultation (1 per quarter)
 // @access  Private (VIP only)
-router.post('/book-consult', protect, async (req, res) => {
+router.post('/book-consult', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     const { topic } = req.body;
     
@@ -736,7 +737,7 @@ router.post('/book-consult', protect, async (req, res) => {
 // @route   GET /api/credentials/:id
 // @desc    Get single credential
 // @access  Private
-router.get('/:id', protect, async (req, res) => {
+router.get('/:id', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });
@@ -762,7 +763,7 @@ router.get('/:id', protect, async (req, res) => {
 // @route   PUT /api/credentials/:id
 // @desc    Update credential
 // @access  Private
-router.put('/:id', protect, async (req, res) => {
+router.put('/:id', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });
@@ -815,7 +816,7 @@ router.put('/:id', protect, async (req, res) => {
 // @route   DELETE /api/credentials/:id
 // @desc    Delete credential
 // @access  Private
-router.delete('/:id', protect, async (req, res) => {
+router.delete('/:id', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });
@@ -849,7 +850,7 @@ router.delete('/:id', protect, async (req, res) => {
 // @route   POST /api/credentials/:id/log-ceu
 // @desc    Log CEU hours to a credential
 // @access  Private
-router.post('/:id/log-ceu', protect, async (req, res) => {
+router.post('/:id/log-ceu', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });
@@ -921,7 +922,7 @@ const upload = multer({
 // @route   POST /api/credentials/:id/upload
 // @desc    Upload document for a credential
 // @access  Private
-router.post('/:id/upload', protect, upload.single('document'), async (req, res) => {
+router.post('/:id/upload', protect, requireAddon('credentialManagement'), upload.single('document'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });
@@ -958,7 +959,7 @@ router.post('/:id/upload', protect, upload.single('document'), async (req, res) 
 // @route   DELETE /api/credentials/:id/document
 // @desc    Delete document from credential
 // @access  Private
-router.delete('/:id/document', protect, async (req, res) => {
+router.delete('/:id/document', protect, requireAddon('credentialManagement'), async (req, res) => {
   try {
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ error: 'Invalid ID' });

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -589,8 +589,10 @@ router.get('/my/syndication', protect, requirePartnerAdmin, async (req, res) => 
     if (!partner) return res.status(404).json({ error: 'Partner not found' });
 
     const syn = partner.syndication || {};
+    // Always return false — import program removed June 2026
+    if (partner.syndication) partner.syndication.importPlatformCourses = false;
     const rate = syn.distributorRate ?? 0.15;
-    const anyOn = !!(syn.importPlatformCourses || syn.listInMarketplace);
+    const anyOn = !!(syn.listInMarketplace);
     const accepted = syn.agreedVersion === MARKETPLACE_AGREEMENT.version;
 
     const [platformCount, myPublished] = await Promise.all([
@@ -634,6 +636,14 @@ router.put('/my/syndication', protect, requirePartnerAdmin, async (req, res) => 
     const partnerId = req.partnerId || req.user.partnerId;
     const partner = await Partner.findById(partnerId);
     if (!partner) return res.status(404).json({ error: 'Partner not found' });
+
+    // Import Platform Courses program removed June 2026
+    if (req.body.importPlatformCourses === true) {
+      return res.status(400).json({
+        error: 'The "Import Platform Courses" program is no longer available. Partners can list their own courses in the CounselorReady marketplace instead.',
+        code: 'IMPORT_DISABLED'
+      });
+    }
 
     const { importPlatformCourses, listInMarketplace, acceptedVersion } = req.body;
     if (!partner.syndication) partner.syndication = {};
@@ -742,13 +752,8 @@ router.get('/my/library', protect, requirePartnerAdmin, async (req, res) => {
       .select('title slug ceHours status price accessType pricingTier description')
       .sort({ createdAt: -1 }).lean();
 
-    let syndicated = [];
-    if (partner.syndication?.importPlatformCourses) {
-      syndicated = await InteractiveCourse.find({
-        $or: [{ partnerId: null }, { partnerId: { $exists: false } }],
-        status: 'published'
-      }).select('title slug ceHours price accessType pricingTier description').sort({ title: 1 }).lean();
-    }
+    // Import program removed June 2026 — syndicated always returns empty
+    const syndicated = [];
 
     res.json({
       own: own.map(c => ({ ...c, source: 'own' })),

--- a/server/src/routes/toolRoutes.js
+++ b/server/src/routes/toolRoutes.js
@@ -15,6 +15,21 @@ const router = express.Router();
 // ═══════════════════════════════════════════════════════════════════════════════
 router.post('/:tool/verify-license', async (req, res) => {
   try {
+    // Partner feature gate — clinical tools require add-on
+    if (req.user?.partnerId) {
+      const Partner = (await import('../models/Partner.js')).default;
+      const partner = await Partner.findById(req.user.partnerId).select('premiumAddons').lean();
+      if (!partner?.premiumAddons?.clinicalTools?.enabled) {
+        return res.status(403).json({
+          error: 'Feature not available',
+          code: 'ADDON_REQUIRED',
+          addon: 'clinicalTools',
+          message: 'Clinical tools require a premium add-on.',
+          upgradeUrl: '/partner-billing.html#addons'
+        });
+      }
+    }
+
     const { tool } = req.params;
     const {
       name, licenseNumber, licenseState, credentialType, email,
@@ -129,6 +144,21 @@ router.post('/:tool/verify-license', async (req, res) => {
 // ═══════════════════════════════════════════════════════════════════════════════
 router.post('/:tool/track', async (req, res) => {
   try {
+    // Partner feature gate — clinical tools require add-on
+    if (req.user?.partnerId) {
+      const Partner = (await import('../models/Partner.js')).default;
+      const partner = await Partner.findById(req.user.partnerId).select('premiumAddons').lean();
+      if (!partner?.premiumAddons?.clinicalTools?.enabled) {
+        return res.status(403).json({
+          error: 'Feature not available',
+          code: 'ADDON_REQUIRED',
+          addon: 'clinicalTools',
+          message: 'Clinical tools require a premium add-on.',
+          upgradeUrl: '/partner-billing.html#addons'
+        });
+      }
+    }
+
     const { tool } = req.params;
     const { event, licenseNumber, email, timestamp, ...extraData } = req.body;
 

--- a/server/src/routes/tools.js
+++ b/server/src/routes/tools.js
@@ -154,6 +154,21 @@ router.get('/note-limit', optionalAuth, (req, res) => {
 // ═══════════════════════════════════════════
 router.post('/generate-note', optionalAuth, async (req, res) => {
   try {
+    // Partner feature gate — clinical tools require add-on
+    if (req.user?.partnerId) {
+      const Partner = (await import('../models/Partner.js')).default;
+      const partner = await Partner.findById(req.user.partnerId).select('premiumAddons').lean();
+      if (!partner?.premiumAddons?.clinicalTools?.enabled) {
+        return res.status(403).json({
+          error: 'Feature not available',
+          code: 'ADDON_REQUIRED',
+          addon: 'clinicalTools',
+          message: 'Clinical tools require a premium add-on.',
+          upgradeUrl: '/partner-billing.html#addons'
+        });
+      }
+    }
+
     // 1. Determine tier and rate limit
     const tier = getUserTier(req.user);
     const identifier = req.user ? `user:${req.user.id}` : `ip:${req.ip}`;

--- a/server/src/utils/planLimits.js
+++ b/server/src/utils/planLimits.js
@@ -38,3 +38,37 @@ export function getPlanLimits(plan) {
 export function getAiBudgetCents(plan) {
   return getPlanLimits(plan).aiBudgetCents || 0;
 }
+
+/**
+ * Premium add-on definitions. These are CR-proprietary features
+ * that partners can unlock for an additional monthly fee.
+ * Every enabled add-on displays a "Powered by CounselorReady™" badge.
+ */
+export const PREMIUM_ADDONS = {
+  certTracking: {
+    name: 'Certificate Tracking',
+    description: 'Issue and track CE certificates for your users',
+    monthlyPriceCents: 2500,  // $25/mo
+    poweredBy: true
+  },
+  credentialManagement: {
+    name: 'Credential Management',
+    description: 'License and credential tracking for your team',
+    monthlyPriceCents: 2000,  // $20/mo
+    poweredBy: true
+  },
+  complianceTracking: {
+    name: 'Compliance Tracking',
+    description: 'State and board compliance tracking and reporting',
+    monthlyPriceCents: 2500,  // $25/mo
+    poweredBy: true
+  },
+  clinicalTools: {
+    name: 'Clinical Tools Suite',
+    description: 'Treatment plans, safety plans, note writer, and more',
+    monthlyPriceCents: 3000,  // $30/mo
+    poweredBy: true
+  }
+};
+
+export const PREMIUM_BUNDLE_PRICE_CENTS = 10000; // $100/mo for all 4 (no discount)


### PR DESCRIPTION
## Summary

- **Prompt 1 — Backend foundation:** `Partner.js` model adds `premiumAddons` sub-schema (certTracking, credentialManagement, complianceTracking, clinicalTools). `planLimits.js` adds `PREMIUM_ADDONS` and `PREMIUM_BUNDLE_PRICE_CENTS` exports. New `partnerFeatureGate.js` middleware with `requireAddon()`, `getPartnerFeatureFlags()`, and `bustAddonCache()`.
- **Prompt 2 — Route gating:** `requireAddon()` applied to `certificates.js` (8 routes), `credentials.js` (14 routes), `complianceRoutes.js` (12 routes), `tools.js` (inline clinicalTools check), `toolRoutes.js` (inline check). `/api/auth/features` endpoint added.
- **Prompt 3 — Kill Import Platform Courses:** `partners.js` syndication routes return 400/disabled; library handler no longer fetches syndicated courses. `partner-marketplace.html` removes the toggle UI.
- **Prompt 4 — Frontend gating:** `nav-footer.js` fetches feature flags and hides nav links for disabled add-ons. 14 static pages (certificates, credentials, compliance, all tools) get async lock-screen gate. `dashboard.html` hides Clinical Tools card for gated partner users.

## Test plan
- [ ] Direct subscriber (no `partnerId`) — all routes pass through unaffected
- [ ] Partner user with `certTracking: false` — certificates routes return 403 ADDON_REQUIRED; certificates.html shows lock screen
- [ ] Partner user with all addons enabled — all routes pass; "Powered by CounselorReady™" badge visible on each page
- [ ] Admin user — bypass all gates (admin short-circuit in `requireAddon`)
- [ ] `/api/auth/features` returns correct flags for each user type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0161G8tnE4TmhkYruQVBfPFr)_