### PR TITLE
fix(partner-page): correct NBCC compliance language — partner courses use own approving body, #7760 case-by-case only

### DIFF
--- a/client/public/partner.html
+++ b/client/public/partner.html
@@ -6,23 +6,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:image" content="https://counselorready.com/images/og-social.png">
   <title>Become a Partner | CounselorReady™</title>
-  <meta name="description" content="Launch your own branded continuing-education academy. White-label the CounselorReady platform under your brand and domain, sell CE courses backed by NBCC Approved Continuing Education Provider (ACEP #7760) status, and earn on every course.">
+  <meta name="description" content="Launch your own branded continuing-education academy. White-label the CounselorReady™ platform under your brand and domain. Sell CE courses under your own approving body, or apply for NBCC ACEP accreditation through GAITP LLC (ACEP #7760) — and earn on every sale.">
   <link rel="canonical" href="https://counselorready.com/partner">
   <!-- Open Graph -->
   <meta property="og:site_name" content="CounselorReady">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://counselorready.com/partner">
-  <meta property="og:title" content="Host CE Courses on CounselorReady | NBCC ACEP Partner Program">
-  <meta property="og:description" content="Launch a branded CE academy on CounselorReady's platform. Built-in posttests, certificate generation, and a growing audience of licensed counselors. NBCC Approved Continuing Education Provider (ACEP #7760).">
+  <meta property="og:title" content="Host CE Courses on CounselorReady | CE Partner Program">
+  <meta property="og:description" content="Launch a branded CE academy on CounselorReady's platform. Built-in posttests, certificate generation, and a growing audience of licensed counselors. Issue CE credits under your own approving body or apply for NBCC ACEP accreditation case-by-case.">
   <meta property="og:image" content="https://counselorready.com/images/og-social.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="CounselorReady Partner Program — Host CE Courses | NBCC ACEP #7760">
+  <meta property="og:image:alt" content="CounselorReady Partner Program — Host CE Courses for Licensed Counselors">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@CounselorReady">
-  <meta name="twitter:title" content="Host CE Courses on CounselorReady | NBCC ACEP Partner Program">
-  <meta name="twitter:description" content="Launch a branded CE academy with NBCC Approved Continuing Education Provider (ACEP #7760) backing. Built-in posttests, certificates, and a licensed counselor audience.">
+  <meta name="twitter:title" content="Host CE Courses on CounselorReady | CE Partner Program">
+  <meta name="twitter:description" content="Launch a branded CE academy on CounselorReady's platform. Issue CE credits under your own approving body. Built-in posttests, certificates, and a licensed counselor audience.">
   <meta name="twitter:image" content="https://counselorready.com/images/og-social.png">
   <!-- Structured Data -->
   <script type="application/ld+json">
@@ -33,7 +33,7 @@
     "serviceType": "Continuing Education Hosting Platform",
     "name": "CounselorReady CE Partner Program",
     "url": "https://counselorready.com/partner",
-    "description": "CE providers and counseling educators can host courses on CounselorReady's white-label platform, backed by NBCC Approved Continuing Education Provider (ACEP #7760) status — with built-in posttest authoring, certificate generation, learner tracking, and access to a licensed counselor audience.",
+    "description": "CE providers and counseling educators can host courses on CounselorReady's white-label platform with built-in posttest authoring, certificate generation, learner tracking, and access to a licensed counselor audience. Partners issue CE credits under their own approving body; NBCC ACEP accreditation through GAITP LLC (ACEP #7760) is available case-by-case.",
     "provider": {
       "@type": "EducationalOrganization",
       "@id": "https://counselorready.com/#org",
@@ -88,7 +88,7 @@
   <!-- Hero -->
   <section class="max-w-6xl mx-auto px-6 pt-16 pb-10 text-center">
     <h1 class="font-display text-4xl sm:text-5xl font-bold text-burgundy-900 leading-tight">Launch your own branded<br>continuing-education academy</h1>
-    <p class="text-lg text-stone-600 mt-4 max-w-2xl mx-auto">White-label the CounselorReady™ platform under your brand and domain. Offer NBCC ACEP-accredited CE to your audience, or sell your own courses — and earn on every sale.</p>
+    <p class="text-lg text-stone-600 mt-4 max-w-2xl mx-auto">White-label the CounselorReady™ platform under your brand and domain. Sell CE courses under your own approving body, earn on every sale — or apply to offer NBCC-approved CE through our ACEP program.</p>
     <div class="flex items-center justify-center gap-3 mt-7">
       <a href="#start" class="bg-burgundy-800 hover:bg-burgundy-900 text-white px-6 py-3 rounded-xl font-semibold">Start your free trial</a>
       <a href="#pricing" class="border border-stone-300 hover:bg-white text-stone-700 px-6 py-3 rounded-xl font-semibold">See pricing</a>


### PR DESCRIPTION
## Summary

Fixes inaccurate NBCC compliance language on `client/public/partner.html`. The page previously implied all partner courses are "backed by NBCC ACEP #7760" — ACEP #7760 applies only to courses CounselorReady has reviewed and accredited case-by-case. Partners issue their own approving body credentials for their own courses.

**8 exact-text replacements — no layout, style, or functional changes:**

1. `<meta name="description">` — removed "backed by NBCC ACEP #7760 status"; added "own approving body" + "case-by-case" language
2. OG title — removed "NBCC ACEP Partner Program" → "CE Partner Program"
3. OG description — replaced ACEP blanket claim with "own approving body or apply case-by-case"
4. OG image alt — removed "NBCC ACEP #7760" → "for Licensed Counselors"
5. Twitter title — same as OG title
6. Twitter description — replaced ACEP backing claim with "own approving body"
7. Structured data `description` — removed "backed by ACEP #7760 status"; added accurate case-by-case language
8. Hero subheading — replaced "Offer NBCC ACEP-accredited CE" with accurate opt-in framing

## Note

`client/public/partner.html` L110 contains a separate instance of "NBCC ACEP-accredited CE" in the body copy (not named in the task scope). Please review whether that line also needs updating.

## Verification gates

```
grep -c "backed by NBCC"         → 0  ✓
grep -c "ACEP #7760 status"      → 0  ✓
grep -c "NBCC ACEP Partner Program" → 0  ✓
grep -c "ACEP #7760 backing"     → 0  ✓
grep -c "your own approving body" → 4  ✓
grep -c "case-by-case"           → 2  ✓
grep -c "ACEP #7760"             → 2  ✓ (still referenced accurately)
git diff --stat → partner.html only, 8 insertions / 8 deletions  ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbEzxdzC6TS7imYJ8vz6wm)_