### PR TITLE
feat(certs): separate partner certificate path (own approving body, no #7760)

### DIFF
--- a/client/src/components/course-builder/courseBuilderApi.js
+++ b/client/src/components/course-builder/courseBuilderApi.js
@@ -41,6 +41,9 @@ async function handleResponse(res) {
  */
 export async function saveCourse(state) {
   const payload = buildSavePayload(state, false);
+  // approvals[] must survive the round-trip — make it explicit so the per-body
+  // approval data is never silently dropped on save (partner cert path depends on it).
+  if (Array.isArray(state.approvals)) payload.approvals = state.approvals;
   const res = await fetch(`${API_BASE}/course-builder/save`, {
     method: "POST",
     headers: authHeaders(),
@@ -58,6 +61,8 @@ export async function saveCourse(state) {
  */
 export async function publishCourse(state) {
   const payload = buildSavePayload(state, true);
+  // approvals[] must survive the round-trip — see saveCourse note above.
+  if (Array.isArray(state.approvals)) payload.approvals = state.approvals;
   const res = await fetch(`${API_BASE}/course-builder/publish`, {
     method: "POST",
     headers: authHeaders(),

--- a/client/src/components/course-builder/courseBuilderReducer.js
+++ b/client/src/components/course-builder/courseBuilderReducer.js
@@ -27,6 +27,12 @@ export const INITIAL_STATE = {
   objectives: [],
   targetAudience: [],
 
+  // Multi-approval-body authoring (partner courses issue under their own body).
+  // Each entry: { body, providerNumber, providerName, status, deliveryFormat,
+  //               hourBreakdown: [{ label, hours }] }. Edited in MetadataTab and
+  // round-tripped to InteractiveCourse.approvals[] via the save payload.
+  approvals: [],
+
   // ACEP — hardcoded per platform spec
   instructor:     ACEP_PROVIDER.name,
   approvingBody:  ACEP_PROVIDER.approvalBody,

--- a/client/src/components/course-builder/tabs/MetadataTab.jsx
+++ b/client/src/components/course-builder/tabs/MetadataTab.jsx
@@ -52,6 +52,24 @@ const S = {
     background: "none", border: "none", cursor: "pointer",
     color: C.burgundy, fontSize: 14, lineHeight: 1, padding: 0,
   },
+  approvalCard: {
+    border: `1px solid ${C.border}`, borderRadius: 8, padding: 16,
+    marginBottom: 12, background: C.stone,
+  },
+  smallBtn: {
+    padding: "6px 12px", borderRadius: 6, border: "none",
+    background: C.hunterGreen, color: "#fff", fontSize: 12,
+    fontWeight: 600, cursor: "pointer",
+  },
+  ghostBtn: {
+    padding: "6px 12px", borderRadius: 6, border: `1px solid ${C.border}`,
+    background: "#fff", color: C.burgundy, fontSize: 12,
+    fontWeight: 600, cursor: "pointer",
+  },
+  hourRow: {
+    display: "grid", gridTemplateColumns: "1fr 110px 32px", gap: 8,
+    alignItems: "center", marginBottom: 8,
+  },
   addRow: { display: "flex", gap: 8, marginTop: 8 },
   addInput: {
     flex: 1, padding: "8px 12px", borderRadius: 7,
@@ -79,6 +97,24 @@ function TagList({ items, onRemove }) {
     </div>
   );
 }
+
+// Approving-body enum (mirrors InteractiveCourse.approvals[].body)
+const APPROVAL_BODIES = [
+  "NBCC", "ACEP", "LPCAGA", "GSCSW", "ACA",
+  "NASW", "APA", "ASWB", "AAMFT", "State Board", "Other",
+];
+
+// Delivery format enum (mirrors InteractiveCourse.approvals[].deliveryFormat)
+const DELIVERY_FORMATS = [
+  { value: "asynchronous",        label: "Asynchronous" },
+  { value: "live-webinar",        label: "Live Webinar" },
+  { value: "multi-live-workshop", label: "Multi-Session Live Workshop" },
+  { value: "in-person-single",    label: "In-Person" },
+  { value: "in-person-conference",label: "In-Person Conference" },
+];
+
+// Approval status enum (mirrors InteractiveCourse.approvals[].status)
+const APPROVAL_STATUSES = ["approved", "pending", "expired", "not-applied"];
 
 function AddItemRow({ placeholder, onAdd }) {
   const [value, setValue] = useState("");
@@ -125,6 +161,37 @@ export default function MetadataTab() {
   }
 
   const targetWordCount = (state.ceHours || 0) * 6000;
+
+  // ── Approvals authoring (round-trips to InteractiveCourse.approvals[]) ──
+  const approvals = state.approvals || [];
+
+  function setApprovals(next) {
+    setMeta("approvals", next);
+  }
+  function addApproval() {
+    setApprovals([
+      ...approvals,
+      { body: "Other", providerNumber: "", providerName: "", status: "approved", deliveryFormat: "asynchronous", hourBreakdown: [] },
+    ]);
+  }
+  function removeApproval(i) {
+    setApprovals(approvals.filter((_, idx) => idx !== i));
+  }
+  function updateApproval(i, patch) {
+    setApprovals(approvals.map((a, idx) => (idx === i ? { ...a, ...patch } : a)));
+  }
+  function addHourRow(i) {
+    const hb = approvals[i].hourBreakdown || [];
+    updateApproval(i, { hourBreakdown: [...hb, { label: "", hours: 0 }] });
+  }
+  function updateHourRow(i, hi, patch) {
+    const hb = (approvals[i].hourBreakdown || []).map((h, idx) => (idx === hi ? { ...h, ...patch } : h));
+    updateApproval(i, { hourBreakdown: hb });
+  }
+  function removeHourRow(i, hi) {
+    const hb = (approvals[i].hourBreakdown || []).filter((_, idx) => idx !== hi);
+    updateApproval(i, { hourBreakdown: hb });
+  }
 
   return (
     <div style={{ maxWidth: 820, margin: "0 auto" }}>
@@ -286,6 +353,107 @@ export default function MetadataTab() {
           </div>
         </div>
         <p style={S.hint}>Provider info is set at the platform level and cannot be changed per course.</p>
+      </div>
+
+      {/* ── Approvals (per-body approval letters) ── */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>Approvals</div>
+        <p style={{ ...S.hint, marginTop: 0, marginBottom: 16 }}>
+          Add one row per approving body. Partner-owned courses issue certificates
+          under these approvals (their own provider numbers) — not the platform&apos;s NBCC #7760.
+        </p>
+
+        {approvals.length === 0 && (
+          <p style={{ fontSize: 13, color: C.textMuted, marginBottom: 12 }}>No approvals added yet.</p>
+        )}
+
+        {approvals.map((appr, i) => (
+          <div key={i} style={S.approvalCard}>
+            <div style={S.row3}>
+              <div>
+                <label style={S.label}>Approving Body</label>
+                <select
+                  style={S.select}
+                  value={appr.body || "Other"}
+                  onChange={e => updateApproval(i, { body: e.target.value })}
+                >
+                  {APPROVAL_BODIES.map(b => <option key={b} value={b}>{b}</option>)}
+                </select>
+              </div>
+              <div>
+                <label style={S.label}>Status</label>
+                <select
+                  style={S.select}
+                  value={appr.status || "approved"}
+                  onChange={e => updateApproval(i, { status: e.target.value })}
+                >
+                  {APPROVAL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                </select>
+              </div>
+              <div>
+                <label style={S.label}>Delivery Format</label>
+                <select
+                  style={S.select}
+                  value={appr.deliveryFormat || "asynchronous"}
+                  onChange={e => updateApproval(i, { deliveryFormat: e.target.value })}
+                >
+                  {DELIVERY_FORMATS.map(d => <option key={d.value} value={d.value}>{d.label}</option>)}
+                </select>
+              </div>
+            </div>
+
+            <div style={S.row2}>
+              <div>
+                <label style={S.label}>Provider Number</label>
+                <input
+                  style={S.input}
+                  value={appr.providerNumber || ""}
+                  onChange={e => updateApproval(i, { providerNumber: e.target.value })}
+                  placeholder="e.g. 1234 or A-0426-564"
+                />
+              </div>
+              <div>
+                <label style={S.label}>Provider Name</label>
+                <input
+                  style={S.input}
+                  value={appr.providerName || ""}
+                  onChange={e => updateApproval(i, { providerName: e.target.value })}
+                  placeholder="e.g. American Psychological Association"
+                />
+              </div>
+            </div>
+
+            <label style={S.label}>Hour Breakdown</label>
+            {(appr.hourBreakdown || []).map((h, hi) => (
+              <div key={hi} style={S.hourRow}>
+                <input
+                  style={S.input}
+                  value={h.label || ""}
+                  onChange={e => updateHourRow(i, hi, { label: e.target.value })}
+                  placeholder="e.g. ethics"
+                />
+                <input
+                  type="number" min="0" step="0.5"
+                  style={S.input}
+                  value={h.hours ?? 0}
+                  onChange={e => updateHourRow(i, hi, { hours: Number(e.target.value) })}
+                  placeholder="Hours"
+                />
+                <button
+                  style={S.tagRemove}
+                  onClick={() => removeHourRow(i, hi)}
+                  aria-label="Remove hour row"
+                >×</button>
+              </div>
+            ))}
+            <div style={S.addRow}>
+              <button style={S.smallBtn} onClick={() => addHourRow(i)}>+ Hour Type</button>
+              <button style={S.ghostBtn} onClick={() => removeApproval(i)}>Remove Approval</button>
+            </div>
+          </div>
+        ))}
+
+        <button style={S.addBtn} onClick={addApproval}>+ Add Approval</button>
       </div>
 
     </div>

--- a/server/src/models/Certificate.js
+++ b/server/src/models/Certificate.js
@@ -155,7 +155,7 @@ const certificateSchema = new mongoose.Schema({
   },
   source: {
     type: String,
-    enum: ['upload', 'platform', 'import'],
+    enum: ['upload', 'platform', 'import', 'partner'],
     default: 'upload'
   },
   // CE Broker integration

--- a/server/src/routes/certificates.js
+++ b/server/src/routes/certificates.js
@@ -12,8 +12,10 @@ import Certificate from '../models/Certificate.js';
 import { protect } from '../middleware/auth.js';
 import { requireAddon } from '../middleware/partnerFeatureGate.js';
 import { generateCertificate, generateCertificateNumber } from '../utils/certificate.js';
+import { generatePartnerCertificate, buildPartnerApprovalBlock } from '../utils/partnerCertificate.js';
 import User from '../models/User.js';
 import Course from '../models/Course.js';
+import Partner from '../models/Partner.js';
 import { Course as InteractiveCourse, CourseProgress } from '../models/InteractiveCourse.js';
 import { logActivity, ACTIVITY_TYPES } from '../services/activityTrackingService.js';
 import logger from '../utils/logger.js';
@@ -442,11 +444,25 @@ router.post('/generate/:courseId', protect, requireAddon('certTracking'), async 
 
     logger.info({ courseId, userId, requestId: req.requestId }, 'Certificate generation request');
 
+    // Get course and verify completion (try both legacy and interactive models)
+    let course = await Course.findById(courseId);
+    if (!course) {
+      course = await InteractiveCourse.findById(courseId);
+    }
+    if (!course) {
+      return res.status(404).json({ success: false, error: 'Course not found' });
+    }
+
+    // Partner-owned courses issue under the partner path (source:'partner');
+    // platform courses under 'platform'. Dedup on the matching source so the
+    // two paths never collide.
+    const certSource = course.partnerId ? 'partner' : 'platform';
+
     // Check if certificate already exists
     const existingCert = await Certificate.findOne({
       userId,
       courseId,
-      source: 'platform'
+      source: certSource
     });
 
     if (existingCert) {
@@ -455,15 +471,6 @@ router.post('/generate/:courseId', protect, requireAddon('certTracking'), async 
         error: 'Certificate already exists for this course',
         certificate: existingCert
       });
-    }
-
-    // Get course and verify completion (try both legacy and interactive models)
-    let course = await Course.findById(courseId);
-    if (!course) {
-      course = await InteractiveCourse.findById(courseId);
-    }
-    if (!course) {
-      return res.status(404).json({ success: false, error: 'Course not found' });
     }
 
     const progress = await CourseProgress.findOne({ userId, courseId });
@@ -488,6 +495,101 @@ router.post('/generate/:courseId', protect, requireAddon('certTracking'), async 
     // Generate certificate number and verification code
     const certNumber = await generateCertificateNumber();
     const verificationCode = certNumber.replace('CR-', '').toLowerCase();
+
+    // ── PARTNER-OWNED COURSE → separate cert path (never #7760) ──
+    // Branches on course ownership. Partner courses issue under their OWN
+    // approving body (from course.approvals[]); the platform #7760 path below
+    // is left untouched.
+    if (course.partnerId) {
+      const partner = await Partner.findById(course.partnerId).lean();
+      const selectedBody = user?.profile?.preferredApprovalBody || null;
+      const block = buildPartnerApprovalBlock(
+        course.approvals, selectedBody, course.ceHours || course.ceuHours || 0
+      );
+
+      const pdfBuffer = await generatePartnerCertificate({
+        holderName,
+        courseName: course.title,
+        completionDate: progress.completedAt || new Date(),
+        ceHours: course.ceHours || course.ceuHours || 0,
+        certificateNumber: certNumber,
+        verificationCode,
+        partnerName: partner?.branding?.companyName || partner?.name || 'Provider',
+        primaryColor: partner?.branding?.primaryColor || '#6B1D34',
+        accentColor: partner?.branding?.accentColor || '#D4A855',
+        logoUrl: partner?.branding?.logoUrl || null,
+        approvalRows: block.rows,
+        completionOnly: !!block.completionOnly,
+      });
+
+      // Upload to Cloudinary (mirror the platform upload)
+      const uploadResult = await new Promise((resolve, reject) => {
+        const stream = cloudinary.uploader.upload_stream(
+          {
+            folder: `certificates/${userId}`,
+            resource_type: 'raw',
+            public_id: `cert_${certNumber.replace(/[^a-zA-Z0-9]/g, '_')}`,
+            format: 'pdf'
+          },
+          (error, result) => error ? reject(error) : resolve(result)
+        );
+        stream.end(pdfBuffer);
+      });
+
+      // Which approval (if any) backed this certificate — drives the stored
+      // approving-body metadata. Never default to NBCC/#7760 for partners.
+      const matched = Array.isArray(course.approvals)
+        ? course.approvals.find(a => a.body === selectedBody) || course.approvals.find(a => a.status === 'approved')
+        : null;
+
+      const certificate = await Certificate.create({
+        userId,
+        courseId,
+        title: course.title,
+        provider: partner?.branding?.companyName || partner?.name || 'Provider',
+        completionDate: progress.completedAt || new Date(),
+        ceHours: course.ceHours || course.ceuHours || 0,
+        category: course.categories?.[0] || 'General',
+        nbccApproved: matched?.body === 'NBCC',
+        approvingBody: matched?.body || null,
+        approvalNumber: matched?.providerNumber || null,
+        acepNumber: null,
+        certificateNumber: certNumber,
+        fileUrl: uploadResult.secure_url,
+        fileKey: uploadResult.public_id,
+        cloudinaryPublicId: uploadResult.public_id,
+        source: 'partner',
+        verificationCode,
+        verificationUrl: `https://counselorready.com/verify/${verificationCode}`
+      });
+
+      // Update progress with certificate reference
+      progress.certificateId = certificate._id;
+      progress.certificateIssuedAt = new Date();
+      progress.status = 'certified';
+      await progress.save();
+
+      // Notify admin of certificate generation
+      logActivity(ACTIVITY_TYPES.CERTIFICATE_GENERATED, {
+        courseName: course.title,
+        certificateNumber: certNumber,
+        ceHours: course.ceHours || course.ceuHours || 0
+      }, {
+        userId,
+        userName: holderName,
+        userEmail: user?.email || ''
+      }).catch(() => {});
+
+      return res.json({
+        success: true,
+        certificate: {
+          id: certificate._id,
+          certificateNumber: certNumber,
+          fileUrl: uploadResult.secure_url,
+          verificationCode
+        }
+      });
+    }
 
     // Build customization from course settings
     const customization = course.settings?.certificateCustomization || {};

--- a/server/src/utils/partnerCertificate.js
+++ b/server/src/utils/partnerCertificate.js
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) 2026 GA Integrated Therapeutic Perspectives, LLC.
+ * All rights reserved. Proprietary and confidential.
+ *
+ * Partner Certificate Generator — issues certificates for PARTNER-OWNED
+ * courses under the partner's OWN approving body (APA, ASWB, a state board,
+ * the partner's own ACEP number, etc.).
+ *
+ * This file is intentionally separate from utils/certificate.js. The platform
+ * generator defaults to CounselorReady's own NBCC ACEP provider number; that
+ * default is CORRECT for platform courses and WRONG for partner courses. To
+ * keep the two paths from ever leaking into each other, this generator:
+ *   - never references the platform ACEP provider number
+ *   - never prints "NBCC Approved Continuing Education Provider" language
+ *   - derives all approval data from the course's own approvals[] array
+ *   - falls back to a clean Certificate of Completion (no provider claim) when
+ *     no usable approval is present, instead of defaulting to NBCC.
+ *
+ * Primitives (drawDiamond / drawOrnamentalRule / page + font setup) are COPIED
+ * from certificate.js, not imported, so the platform file stays frozen.
+ */
+
+import PDFDocument from 'pdfkit';
+
+const DEFAULT_PRIMARY = '#6B1D34';   // burgundy
+const DEFAULT_ACCENT  = '#D4A855';   // honey gold
+const HUNTER_GREEN    = '#4A7C59';
+const NAVY            = '#284157';
+const TEXT_GRAY       = '#555555';
+const MUTED_GRAY      = '#777777';
+
+const VERIFY_URL  = 'counselorready.com/verify';
+const POWERED_BY  = 'Powered by CounselorReady™';
+
+// ── Delivery format label map (LPCA-GA taxonomy → human-readable) ──
+// Copied from certificate.js — do not import (keeps platform file frozen).
+const DELIVERY_FORMAT_LABELS = {
+  'asynchronous':         'Asynchronous',
+  'live-webinar':         'Live Webinar',
+  'multi-live-workshop':  'Multi-Session Live Workshop',
+  'in-person-single':     'In-Person',
+  'in-person-conference': 'In-Person Conference',
+};
+
+// ============================================================================
+// buildPartnerApprovalBlock
+// ----------------------------------------------------------------------------
+// Transforms a partner course's approvals[] array + the learner's selected
+// approval body into the rows expected by generatePartnerCertificate().
+//
+// Deliberately DIFFERENT from certificate.js buildApprovalBlock(): on no match
+// it returns { completionOnly: true, rows: [] } instead of falling back to a
+// platform NBCC row. Partner certificates must never claim NBCC approval.
+//
+//   match → one row per hourBreakdown entry (or a single total-hours row),
+//           using the entry's own providerNumber/providerName for the code.
+//   no match → completion-only certificate (no provider number, no body code).
+// ============================================================================
+export function buildPartnerApprovalBlock(courseApprovals, selectedBody, fallbackHours = 1) {
+  const usable = (a) => a && a.status !== 'expired' && a.status !== 'not-applied';
+
+  const match = Array.isArray(courseApprovals)
+    ? (courseApprovals.find(a => a.body === selectedBody && usable(a)) ||
+       courseApprovals.find(a => usable(a)) ||
+       null)
+    : null;
+
+  // No usable approval → clean Certificate of Completion. Never inject a platform NBCC default.
+  if (!match) {
+    return { completionOnly: true, rows: [] };
+  }
+
+  const providerNum  = (match.providerNumber || '').trim();
+  const providerName = (match.providerName || '').trim();
+  const deliveryFormat = match.deliveryFormat || 'asynchronous';
+
+  // Display code for the approving body. Only an NBCC entry that literally
+  // carries its own number renders an "ACEP #" — never a platform default.
+  let code = '';
+  if (match.body === 'NBCC') {
+    code = providerNum ? `ACEP #${providerNum.replace(/[^0-9]/g, '') || providerNum}` : '';
+  } else if (providerNum) {
+    code = providerNum;
+  } else if (providerName) {
+    code = providerName;
+  }
+
+  const breakdown = Array.isArray(match.hourBreakdown) && match.hourBreakdown.length
+    ? match.hourBreakdown
+    : [{ label: '', hours: fallbackHours }];
+
+  const rows = breakdown.map(({ label, hours }) => ({
+    body:           match.body,
+    code,
+    providerName,
+    hours:          Number(hours) || 0,
+    category:       label ? label.charAt(0).toUpperCase() + label.slice(1) : '',
+    deliveryFormat,
+  }));
+
+  return { completionOnly: false, rows };
+}
+
+// ── Filled diamond accent (copied from certificate.js) ──
+function drawDiamond(doc, cx, cy, size, color) {
+  doc.save().fillColor(color);
+  doc.moveTo(cx, cy - size)
+     .lineTo(cx + size, cy)
+     .lineTo(cx, cy + size)
+     .lineTo(cx - size, cy)
+     .closePath()
+     .fill();
+  doc.restore();
+}
+
+// ── Decorative horizontal rule with center diamond (copied from certificate.js) ──
+function drawOrnamentalRule(doc, cx, y, halfWidth, color) {
+  doc.save().lineWidth(0.8).strokeColor(color);
+  doc.moveTo(cx - halfWidth, y).lineTo(cx - 8, y).stroke();
+  doc.moveTo(cx + 8, y).lineTo(cx + halfWidth, y).stroke();
+  doc.fillColor(color);
+  const d = 3;
+  doc.moveTo(cx, y - d).lineTo(cx + d, y).lineTo(cx, y + d).lineTo(cx - d, y).closePath().fill();
+  doc.restore();
+}
+
+// Best-effort fetch of a remote logo into a Buffer. Returns null on any failure
+// so a missing/unreachable logo never blocks certificate issuance.
+async function fetchLogoBuffer(logoUrl) {
+  if (!logoUrl || typeof logoUrl !== 'string' || !/^https?:\/\//i.test(logoUrl)) return null;
+  try {
+    const res = await fetch(logoUrl);
+    if (!res.ok) return null;
+    const ctype = res.headers.get('content-type') || '';
+    if (!/image\/(png|jpe?g)/i.test(ctype)) return null;
+    return Buffer.from(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+export async function generatePartnerCertificate(data) {
+  const holderName        = String(data.holderName || 'Participant').trim();
+  const courseName        = String(data.courseName || 'Course').trim();
+  const ceHours           = Number(data.ceHours) || 0;
+  const certificateNumber = String(data.certificateNumber || 'CR-000000');
+  const verificationCode  = String(data.verificationCode || certificateNumber);
+  const partnerName       = String(data.partnerName || 'Provider').trim();
+  const primaryColor      = String(data.primaryColor || DEFAULT_PRIMARY);
+  const accentColor       = String(data.accentColor || DEFAULT_ACCENT);
+  const completionOnly    = !!data.completionOnly;
+  const approvalRows      = Array.isArray(data.approvalRows) ? data.approvalRows : [];
+  const completionDate    = data.completionDate ? new Date(data.completionDate) : new Date();
+
+  const deliveryLabel = DELIVERY_FORMAT_LABELS[approvalRows[0]?.deliveryFormat] || 'Asynchronous';
+
+  const formattedDate = completionDate.toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric'
+  });
+
+  // Fetch the partner logo (if any) up front — image embedding is synchronous.
+  const logoBuffer = await fetchLogoBuffer(data.logoUrl);
+
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({
+        size: 'LETTER',
+        layout: 'landscape',
+        margins: { top: 0, bottom: 0, left: 0, right: 0 },
+        info: {
+          Title:    `Certificate of Completion — ${courseName}`,
+          Author:   partnerName,
+          Subject:  `${ceHours} CE Hour${ceHours !== 1 ? 's' : ''}`,
+          Creator:  'CounselorReady',
+          Keywords: `continuing education, ${partnerName}`
+        }
+      });
+
+      const chunks = [];
+      doc.on('data',  c => chunks.push(c));
+      doc.on('end',   () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      const W = doc.page.width;
+      const H = doc.page.height;
+      const cx = W / 2;
+
+      // 1. Paper — warm tint
+      doc.rect(0, 0, W, H).fill('#FFFDF8');
+
+      // 2. Partner-colored OUTER + HUNTER GREEN INNER border
+      doc.rect(22, 22, W - 44, H - 44).lineWidth(3).stroke(primaryColor);
+      doc.rect(34, 34, W - 68, H - 68).lineWidth(1.2).stroke(HUNTER_GREEN);
+
+      // 3. Accent diamond corner accents — anchored at the outer border corners
+      const dCorner = 22;
+      const diamondSize = 5;
+      drawDiamond(doc, dCorner,     dCorner,     diamondSize, accentColor);
+      drawDiamond(doc, W - dCorner, dCorner,     diamondSize, accentColor);
+      drawDiamond(doc, dCorner,     H - dCorner, diamondSize, accentColor);
+      drawDiamond(doc, W - dCorner, H - dCorner, diamondSize, accentColor);
+
+      // 4. Partner logo watermark — centered behind body content at low opacity
+      if (logoBuffer) {
+        const wmSize = 220;
+        try {
+          doc.opacity(0.10)
+             .image(logoBuffer, (W - wmSize) / 2, (H - wmSize) / 2 - 10, {
+               fit: [wmSize, wmSize], align: 'center', valign: 'center'
+             })
+             .opacity(1);
+        } catch { /* bad image data — skip watermark */ }
+      }
+
+      // 5. HEADER — partner name (HUNTER GREEN bold-italic)
+      doc.font('Times-BoldItalic').fontSize(22).fillColor(HUNTER_GREEN)
+         .text(partnerName, 0, 58, { align: 'center', width: W });
+
+      // Ornamental rule under the partner name (no NBCC credential line)
+      drawOrnamentalRule(doc, cx, 92, 180, accentColor);
+
+      // 6. HEADLINE
+      doc.font('Times-Italic').fontSize(38).fillColor(primaryColor)
+         .text('Certificate of Completion', 0, 104, { align: 'center', width: W });
+
+      // 7. RECIPIENT BLOCK
+      doc.font('Times-Italic').fontSize(12).fillColor(NAVY)
+         .text('This certifies that', 0, 158, { align: 'center', width: W });
+
+      const nameY = 180;
+      doc.font('Times-Bold').fontSize(28).fillColor(NAVY);
+      const nameWidth = doc.widthOfString(holderName);
+      const nameX = (W - nameWidth) / 2;
+      doc.text(holderName, nameX, nameY, { lineBreak: false });
+
+      // Accent hairline under name
+      const flourishY = nameY + 38;
+      const flourishHalfWidth = Math.min(200, nameWidth / 2 + 30);
+      doc.save().lineWidth(1.5).strokeColor(accentColor)
+         .moveTo(cx - flourishHalfWidth, flourishY)
+         .lineTo(cx + flourishHalfWidth, flourishY)
+         .stroke()
+         .restore();
+
+      doc.font('Times-Italic').fontSize(12).fillColor(NAVY)
+         .text('has successfully completed', 0, flourishY + 12, { align: 'center', width: W });
+
+      // 8. COURSE TITLE
+      const courseY = flourishY + 32;
+      const courseFontSize = courseName.length > 70 ? 17 : courseName.length > 45 ? 19 : 22;
+      doc.font('Times-Bold').fontSize(courseFontSize).fillColor(primaryColor)
+         .text(courseName, 70, courseY, { align: 'center', width: W - 140 });
+
+      let cursor = doc.y + 8;
+
+      // 9. COMPLETION + DELIVERY
+      doc.font('Helvetica').fontSize(11).fillColor(NAVY)
+         .text(`Completed ${formattedDate}`, 0, cursor, { align: 'center', width: W });
+      cursor += 18;
+      doc.font('Helvetica-Oblique').fontSize(9).fillColor(primaryColor)
+         .text(deliveryLabel, 0, cursor, { align: 'center', width: W });
+
+      // ─── BOTTOM ROW — approval block (LEFT) | serial bar (CENTER) ───
+      const bottomY = H - 188;
+
+      // ── CENTER COLUMN: accent serial bar with the certificate number ──
+      const serialBarY = bottomY + 30;
+      const serialBarH = 18;
+      const serialBarW = 200;
+      const serialBarX = cx - serialBarW / 2;
+      const tab = 8;
+      doc.save()
+         .moveTo(serialBarX, serialBarY)
+         .lineTo(serialBarX + serialBarW, serialBarY)
+         .lineTo(serialBarX + serialBarW + tab, serialBarY + serialBarH / 2)
+         .lineTo(serialBarX + serialBarW, serialBarY + serialBarH)
+         .lineTo(serialBarX, serialBarY + serialBarH)
+         .lineTo(serialBarX - tab, serialBarY + serialBarH / 2)
+         .closePath()
+         .fillAndStroke(accentColor, primaryColor);
+      doc.restore();
+      doc.font('Times-Bold').fontSize(9).fillColor(primaryColor)
+         .text(certificateNumber, serialBarX, serialBarY + 4, {
+           width: serialBarW, align: 'center', characterSpacing: 0.8
+         });
+
+      // ── LEFT COLUMN: approval block (data-driven) OR hours-only ──
+      const apprX = 50;
+      const apprW = 220;
+
+      doc.font('Times-Italic').fontSize(11).fillColor(HUNTER_GREEN)
+         .text(completionOnly ? 'CE Hours' : 'Course Approval', apprX, bottomY + 22, {
+           width: apprW, align: 'center'
+         });
+
+      doc.save().lineWidth(0.8).strokeColor(HUNTER_GREEN)
+         .moveTo(apprX + 30, bottomY + 50)
+         .lineTo(apprX + apprW - 30, bottomY + 50)
+         .stroke()
+         .restore();
+
+      let apprCursor = bottomY + 56;
+
+      if (completionOnly || approvalRows.length === 0) {
+        // Completion-only: total hours, no provider claim, no body code.
+        if (ceHours) {
+          doc.font('Helvetica-Bold').fontSize(9).fillColor(primaryColor)
+             .text(`${ceHours} CE Hour${ceHours !== 1 ? 's' : ''}`, apprX, apprCursor, {
+               width: apprW, align: 'center'
+             });
+          apprCursor += 12;
+        }
+        doc.font('Helvetica-Oblique').fontSize(8).fillColor(TEXT_GRAY)
+           .text('Certificate of Completion', apprX, apprCursor, {
+             width: apprW, align: 'center'
+           });
+      } else {
+        approvalRows.forEach((appr) => {
+          const body = String(appr.body || '').trim();
+          const code = String(appr.code || '').trim();
+          const hrs  = Number(appr.hours) || 0;
+          const cat  = String(appr.category || '').trim();
+          if (!body) return;
+
+          // Body + code header line
+          doc.font('Helvetica-Bold').fontSize(8.5).fillColor(NAVY)
+             .text(code ? `${body}  ·  ${code}` : body, apprX, apprCursor, {
+               width: apprW, align: 'center'
+             });
+          apprCursor += 11;
+
+          if (hrs) {
+            doc.font('Helvetica-Bold').fontSize(9).fillColor(primaryColor)
+               .text(`${hrs} CE Hour${hrs !== 1 ? 's' : ''}`, apprX, apprCursor, {
+                 width: apprW, align: 'center'
+               });
+            apprCursor += 12;
+          }
+
+          if (cat) {
+            doc.font('Helvetica-Oblique').fontSize(8).fillColor(TEXT_GRAY)
+               .text(cat, apprX, apprCursor, {
+                 width: apprW, align: 'center', lineBreak: true
+               });
+            apprCursor = doc.y + 6;
+          } else {
+            apprCursor += 4;
+          }
+        });
+      }
+
+      // ── RIGHT COLUMN: issued-by (partner) ──
+      const sigColX = W - 280;
+      const sigColW = 240;
+      doc.font('Times-Italic').fontSize(11).fillColor(HUNTER_GREEN)
+         .text('Issued By', sigColX, bottomY + 22, { width: sigColW, align: 'center' });
+      doc.save().lineWidth(0.8).strokeColor(HUNTER_GREEN)
+         .moveTo(sigColX + 30, bottomY + 50)
+         .lineTo(sigColX + sigColW - 30, bottomY + 50)
+         .stroke()
+         .restore();
+      doc.font('Helvetica-Bold').fontSize(9).fillColor(NAVY)
+         .text(partnerName, sigColX, bottomY + 56, { width: sigColW, align: 'center' });
+      doc.font('Times-Italic').fontSize(9).fillColor(MUTED_GRAY)
+         .text('Approved Provider', sigColX, bottomY + 70, { width: sigColW, align: 'center' });
+
+      // 14. Powered-by line — replaces the platform's NBCC disclaimer entirely.
+      const poweredY = H - 66;
+      doc.font('Helvetica').fontSize(7).fillColor(MUTED_GRAY)
+         .text(POWERED_BY, 60, poweredY, { width: W - 120, align: 'center' });
+
+      // 15. Verify URL — bottom center, inside cert frame
+      doc.font('Helvetica-Bold').fontSize(7).fillColor(NAVY)
+         .text(`Verify at ${VERIFY_URL}/${verificationCode}`, 0, H - 50, {
+           align: 'center', width: W
+         });
+
+      doc.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+export default {
+  generatePartnerCertificate,
+  buildPartnerApprovalBlock,
+};


### PR DESCRIPTION
## Summary

Adds a **parallel** certificate path for partner-owned courses so they issue certificates under their **own** approving body (APA, ASWB, a state board, the partner's own ACEP number, etc.) instead of CounselorReady's NBCC ACEP #7760. The fix is additive — it branches on `course.partnerId` and **does not touch the platform path**.

### Prime directive honored — platform path FROZEN
`server/src/utils/certificate.js` and `server/src/services/certificateService.js` are **byte-for-byte unchanged**. `buildApprovalBlock`'s #7760 fallback is untouched (correct for platform courses). The platform branch of `routes/certificates.js` is intact and only runs for non-partner courses (the partner branch returns early before it).

## Changes

**NEW `server/src/utils/partnerCertificate.js`**
- `generatePartnerCertificate(data)` → partner-branded landscape PDF. Header/footer use partner branding (`companyName`, `primaryColor`, `accentColor`, `logoUrl`). Footer reads **`Powered by CounselorReady™`** — never "NBCC Approved Continuing Education Provider", never `#7760`.
- `completionOnly` mode → clean Certificate of Completion (no provider number, no "Approved Provider" claim).
- `buildPartnerApprovalBlock(courseApprovals, selectedBody, fallbackHours)` → matches a non-expired/non-`not-applied` approval (selected body, else first usable); builds rows from `hourBreakdown` using the entry's own `providerNumber`/`providerName`. **No match → `{ completionOnly: true, rows: [] }`** — never falls back to NBCC/#7760 (the one behavior that must differ from `certificate.js`).
- Primitives (`drawDiamond`, `drawOrnamentalRule`, page/font setup) are **copied**, not imported, so the platform file stays frozen.

**`server/src/routes/certificates.js`** (additive)
- Imports `Partner` and `{ generatePartnerCertificate, buildPartnerApprovalBlock }`.
- Partner branch inserted after `verificationCode` and **before** the platform `generateCertificate(` call; returns early for partner courses. Stores `source: 'partner'`, `nbccApproved: matched?.body === 'NBCC'`, `acepNumber: null`, partner provider/approval metadata.
- Dedup computed once (`course.partnerId ? 'partner' : 'platform'`) and used in the existing `findOne` so the two paths never collide.

**`server/src/models/Certificate.js`** — `source` enum now allows `'partner'` (additive).

**Course builder** — Approvals authoring section in `MetadataTab.jsx` (repeatable rows: body / status / delivery format / provider number / provider name / hour-breakdown rows). `approvals` added to reducer initial state and made explicit in the `saveCourse`/`publishCourse` payloads so it can't be silently dropped on save.

## Verification gates (all pass)
```
git diff --stat origin/main -- certificate.js certificateService.js   -> empty (frozen)
grep -c "ACEP #${ACEP_NUMBER}" certificate.js                          -> 2 (unchanged)
grep -c "7760" partnerCertificate.js                                   -> 0
grep -c "generatePartnerCertificate|buildPartnerApprovalBlock" ...     -> 6
branch line 503  <  platform generateCertificate line 598              -> ok
grep -c "source: 'platform'" / "nbccApproved: true" certificates.js    -> 1 / 1
grep -c "'partner'" Certificate.js                                     -> 1
approvals in MetadataTab / api / reducer                               -> 16 / 4 / 2
node --check on all 3 JS files                                         -> OK
esbuild parse of MetadataTab.jsx                                       -> OK
```

## Out of scope (untouched)
Payment/settlement, backfilling `approvals[]` on existing platform courses, any edit to `certificate.js`/`certificateService.js`/`buildApprovalBlock`, body-enum extension (use `'Other'` + `providerName`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vyk32z53RuSuBwxj4MsStW)_