### PR TITLE
feat(certs): partner cert white-label — header logo, objectives, custom footer

### DIFF
--- a/client/public/partner-branding.html
+++ b/client/public/partner-branding.html
@@ -76,6 +76,11 @@
             <input id="logoUrl" class="fld" placeholder="https://.../logo.png" oninput="syncPreview()">
             <p class="text-xs text-stone-400 mt-1">Paste a hosted image URL (PNG/SVG). Recommended height ~48px.</p>
           </div>
+          <div>
+            <label class="lbl" for="certFooter">Certificate footer</label>
+            <textarea id="certFooter" class="fld" rows="2" placeholder="Business name, address, license disclaimer…"></textarea>
+            <p class="text-xs text-stone-400 mt-1">Shown at the bottom of your certificates — e.g. business name, address, license disclaimer. Keep to ~2 lines.</p>
+          </div>
         </div>
 
         <div class="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
@@ -222,6 +227,7 @@
         document.getElementById('companyName').value = b.companyName || partner.name || '';
         document.getElementById('tagline').value = b.tagline || '';
         document.getElementById('logoUrl').value = b.logoUrl || '';
+        document.getElementById('certFooter').value = b.certFooter || '';
         document.getElementById('primaryColor').value = b.primaryColor || '#6B1D34';
         document.getElementById('primaryHex').value = b.primaryColor || '#6B1D34';
         document.getElementById('accentColor').value = b.accentColor || '#D4A855';
@@ -283,6 +289,7 @@
         companyName: document.getElementById('companyName').value.trim(),
         tagline: document.getElementById('tagline').value.trim(),
         logoUrl: document.getElementById('logoUrl').value.trim(),
+        certFooter: document.getElementById('certFooter').value.trim(),
         primaryColor: document.getElementById('primaryHex').value.trim(),
         accentColor: document.getElementById('accentHex').value.trim(),
         customDomain: document.getElementById('customDomain').value.trim().toLowerCase()

--- a/server/src/models/Partner.js
+++ b/server/src/models/Partner.js
@@ -24,6 +24,9 @@ const partnerSchema = new mongoose.Schema({
   // Branding
   branding: {
     logoUrl: { type: String },
+    // Partner-set certificate footer (license disclaimer / address / contact /
+    // board-approval statement). Rendered above the verify line on partner certs.
+    certFooter: { type: String },
     primaryColor: { type: String, default: '#6B1D34' },
     companyName: { type: String },
     tagline: { type: String },

--- a/server/src/routes/certificates.js
+++ b/server/src/routes/certificates.js
@@ -518,6 +518,8 @@ router.post('/generate/:courseId', protect, requireAddon('certTracking'), async 
         primaryColor: partner?.branding?.primaryColor || '#6B1D34',
         accentColor: partner?.branding?.accentColor || '#D4A855',
         logoUrl: partner?.branding?.logoUrl || null,
+        objectives: course.objectives,
+        certFooter: partner?.branding?.certFooter,
         approvalRows: block.rows,
         completionOnly: !!block.completionOnly,
       });

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -439,8 +439,9 @@ router.put('/my-branding', protect, requirePartnerAdmin, async (req, res) => {
       return res.status(404).json({ error: 'Partner not found' });
     }
 
-    const { logoUrl, primaryColor, companyName, tagline, colorScheme, accentColor, customDomain } = req.body;
+    const { logoUrl, certFooter, primaryColor, companyName, tagline, colorScheme, accentColor, customDomain } = req.body;
     if (logoUrl !== undefined) partner.branding.logoUrl = logoUrl;
+    if (certFooter !== undefined) partner.branding.certFooter = certFooter;
     if (primaryColor !== undefined) partner.branding.primaryColor = primaryColor;
     if (companyName !== undefined) partner.branding.companyName = companyName;
     if (tagline !== undefined) partner.branding.tagline = tagline;

--- a/server/src/utils/partnerCertificate.js
+++ b/server/src/utils/partnerCertificate.js
@@ -158,8 +158,11 @@ export async function generatePartnerCertificate(data) {
     year: 'numeric', month: 'long', day: 'numeric'
   });
 
-  // Fetch the partner logo (if any) up front — image embedding is synchronous.
-  const logoBuffer = await fetchLogoBuffer(data.logoUrl);
+  // Resolve the partner logo (if any) up front — image embedding is synchronous.
+  // Prefer a pre-fetched/uploaded buffer; fall back to fetching the URL.
+  const logoBuffer = (data.logoBuffer && Buffer.isBuffer(data.logoBuffer))
+    ? data.logoBuffer
+    : await fetchLogoBuffer(data.logoUrl);
 
   return new Promise((resolve, reject) => {
     try {
@@ -200,23 +203,25 @@ export async function generatePartnerCertificate(data) {
       drawDiamond(doc, dCorner,     H - dCorner, diamondSize, accentColor);
       drawDiamond(doc, W - dCorner, H - dCorner, diamondSize, accentColor);
 
-      // 4. Partner logo watermark — centered behind body content at low opacity
+      // 4/5. HEADER — partner logo (if present) + partner name.
+      // A real header logo (letterhead mark), not a watermark. When a logo is
+      // present the partner name tucks beneath it at a smaller size; otherwise
+      // the name carries the header on its own.
       if (logoBuffer) {
-        const wmSize = 220;
+        const logoW = 170, logoH = 34;
         try {
-          doc.opacity(0.10)
-             .image(logoBuffer, (W - wmSize) / 2, (H - wmSize) / 2 - 10, {
-               fit: [wmSize, wmSize], align: 'center', valign: 'center'
-             })
-             .opacity(1);
-        } catch { /* bad image data — skip watermark */ }
+          doc.image(logoBuffer, (W - logoW) / 2, 40, {
+            fit: [logoW, logoH], align: 'center', valign: 'center'
+          });
+        } catch { /* bad image data — skip logo */ }
+        doc.font('Times-BoldItalic').fontSize(13).fillColor(HUNTER_GREEN)
+           .text(partnerName, 0, 76, { align: 'center', width: W });
+      } else {
+        doc.font('Times-BoldItalic').fontSize(22).fillColor(HUNTER_GREEN)
+           .text(partnerName, 0, 58, { align: 'center', width: W });
       }
 
-      // 5. HEADER — partner name (HUNTER GREEN bold-italic)
-      doc.font('Times-BoldItalic').fontSize(22).fillColor(HUNTER_GREEN)
-         .text(partnerName, 0, 58, { align: 'center', width: W });
-
-      // Ornamental rule under the partner name (no NBCC credential line)
+      // Ornamental rule under the header (no NBCC credential line)
       drawOrnamentalRule(doc, cx, 92, 180, accentColor);
 
       // 6. HEADLINE
@@ -259,6 +264,24 @@ export async function generatePartnerCertificate(data) {
       cursor += 18;
       doc.font('Helvetica-Oblique').fontSize(9).fillColor(primaryColor)
          .text(deliveryLabel, 0, cursor, { align: 'center', width: W });
+
+      // 9b. LEARNING OBJECTIVES — ACEP-style; suppressed on completion-only certs
+      // (no CE claim → no objectives). Mirrors the platform cert's objectives block.
+      const objectives = Array.isArray(data.objectives) ? data.objectives.slice(0, 5) : [];
+      if (!completionOnly && objectives.length) {
+        let objY = doc.y + 24;
+        doc.font('Times-Italic').fontSize(13).fillColor(HUNTER_GREEN)
+           .text('Learning Objectives', 0, objY, { align: 'center', width: W });
+        objY = doc.y + 8;
+        const objW = W - 260;
+        const objX = (W - objW) / 2;
+        doc.font('Helvetica').fontSize(9).fillColor(TEXT_GRAY);
+        objectives.forEach((o) => {
+          const txt = `•  ${String(o).trim()}`;
+          doc.text(txt, objX, objY, { width: objW, align: 'left', lineGap: 1 });
+          objY = doc.y + 4;
+        });
+      }
 
       // ─── BOTTOM ROW — approval block (LEFT) | serial bar (CENTER) ───
       const bottomY = H - 188;
@@ -315,38 +338,30 @@ export async function generatePartnerCertificate(data) {
              width: apprW, align: 'center'
            });
       } else {
-        approvalRows.forEach((appr) => {
-          const body = String(appr.body || '').trim();
-          const code = String(appr.code || '').trim();
-          const hrs  = Number(appr.hours) || 0;
-          const cat  = String(appr.category || '').trim();
-          if (!body) return;
+        // Compact, fixed-height summary (body · code / total hours / category mix)
+        // so a multi-category breakdown never grows into the footer band.
+        const first = approvalRows[0] || {};
+        const body  = String(first.body || '').trim();
+        const code  = String(first.code || '').trim();
+        const totalHrs = approvalRows.reduce((s, r) => s + (Number(r.hours) || 0), 0);
+        const catParts = approvalRows
+          .filter(r => r.category)
+          .map(r => `${Number(r.hours) || 0} ${r.category}`);
 
-          // Body + code header line
+        if (body) {
           doc.font('Helvetica-Bold').fontSize(8.5).fillColor(NAVY)
-             .text(code ? `${body}  ·  ${code}` : body, apprX, apprCursor, {
-               width: apprW, align: 'center'
-             });
-          apprCursor += 11;
-
-          if (hrs) {
-            doc.font('Helvetica-Bold').fontSize(9).fillColor(primaryColor)
-               .text(`${hrs} CE Hour${hrs !== 1 ? 's' : ''}`, apprX, apprCursor, {
-                 width: apprW, align: 'center'
-               });
-            apprCursor += 12;
-          }
-
-          if (cat) {
-            doc.font('Helvetica-Oblique').fontSize(8).fillColor(TEXT_GRAY)
-               .text(cat, apprX, apprCursor, {
-                 width: apprW, align: 'center', lineBreak: true
-               });
-            apprCursor = doc.y + 6;
-          } else {
-            apprCursor += 4;
-          }
-        });
+             .text(code ? `${body}  ·  ${code}` : body, apprX, apprCursor, { width: apprW, align: 'center' });
+          apprCursor += 12;
+        }
+        if (totalHrs) {
+          doc.font('Helvetica-Bold').fontSize(9).fillColor(primaryColor)
+             .text(`${totalHrs} CE Hour${totalHrs !== 1 ? 's' : ''}`, apprX, apprCursor, { width: apprW, align: 'center' });
+          apprCursor += 12;
+        }
+        if (catParts.length) {
+          doc.font('Helvetica-Oblique').fontSize(8).fillColor(TEXT_GRAY)
+             .text(catParts.join('  ·  '), apprX, apprCursor, { width: apprW, align: 'center' });
+        }
       }
 
       // ── RIGHT COLUMN: issued-by (partner) ──
@@ -364,10 +379,15 @@ export async function generatePartnerCertificate(data) {
       doc.font('Times-Italic').fontSize(9).fillColor(MUTED_GRAY)
          .text('Approved Provider', sigColX, bottomY + 70, { width: sigColW, align: 'center' });
 
-      // 14. Powered-by line — replaces the platform's NBCC disclaimer entirely.
-      const poweredY = H - 66;
-      doc.font('Helvetica').fontSize(7).fillColor(MUTED_GRAY)
-         .text(POWERED_BY, 60, poweredY, { width: W - 120, align: 'center' });
+      // 13b. Partner custom footer (license disclaimer / address / contact /
+      // board-approval statement) — partner-set, above the verify line.
+      const certFooter = String(data.certFooter || '').trim();
+      if (certFooter) {
+        doc.font('Helvetica').fontSize(7.5).fillColor(TEXT_GRAY)
+           .text(certFooter, 80, H - 80, { width: W - 160, align: 'center', lineGap: 1 });
+      }
+
+      // 14. White-label: no "Powered by CounselorReady" line on partner certs.
 
       // 15. Verify URL — bottom center, inside cert frame
       doc.font('Helvetica-Bold').fontSize(7).fillColor(NAVY)


### PR DESCRIPTION
## Summary

Follow-on to the merged partner certificate path (#603). Makes partner-owned course certificates **fully white-labeled** and richer. The platform NBCC #7760 path stays **frozen** — `certificate.js` and `certificateService.js` are byte-for-byte unchanged.

> **Note:** #603 is already merged, so this is a **fresh branch off `main`** (`claude/partner-cert-branding`) and a new PR — not a reopen of #603. The handoff doc referenced the #603 branch, but that's merged, so this is the correct vehicle.

## Changes

**Generator — `server/src/utils/partnerCertificate.js`** (drop-in replacement)
- **Header logo** (letterhead mark, top-center) via `data.logoBuffer` or fetched `data.logoUrl`, replacing the faint watermark. Partner name tucks beneath it.
- **Learning Objectives** block (mid-section), suppressed when `completionOnly` is true.
- **Partner custom footer** (`data.certFooter`) above the verify line.
- **Compact approval summary** (`body · code` / total hours / category mix) so multi-category breakdowns never collide with the footer.
- **No "Powered by CounselorReady™" line** — full white-label.
- Still #7760-free; no-match still yields a clean Certificate of Completion (never NBCC fallback).

**Wiring**
- `models/Partner.js` — add `branding.certFooter` (additive).
- `routes/partners.js` — persist `certFooter` in `PUT /my-branding`.
- `routes/certificates.js` — partner branch passes `objectives: course.objectives` + `certFooter: partner?.branding?.certFooter` into the generator.
- `public/partner-branding.html` — Certificate Footer textarea, loaded on fetch and included in the save payload (static HTML + vanilla JS, existing tokens).

## Verification (all pass)
```
grep -c "7760" partnerCertificate.js                  -> 0
grep -c "text(POWERED_BY" partnerCertificate.js       -> 0   (CR line dropped)
grep -c "Learning Objectives" partnerCertificate.js   -> 1
grep -c "certFooter" partnerCertificate.js            -> 3
grep -c "data.logoBuffer" partnerCertificate.js       -> 2
git diff --stat origin/main -- certificate.js certificateService.js  -> empty (frozen)
certFooter in Partner.js / partners.js / partner-branding.html        -> 1 / 2 / 4
objectives in certificates.js (partner gen call)                      -> 1
node --check on all 4 JS files                                        -> OK
```

**Sample render eyeballed** (provided `partner_cert_own_NBCC.pdf`): header logo, objectives, custom footer, and an **"NBCC · ACEP #7123"** approval block — the partner's *own* ACEP number, proving the white-label path never injects #7760. No "Powered by" line.

## Open calls (from handoff, not addressed here)
- **Verify URL** still reads `counselorready.com/verify/…` — left functional; pointing it at `branding.subdomain`/`customDomain` for total white-label is a separate small change.
- **Objectives authoring**: course objectives already have an editor in `MetadataTab` (Learning Objectives section) — no builder change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vyk32z53RuSuBwxj4MsStW)_