### PR TITLE
Persist wordCount on CR-AI seeds so admin panel shows word counts

### DIFF
--- a/server/src/scripts/seedCR-AI-101-Foundations_of_AI_in_Mental_Health-12684words.js
+++ b/server/src/scripts/seedCR-AI-101-Foundations_of_AI_in_Mental_Health-12684words.js
@@ -648,10 +648,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-102-Ethics_of_AI_in_Clinical_Practice-18545words.js
+++ b/server/src/scripts/seedCR-AI-102-Ethics_of_AI_in_Clinical_Practice-18545words.js
@@ -679,10 +679,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-103-AI_Assisted_Clinical_Documentation-12578words.js
+++ b/server/src/scripts/seedCR-AI-103-AI_Assisted_Clinical_Documentation-12578words.js
@@ -597,10 +597,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-104-Chatbots_and_Conversational_AI-18510words.js
+++ b/server/src/scripts/seedCR-AI-104-Chatbots_and_Conversational_AI-18510words.js
@@ -568,10 +568,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-105-Algorithmic_Bias_and_Health_Equity-12573words.js
+++ b/server/src/scripts/seedCR-AI-105-Algorithmic_Bias_and_Health_Equity-12573words.js
@@ -658,10 +658,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-106-AI_Suicide_Risk_Prediction-18771words.js
+++ b/server/src/scripts/seedCR-AI-106-AI_Suicide_Risk_Prediction-18771words.js
@@ -584,10 +584,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-107-Data_Privacy_HIPAA_and_AI_Tools-12038words.js
+++ b/server/src/scripts/seedCR-AI-107-Data_Privacy_HIPAA_and_AI_Tools-12038words.js
@@ -698,10 +698,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-108-Clinical_Decision_Support_and_Diagnostic_AI-18416words.js
+++ b/server/src/scripts/seedCR-AI-108-Clinical_Decision_Support_and_Diagnostic_AI-18416words.js
@@ -677,10 +677,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-109-Talking_to_Clients_About_AI-12532words.js
+++ b/server/src/scripts/seedCR-AI-109-Talking_to_Clients_About_AI-12532words.js
@@ -507,10 +507,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}

--- a/server/src/scripts/seedCR-AI-110-Implementing_AI_Responsibly-12430words.js
+++ b/server/src/scripts/seedCR-AI-110-Implementing_AI_Responsibly-12430words.js
@@ -632,10 +632,11 @@ function validate(course){
   if(course.maxAttempts!==3) errors.push('maxAttempts≠3');
   if((course.references||[]).length<15) errors.push(`Refs: ${(course.references||[]).length}<15`);
   else console.log(`✅ Refs: ${course.references.length}`);
-  return{errors,warnings};
+  return{errors,warnings,total};
 }
 async function main(){
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
   warnings.forEach(w=>console.warn('⚠️',w));
   if(errors.length){errors.forEach(e=>console.error('❌',e));process.exit(1);}
   if(process.env.DRY_RUN){console.log('✅ DRY_RUN validation passed —',SLUG);process.exit(0);}


### PR DESCRIPTION
## Problem

The 10 AI in Mental Health courses seeded successfully but show **no word count in the admin panel**.

Root cause: the AI seed scripts compute a word-count total only for their validation gate and **never write a `wordCount` field** to the document. The admin courses panel reads a pre-computed `course.wordCount` from the DB (`client/public/admin-courses.html:339-340`); when it's absent, the on-the-fly fallback (line 347) only sums a few block fields and needs full `sections` in the list payload, so AI courses display blank. The SXH seeds already persist `wordCount` (`COURSE.wordCount = wc`), which is why those display correctly.

## Fix

Mirror the SXH pattern in all 10 AI seeds — a 2-line change per file:
- `validate()` now returns its computed `total`
- `main()` sets `COURSE.wordCount = total` before the insert/update

No content, schema, or render changes. Block types and fields unchanged.

```
-  return{errors,warnings};
+  return{errors,warnings,total};
-  const{errors,warnings}=validate(COURSE);
+  const{errors,warnings,total}=validate(COURSE);
+  COURSE.wordCount=total;
```

## Verification

Offline harness (shimmed `mongoose`/`dotenv`, no DB writes) — all 10 persist the correct `wordCount`, no syntax errors:

| Seed | wordCount persisted |
|---|---:|
| AI-101 Foundations | 12,684 |
| AI-102 Ethics | 18,545 |
| AI-103 Documentation | 12,578 |
| AI-104 Chatbots | 18,510 |
| AI-105 Algorithmic Bias | 12,573 |
| AI-106 Suicide Risk | 18,771 |
| AI-107 Data Privacy/HIPAA | 12,038 |
| AI-108 Decision Support | 18,416 |
| AI-109 Talking to Clients | 12,532 |
| AI-110 Implementing AI | 12,430 |

## Action required after merge

These courses are already in the DB without the field. Re-run each AI seed (idempotent upsert by slug) to backfill `wordCount`:
```
cd server
for f in src/scripts/seedCR-AI-*.js; do node "$f" || echo "FAILED: $f"; done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tzZpjxixqVhuccviuh2px

---
_Generated by [Claude Code](https://claude.ai/code/session_016tzZpjxixqVhuccviuh2px)_