### PR TITLE
feat(live): presenter photoUrl for Whereby camera-off avatar

### DIFF
--- a/client/public/live-host.html
+++ b/client/public/live-host.html
@@ -136,7 +136,15 @@
         const frame = document.getElementById('roomFrame');
         // Append Whereby embed params to minimise Whereby chrome
         const sep = data.roomUrl.includes('?') ? '&' : '?';
-        frame.src = data.roomUrl + sep + 'minimal=on&lang=en&skipMediaPermissionPrompt=on';
+        let embedUrl = data.roomUrl + sep + 'minimal=on&lang=en&skipMediaPermissionPrompt=on';
+        // Presenter avatar shown when the host camera is off. Whereby requires an
+        // https, square png/jpg (<=64x64) URL with NO query params; only append
+        // when the stored value satisfies that, otherwise skip silently.
+        const avatar = data.session && data.session.presenter && data.session.presenter.photoUrl;
+        if (avatar && avatar.startsWith('https://') && !avatar.includes('?')) {
+          embedUrl += '&avatarUrl=' + encodeURIComponent(avatar);
+        }
+        frame.src = embedUrl;
         frame.classList.remove('hidden');
         document.getElementById('roomGate').classList.add('hidden');
       } catch (e) {

--- a/server/src/models/LiveSession.js
+++ b/server/src/models/LiveSession.js
@@ -61,7 +61,11 @@ const liveSessionSchema = new mongoose.Schema({
   description: { type: String, default: '' },
   presenter: {
     name: { type: String, default: 'Kejuiana Johnson, MA, LPC, NCC, CPCS, BC-TMH' },
-    credentials: String
+    credentials: String,
+    // Camera-off avatar (passed to Whereby as avatarUrl). Set via env so the URL
+    // is changeable without a code deploy. Whereby requires an https, square
+    // png/jpg (<=64x64) Cloudinary URL with NO query params.
+    photoUrl: { type: String, default: process.env.LIVE_PRESENTER_AVATAR_URL || '' }
   },
 
   sessionType: {


### PR DESCRIPTION
## Summary

- Adds `presenter.photoUrl` to the `LiveSession` schema, defaulting to `process.env.LIVE_PRESENTER_AVATAR_URL || ''`. No migration needed — existing documents will read the env default on next save.
- In `live-host.html`, replaces the hard-coded `frame.src` assignment in `joinRoom()` with a guarded append: if `presenter.photoUrl` is set, starts with `https://`, and contains no `?`, it is encoded and appended to the Whereby embed URL as `avatarUrl`.
- `toPublicJSON()` already returns `presenter: this.presenter`, so the new field reaches the `/join` response with zero route changes.

## Files changed

| File | Change |
|---|---|
| `server/src/models/LiveSession.js` | +5 lines — `photoUrl` field added to `presenter` sub-schema |
| `client/public/live-host.html` | +9 lines — guarded `avatarUrl` param append in `joinRoom()` |

## Verification gates (all passed)

```
git diff --name-only origin/main   → LiveSession.js + live-host.html only
grep -c "photoUrl" server/src/models/LiveSession.js             → 1
grep -c "presenter: this.presenter" server/src/models/LiveSession.js  → 1 (unchanged)
grep -c "avatarUrl" client/public/live-host.html                → 1
node --check server/src/models/LiveSession.js                   → OK
```

## Non-code steps required before the feature is live (Ke)

1. **Set env var** `LIVE_PRESENTER_AVATAR_URL` in Render → a Cloudinary delivery URL that is `https`, square ≤64×64 px, png/jpg, **no query string**. Recommended transform path: `c_fill,g_face,h_64,w_64,f_png`.
2. **Allowlist domain** in the Whereby dashboard → Embedded app → Allowed domains → add `res.cloudinary.com`. Without this Whereby ignores the param.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L32iyvwJkCdCoGBtLhuU8T)_