### PR TITLE
fix(billing): remove phantom Basic plan from subscription.html

### DIFF
--- a/client/public/subscription.html
+++ b/client/public/subscription.html
@@ -103,38 +103,6 @@
           </button>
         </div>
 
-        <!-- Basic Plan -->
-        <div class="bg-white rounded-xl border border-hunter-300 shadow-sm p-6">
-          <h3 class="font-display text-xl font-semibold text-hunter-800 mb-2">Basic</h3>
-          <div class="mb-4">
-            <span class="text-3xl font-bold text-hunter-900">$15</span>
-            <span class="text-hunter-600">/month</span>
-          </div>
-          <ul class="space-y-2 mb-6 text-sm text-hunter-700">
-            <li class="flex items-center gap-2">
-              <span class="text-green-500">✓</span> <strong>Unlimited 1–3 hr CE courses</strong>
-            </li>
-            <li class="flex items-center gap-2">
-              <span class="text-green-500">✓</span> Full credential tracking
-            </li>
-            <li class="flex items-center gap-2">
-              <span class="text-green-500">✓</span> AI certificate scanning
-            </li>
-            <li class="flex items-center gap-2">
-              <span class="text-green-500">✓</span> Digital certificates
-            </li>
-            <li class="flex items-center gap-2 text-hunter-400">
-              <span>✗</span> 4+ hour &amp; certification courses
-            </li>
-            <li class="flex items-center gap-2 text-hunter-400">
-              <span>✗</span> Multi-state tracking
-            </li>
-          </ul>
-          <button onclick="selectPlan('basic')" class="w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold" id="basicBtn">
-            Upgrade Now
-          </button>
-        </div>
-
         <!-- Starter Plan -->
         <div class="bg-white rounded-xl border border-hunter-300 shadow-sm p-6">
           <h3 class="font-display text-xl font-semibold text-hunter-800 mb-2">Starter</h3>
@@ -365,7 +333,6 @@
     // Plan pricing - 4-tier model
     const PLANS = {
       free: { name: 'Free', price: 0, interval: 'month', priceId: null, maxCourseHours: 4, maxStates: 1, consultsPerQuarter: 0 },
-      basic: { name: 'Basic', price: 15, interval: 'month', priceId: 'price_1TmXydBV8IIVTFOINugDavAD', maxCourseHours: 3, maxStates: 1, consultsPerQuarter: 0 },
       starter: { name: 'Starter', price: 19.99, interval: 'month', priceId: 'price_1TiMorBV8IIVTFOIosEIoMCn', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       professional: { name: 'Professional', price: 29.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIoxYzFOcd', maxCourseHours: 999, maxStates: 1, consultsPerQuarter: 0 },
       vip: { name: 'VIP', price: 49.99, interval: 'month', priceId: 'price_1TiMosBV8IIVTFOIxdJ5FQ0q', maxCourseHours: 999, maxStates: 999, consultsPerQuarter: 1, hardshipMonths: 1 },
@@ -510,7 +477,6 @@
 
     function updatePlanButtons(currentPlan) {
       const freeBtn = document.getElementById('freeBtn');
-      const basicBtn = document.getElementById('basicBtn');
       const starterBtn = document.getElementById('starterBtn');
       const proBtn = document.getElementById('proBtn');
       const vipBtn = document.getElementById('vipBtn');
@@ -532,10 +498,6 @@
       freeBtn.textContent = currentPlan === 'free' ? 'Current Plan' : 'Downgrade';
       freeBtn.disabled = currentPlan === 'free';
       
-      // Basic
-      setButton(basicBtn, currentPlan === 'basic', 'Upgrade Now',
-        'w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold');
-
       // Starter
       setButton(starterBtn, currentPlan === 'starter', 'Upgrade Now',
         'w-full py-2 bg-hunter-600 hover:bg-hunter-700 text-white rounded-lg transition-colors font-semibold');


### PR DESCRIPTION
## Summary

Removes all traces of the `basic` plan from `client/public/subscription.html`. The Basic plan ($15/mo) has no real Stripe price in the platform account and was never wired into the backend `PRICE_IDS` map — clicking it would silently fail. This is Fix 3 from the billing remediation task (Fixes 1 & 2 shipped in PR #615).

**Three removals:**
- Deleted the entire Basic plan card (HTML, L106–136)
- Removed `basic` entry from the `PLANS` JS object
- Removed `basicBtn` variable declaration and its `setButton()` call from `updatePlanButtons()`

## Verification gates

```
grep -c "basic"        subscription.html  → 0  ✓
grep -c "Basic"        subscription.html  → 0  ✓
grep -c "basicBtn"     subscription.html  → 0  ✓
grep -c "price_1TmXyd" subscription.html  → 0  ✓
git diff --stat        → subscription.html only  ✓
node --check payments.js                 → OK  ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbEzxdzC6TS7imYJ8vz6wm)_