### PR TITLE
feat(marketing): add partner offer CTA to homepage + dismissible dashboard banner

### DIFF
--- a/client/public/dashboard.html
+++ b/client/public/dashboard.html
@@ -101,6 +101,24 @@
     </div>
   </main>
 
+  <!-- Partner offer banner — shown to non-partner users only -->
+  <div id="partnerOfferBanner" class="max-w-4xl mx-auto px-4 mb-6" style="display:none">
+    <div class="bg-gradient-to-r from-burgundy-50 to-hunter-50 border border-burgundy-200 rounded-xl p-4 flex flex-col sm:flex-row items-center gap-4">
+      <div class="flex-1 text-center sm:text-left">
+        <p class="text-sm font-semibold text-burgundy-900">Do you create CE courses or train other counselors?</p>
+        <p class="text-xs text-stone-500 mt-0.5">Launch your own branded CE academy — white-label platform, direct payouts, 14-day free trial.</p>
+      </div>
+      <div class="flex items-center gap-3 flex-shrink-0">
+        <a href="/become-a-partner" class="bg-burgundy-800 hover:bg-burgundy-900 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors">
+          Learn more
+        </a>
+        <button onclick="document.getElementById('partnerOfferBanner').style.display='none';localStorage.setItem('partnerBannerDismissed','1')" class="text-stone-400 hover:text-stone-600 text-xs underline">
+          Dismiss
+        </button>
+      </div>
+    </div>
+  </div>
+
   <!-- Footer — full burgundy with NBCC badge + provider disclosure + policy links -->
   <div id="cr-footer"></div>
 
@@ -229,6 +247,14 @@
       }).join('');
     }
     loadStats();
+    // Show partner offer banner to non-partner, non-dismissed users
+    (function() {
+      if (localStorage.getItem('partnerBannerDismissed')) return;
+      const u = JSON.parse(localStorage.getItem('user') || '{}');
+      if (u.role === 'partner_admin' || u.role === 'partner_user') return;
+      const banner = document.getElementById('partnerOfferBanner');
+      if (banner) banner.style.display = 'block';
+    })();
     </script>
 </body>
 </html>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -702,6 +702,25 @@
     </div>
   </section>
 
+  <!-- Partner offer -->
+  <section class="py-16 px-4 bg-stone-100 border-y border-stone-200">
+    <div class="max-w-4xl mx-auto flex flex-col md:flex-row items-center gap-8">
+      <div class="flex-1 text-center md:text-left">
+        <div class="inline-block bg-honey-100 text-honey-800 text-xs font-semibold px-3 py-1 rounded-full mb-3 tracking-wide uppercase">For CE Providers & Educators</div>
+        <h2 class="font-display text-2xl md:text-3xl font-bold text-burgundy-900 mb-3">Do you create or deliver continuing education?</h2>
+        <p class="text-stone-600 text-base mb-1">Launch your own branded CE academy on CounselorReady's platform. Issue credits under your own approving body, set your own pricing, and earn on every sale.</p>
+        <p class="text-stone-500 text-sm">White-label platform · Direct Stripe payouts · 14-day free trial</p>
+      </div>
+      <div class="flex-shrink-0">
+        <a href="/become-a-partner" class="inline-flex items-center gap-2 bg-burgundy-800 hover:bg-burgundy-900 text-white font-semibold px-7 py-3.5 rounded-xl transition-colors shadow-md">
+          Become a Partner
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+        </a>
+        <p class="text-xs text-stone-400 text-center mt-2">No card required to start</p>
+      </div>
+    </div>
+  </section>
+
   <!-- CTA -->
   <section class="py-24 px-4 bg-gradient-to-br from-hunter-800 via-hunter-700 to-burgundy-800 relative overflow-hidden">
     <div class="absolute inset-0 bg-texture opacity-5"></div>


### PR DESCRIPTION
## Summary

Two additive changes to surface the partner offer to counselors who are also educators, supervisors, or org leaders.

### 1. `client/public/index.html` — Partner CTA section
Inserted a new section directly before `<!-- CTA -->` (the "Ready to simplify" learner CTA). Targets a different audience (CE providers/educators). Links to `/become-a-partner`. Existing CTA section untouched.

### 2. `client/public/dashboard.html` — Soft dismissible banner
- Added `#partnerOfferBanner` div before `<div id="cr-footer">` — hidden by default (`display:none`)
- Appended a self-invoking function inside the existing `<script>` block that shows the banner only to non-partner, non-dismissed users (checks `localStorage.getItem('user')` role and `partnerBannerDismissed` flag)
- Dismiss button sets `partnerBannerDismissed` in localStorage so it doesn't reappear

## Verification gates

```
index.html:
  grep -c "Become a Partner"                → 1  ✓
  grep -c "become-a-partner"               → 1  ✓
  grep -c "For CE Providers"               → 1  ✓
  grep -c "Ready to simplify your CE"      → 1  ✓ (existing CTA untouched)

dashboard.html:
  grep -c "partnerOfferBanner"             → 3  ✓ (div id + script ref + dismiss handler)
  grep -c "become-a-partner"              → 1  ✓
  grep -c "partnerBannerDismissed"        → 2  ✓
  grep -c "cr-footer"                     → 1  ✓ (footer intact)

git diff --stat → index.html + dashboard.html only, 45 insertions  ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbEzxdzC6TS7imYJ8vz6wm)_