### PR TITLE
feat(partner-portal): wire Connect/payouts into dashboard tile + onboarding checklist

### DIFF
--- a/client/public/partner-dashboard.html
+++ b/client/public/partner-dashboard.html
@@ -117,6 +117,10 @@
           <i class="fas fa-coins text-hunter-500 text-lg mb-1"></i>
           <p class="text-xs font-medium text-stone-700">Earnings</p>
         </a>
+        <a href="/partner/connect" class="bg-white rounded-xl border border-gray-200 p-3 text-center hover:shadow-md transition-shadow">
+          <i class="fas fa-university text-hunter-500 text-lg mb-1"></i>
+          <p class="text-xs font-medium text-stone-700">Payouts</p>
+        </a>
       </div>
 
       <!-- Marketing additive: syndication promo -->

--- a/server/src/routes/partners.js
+++ b/server/src/routes/partners.js
@@ -1709,6 +1709,14 @@ router.get('/my/onboarding', protect, requirePartnerAdmin, async (req, res) => {
         completed: !!partner.domainVerification?.verified,
         link: '/partner/domain',
         optional: true
+      },
+      {
+        id: 'connect',
+        title: 'Set up payouts',
+        description: 'Connect your Stripe account to receive course revenue directly',
+        completed: !!(partner.billing?.connectOnboardingComplete && partner.billing?.connectAccountId),
+        link: '/partner/connect',
+        optional: true
       }
     ];
 


### PR DESCRIPTION
## Summary

Two additive changes to make `partner-connect.html` reachable from the partner dashboard and onboarding flow.

- **Dashboard tile** (`client/public/partner-dashboard.html`): Added a "Payouts" tile after the existing "Earnings" tile, linking to `/partner/connect`. Matches the exact same tile markup pattern as adjacent tiles.
- **Onboarding step** (`server/src/routes/partners.js`): Added a `connect` step to the `GET /my/onboarding` steps array, after the `domain` step. Marked `optional: true` — partners who only use CR's platform courses don't need Connect. Completion gated on `partner.billing.connectOnboardingComplete && partner.billing.connectAccountId`.

No other files touched. No existing steps, tiles, or logic changed.

## Verification gates

```
grep -c "partner/connect"          partner-dashboard.html  → 1  ✓
grep -c "Payouts"                  partner-dashboard.html  → 1  ✓
grep -c "'connect'"                partners.js             → 3  ✓
grep -c "Set up payouts"           partners.js             → 1  ✓
grep -c "connectOnboardingComplete" partners.js            → 5  ✓
grep -c "partner-earnings.html"    partner-dashboard.html  → 1  ✓ (untouched)
grep -c "partner/bulk-upload"      partner-dashboard.html  → 1  ✓ (untouched)
node --check partners.js                                   → OK ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbEzxdzC6TS7imYJ8vz6wm)_