### PR TITLE
feat(payments): Stripe Connect Express — partner course revenue via destination charges

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -60,6 +60,8 @@
 /partner-email-templates  /partner-email-templates.html  200
 /partner/domain           /partner-domain.html           200
 /partner-domain           /partner-domain.html           200
+/partner/connect          /partner-connect.html          200
+/partner-connect          /partner-connect.html          200
 /partner/bulk-upload      /partner-bulk-upload.html      200
 /partner-bulk-upload      /partner-bulk-upload.html      200
 /admin-payouts       /admin-payouts.html        200

--- a/client/public/partner-connect.html
+++ b/client/public/partner-connect.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Stripe Connect | Partner Portal | CounselorReady</title>
+  <link rel="stylesheet" href="/css/design-tokens.css">
+  <link rel="stylesheet" href="/css/typography.css">
+  <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+  <script src="/js/tailwind-config.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <style>
+    body { background: #F8F7F4; font-family: 'Lato', system-ui, sans-serif; }
+    .font-display { font-family: 'Cormorant Garamond', Georgia, serif; }
+  </style>
+  <script src="/js/cr-gtag.js"></script>
+</head>
+<body class="bg-stone-50 min-h-screen">
+
+  <div id="cr-header"></div>
+  <script src="/shared/nav-footer.js"></script>
+
+  <main class="max-w-3xl mx-auto px-6 py-8">
+
+    <a href="/partner-dashboard.html" class="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-burgundy-700 mb-4">
+      <i class="fas fa-chevron-left text-xs"></i> Partner Dashboard
+    </a>
+
+    <div class="mb-6">
+      <h1 class="font-display text-3xl font-semibold text-burgundy-900">Stripe Connect</h1>
+      <p class="text-gray-500 mt-1">Receive course revenue directly in your Stripe account</p>
+    </div>
+
+    <!-- Loading -->
+    <div id="stateLoading" class="text-center py-16">
+      <div class="animate-spin rounded-full h-10 w-10 border-4 border-burgundy-200 border-t-burgundy-700 mx-auto mb-4"></div>
+      <p class="text-gray-500">Checking connection status…</p>
+    </div>
+
+    <!-- State A: not started -->
+    <div id="stateNotStarted" class="hidden bg-white rounded-xl border border-gray-200 p-8">
+      <div class="flex items-start gap-4 mb-6">
+        <div class="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center flex-shrink-0">
+          <i class="fab fa-stripe text-purple-600 text-xl"></i>
+        </div>
+        <div>
+          <h2 class="text-lg font-semibold text-stone-900">Connect your Stripe account</h2>
+          <p class="text-stone-500 text-sm mt-1">
+            Receive course revenue directly into your own Stripe account. CounselorReady retains a
+            <strong>15% platform fee</strong>; the remaining <strong>85%</strong> is deposited straight
+            to your connected account at the time of each sale — no waiting for monthly payouts.
+          </p>
+        </div>
+      </div>
+
+      <ul class="space-y-2 mb-8 text-sm text-stone-600">
+        <li class="flex items-center gap-2"><i class="fas fa-check text-green-500"></i> Instant split at purchase time</li>
+        <li class="flex items-center gap-2"><i class="fas fa-check text-green-500"></i> Stripe handles KYC and tax forms (1099-K)</li>
+        <li class="flex items-center gap-2"><i class="fas fa-check text-green-500"></i> Works with an existing or new Stripe account</li>
+      </ul>
+
+      <button id="btnConnect" onclick="startOnboarding()"
+        class="inline-flex items-center gap-2 px-6 py-3 bg-burgundy-700 hover:bg-burgundy-800 text-white rounded-lg font-medium transition-colors">
+        <i class="fab fa-stripe"></i> Connect with Stripe
+      </button>
+    </div>
+
+    <!-- State B: started but incomplete -->
+    <div id="stateIncomplete" class="hidden bg-white rounded-xl border border-amber-200 p-8">
+      <div class="flex items-start gap-4 mb-6">
+        <div class="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+          <i class="fas fa-clock text-amber-600 text-xl"></i>
+        </div>
+        <div>
+          <h2 class="text-lg font-semibold text-stone-900">Finish setting up your Stripe account</h2>
+          <p class="text-stone-500 text-sm mt-1">
+            Your Stripe Express account was created but onboarding isn't complete yet. Finish
+            the setup to start receiving course revenue directly.
+          </p>
+        </div>
+      </div>
+      <button id="btnResume" onclick="startOnboarding()"
+        class="inline-flex items-center gap-2 px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors">
+        <i class="fas fa-arrow-right"></i> Resume Stripe Setup
+      </button>
+    </div>
+
+    <!-- State C: connected -->
+    <div id="stateConnected" class="hidden bg-white rounded-xl border border-green-200 p-8">
+      <div class="flex items-start gap-4 mb-4">
+        <div class="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+          <i class="fas fa-check-circle text-green-600 text-xl"></i>
+        </div>
+        <div>
+          <h2 class="text-lg font-semibold text-stone-900">Your Stripe account is connected</h2>
+          <p class="text-stone-500 text-sm mt-1">
+            Course revenue will be deposited directly into your Stripe account at the time of each sale.
+          </p>
+        </div>
+      </div>
+      <div class="mt-4 p-4 bg-stone-50 rounded-lg border border-stone-200 text-sm text-stone-500 font-mono" id="accountIdDisplay"></div>
+    </div>
+
+    <!-- Error -->
+    <div id="stateError" class="hidden mt-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+      <p class="text-sm text-red-700" id="errorMsg"></p>
+      <button onclick="loadStatus()" class="mt-3 px-4 py-2 text-sm rounded-lg border border-red-300 text-red-700 hover:bg-red-50">Try Again</button>
+    </div>
+
+  </main>
+
+  <div id="cr-footer"></div>
+
+  <script>
+    const API = 'https://api.counselorready.com';
+    const token = localStorage.getItem('token');
+
+    if (!token) {
+      window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
+    }
+
+    function showState(id) {
+      ['stateLoading','stateNotStarted','stateIncomplete','stateConnected','stateError']
+        .forEach(s => document.getElementById(s).classList.add('hidden'));
+      document.getElementById(id).classList.remove('hidden');
+    }
+
+    async function loadStatus() {
+      showState('stateLoading');
+      try {
+        const r = await fetch(`${API}/api/partners/my/connect/status`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!r.ok) {
+          const d = await r.json().catch(() => ({}));
+          throw new Error(d.error || `Server error ${r.status}`);
+        }
+        const data = await r.json();
+
+        if (data.onboardingComplete && data.chargesEnabled) {
+          document.getElementById('accountIdDisplay').textContent =
+            'Connected account: ' + (data.connectAccountId || '');
+          showState('stateConnected');
+        } else if (data.connectAccountId) {
+          showState('stateIncomplete');
+        } else {
+          showState('stateNotStarted');
+        }
+      } catch (err) {
+        document.getElementById('errorMsg').textContent = err.message;
+        showState('stateError');
+      }
+    }
+
+    async function startOnboarding() {
+      const btn = document.getElementById('btnConnect') || document.getElementById('btnResume');
+      if (btn) { btn.disabled = true; btn.textContent = 'Redirecting to Stripe…'; }
+      try {
+        const r = await fetch(`${API}/api/partners/my/connect/onboard`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+        });
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error || `Server error ${r.status}`);
+        if (data.alreadyConnected) { loadStatus(); return; }
+        window.location.href = data.url;
+      } catch (err) {
+        document.getElementById('errorMsg').textContent = err.message;
+        showState('stateError');
+      }
+    }
+
+    // Handle Stripe return params
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('refresh') === '1') {
+      // Link expired — get a fresh one automatically
+      (async () => {
+        try {
+          const r = await fetch(`${API}/api/partners/my/connect/onboard`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+          });
+          const data = await r.json();
+          if (data.url) window.location.href = data.url;
+          else loadStatus();
+        } catch { loadStatus(); }
+      })();
+    } else if (params.get('success') === '1') {
+      // Returned from Stripe — re-fetch status to confirm charges_enabled
+      loadStatus();
+    } else {
+      loadStatus();
+    }
+  </script>
+
+</body>
+</html>

--- a/server/src/models/Partner.js
+++ b/server/src/models/Partner.js
@@ -67,6 +67,8 @@ const partnerSchema = new mongoose.Schema({
   // Billing
   billing: {
     stripeCustomerId: { type: String },
+    connectAccountId: { type: String },           // Stripe Express account id (acct_...)
+    connectOnboardingComplete: { type: Boolean, default: false }, // charges_enabled confirmed
     stripeSubscriptionId: { type: String },
     plan: {
       type: String,

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -395,6 +395,11 @@ router.post('/admin/commissions/settle', protect, requireAdmin, async (req, res)
 
     let payoutRef = reference || null;
 
+    // Connect: money already routed at charge time via destination charge — bookkeeping only
+    if (method === 'connect') {
+      payoutRef = pending[0]?.paymentIntentId || 'connect-destination';
+    }
+
     // Cheapest path: apply as account credit against their CounselorReady partner invoice
     if (method === 'credit') {
       const partner = await Partner.findById(partnerId);
@@ -421,6 +426,81 @@ router.post('/admin/commissions/settle', protect, requireAdmin, async (req, res)
     );
 
     res.json({ message: `Settled $${owedRounded.toFixed(2)} across ${upd.modifiedCount} entr${upd.modifiedCount !== 1 ? 'ies' : 'y'}`, settled: owedRounded, count: upd.modifiedCount, method, payoutRef });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Partner admin: initiate Stripe Connect Express onboarding ──
+router.post('/my/connect/onboard', protect, requirePartnerAdmin, async (req, res) => {
+  try {
+    if (!stripe) return res.status(503).json({ error: 'Payment system not configured' });
+    const partnerId = req.partnerId || req.user.partnerId;
+    if (!partnerId) return res.status(400).json({ error: 'No partner association found' });
+
+    const partner = await Partner.findById(partnerId);
+    if (!partner) return res.status(404).json({ error: 'Partner not found' });
+
+    if (partner.billing?.connectAccountId && partner.billing?.connectOnboardingComplete) {
+      return res.json({ alreadyConnected: true });
+    }
+
+    let connectAccountId = partner.billing?.connectAccountId;
+    if (!connectAccountId) {
+      const account = await stripe.accounts.create({
+        type: 'express',
+        email: partner.contact?.email || req.user.email,
+        metadata: { partnerId: partner._id.toString() }
+      });
+      connectAccountId = account.id;
+      partner.billing.connectAccountId = connectAccountId;
+      await partner.save();
+    }
+
+    const CLIENT_URL = process.env.CLIENT_URL || 'https://counselorready.com';
+    const accountLink = await stripe.accountLinks.create({
+      account: connectAccountId,
+      refresh_url: `${CLIENT_URL}/partner/connect?refresh=1`,
+      return_url: `${CLIENT_URL}/partner/connect?success=1`,
+      type: 'account_onboarding'
+    });
+
+    res.json({ url: accountLink.url });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ── Partner admin: check Stripe Connect status ──
+router.get('/my/connect/status', protect, requirePartnerAdmin, async (req, res) => {
+  try {
+    if (!stripe) return res.status(503).json({ error: 'Payment system not configured' });
+    const partnerId = req.partnerId || req.user.partnerId;
+    if (!partnerId) return res.status(400).json({ error: 'No partner association found' });
+
+    const partner = await Partner.findById(partnerId);
+    if (!partner) return res.status(404).json({ error: 'Partner not found' });
+
+    const connectAccountId = partner.billing?.connectAccountId || null;
+    let chargesEnabled = false;
+    let payoutsEnabled = false;
+
+    if (connectAccountId) {
+      const account = await stripe.accounts.retrieve(connectAccountId);
+      chargesEnabled = !!account.charges_enabled;
+      payoutsEnabled = !!account.payouts_enabled;
+      if (chargesEnabled && !partner.billing.connectOnboardingComplete) {
+        partner.billing.connectOnboardingComplete = true;
+        await partner.save();
+      }
+    }
+
+    res.json({
+      connectAccountId,
+      onboardingComplete: partner.billing?.connectOnboardingComplete || false,
+      chargesEnabled,
+      payoutsEnabled
+    });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -584,6 +584,24 @@ router.post('/create-course-checkout', protect, async (req, res) => {
       return res.status(400).json({ error: 'Course is free' });
     }
 
+    // ── If partner-owned course: route through Connect destination charge ──
+    const isPartnerCourse = !!course.partnerId;
+    let connectAccountId = null;
+    let applicationFeeAmount = null;
+
+    if (isPartnerCourse) {
+      const coursePartner = await Partner.findById(course.partnerId)
+        .select('billing.connectAccountId billing.connectOnboardingComplete').lean();
+      if (!coursePartner?.billing?.connectAccountId || !coursePartner?.billing?.connectOnboardingComplete) {
+        return res.status(402).json({
+          error: 'This course is not yet available for purchase — provider has not completed payment setup.',
+          code: 'CONNECT_NOT_READY'
+        });
+      }
+      connectAccountId = coursePartner.billing.connectAccountId;
+      applicationFeeAmount = Math.round(course.price * 100 * 0.15); // CR's 15%
+    }
+
     const user = await User.findById(req.user._id);
 
     // Create or get Stripe customer
@@ -621,8 +639,15 @@ router.post('/create-course-checkout', protect, async (req, res) => {
         type: 'course_purchase',
         courseId: course._id.toString(),
         userId: req.user._id.toString(),
-        slug: course.slug || ''
-      }
+        slug: course.slug || '',
+        partnerId: course.partnerId?.toString() || ''
+      },
+      ...(connectAccountId ? {
+        payment_intent_data: {
+          application_fee_amount: applicationFeeAmount,
+          transfer_data: { destination: connectAccountId }
+        }
+      } : {})
     });
 
     res.json({ sessionId: session.id, url: session.url });
@@ -1064,6 +1089,20 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         break;
       }
       
+      case 'account.updated': {
+        const account = event.data.object;
+        const partnerId = account.metadata?.partnerId;
+        if (!partnerId) break;
+        if (account.charges_enabled) {
+          await Partner.findByIdAndUpdate(partnerId, {
+            'billing.connectOnboardingComplete': true,
+            'billing.connectAccountId': account.id
+          });
+          logger.info({ partnerId, accountId: account.id, requestId: req.requestId }, 'Connect account charges enabled');
+        }
+        break;
+      }
+
       default:
         logger.info({ eventType: event.type, requestId: req.requestId }, 'Unhandled Stripe event type');
     }


### PR DESCRIPTION
## Summary

- **Partner.js** — adds `billing.connectAccountId` and `billing.connectOnboardingComplete` (additive, no existing fields touched)
- **partners.js** — two new partner-admin routes (`POST /my/connect/onboard`, `GET /my/connect/status`) plus a `connect` branch in the existing settle route (bookkeeping-only acknowledgement — money already moved at charge time)
- **payments.js** — `account.updated` webhook case auto-confirms `charges_enabled`; partner-course checkout branch blocks purchases when Connect isn't ready (`CONNECT_NOT_READY`) and attaches `payment_intent_data` with `application_fee_amount` (15% CR fee) and `transfer_data.destination` for eligible sessions
- **partner-connect.html** — new static page with three states: not started → Stripe onboarding link; incomplete → resume link + auto-refresh on `?refresh=1`; connected → confirmation with truncated account ID on `?success=1`
- **_redirects** — `/partner/connect` and `/partner-connect` aliases (additive, zero deletions)

## Verification gates (all pass)

```
grep -c "connectAccountId" server/src/models/Partner.js           → 1
grep -c "connectOnboardingComplete" server/src/models/Partner.js  → 1
grep -c "connect/onboard" server/src/routes/partners.js           → 1
grep -c "connect/status" server/src/routes/partners.js            → 1
grep -c "account.updated" server/src/routes/payments.js           → 1
grep -c "connectAccountId" server/src/routes/payments.js          → 7
grep -c "application_fee_amount" server/src/routes/payments.js    → 1
grep -c "transfer_data" server/src/routes/payments.js             → 1
grep -c "CONNECT_NOT_READY" server/src/routes/payments.js         → 1
awk settle connect payoutRef line                                  → 400
node --check all three server files                               → OK
_redirects deletions                                               → 0
```

## Post-merge manual steps (Stripe dashboard — not code)

1. Add `account.updated` to the webhook's event list
2. Enable Connect in Stripe dashboard (Stripe > Connect > Get started)
3. Confirm Express accounts are available on the account tier

## Out of scope

- Refund reversals on Connect charges (`stripe.transfers.createReversal`) — follow-on task
- Partner-facing earnings dashboard — already built, no changes needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01XopryZY3HoEQo2JvGTmgQQ)_