### PR TITLE
feat: add Manage Breaks UI to admin-live-sessions.html

### DIFF
--- a/client/public/admin-live-sessions.html
+++ b/client/public/admin-live-sessions.html
@@ -355,6 +355,10 @@
                 onclick="viewAttendance(event,'${s._id}')">
                 <i class="fas fa-chart-bar text-xs"></i> Attendance
               </a>
+              <button onclick="openBreaksModal('${s._id}')"
+                class="px-2.5 py-1.5 rounded-lg border border-gray-200 text-xs text-forest-700 hover:bg-stone-50 transition-colors flex items-center gap-1">
+                <i class="fas fa-mug-hot text-xs"></i> Breaks${(s.breaks && s.breaks.length) ? ` <span class="px-1.5 rounded-full" style="background:#F3E6C8;color:#8B6914;">${s.breaks.length}</span>` : ''}
+              </button>
               ${s.status === 'completed' ? `
               <button onclick="issueCerts('${s._id}', this)"
                 class="px-2.5 py-1.5 rounded-lg border border-burgundy-200 text-xs text-burgundy-700 hover:bg-burgundy-50 transition-colors flex items-center gap-1">
@@ -572,6 +576,119 @@
     document.getElementById('createModal').addEventListener('click', e => {
       if (e.target === document.getElementById('createModal')) closeCreateModal();
     });
+
+    /* ── Manage breaks (writes LiveSession.breaks[] that the producer reads) ── */
+    let breaksDraft = [];
+    let breaksSessionId = null;
+
+    function openBreaksModal(id) {
+      breaksSessionId = id;
+      const s = sessions.find(x => x._id === id);
+      breaksDraft = ((s && s.breaks) || []).map(b => Object.assign(
+        { label: b.label || 'Break', startsAt: b.startsAt, durationMin: b.durationMin },
+        b.resumeReminderSentAt ? { resumeReminderSentAt: b.resumeReminderSentAt } : {}
+      ));
+      renderBreaksModal();
+    }
+
+    function renderBreaksModal() {
+      const s = sessions.find(x => x._id === breaksSessionId) || {};
+      const rows = breaksDraft.length ? breaksDraft.map((b, i) => `
+        <tr class="border-b border-gray-100">
+          <td class="px-3 py-2">${escHtml(b.label)}</td>
+          <td class="px-3 py-2 text-xs">${b.startsAt ? new Date(b.startsAt).toLocaleString('en-US', { month:'short', day:'numeric', hour:'numeric', minute:'2-digit' }) : '—'}</td>
+          <td class="px-3 py-2 text-center">${b.durationMin} min</td>
+          <td class="px-3 py-2 text-right">
+            <button onclick="removeBreakDraft(${i})" class="text-red-500 hover:text-red-700 text-xs" title="Remove"><i class="fas fa-trash"></i></button>
+          </td>
+        </tr>`).join('') : '<tr><td colspan="4" class="text-center py-5 text-forest-500 text-sm">No breaks declared yet.</td></tr>';
+
+      showModal(`
+        <div class="p-6">
+          <h3 class="font-display text-xl font-semibold text-burgundy-900 mb-1">Scheduled Breaks</h3>
+          <p class="text-xs text-forest-500 mb-4">${escHtml(s.title || '')} &mdash; break minutes are excluded from the NBCC attendance denominator, and attendees get an automatic resume reminder ~3 min before each break ends.</p>
+          <div class="overflow-x-auto border border-gray-100 rounded-lg mb-4">
+            <table class="w-full text-sm">
+              <thead class="bg-stone-50"><tr>
+                <th class="text-left px-3 py-2 font-semibold text-burgundy-800">Label</th>
+                <th class="text-left px-3 py-2 font-semibold text-burgundy-800">Starts</th>
+                <th class="px-3 py-2 font-semibold text-burgundy-800">Duration</th>
+                <th class="px-3 py-2"></th>
+              </tr></thead>
+              <tbody>${rows}</tbody>
+            </table>
+          </div>
+          <div class="grid grid-cols-12 gap-2 items-end bg-stone-50 rounded-lg p-3 mb-3">
+            <div class="col-span-4">
+              <label class="block text-xs font-medium text-burgundy-800 mb-1">Label</label>
+              <input id="brkLabel" type="text" value="Break" class="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:border-burgundy-500">
+            </div>
+            <div class="col-span-5">
+              <label class="block text-xs font-medium text-burgundy-800 mb-1">Starts at <span class="text-red-500">*</span></label>
+              <input id="brkStart" type="datetime-local" class="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:border-burgundy-500">
+            </div>
+            <div class="col-span-2">
+              <label class="block text-xs font-medium text-burgundy-800 mb-1">Min <span class="text-red-500">*</span></label>
+              <input id="brkDur" type="number" min="1" max="120" value="10" class="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:border-burgundy-500">
+            </div>
+            <div class="col-span-1">
+              <button onclick="addBreakDraft()" class="w-full px-2 py-1.5 rounded-lg bg-forest-700 hover:bg-forest-800 text-white text-sm font-semibold" title="Add break">+</button>
+            </div>
+          </div>
+          <div id="brkErr" class="hidden text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3"></div>
+          <div class="flex items-center justify-end gap-3 pt-2 border-t border-gray-100">
+            <button onclick="closeInfoModal()" class="px-4 py-2 rounded-lg border border-gray-300 text-sm text-forest-700 hover:bg-stone-50 transition-colors">Cancel</button>
+            <button onclick="saveBreaks(this)" class="px-5 py-2 rounded-lg bg-burgundy-800 hover:bg-burgundy-900 text-white text-sm font-semibold">Save Breaks</button>
+          </div>
+        </div>`);
+    }
+
+    function showBrkErr(msg) {
+      const err = document.getElementById('brkErr');
+      err.textContent = msg; err.classList.remove('hidden');
+    }
+
+    function addBreakDraft() {
+      const label = (document.getElementById('brkLabel').value || 'Break').trim();
+      const startVal = document.getElementById('brkStart').value;
+      const dur = parseInt(document.getElementById('brkDur').value, 10);
+      document.getElementById('brkErr').classList.add('hidden');
+      if (!startVal) return showBrkErr('Start time is required.');
+      if (!dur || dur < 1 || dur > 120) return showBrkErr('Duration must be between 1 and 120 minutes.');
+      breaksDraft.push({ label: label || 'Break', startsAt: new Date(startVal).toISOString(), durationMin: dur });
+      breaksDraft.sort((a, b) => new Date(a.startsAt) - new Date(b.startsAt));
+      renderBreaksModal();
+    }
+
+    function removeBreakDraft(i) {
+      breaksDraft.splice(i, 1);
+      renderBreaksModal();
+    }
+
+    async function saveBreaks(btn) {
+      btn.disabled = true; btn.textContent = 'Saving…';
+      try {
+        const controller = new AbortController();
+        const tid = setTimeout(() => controller.abort(), 10000);
+        const r = await fetch(`${API}/${breaksSessionId}`, {
+          method: 'PATCH',
+          headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ breaks: breaksDraft }),
+          signal: controller.signal
+        });
+        clearTimeout(tid);
+        const d = await r.json();
+        if (!r.ok) throw new Error(d.error || 'Failed');
+        const s = sessions.find(x => x._id === breaksSessionId);
+        if (s) s.breaks = (d.session && d.session.breaks) || breaksDraft;
+        closeInfoModal();
+        showToast(`Saved ${breaksDraft.length} break(s).`, '#284157');
+        renderTable();
+      } catch (e) {
+        showBrkErr('Error: ' + e.message);
+        btn.disabled = false; btn.textContent = 'Save Breaks';
+      }
+    }
 
     checkAuth();
   </script>


### PR DESCRIPTION
Replaces #596 — rebased cleanly on current main (no conflicts, only `admin-live-sessions.html` changed, +117 lines).

## Summary

- Adds a **Manage Breaks** button to each session row
- Opens a modal where admins can declare scheduled breaks (label, start time, duration in minutes)
- Count badge appears on row when breaks exist
- Saves via `PATCH /api/live-sessions/:id` with the full `breaks[]` array
- Preserves `resumeReminderSentAt` on existing breaks so mid-flight edits don't re-fire producer reminders
- Break minutes excluded from NBCC attendance denominator; resume reminders sent by existing session producer

## Files changed
- `client/public/admin-live-sessions.html` only — no backend changes, no new files

## Verification
```
grep -c "openBreaksModal('${s._id}')" → 1
functions: openBreaksModal, renderBreaksModal, addBreakDraft, removeBreakDraft, saveBreaks, showBrkErr (all 6)
git diff --stat HEAD → only admin-live-sessions.html, +117 lines
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0124p5tmxfH95QZr8hG6UEhD)_