### PR TITLE
fix(payments): filter invoices to paid-only; add price-ID plan fallback on checkout

### DIFF
--- a/server/src/routes/payments.js
+++ b/server/src/routes/payments.js
@@ -102,6 +102,7 @@ router.get('/invoices', protect, async (req, res) => {
     // Get invoices from Stripe
     const invoices = await stripe.invoices.list({
       customer: user.subscription.stripeCustomerId,
+      status: 'paid',
       limit: 20
     });
 
@@ -532,6 +533,7 @@ router.get('/billing-history', protect, async (req, res) => {
 
     const invoices = await stripe.invoices.list({
       customer: user.subscription.stripeCustomerId,
+      status: 'paid',
       limit: 20
     });
 
@@ -835,10 +837,27 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         }
 
         // Handle subscription purchase
-        if (userId && plan) {
+        // Resolve plan from metadata; fall back to price ID lookup so sessions
+        // created before subscription_data.metadata was wired still activate correctly.
+        let resolvedPlan = plan;
+        if (!resolvedPlan && session.subscription) {
+          try {
+            const sub = await stripe.subscriptions.retrieve(session.subscription);
+            const priceId = sub.items?.data?.[0]?.price?.id;
+            if (priceId) {
+              for (const [key, val] of Object.entries(PRICE_IDS)) {
+                if (val === priceId) { resolvedPlan = key; break; }
+              }
+            }
+          } catch (e) {
+            logger.warn({ err: e, userId, requestId: req.requestId }, 'checkout.session.completed: price-ID plan fallback failed');
+          }
+        }
+
+        if (userId && resolvedPlan) {
           await User.findByIdAndUpdate(userId, {
             'subscription.stripeSubscriptionId': session.subscription,
-            'subscription.plan': plan,
+            'subscription.plan': resolvedPlan,
             'subscription.status': 'active',
             'subscription.currentPeriodStart': new Date(),
             'subscription.currentPeriodEnd': new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
@@ -846,7 +865,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
           });
           const subscriber = await User.findById(userId).select('email profile.firstName');
           logActivity(ACTIVITY_TYPES.PAYMENT_SUCCEEDED, {
-            plan,
+            plan: resolvedPlan,
             amount: session.amount_total,
             type: 'subscription'
           }, {
@@ -854,13 +873,13 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
             userName: subscriber?.profile?.firstName || '',
             userEmail: subscriber?.email || ''
           }).catch(() => {});
-          logger.info({ userId, plan, requestId: req.requestId, action: 'subscription_activated' }, 'Subscription activated');
+          logger.info({ userId, plan: resolvedPlan, requestId: req.requestId, action: 'subscription_activated' }, 'Subscription activated');
 
           // SMS: new subscription
           if (twilioClient && process.env.ADMIN_PHONE) {
             const amount = session.amount_total ? `$${(session.amount_total / 100).toFixed(2)}` : 'discounted';
             twilioClient.messages.create({
-              body: `CounselorReady: New Subscription\n${subscriber?.email}\nPlan: ${plan} · ${amount}/mo`,
+              body: `CounselorReady: New Subscription\n${subscriber?.email}\nPlan: ${resolvedPlan} · ${amount}/mo`,
               from: process.env.TWILIO_PHONE_NUMBER,
               to: process.env.ADMIN_PHONE
             }).catch(e => logger.error({ err: e, userId, requestId: req.requestId }, 'SMS subscription notification error'));


### PR DESCRIPTION
## Summary

- **Fix 1 — Invoice list:** Both `/api/payments/invoices` and `/api/payments/billing-history` now pass `status: 'paid'` to `stripe.invoices.list()`, filtering out void/draft/open invoices that caused the 7 duplicate $0.00 entries in billing history.
- **Fix 2 — Checkout plan fallback:** `checkout.session.completed` now resolves the plan via a price-ID lookup (`stripe.subscriptions.retrieve` → `items.data[0].price.id` → `PRICE_IDS` reverse map) when `session.metadata.plan` is missing. This prevents the silent skip that left the first real subscriber showing "Free / Active" after a successful $19.99 payment. All internal references to `plan` in this block updated to `resolvedPlan`.

## Files changed

- `server/src/routes/payments.js` only — 24 insertions, 5 deletions

## Verification gates

```
grep -c "status: 'paid'"          → 2  ✓
grep -c "resolvedPlan"            → 8  ✓
grep -c "price-ID plan fallback"  → 1  ✓
git diff --stat origin/main       → payments.js only  ✓
node --check payments.js          → OK  ✓
```

## Post-deploy manual repair

After deploying, run the one-time repair for `tanarasmithwoods@gmail.com` in the Render shell as documented in the task prompt (set `subscription.plan: 'starter'`, `subscription.status: 'active'`). This PR does not include that script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbEzxdzC6TS7imYJ8vz6wm)_