### PR TITLE
feat(subscription): add Basic tier ($15/mo, unlimited 1–3 hr courses)

### DIFF
--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -365,7 +365,7 @@
     // Plan pricing - 4-tier model
     const PLANS = {
       free: { name: 'Free', price: 0, interval: 'month', priceId: null, maxCourseHours: 4, maxStates: 1, consultsPerQuarter: 0 },
-      basic: { name: 'Basic', price: 15, interval: 'month', priceId: 'price_REPLACE_WITH_BASIC_ID', maxCourseHours: 3, maxStates: 1, consultsPerQuarter: 0 },
+      basic: { name: 'Basic', price: 15, interval: 'month', priceId: 'price_1TmXydBV8IIVTFOINugDavAD', maxCourseHours: 3, maxStates: 1, consultsPerQuarter: 0 },
       starter: { name: 'Starter', price: 19.99, interval: 'month', priceId: 'price_1TiMorBV8IIVTFOIosEIoMCn', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       professional: { name: 'Professional', price: 29.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIoxYzFOcd', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       vip: { name: 'VIP', price: 49.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIxdJ5FQ0q', maxCourseHours: 999, maxStates: 999, consultsPerQuarter: 1, hardshipMonths: 1 },

--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -69,7 +69,7 @@
     <section class="mb-8">
       <h2 class="text-xl font-semibold text-burgundy-900 mb-6 text-center">Choose Your Plan</h2>
       
-      <div class="grid md:grid-cols-4 gap-6">
+      <div class="grid md:grid-cols-2 lg:grid-cols-5 gap-6">
         
         <!-- Free Plan -->
         <div class="bg-white rounded-xl border border-hunter-200 shadow-sm p-6">
@@ -100,6 +100,38 @@
           </ul>
           <button onclick="selectPlan('free')" class="w-full py-2 border border-hunter-300 text-hunter-700 rounded-lg hover:bg-hunter-50 transition-colors font-medium" id="freeBtn">
             Current Plan
+          </button>
+        </div>
+
+        <!-- Basic Plan -->
+        <div class="bg-white rounded-xl border border-hunter-300 shadow-sm p-6">
+          <h3 class="font-display text-xl font-semibold text-hunter-800 mb-2">Basic</h3>
+          <div class="mb-4">
+            <span class="text-3xl font-bold text-hunter-900">$15</span>
+            <span class="text-hunter-600">/month</span>
+          </div>
+          <ul class="space-y-2 mb-6 text-sm text-hunter-700">
+            <li class="flex items-center gap-2">
+              <span class="text-green-500">✓</span> <strong>Unlimited 1–3 hr CE courses</strong>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="text-green-500">✓</span> Full credential tracking
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="text-green-500">✓</span> AI certificate scanning
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="text-green-500">✓</span> Digital certificates
+            </li>
+            <li class="flex items-center gap-2 text-hunter-400">
+              <span>✗</span> 4+ hour &amp; certification courses
+            </li>
+            <li class="flex items-center gap-2 text-hunter-400">
+              <span>✗</span> Multi-state tracking
+            </li>
+          </ul>
+          <button onclick="selectPlan('basic')" class="w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold" id="basicBtn">
+            Upgrade Now
           </button>
         </div>
 
@@ -333,6 +365,7 @@
     // Plan pricing - 4-tier model
     const PLANS = {
       free: { name: 'Free', price: 0, interval: 'month', priceId: null, maxCourseHours: 4, maxStates: 1, consultsPerQuarter: 0 },
+      basic: { name: 'Basic', price: 15, interval: 'month', priceId: 'price_REPLACE_WITH_BASIC_ID', maxCourseHours: 3, maxStates: 1, consultsPerQuarter: 0 },
       starter: { name: 'Starter', price: 19.99, interval: 'month', priceId: 'price_1TiMorBV8IIVTFOIosEIoMCn', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       professional: { name: 'Professional', price: 29.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIoxYzFOcd', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       vip: { name: 'VIP', price: 49.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIxdJ5FQ0q', maxCourseHours: 999, maxStates: 999, consultsPerQuarter: 1, hardshipMonths: 1 },
@@ -477,6 +510,7 @@
 
     function updatePlanButtons(currentPlan) {
       const freeBtn = document.getElementById('freeBtn');
+      const basicBtn = document.getElementById('basicBtn');
       const starterBtn = document.getElementById('starterBtn');
       const proBtn = document.getElementById('proBtn');
       const vipBtn = document.getElementById('vipBtn');
@@ -498,8 +532,12 @@
       freeBtn.textContent = currentPlan === 'free' ? 'Current Plan' : 'Downgrade';
       freeBtn.disabled = currentPlan === 'free';
       
+      // Basic
+      setButton(basicBtn, currentPlan === 'basic', 'Upgrade Now',
+        'w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold');
+
       // Starter
-      setButton(starterBtn, currentPlan === 'starter', 'Upgrade Now', 
+      setButton(starterBtn, currentPlan === 'starter', 'Upgrade Now',
         'w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold');
       
       // Professional

--- a/server/src/routes/interactiveCourseRoutes.js
+++ b/server/src/routes/interactiveCourseRoutes.js
@@ -39,6 +39,7 @@ async function findCourseByIdOrSlug(param) {
 const FREE_COURSES_PER_MONTH = 4;   // free plan: 4 courses/month
 const FREE_MAX_COURSE_HOURS  = 1;   // free plan covers 1-CE-hour courses only
 const TRIAL_COURSES_TOTAL    = 2;   // no-card trial: 2 one-CE courses, lifetime
+const BASIC_MAX_COURSE_HOURS = 3;   // basic plan: unlimited courses up to 3 CE hours
 
 /**
  * Strip sensitive content from course for preview/unauthenticated users.
@@ -110,6 +111,18 @@ function freeTierDecision(user, course) {
   return { allowed: true, code: 'FREE_OK' };
 }
 
+// True if an active PAID plan covers THIS course. Accounts for the basic-tier
+// hour cap: basic gets unlimited courses up to BASIC_MAX_COURSE_HOURS CE hours;
+// all other paid plans (starter/professional/vip) are unlimited. free → false.
+function planCoversCourse(plan, course) {
+  if (plan === 'free') return false;
+  if (plan === 'basic') {
+    const hrs = course.ceHours || course.ceuHours || 1;
+    return hrs <= BASIC_MAX_COURSE_HOURS;
+  }
+  return true;
+}
+
 // True if user already has paid/admin/free-course access (no slot needed).
 function hasPaidOrFreeAccess(user, course) {
   if (!user) return false;
@@ -121,7 +134,7 @@ function hasPaidOrFreeAccess(user, course) {
   const status = user.subscription?.status || 'free';
   const plan   = user.subscription?.plan   || 'free';
   // trial is NOT unlimited — it routes through freeTierDecision (2-course / 1-hr caps)
-  return ['active','lifetime'].includes(status) && plan !== 'free';
+  return ['active','lifetime'].includes(status) && planCoversCourse(plan, course);
 }
 
 // Atomically persist consumption of one monthly free slot (month-aware).
@@ -171,7 +184,7 @@ async function gateContent(courseObj, user) {
   const subStatus = user.subscription?.status || 'free';
   const isActiveSub = ['active', 'trial', 'lifetime'].includes(subStatus);
 
-  if (isActiveSub && subPlan !== 'free') return courseObj;
+  if (isActiveSub && planCoversCourse(subPlan, courseObj)) return courseObj;
 
   // Free-tier user on a paid course: full content ONLY if already enrolled.
   // Enrollment (POST /enroll or first GET /progress) is the single chokepoint that
@@ -497,7 +510,7 @@ router.post('/:id/enroll', protect, async (req, res) => {
 
     if (isAdmin || isFree || hasPurchased) {
       accessGranted = true;
-    } else if (isActiveSub && subPlan !== 'free') {
+    } else if (isActiveSub && planCoversCourse(subPlan, course)) {
       accessGranted = true;
     } else {
       const decision = freeTierDecision(user, course);


### PR DESCRIPTION
## Summary
Adds the **Basic** subscription tier — **$15/mo, unlimited CE courses up to 3 CE hours**, sitting between Free and Starter.

## Frontend — `client/public/subscription.html`
- New **Basic** plan card ($15/mo) inserted between Free and Starter.
- `PLANS.basic` entry (`maxCourseHours: 3`) with live Stripe price ID `price_1TmXyd…`.
- Plan grid widened from `md:grid-cols-4` → `md:grid-cols-2 lg:grid-cols-5` to fit 5 cards.
- Wired into `selectPlan('basic')` and `updatePlanButtons` (button shows Current Plan / Upgrade Now correctly).

## Backend — `server/src/routes/interactiveCourseRoutes.js`
This is where the hour cap is actually enforced (the frontend `maxCourseHours` field is display-only and never read server-side).
- Added `BASIC_MAX_COURSE_HOURS = 3` and a `planCoversCourse(plan, course)` helper.
- Routed all three access chokepoints — content gate, `/enroll`, `/progress` — through the helper.
  - `basic` → unlimited courses with `ceHours ≤ 3`.
  - `basic` on a 4+ hr course → falls through to the existing `freeTierDecision` "purchase or upgrade" denial.
  - `starter` / `professional` / `vip` → unlimited (unchanged).
- Surgical, additive edits only. File still 1683 lines; `node --check` passes.

## Verification
```
grep -c "price_REPLACE_WITH_BASIC_ID" subscription.html      # 0
node --check server/src/routes/interactiveCourseRoutes.js     # OK
wc -l server/src/routes/interactiveCourseRoutes.js            # 1683
```

## Open question for reviewer
A Basic user denied a 4+ hr course currently sees the shared free-tier copy ("Free access covers 1 CE-hour courses only…"). Functionally correct but says "Free" — can tailor a Basic-specific message if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGN4dQY99fsAVQow7R4E3T